### PR TITLE
upgrade modelruns branch to Scala 2.11 and sbt 0.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@
 /// ThisBuild -- applies to subprojects too
 ///
 
-scalaVersion in ThisBuild := "2.10.4"
+scalaVersion in ThisBuild := "2.11.5"
 
 scalacOptions in ThisBuild ++=
   "-deprecation -unchecked -feature -Xcheckinit -encoding us-ascii -target:jvm-1.6 -Xfatal-warnings -Ywarn-adapted-args -Yinline-warnings"
@@ -26,13 +26,14 @@ threed in ThisBuild := { System.setProperty("org.nlogo.is3d", "true") }
 nogen in ThisBuild  := { System.setProperty("org.nlogo.noGenerator", "true") }
 
 libraryDependencies in ThisBuild ++= Seq(
+  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.3",
   "asm" % "asm-all" % "3.3.1",
   "org.picocontainer" % "picocontainer" % "2.13.6",
   "org.jmock" % "jmock" % "2.5.1" % "test",
   "org.jmock" % "jmock-legacy" % "2.5.1" % "test",
   "org.jmock" % "jmock-junit4" % "2.5.1" % "test",
-  "org.scalacheck" %% "scalacheck" % "1.10.0" % "test",
-  "org.scalatest" %% "scalatest" % "2.0" % "test"
+  "org.scalacheck" %% "scalacheck" % "1.12.0" % "test",
+  "org.scalatest" %% "scalatest" % "2.2.1" % "test"
 )
 
 ///

--- a/headless/src/main/org/nlogo/compile/Assembler.scala
+++ b/headless/src/main/org/nlogo/compile/Assembler.scala
@@ -43,7 +43,7 @@ private class Assembler {
     proc.code = code.map(tailRecurse).toArray
   }
   def assembleStatements(stmts: parse.Statements): collection.mutable.ArrayBuffer[Command] = {
-    stmts.foreach(stmt =>
+    stmts.stmts.foreach(stmt =>
       stmt.command match {
         case ca: CustomAssembled => ca.assemble(new Assistant(stmt))
         case _ => code += stmt.command
@@ -81,12 +81,12 @@ private class Assembler {
         case None => gotoMark = code.size
       }
     }
-    def block() { block(stmt.size - 1) }
+    def block() { block(stmt.args.size - 1) }
     def block(pos: Int) {
-      assembleStatements(stmt(pos).asInstanceOf[parse.CommandBlock].statements)
+      assembleStatements(stmt.args(pos).asInstanceOf[parse.CommandBlock].statements)
     }
-    def argCount = stmt.size
-    def arg(i: Int) = stmt(i).asInstanceOf[parse.ReporterApp].reporter
+    def argCount = stmt.args.size
+    def arg(i: Int) = stmt.args(i).asInstanceOf[parse.ReporterApp].reporter
     def removeArg(i: Int) {
       stmt.command.args =
         (stmt.command.args.take(i) ++ stmt.command.args.drop(i + 1)).toArray

--- a/headless/src/main/org/nlogo/compile/CarefullyVisitor.scala
+++ b/headless/src/main/org/nlogo/compile/CarefullyVisitor.scala
@@ -18,9 +18,9 @@ private class CarefullyVisitor extends parse.DefaultAstVisitor {
       case c:_carefully =>
         // carefully takes two arguments, both command blocks.
         // error-message is allowed only within the second block.
-        stmt(0).accept(this)
+        stmt.args(0).accept(this)
         stack.push(c)
-        stmt(1).accept(this)
+        stmt.args(1).accept(this)
         stack.pop()
       case _ => super.visitStatement(stmt)
     }

--- a/headless/src/main/org/nlogo/compile/LocalsVisitor.scala
+++ b/headless/src/main/org/nlogo/compile/LocalsVisitor.scala
@@ -51,7 +51,7 @@ private class LocalsVisitor extends parse.DefaultAstVisitor {
           procedure.lets = procedure.lets.filterNot(_ eq l.let)
           super.visitStatement(stmt)
         }
-        else stmt.drop(1).foreach(_.accept(this)) // drop(1) skips the _letvariable which won't be evaluated
+        else stmt.args.drop(1).foreach(_.accept(this)) // drop(1) skips the _letvariable which won't be evaluated
         currentLet = null
       case r: _repeat =>
         if(!procedure.isTask && askNestingLevel == 0) {

--- a/headless/src/main/org/nlogo/compile/Optimizer.scala
+++ b/headless/src/main/org/nlogo/compile/Optimizer.scala
@@ -73,7 +73,7 @@ private class Optimizer(is3D: Boolean) extends parse.DefaultAstVisitor {
       node match {
         case stmt: parse.Statement if !stmt.args.isEmpty =>
           stmt.args.last match {
-            case block: parse.CommandBlock if block.statements.size == 0 =>
+            case block: parse.CommandBlock if block.statements.stmts.isEmpty =>
               new Match(block)
             case _ =>
               throw new MatchFailedException

--- a/headless/src/main/org/nlogo/compile/ReferenceVisitor.scala
+++ b/headless/src/main/org/nlogo/compile/ReferenceVisitor.scala
@@ -12,7 +12,7 @@ private class ReferenceVisitor extends parse.DefaultAstVisitor {
     // be removed, so exempt _extern - ST 2/15/11
     if(index != -1 && !stmt.command.isInstanceOf[prim._extern]) {
       stmt.command.reference =
-        stmt(index).asInstanceOf[parse.ReporterApp].reporter
+        stmt.args(index).asInstanceOf[parse.ReporterApp].reporter
           .asInstanceOf[prim._reference].reference
       stmt.removeArgument(index)
     }

--- a/headless/src/main/org/nlogo/lab/Protocol.scala
+++ b/headless/src/main/org/nlogo/lab/Protocol.scala
@@ -21,7 +21,7 @@ case class Protocol(name: String,
   // Iterator here so that each combination we generate can be garbage collected when we're done
   // with it, instead of them all being held in memory until the end of the experiment.
   // - ST 5/1/08, see bug #63 - ST 2/28/12
-  type SettingsIterator = Iterator[List[Pair[String, Any]]]
+  type SettingsIterator = Iterator[List[(String, Any)]]
   def elements: SettingsIterator = {
     def combinations(sets: List[ValueSet]): SettingsIterator =
       sets match {

--- a/headless/src/main/org/nlogo/lab/ProtocolSaver.scala
+++ b/headless/src/main/org/nlogo/lab/ProtocolSaver.scala
@@ -37,7 +37,7 @@ object ProtocolSaver
     hd.endDocument()
     out.toString.replaceAll("\r\n", "\n")
   }
-  def attributes(specs: Pair[String,String]*) = {
+  def attributes(specs: (String, String)*) = {
     val result = new AttributesImpl
     for((name,value) <- specs)
       result.addAttribute("", "", name, "CDATA", value)

--- a/headless/src/main/org/nlogo/lab/SpreadsheetExporter.scala
+++ b/headless/src/main/org/nlogo/lab/SpreadsheetExporter.scala
@@ -19,7 +19,7 @@ class SpreadsheetExporter(modelFileName: String,
   extends Exporter(modelFileName, initialDims, protocol, out)
 {
   val runs = new collection.mutable.HashMap[Int,Run]
-  override def runStarted(w: Workspace, runNumber: Int, settings: List[Pair[String,Any]]) {
+  override def runStarted(w: Workspace, runNumber: Int, settings: List[(String, Any)]) {
     runs(runNumber) = new Run(settings)
   }
   override def measurementsTaken(w: Workspace, runNumber: Int, step: Int, values: List[AnyRef]) {
@@ -133,7 +133,7 @@ class SpreadsheetExporter(modelFileName: String,
     }
   }
   ///
-  class Run(val settings: List[Pair[String,Any]]) {
+  class Run(val settings: List[(String, Any)]) {
     var done = false
     var steps = 0
     // values for the metrics at each time step; the values are often Doubles, but not necessarily.

--- a/headless/src/main/org/nlogo/lab/TableExporter.scala
+++ b/headless/src/main/org/nlogo/lab/TableExporter.scala
@@ -12,13 +12,13 @@ class TableExporter(modelFileName: String,
                     out: java.io.PrintWriter)
   extends Exporter(modelFileName, initialDims, protocol, out)
 {
-  val settings = new collection.mutable.HashMap[Int,List[Pair[String,Any]]]
+  val settings = new collection.mutable.HashMap[Int,List[(String, Any)]]
   override def experimentStarted() {
     writeExportHeader()
     writeExperimentHeader()
     out.flush()
   }
-  override def runStarted(w: Workspace, runNumber: Int,runSettings: List[Pair[String,Any]]) {
+  override def runStarted(w: Workspace, runNumber: Int,runSettings: List[(String, Any)]) {
     settings(runNumber) = runSettings
   }
   override def measurementsTaken(w: Workspace, runNumber: Int, step: Int, values: List[AnyRef]) {

--- a/headless/src/main/org/nlogo/lab/Worker.scala
+++ b/headless/src/main/org/nlogo/lab/Worker.scala
@@ -71,7 +71,7 @@ class Worker(val protocol: Protocol)
       else Some(workspace.compileReporter(protocol.exitCondition))
     val metricProcedures = protocol.metrics.map(workspace.compileReporter(_))
   }
-  class Runner(runNumber: Int, settings: List[Pair[String, Any]], fn: ()=>Workspace)
+  class Runner(runNumber: Int, settings: List[(String, Any)], fn: ()=>Workspace)
     extends Callable[Unit]
   {
     class FailedException(message: String) extends LogoException(message)
@@ -103,7 +103,7 @@ class Worker(val protocol: Protocol)
           newProcedures
         }
       import procedures._
-      def setVariables(settings: List[Pair[String, Any]]) {
+      def setVariables(settings: List[(String, Any)]) {
         val world = ws.world
         var d = world.getDimensions
         for((name, value) <- settings) {

--- a/headless/src/main/org/nlogo/nvm/LabInterface.scala
+++ b/headless/src/main/org/nlogo/nvm/LabInterface.scala
@@ -16,7 +16,7 @@ object LabInterface {
     def experimentStarted() { }
     def experimentAborted() { }
     def experimentCompleted() { }
-    def runStarted(w: Workspace, runNumber: Int, settings: List[Pair[String, Any]]) { }
+    def runStarted(w: Workspace, runNumber: Int, settings: List[(String, Any)]) { }
     def measurementsTaken(w: Workspace, runNumber: Int, step: Int, values: List[AnyRef]) { }
     def stepCompleted(w: Workspace, step: Int) { }
     def runCompleted(w: Workspace, runNumber: Int, steps: Int) { }

--- a/headless/src/main/org/nlogo/parse/AstNode.scala
+++ b/headless/src/main/org/nlogo/parse/AstNode.scala
@@ -46,7 +46,8 @@ trait Expression extends AstNode {
  * of a command application). This is used when parsing arguments, when we
  * don't care what kind of application the args are for.
  */
-trait Application extends AstNode with collection.SeqProxy[Expression] {
+trait Application extends AstNode {
+  def args: Seq[Expression]
   def instruction: Instruction
   def end_=(end: Int)
   def addArgument(arg: Expression)
@@ -70,16 +71,16 @@ class ProcedureDefinition(val procedure: Procedure, val statements: Statements) 
  * (enclosed in [], in particular). This class is used to represent other
  * groups of statements as well, for instance procedure bodies.
  */
-class Statements(val file: String) extends AstNode with collection.SeqProxy[Statement] {
+class Statements(val file: String) extends AstNode {
   var start: Int = _
   var end: Int = _
-  def self = stmts // for SeqProxy
   /**
    * a List of the actual Statement objects.
    */
-  private val stmts = new collection.mutable.ArrayBuffer[Statement]
+  private val _stmts = collection.mutable.Buffer[Statement]()
+  def stmts: Seq[Statement] = _stmts
   def addStatement(stmt: Statement) {
-    stmts.append(stmt)
+    _stmts.append(stmt)
     recomputeStartAndEnd()
   }
   private def recomputeStartAndEnd() {
@@ -95,15 +96,15 @@ class Statements(val file: String) extends AstNode with collection.SeqProxy[Stat
  * application.
  */
 class Statement(var command: Command, var start: Int, var end: Int, val file: String)
-    extends Application with collection.SeqProxy[Expression] {
-  val args = new collection.mutable.ArrayBuffer[Expression]
+    extends Application {
+  private val _args = collection.mutable.Buffer[Expression]()
+  override def args: Seq[Expression] = _args
   def instruction = command // for Application
-  def self = args // for SeqProxy
-  def addArgument(arg: Expression) { args.append(arg) }
+  def addArgument(arg: Expression) { _args.append(arg) }
   override def toString = command.toString + "[" + args.mkString(", ") + "]"
   def accept(v: AstVisitor) { v.visitStatement(this) }
-  def replaceArg(index: Int, expr: Expression) { args(index) = expr }
-  def removeArgument(index: Int) { args.remove(index) }
+  def replaceArg(index: Int, expr: Expression) { _args(index) = expr }
+  def removeArgument(index: Int) { _args.remove(index) }
 }
 
 /**
@@ -154,18 +155,18 @@ class ReporterBlock(val app: ReporterApp, var start: Int, var end: Int, val file
  * applications as they're parsed.
  */
 class ReporterApp(var reporter: Reporter, var start: Int, var end: Int, val file: String)
-extends Expression with Application with collection.SeqProxy[Expression] {
+extends Expression with Application {
   /**
    * the args for this application.
    */
-  val args = new collection.mutable.ArrayBuffer[Expression]
-  def self = args // for SeqProxy
+  private val _args = collection.mutable.Buffer[Expression]()
+  override def args: Seq[Expression] = _args
   def instruction = reporter // for Application
-  def addArgument(arg: Expression) { args.append(arg) }
+  def addArgument(arg: Expression) { _args.append(arg) }
   def reportedType() = reporter.syntax.ret
   def accept(v: AstVisitor) { v.visitReporterApp(this) }
-  def removeArgument(index: Int) { args.remove(index) }
-  def replaceArg(index: Int, expr: Expression) { args(index) = expr }
-  def clearArgs() { args.clear() }
+  def removeArgument(index: Int) { _args.remove(index) }
+  def replaceArg(index: Int, expr: Expression) { _args(index) = expr }
+  def clearArgs() { _args.clear() }
   override def toString = reporter.toString + "[" + args.mkString(", ") + "]"
 }

--- a/headless/src/main/org/nlogo/parse/AstVisitor.scala
+++ b/headless/src/main/org/nlogo/parse/AstVisitor.scala
@@ -24,8 +24,8 @@ trait AstVisitor {
 class DefaultAstVisitor extends AstVisitor {
   def visitProcedureDefinition(proc: ProcedureDefinition) { proc.statements.accept(this) }
   def visitCommandBlock(block: CommandBlock) { block.statements.accept(this) }
-  def visitReporterApp(app: ReporterApp) { app.foreach(_.accept(this)) }
+  def visitReporterApp(app: ReporterApp) { app.args.foreach(_.accept(this)) }
   def visitReporterBlock(block: ReporterBlock) { block.app.accept(this) }
-  def visitStatement(stmt: Statement) { stmt.foreach(_.accept(this)) }
-  def visitStatements(stmts: Statements) { stmts.foreach(_.accept(this)) }
+  def visitStatement(stmt: Statement) { stmt.args.foreach(_.accept(this)) }
+  def visitStatements(stmts: Statements) { stmts.stmts.foreach(_.accept(this)) }
 }

--- a/headless/src/main/org/nlogo/parse/AutoConverter2.scala
+++ b/headless/src/main/org/nlogo/parse/AutoConverter2.scala
@@ -152,7 +152,7 @@ class AutoConverter2(workspace: Workspace, ignoreErrors: Boolean, tokenizer: Tok
       val oldReporter = app.reporter
       oldReporter match {
         case _: org.nlogo.prim.dead._valuefrom | _: org.nlogo.prim.dead._valuesfrom =>
-          val arg1 = app(1).asInstanceOf[ReporterBlock]
+          val arg1 = app.args(1).asInstanceOf[ReporterBlock]
           replacements += new Replacement(app.reporter.token.startPos,
                                           app.reporter.token.endPos,
                                           app.reporter.token.name,
@@ -163,7 +163,7 @@ class AutoConverter2(workspace: Workspace, ignoreErrors: Boolean, tokenizer: Tok
                                           source.substring(start, arg1.end), "")
         case _: org.nlogo.prim.dead._randomorrandomfloat =>
           var choice: String = null
-          val arg = app(0).asInstanceOf[ReporterApp].reporter
+          val arg = app.args(0).asInstanceOf[ReporterApp].reporter
           if(arg.isInstanceOf[_constdouble] && arg.asInstanceOf[_constdouble].report(null).isInstanceOf[java.lang.Double])
             choice = if(arg.token.name.indexOf('.') == -1) "random" else "random-float"
           else if(arg.token.name.equalsIgnoreCase("WORLD-WIDTH") ||
@@ -186,7 +186,7 @@ class AutoConverter2(workspace: Workspace, ignoreErrors: Boolean, tokenizer: Tok
     override def visitStatement(stmt: Statement) {
       val oldCommand = stmt.command
       if(oldCommand.isInstanceOf[org.nlogo.prim.dead._histogramfrom]) {
-        val arg1 = stmt(1).asInstanceOf[ReporterBlock]
+        val arg1 = stmt.args(1).asInstanceOf[ReporterBlock]
         var start = arg1.start
         replacements += new Replacement(oldCommand.token.startPos,
                                         oldCommand.token.endPos,

--- a/headless/src/main/org/nlogo/parse/ExpressionParser.scala
+++ b/headless/src/main/org/nlogo/parse/ExpressionParser.scala
@@ -139,7 +139,7 @@ class ExpressionParser(
         // at this point is lower precedence, or we would already
         // have consumed it. so if we have a non-default number of
         // args, this is definitely illegal.
-        cAssert(app.size == app.instruction.syntax.totalDefault, INVALID_VARIADIC_CONTEXT, app)
+        cAssert(app.args.size == app.instruction.syntax.totalDefault, INVALID_VARIADIC_CONTEXT, app)
         done = true
       }
       // note: if it's a reporter, it must be the beginning
@@ -206,8 +206,8 @@ class ExpressionParser(
     if(syntax.isInfix) {
       val tpe = syntax.left
       // this shouldn't really be possible here...
-      cAssert(app.size >= 1, missingInput(app, false), app)
-      app.replaceArg(0, resolveType(tpe, app(0), app.instruction.displayName))
+      cAssert(app.args.size >= 1, missingInput(app, false), app)
+      app.replaceArg(0, resolveType(tpe, app.args(0), app.instruction.displayName))
       // the first right arg is the second arg.
       actual1 = 1
     }
@@ -215,27 +215,27 @@ class ExpressionParser(
     var formal1 = 0
     val types = syntax.right
     while(formal1 < types.length && !compatible(Syntax.RepeatableType, types(formal1))) {
-      if(formal1 == types.length - 1 && app.size == types.length - 1 &&
+      if(formal1 == types.length - 1 && app.args.size == types.length - 1 &&
          compatible(Syntax.OptionalType, types(formal1)))
         return
-      cAssert(app.size > actual1, missingInput(app, true), app)
-      app.replaceArg(actual1, resolveType(types(formal1), app(actual1), app.instruction.displayName))
+      cAssert(app.args.size > actual1, missingInput(app, true), app)
+      app.replaceArg(actual1, resolveType(types(formal1), app.args(actual1), app.instruction.displayName))
       formal1 += 1
       actual1 += 1
     }
     if(formal1 < types.length) {
       // then we encountered a repeatable arg, so we look at right args from right-to-left...
-      var actual2 = app.size - 1
+      var actual2 = app.args.size - 1
       var formal2 = types.length - 1
       while(formal2 >= 0 && !compatible(Syntax.RepeatableType, types(formal2))) {
-        cAssert(app.size > actual2 && actual2 > -1, missingInput(app, true), app)
-        app.replaceArg(actual2, resolveType(types(formal2), app(actual2), app.instruction.displayName))
+        cAssert(app.args.size > actual2 && actual2 > -1, missingInput(app, true), app)
+        app.replaceArg(actual2, resolveType(types(formal2), app.args(actual2), app.instruction.displayName))
         formal2 -= 1
         actual2 -= 1
       }
       // now we check any repeatable args...
       while(actual1 <= actual2) {
-        app.replaceArg(actual1, resolveType(types(formal1), app(actual1), app.instruction.displayName))
+        app.replaceArg(actual1, resolveType(types(formal1), app.args(actual1), app.instruction.displayName))
         actual1 += 1
       }
     }
@@ -492,7 +492,7 @@ class ExpressionParser(
     recurse()
     val end = results.last.endPos
     results += Token.eof
-    new DelayedBlock(results.readOnly,
+    new DelayedBlock(results.toList,
                      results.head.startPos, end, openBracket.fileName)
   }
 

--- a/headless/src/main/org/nlogo/parse/SetVisitor.scala
+++ b/headless/src/main/org/nlogo/parse/SetVisitor.scala
@@ -19,7 +19,7 @@ class SetVisitor extends DefaultAstVisitor {
   override def visitStatement(stmt: Statement) {
     super.visitStatement(stmt)
     if(stmt.command.isInstanceOf[_set]) {
-      val rApp = stmt(0).asInstanceOf[ReporterApp]
+      val rApp = stmt.args(0).asInstanceOf[ReporterApp]
       val newCommandClass = SetVisitor.classes.get(rApp.reporter.getClass)
         .getOrElse(exception(INVALID_SET, stmt))
       val newCommand = Instantiator.newInstance[Command](newCommandClass, rApp.reporter)

--- a/headless/src/main/org/nlogo/sdm/Loader.scala
+++ b/headless/src/main/org/nlogo/sdm/Loader.scala
@@ -76,7 +76,9 @@ object Loader {
           }
           // skip GUI-only stuff, until eol - ST 1/25/05
           while(tokens.hasNext && tokens.next() != EOLToken)
-            { }
+          { }
+        case t =>
+          throw new RuntimeException(s"unexpected token: $t")
       }
     model
   }

--- a/headless/src/main/org/nlogo/sdm/ModelElement.scala
+++ b/headless/src/main/org/nlogo/sdm/ModelElement.scala
@@ -2,7 +2,7 @@
 
 package org.nlogo.sdm
 
-import scala.reflect.{ BeanProperty, BooleanBeanProperty }
+import scala.beans.{ BeanProperty, BooleanBeanProperty }
 
 // Model Elements need to be serializable because they are contained in the model element figures
 // which are added to the jhotdraw figures which require serializability.

--- a/headless/src/main/org/nlogo/util/Utils.scala
+++ b/headless/src/main/org/nlogo/util/Utils.scala
@@ -72,7 +72,7 @@ object Utils {
   private[util] def reader2String(reader: java.io.Reader, bufferSize: Int): String = {
     assert(bufferSize > 0)
     val sb = new StringBuilder
-    val buffer = Array.fill(bufferSize)('\0')
+    val buffer = Array.fill(bufferSize)('\u0000')
     Iterator.continually(reader.read(buffer))
       .takeWhile(_ != -1)
       .foreach(sb.appendAll(buffer, 0, _))

--- a/headless/src/test/org/nlogo/compile/ConstantFolderTests.scala
+++ b/headless/src/test/org/nlogo/compile/ConstantFolderTests.scala
@@ -22,7 +22,7 @@ class ConstantFolderTests extends FunSuite {
         .process(results.tokens(procedure).iterator, procedure)
     val procdef = new ExpressionParser(procedure).parse(tokens).head
     procdef.accept(new ConstantFolder)
-    procdef.statements.head.head.toString
+    procdef.statements.stmts.head.args.head.toString
   }
 
   /// not pure

--- a/headless/src/test/org/nlogo/compile/OptimizerTests.scala
+++ b/headless/src/test/org/nlogo/compile/OptimizerTests.scala
@@ -9,10 +9,10 @@ import org.nlogo.{ nvm, parse }
 class OptimizerTests extends FunSuite {
   def compileReporter(source: String) =
     compile("globals [glob1] breed [frogs frog] to-report __test [x] report " + source + "\nend")
-      .statements.head.head.toString
+      .statements.stmts.head.args.head.toString
   def compileCommands(source: String) =
     compile("globals [glob1] breed [frogs frog] to __test [x] " + source + "\nend")
-      .statements.head.toString
+      .statements.stmts.head.toString
   def compile(source: String): parse.ProcedureDefinition = {
     import parse._
     val results = new StructureParser(Parser.Tokenizer2D.tokenize(source), None,

--- a/headless/src/test/org/nlogo/headless/TestChecksums.scala
+++ b/headless/src/test/org/nlogo/headless/TestChecksums.scala
@@ -43,7 +43,6 @@ object TestChecksums extends ChecksumTester(println _) {
   def main(args: Array[String]) {
 
     val runTimes = new collection.mutable.HashMap[String, Long]
-            with collection.mutable.SynchronizedMap[String, Long]
     val executor = Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors)
 
     val checksums = this.checksums
@@ -52,11 +51,13 @@ object TestChecksums extends ChecksumTester(println _) {
       def doit() {
         try {
           print(".")
-          runTimes.update(entry.path, System.currentTimeMillis)
+          val start = System.currentTimeMillis
           // for now, store current time; we'll replace it later with the difference
           // between this value and the time then - ST 3/27/08
           testChecksum(entry.path, entry.worldSum, entry.graphicsSum, entry.revision)
-          runTimes.update(entry.path, System.currentTimeMillis - runTimes(entry.path))
+          runTimes.synchronized{
+            runTimes.update(entry.path, System.currentTimeMillis - start)
+          }
         }
         catch {
           case t: Throwable =>

--- a/headless/src/test/org/nlogo/parse/ExpressionParserTests.scala
+++ b/headless/src/test/org/nlogo/parse/ExpressionParserTests.scala
@@ -52,7 +52,8 @@ class ExpressionParserTests extends FunSuite {
     override def visitReporterBlock(node: ReporterBlock) { visit(node); super.visitReporterBlock(node) }
     override def visitStatement(node: Statement) { visit(node); super.visitStatement(node) }
     override def visitStatements(node: Statements) {
-      if (node.size == 0) buf.append(node.getClass.getSimpleName + " '' ")
+      if (node.stmts.isEmpty)
+        buf.append(node.getClass.getSimpleName + " '' ")
       else visit(node)
       super.visitStatements(node)
     }

--- a/project/Scaladoc.scala
+++ b/project/Scaladoc.scala
@@ -28,7 +28,7 @@ object Scaladoc {
     // for a discussion of why this was necessary, see
     // groups.google.com/forum/?fromgroups#!topic/simple-build-tool/jV43_9zpqZs
     // - ST 8/3/12
-    docSmaller <<= (baseDirectory, cacheDirectory, scalacOptions in (Compile, doc), compileInputs in Compile, netlogoVersion, streams) map {
+    docSmaller <<= (baseDirectory, cacheDirectory, scalacOptions in (Compile, doc), compileInputs in (Compile, compile), netlogoVersion, streams) map {
       (base, cache, options, inputs, version, s) =>
         val apiSources = Seq(
           "app/App.scala", "headless/HeadlessWorkspace.scala",

--- a/project/Testing.scala
+++ b/project/Testing.scala
@@ -58,7 +58,7 @@ object Testing {
       (argTask, streams, loadedTestFrameworks, testGrouping in key, testExecution in key, testLoader, fullClasspath in key, javaHome in key, state) flatMap {
         case (args, s, frameworks, groups, config, loader, cp, javaHome, st) =>
           implicit val display = Project.showContextKey(st)
-          val filter = Tests.Filter(Defaults.selectedFilter(Seq(key.key.description.get)))
+          val filter = Tests.Filters(Defaults.selectedFilter(Seq(key.key.description.get)))
           val mungedArgs =
             if(args.isEmpty) Nil
             else List("-n", args.mkString(" "))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-addSbtPlugin("org.ensime" % "ensime-sbt-cmd" % "0.1.1")
-
 libraryDependencies +=
   "de.jflex" % "jflex" % "1.4.3"
 

--- a/sbt
+++ b/sbt
@@ -39,8 +39,8 @@ USE_QUARTZ=-Dapple.awt.graphics.UseQuartz=false
 BOOT=xsbt.boot.Boot
 
 
-SBT_LAUNCH=$HOME/.sbt/sbt-launch-0.12.4.jar
-URL='http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.12.4/sbt-launch.jar'
+SBT_LAUNCH=$HOME/.sbt/sbt-launch-0.13.7.jar
+URL='http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.7/sbt-launch.jar'
 
 if [ ! -f $SBT_LAUNCH ] ; then
   echo "downloading" $URL

--- a/src/main/org/nlogo/lab/gui/ProgressDialog.scala
+++ b/src/main/org/nlogo/lab/gui/ProgressDialog.scala
@@ -150,7 +150,7 @@ private [gui] class ProgressDialog(dialog: java.awt.Dialog, supervisor: Supervis
   /// ProgressListener implementation
 
   override def experimentStarted() {started = System.currentTimeMillis}
-  override def runStarted(w: Workspace, runNumber: Int, settings: List[Pair[String, Any]]) {
+  override def runStarted(w: Workspace, runNumber: Int, settings: List[(String, Any)]) {
     if (!w.isHeadless) {
       runCount = runNumber
       steps = 0

--- a/src/main/org/nlogo/log/XMLFileAppender.scala
+++ b/src/main/org/nlogo/log/XMLFileAppender.scala
@@ -8,7 +8,7 @@ import javax.xml.transform.sax.{ SAXTransformerFactory, TransformerHandler }
 import javax.xml.transform.stream.StreamResult
 import org.xml.sax.helpers.AttributesImpl
 import org.apache.log4j.FileAppender
-import scala.reflect.BeanProperty
+import scala.beans.BeanProperty
 import org.nlogo.util.Exceptions.ignoring
 
 //  This class must be public because log4j needs to be able to find it and we refer to it in the

--- a/src/main/org/nlogo/properties/KeyEditor.scala
+++ b/src/main/org/nlogo/properties/KeyEditor.scala
@@ -33,10 +33,10 @@ abstract class KeyEditor(accessor: PropertyAccessor[Char])
     newEditor
   }
   override def get = Some(
-    if(editor.getText().isEmpty) '\0'
+    if(editor.getText().isEmpty) '\u0000'
     else editor.getText().charAt(0))
   override def set(value: Char) {
-    editor.setText(if(value == '\0') ""
+    editor.setText(if(value == '\u0000') ""
                    else value.toString)
   }
   override def requestFocus() { editor.requestFocus() }

--- a/src/main/org/nlogo/window/GUIWorkspace.scala
+++ b/src/main/org/nlogo/window/GUIWorkspace.scala
@@ -82,9 +82,9 @@ with Events.LoadSectionEventHandler {
   ///
 
   override def startLogging(properties: String) {
-    try new Events.LoggingEvent(LoggingEventType.START_LOGGING,
-                                fileManager.attachPrefix(properties))
-      .raiseLater(this);
+    new Events.LoggingEvent(LoggingEventType.START_LOGGING,
+        fileManager.attachPrefix(properties))
+      .raiseLater(this)
   }
 
   override def zipLogFiles(filename: String) {

--- a/src/test/org/nlogo/app/SmartIndenterTests.scala
+++ b/src/test/org/nlogo/app/SmartIndenterTests.scala
@@ -54,7 +54,7 @@ class SmartIndenterTests extends FunSuite {
   }
 
   class Scaffold(var text: String) extends EditorAreaInterface {
-    import scala.reflect.BeanProperty
+    import scala.beans.BeanProperty
     @BeanProperty var selectionStart = 0
     @BeanProperty var selectionEnd = 0
     selectAll()

--- a/src/tools/org/nlogo/hubnet/HeadlessServerExample.scala
+++ b/src/tools/org/nlogo/hubnet/HeadlessServerExample.scala
@@ -25,7 +25,7 @@ object HeadlessServerExample {
     override def run {
       print("enter command> ")
       while(true){
-        queuedCommands put readLine()
+        queuedCommands put scala.io.StdIn.readLine()
       }
     }
     def runAll() {

--- a/src/tools/org/nlogo/tools/ModelResaver.scala
+++ b/src/tools/org/nlogo/tools/ModelResaver.scala
@@ -36,7 +36,7 @@ object ModelResaver {
   def main(args: Array[String]): Unit = {
     val find = "find models -name test -prune -o -name *.nlogo -print"
     val paths = Process(find)
-      .lines.toSeq
+      .lineStream.toSeq
       .filterNot(_.contains("HubNet")) // for some reason, I'm having a hard time doing this with 'find'
 
     App.main(Array[String]())


### PR DESCRIPTION
I haven't done any real QA on this, I just made sure `sbt fast:test` hasn't regressed and that `sbt run` launches the app and you can run a model.

But I think this should be most — perhaps all, knock on wood! — of what is needed.

Note that in the build, I didn't take advantage of any sbt 0.13 features or clean up the various deprecation warnings. You might look at the NetLogo-Headless build, which is much more 0.13-tastic, to see what I did there.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/netlogo/netlogo/698)
<!-- Reviewable:end -->
