### PR TITLE
Adding ability to create a '.jar' full of Tortoise tests!

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,7 @@ val all = taskKey[Unit]("build all the things!!!")
 
 all := { val _ = (
   (packageBin in Compile).value,
+  (packageBin in Test).value,
   (compile in Test).value,
   Extensions.extensions.value
 )}


### PR DESCRIPTION
It only took me about an eon to figure out, but I managed to tell SBT to include the `test` directory in the `.jar` that gets output by `test:package`.

@SethTisue, please review and merge.  Or maybe not merge.  I don't know....
