### PR TITLE
Correcting dictionary entry for `create-temporary-plot-pen`

### DIFF
--- a/docs/dictionary.html
+++ b/docs/dictionary.html
@@ -1787,10 +1787,9 @@ end
         normal way to make a pen is to make a permanent pen in the
         plot's Edit dialog.
       <p>
-        If a temporary pen with that name already exists in the current
-        plot, no new pen is created, and the existing pen is set to the
-        current pen. If a permanent pen with that name already exists in
-        the current plot, you get a runtime error.
+        If a pen with that name already exists in the current plot, no
+        new pen is created, and the existing pen is set to the current
+        pen.
       <p>
         The new temporary plot pen has the following initial settings:
       <ul>


### PR DESCRIPTION
Looks to me like `create-temporary-plot-pen` has been working this way since when the code was first checked into GitHub more than 3 years ago.

See [here](https://github.com/NetLogo/NetLogo/blob/4fbfaff024e04b95eb08a83137e8ad5d7cc5df46/src/main/org/nlogo/prim/plot/_plotprims.scala#L86) for the code in the original commit.  No runtime exception to be seen.
