### PR TITLE
Benchmark script improvements

### DIFF
--- a/bin/benches.scala
+++ b/bin/benches.scala
@@ -103,12 +103,11 @@ def runIt(name: String) {
       else System.err.println(out)
   printResults()
 }
-
-// run until we have one good result for each model
-Iterator
-  .continually(allNames.filterNot(haveGoodResult))
-  .takeWhile(_.nonEmpty)
-  .foreach(_.foreach(runIt))
+while(true) {
+  allNames.foreach(runIt)
+  // make extra efforts to get at least one good result for each model
+  allNames.filter(!haveGoodResult(_)).foreach(runIt)
+}
 
 // Local Variables:
 // mode: scala


### PR DESCRIPTION
Nothing major:
- don't crash when Bureaucrats is first to run
- stop when we have good results everywhere
- actually write to `tmp`bench.tmp` like it says in the wiki
