### PR TITLE
Documentation of `myself` leaves out links

### DIFF
--- a/docs/dictionary.html
+++ b/docs/dictionary.html
@@ -5282,16 +5282,17 @@ ask turtle 1
           myself
           <br>
           <img alt="Turtle Command" src="images/turtle.gif"> <img alt=
-          "Patch Command" src="images/patch.gif">
+          "Patch Command" src="images/patch.gif"> <img alt="Link Command"
+          src="images/link.gif">
         </h4>
         <p>
           &quot;self&quot; and &quot;myself&quot; are very different.
           &quot;self&quot; is simple; it means &quot;me&quot;.
-          &quot;myself&quot; means &quot;the turtle or patch who asked me
+          &quot;myself&quot; means &quot;the turtle, patch or link who asked me
           to do what I'm doing right now.&quot;
         <p>
           When an agent has been asked to run some code, using myself in
-          that code reports the agent (turtle or patch) that did the
+          that code reports the agent (turtle, patch or link) that did the
           asking.
         <p>
           myself is most often used in conjunction with <tt>of</tt> to read


### PR DESCRIPTION
The [doc for `myself`](http://ccl.northwestern.edu/netlogo/docs/dictionary.html#myself) (as opposed to the [doc for `self`](http://ccl.northwestern.edu/netlogo/docs/dictionary.html#self)) only has icons for the turtle and patch contexts.

It also says that:

> "myself" means "the turtle or patch who asked me to do what I'm doing right now."

But `myself` can be used in the context of a link, and it can also refer to a link:

```
to go
  ca
  crt 2 [ create-links-with other turtles ]
  ; `myself` can be used in the context of a link:
  ask turtles [ ask my-links [ show myself ] ]
  ; `myself` can refer to a link:
  ask links [ ask both-ends [ show myself ] ]
end
```

(I have just encountered a new user who was lead to think otherwise by the docs.)
