### PR TITLE
Allow the NetLogo shell to be invoked from any directory

### DIFF
--- a/bin/shell.sh
+++ b/bin/shell.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
+ROOTDIR="$(dirname -- "$0")/.."
+
 rlwrap java -classpath \
-NetLogo.jar:\
+$ROOTDIR/NetLogo.jar:\
 $HOME/.sbt/boot/scala-2.9.2/lib/scala-library.jar:\
-lib_managed/jars/asm/asm-all/asm-all-3.3.1.jar:\
-lib_managed/bundles/log4j/log4j/log4j-1.2.16.jar:\
-lib_managed/jars/org.picocontainer/picocontainer/picocontainer-2.13.6.jar \
+$ROOTDIR/lib_managed/jars/asm/asm-all/asm-all-3.3.1.jar:\
+$ROOTDIR/lib_managed/bundles/log4j/log4j/log4j-1.2.16.jar:\
+$ROOTDIR/lib_managed/jars/org.picocontainer/picocontainer/picocontainer-2.13.6.jar \
 org.nlogo.headless.Shell "$@"


### PR DESCRIPTION
Currently, `bin/shell.sh` must be invoked from the NetLogo root directory. This fixes that. Thus, you can add the shell to your `PATH` or create an alias, `cd` to a directory with a model, and run `netlogo-shell my-model.nlogo` (or whatever) to open a repl for the model.

I'm using this to quickly test extension commands.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/netlogo/netlogo/675)
<!-- Reviewable:end -->
