### PR TITLE
Add hooks for a hypothetical extension with some sort of custom logging

### DIFF
--- a/src/main/org/nlogo/api/Context.scala
+++ b/src/main/org/nlogo/api/Context.scala
@@ -50,4 +50,18 @@ trait Context {
    */
   def getRNG: org.nlogo.util.MersenneTwisterFast
 
+  /**
+   * Logs a customized message (primarily for use by the Custom Logging extension)
+   *
+   * @param msg Message to be logged
+   */
+  def logCustomMessage(msg: String): Unit
+
+  /**
+   * Allows for interaction with code that wants to log globals in a bulk, selective way (primarily for use by the Custom Logging extension)
+   *
+   * @param nameValuePairs Pairs of (global name, global value) that are to be recorded
+   */
+  def logCustomGlobals(nameValuePairs: Seq[(String, String)]): Unit
+
 }

--- a/src/main/org/nlogo/api/Logger.scala
+++ b/src/main/org/nlogo/api/Logger.scala
@@ -1,0 +1,10 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.api
+
+import org.nlogo.log.{ Logger => L }
+
+object Logger {
+  def logCustomMessage(msg: String):                       Unit = L.logCustomMessage(msg)
+  def logCustomGlobals(nameValuePairs: (String, String)*): Unit = L.logCustomGlobals(nameValuePairs: _*)
+}

--- a/src/main/org/nlogo/headless/HeadlessWorkspace.scala
+++ b/src/main/org/nlogo/headless/HeadlessWorkspace.scala
@@ -462,6 +462,10 @@ with org.nlogo.api.ViewSettings {
    */
   def deleteLogFiles() = unsupported
 
+  def logCustomMessage(msg: String): Unit = unsupported
+
+  def logCustomGlobals(nameValuePairs: Seq[(String, String)]): Unit = unsupported
+
   // This lastLogoException stuff is gross.  We should write methods that are declared to throw
   // LogoException, rather than requiring that this variable be checked. - ST 2/28/05
 

--- a/src/main/org/nlogo/log/LogMessage.scala
+++ b/src/main/org/nlogo/log/LogMessage.scala
@@ -76,6 +76,18 @@ object LogMessage {
                          new LogMessage("breed"))
     msg
   }
+  def createCustomMessage(): LogMessage = {
+    val msg = new LogMessage("special-event")
+    msg.attributes = Array(Array("type", "custom message"))
+    msg.elements = Array(new LogMessage("message"))
+    msg
+  }
+  def createCustomGlobals(): LogMessage = {
+    val msg = new LogMessage("special-event")
+    msg.attributes = Array(Array("type", "custom globals"))
+    msg.elements = Array(new LogMessage("globals"))
+    msg
+  }
 }
 
 class LogMessage private (val tag: String) {
@@ -132,6 +144,18 @@ class LogMessage private (val tag: String) {
   }
   def updateSpeedMessage(value: String) {
     elements(0).data = value
+  }
+  def updateCustomMessage(msg: String): Unit = {
+    elements(0).data = msg
+  }
+  def updateCustomGlobals(nameValuePairs: Seq[(String, String)]): Unit = {
+    val elems = nameValuePairs.map {
+      case (name, value) =>
+        val msg = new LogMessage("global")
+        msg.attributes = Array(Array("name", name), Array("value", value))
+        msg
+    }.toArray
+    elements(0).elements = elems
   }
 
 }

--- a/src/main/org/nlogo/log/Logger.scala
+++ b/src/main/org/nlogo/log/Logger.scala
@@ -23,6 +23,8 @@ object Logger {
   val Speed = JLogger.getLogger(name + ".SPEED")
   val Turtles = JLogger.getLogger(name + ".TURTLES")
   val Links = JLogger.getLogger(name + ".LINKS")
+  val CustomMessages = JLogger.getLogger(name + ".CUSTOM_MESSAGES")
+  val CustomGlobals = JLogger.getLogger(name + ".CUSTOM_GLOBALS")
 
   val widgetMsg = LogMessage.createWidgetMessage()
   val speedMsg = LogMessage.createSpeedMessage()
@@ -36,6 +38,8 @@ object Logger {
   val commandMsg = LogMessage.createCommandMessage()
   val codeTabMsg = LogMessage.createCodeTabMessage()
   val globalMsg = LogMessage.createGlobalMessage("globals")
+  val customMsg = LogMessage.createCustomMessage()
+  val customGlobals = LogMessage.createCustomGlobals()
 
   def logButtonStopped(name: String, onceButton: Boolean, stopping: Boolean) {
     if (Buttons.isInfoEnabled) {
@@ -78,6 +82,14 @@ object Logger {
       Globals.info(globalMsg)
     else
       Globals.debug(globalMsg)
+  }
+  def logCustomMessage(msg: String): Unit = {
+    customMsg.updateCustomMessage(msg)
+    CustomMessages.info(customMsg)
+  }
+  def logCustomGlobals(nameValuePairs: (String, String)*): Unit = {
+    customGlobals.updateCustomGlobals(nameValuePairs)
+    CustomGlobals.info(customGlobals)
   }
 
   ///

--- a/src/main/org/nlogo/nvm/ExtensionContext.java
+++ b/src/main/org/nlogo/nvm/ExtensionContext.java
@@ -2,6 +2,9 @@
 
 package org.nlogo.nvm;
 
+import scala.collection.Seq;
+import scala.Tuple2;
+
 import org.nlogo.util.MersenneTwisterFast;
 
 public strictfp class ExtensionContext
@@ -50,4 +53,15 @@ public strictfp class ExtensionContext
   public void importPcolors(java.awt.image.BufferedImage image, boolean asNetLogoColors) {
     org.nlogo.agent.ImportPatchColors.doImport(image, workspace.world(), asNetLogoColors);
   }
+
+  @Override
+  public void logCustomMessage(String msg) {
+    workspace.logCustomMessage(msg);
+  }
+
+  @Override
+  public void logCustomGlobals(Seq<Tuple2<String, String>> nameValuePairs) {
+    workspace.logCustomGlobals(nameValuePairs);
+  }
+
 }

--- a/src/main/org/nlogo/nvm/Workspace.java
+++ b/src/main/org/nlogo/nvm/Workspace.java
@@ -2,6 +2,9 @@
 
 package org.nlogo.nvm;
 
+import scala.collection.Seq;
+import scala.Tuple2;
+
 import org.nlogo.agent.Agent;
 import org.nlogo.api.CommandRunnable;
 import org.nlogo.api.CompilerException;
@@ -246,4 +249,11 @@ public interface Workspace
   boolean profilingEnabled();
 
   Tracer profilingTracer();
+
+  /*
+   * Primarily for use by Custom Logging extension
+   */
+  void logCustomMessage(String msg);
+  void logCustomGlobals(Seq<Tuple2<String, String>> nameValuePairs);
+
 }

--- a/src/main/org/nlogo/window/GUIWorkspace.java
+++ b/src/main/org/nlogo/window/GUIWorkspace.java
@@ -2,6 +2,9 @@
 
 package org.nlogo.window;
 
+import scala.collection.Seq;
+import scala.Tuple2;
+
 import org.nlogo.agent.Agent;
 import org.nlogo.agent.AgentSet;
 import org.nlogo.agent.BooleanConstraint;
@@ -17,6 +20,7 @@ import org.nlogo.api.PerspectiveJ;
 import org.nlogo.api.RendererInterface;
 import org.nlogo.api.ReporterRunnable;
 import org.nlogo.api.SimpleJobOwner;
+import org.nlogo.log.Logger;
 import org.nlogo.nvm.Procedure;
 import org.nlogo.nvm.Workspace;
 
@@ -1320,6 +1324,16 @@ public abstract strictfp class GUIWorkspace // can't be both abstract and strict
       source = super.getSource(filename);
     }
     return source;
+  }
+
+  @Override
+  public void logCustomMessage(String msg) {
+    Logger.logCustomMessage(msg);
+  }
+
+  @Override
+  public void logCustomGlobals(Seq<Tuple2<String, String>> nameValuePairs) {
+    Logger.logCustomGlobals(nameValuePairs);
   }
 
 }

--- a/src/test/org/nlogo/nvm/DummyWorkspace.scala
+++ b/src/test/org/nlogo/nvm/DummyWorkspace.scala
@@ -82,6 +82,8 @@ class DummyWorkspace extends DummyCompilerServices with Workspace {
   override def behaviorSpaceRunNumber = 0
   override def behaviorSpaceRunNumber(n: Int) = unsupported
   override def previewCommands = unsupported
+  override def logCustomMessage(msg: String): Unit = unsupported
+  override def logCustomGlobals(nameValuePairs: Seq[(String, String)]): Unit = unsupported
 
   // from ImporterUser
   override def setOutputAreaContents(text: String) = unsupported

--- a/src/test/org/nlogo/workspace/DummyAbstractWorkspace.scala
+++ b/src/test/org/nlogo/workspace/DummyAbstractWorkspace.scala
@@ -63,4 +63,6 @@ extends AbstractWorkspaceScala(
   override def zipLogFiles(filename: String) = unsupported
   override def deleteLogFiles(): Unit = unsupported
   override def compiler: CompilerInterface = unsupported
+  override def logCustomMessage(msg: String): Unit = unsupported
+  override def logCustomGlobals(nameValuePairs: Seq[(String, String)]): Unit = unsupported
 }


### PR DESCRIPTION
The title says it all... but this:

The Custom Logging extension needs these changes in order to work in 5.x.  The `signedjars` branch (now just a tag) had these commits in some harebrained form, but they were of less-than-nice code quality, and were somewhat entangled with other logging stuff that I was doing at the time.  Consequently, rather than cherry-picking them over, I just reimplemented them in order to create this PR.  Most of it is just mindless cruft, anyway....

I've tested this with the latest version of the Custom Logging extension (which you can download [here](https://github.com/NetLogo/Custom-Logging-Extension/releases/tag/1.0)), and everything appears to be behaving as expected.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/netlogo/netlogo/699)
<!-- Reviewable:end -->
