### PR TITLE
Fix memory leak in code generation process

### DIFF
--- a/src/main/org/nlogo/generator/Generator.scala
+++ b/src/main/org/nlogo/generator/Generator.scala
@@ -248,9 +248,9 @@ class Generator(source: String, procedure: Procedure, profilingEnabled: Boolean)
         if (sourceStart < 0 || sourceStart > sourceEnd || sourceEnd > source.length) ""
         else source.substring(sourceStart, sourceEnd)
       // disassembly is stored as a thunk, so it's not generated unless used
-      def isBoring(line: String) =
-        List("\\s*LINENUMBER.*", "\\s*MAXSTACK.*", "\\s*MAXLOCALS.*").exists(line.matches(_))
       result.disassembly = new org.nlogo.util.Thunk[String] {
+        def isBoring(line: String) =
+          List("\\s*LINENUMBER.*", "\\s*MAXSTACK.*", "\\s*MAXLOCALS.*").exists(line.matches(_))
         def compute = {
           val sw = new java.io.StringWriter
           new ClassReader(bytecode).accept(new TraceClassVisitor(new java.io.PrintWriter(sw)), 0)


### PR DESCRIPTION
When compiling code, the instruction generator is getting attached to the instructions that it generates. These instructions live for the duration of the model, and thus the instruction generator also lives for the duration of the model (even though it isn't actually needed). Attached are some heapdumps that I ran after opening wolf-sheep headlessly 100 times in NetLogo. Note that a corresponding (but smaller) savings of perhaps 5% of total memory can be expected for NetLogo users who do not open multiple models at once.

Before:
![before1 12 30 58 pm](https://cloud.githubusercontent.com/assets/143198/5823460/87a13190-a0a2-11e4-8844-a77fb04c6c02.png)
![before2 12 34 46 pm](https://cloud.githubusercontent.com/assets/143198/5823464/8a6d56ec-a0a2-11e4-8f11-e5c9e3097070.png)

After:
![after2 at 12 44 08 pm](https://cloud.githubusercontent.com/assets/143198/5823466/919a7364-a0a2-11e4-8d7c-640b96fe97c4.png)
![after2 at 12 42 22 pm](https://cloud.githubusercontent.com/assets/143198/5823468/9512726c-a0a2-11e4-8437-5406e944d034.png)


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/netlogo/netlogo/690)
<!-- Reviewable:end -->
