### PR TITLE
A one-character bug fix on the bin/xsbt script

### DIFF
--- a/bin/xsbt
+++ b/bin/xsbt
@@ -21,7 +21,7 @@ export PATH=$JAVA_HOME/bin:$PATH
 JAVA=$JAVA_HOME/bin/java
 
 $JAVA \
-  -Xss2m Xmx1536m -XX:MaxPermSize=256m \
+  -Xss2m -Xmx1536m -XX:MaxPermSize=256m \
   -Djava.library.path= \
   -Djava.ext.dirs= \
   -Dfile.encoding=UTF-8 \


### PR DESCRIPTION
The bin/xsbt script has a missing hyphen on the JVM flag for setting the heap memory.
