### PR TITLE
Fix #47!  Add doubled modal popup for weird OSX issue

### DIFF
--- a/src/main/org/nlogo/swing/ModalProgressTask.scala
+++ b/src/main/org/nlogo/swing/ModalProgressTask.scala
@@ -6,8 +6,10 @@ import java.awt.BorderLayout
 import javax.swing.{ BorderFactory, JDialog, JLabel, JPanel, SwingConstants }
 import org.nlogo.awt.EventQueue.mustBeEventDispatchThread
 import org.nlogo.awt.Positioning.center
+import org.nlogo.api.Version
 
 object ModalProgressTask {
+  val isMac = System.getProperty("os.name").startsWith("Mac")
 
   def apply(parent: java.awt.Frame, message: String, r: Runnable) {
     mustBeEventDispatchThread()
@@ -39,6 +41,15 @@ object ModalProgressTask {
     boss.setPriority(Thread.MAX_PRIORITY)
     boss.start()
     dialog.setVisible(true)
+
+    // This is a workaround for the menu getting grayed out on macs in 3D mode
+    // See issue #47  FD 6/12/14
+    if(isMac && Version.is3D) {
+      val threedFixBoss = new Boss(dialog, new Runnable() { override def run() {} })
+      threedFixBoss.setPriority(Thread.MAX_PRIORITY)
+      threedFixBoss.start()
+      dialog.setVisible(true)
+    }
   }
 
   private class Boss(dialog: JDialog, r: Runnable)


### PR DESCRIPTION
@SethTisue Please take a look and see if I did anything big and goofy.

As a side question, should we centralize isMac into Version.scala (or maybe somewhere else)?  This is now the third place we look at this system property for exactly this purpose in exactly this way
