### PR TITLE
`WidgetParser` has an unfriendly API

### DIFF
--- a/src/main/org/nlogo/headless/HeadlessModelOpener.scala
+++ b/src/main/org/nlogo/headless/HeadlessModelOpener.scala
@@ -75,7 +75,8 @@ class HeadlessModelOpener(ws: HeadlessWorkspace) {
     if (linkShapeLines.isEmpty) ws.world.linkShapeList.add(LinkShape.getDefaultLinkShape)
   }
 
-  private def finish(constraints: Map[String, List[String]], program: Program, interfaceGlobalCommands: StringBuilder) {
+  private def finish(constraints: Map[String, List[String]], program: Program, interfaceGlobalCommands: String) {
+    val interfaceGlobalCommandsBuffer = new StringBuilder(interfaceGlobalCommands)
     ws.world.realloc()
 
     val errors = ws.plotManager.compileAllPlots()
@@ -89,7 +90,7 @@ class HeadlessModelOpener(ws: HeadlessWorkspace) {
           val vals = ws.compiler.frontEnd.readFromString(spec(1)).asInstanceOf[LogoList]
           val defaultIndex = spec(2).toInt
           val defaultAsString = org.nlogo.api.Dump.logoObject(vals.get(defaultIndex), true, false)
-          interfaceGlobalCommands.append("set " + vname + " " + defaultAsString + "\n")
+          interfaceGlobalCommandsBuffer.append("set " + vname + " " + defaultAsString + "\n")
           new ChooserConstraint(vals, defaultIndex)
         case "SWITCH" => new BooleanConstraint(spec(1))
         case "INPUTBOX" =>
@@ -101,7 +102,7 @@ class HeadlessModelOpener(ws: HeadlessWorkspace) {
       }
       ws.world.observer().setConstraint(ws.world.observerOwnsIndexOf(vname.toUpperCase), con)
     }
-    ws.command(interfaceGlobalCommands.toString)
+    ws.command(interfaceGlobalCommandsBuffer.toString)
   }
 
   private def testCompileWidgets(program: Program, netLogoVersion: String, buttons: List[String], monitors:List[String]) {

--- a/src/main/org/nlogo/workspace/WidgetParser.scala
+++ b/src/main/org/nlogo/workspace/WidgetParser.scala
@@ -8,7 +8,8 @@ import org.nlogo.{ api, plot },
 
 class WidgetParser(worldLoader: WorldLoaderInterface, plotManager: plot.PlotManagerInterface, compilerTestingMode: Boolean) {
 
-  def parseWidgets(widgetsSection: Seq[String], netLogoVersion: String = api.Version.version) = {
+  def parseWidgets(widgetsSection: Seq[String], netLogoVersion: String = api.Version.version):
+      (Seq[String], Map[String, List[String]], Seq[String], Seq[String], String)  = {
 
     // parsing widgets dumps information into these four mutable vals.
     // as well as a few places in the workspace.
@@ -97,7 +98,7 @@ class WidgetParser(worldLoader: WorldLoaderInterface, plotManager: plot.PlotMana
         case _ => // ignore
       }
 
-    (interfaceGlobals, constraints, buttons, monitors, interfaceGlobalCommands)
+    (interfaceGlobals, constraints.toMap, buttons, monitors, interfaceGlobalCommands.toString)
 
   }
 


### PR DESCRIPTION
`WidgetParser` takes a `Workspace` in its constructor, which is kind of annoying.  The `Workspace` isn't necessary when you just want to parse an `.nlogo` file for its interface globals and interface global commands.

Also, the interface global commands are returned as a `StringBuilder`, rather than than the more-likely-expected return type, `String`.

It would be semi-nice if these annoyances could be corrected.

I ran into this when implementing f180588c5a66680ea5f0231005871712dc1268d6.
