### PR TITLE
remember last used directory, fix #720 on Linux

### DIFF
--- a/src/main/org/nlogo/swing/FileDialog.java
+++ b/src/main/org/nlogo/swing/FileDialog.java
@@ -98,6 +98,7 @@ public final strictfp class FileDialog {
       if (result != javax.swing.JFileChooser.APPROVE_OPTION) {
         throw new org.nlogo.awt.UserCancelException();
       }
+      currentDirectory = selectedDirectory(chooser);
       return chooser.getSelectedFile().getAbsolutePath();
     }
     if (!MAC && directoriesOnly) {
@@ -109,6 +110,7 @@ public final strictfp class FileDialog {
           != javax.swing.JFileChooser.APPROVE_OPTION) {
         throw new org.nlogo.awt.UserCancelException();
       }
+      currentDirectory = selectedDirectory(chooser);
       return chooser.getSelectedFile().getAbsolutePath();
     }
     java.awt.FileDialog dialog;
@@ -137,5 +139,11 @@ public final strictfp class FileDialog {
     } else {
       return dialog.getDirectory() + dialog.getFile();
     }
+  }
+
+  private static String selectedDirectory(javax.swing.JFileChooser chooser) {
+    java.io.File file = chooser.getSelectedFile();
+    java.io.File dir = file.isDirectory() ? file : chooser.getCurrentDirectory();
+    return dir.getAbsolutePath();
   }
 }


### PR DESCRIPTION
It appears that the problem (#720) was Linux specific, and it was easy enough to fix.

(@frankduncan: I made the change from the `5.x` branch, but it should be easily mergeable in `6.x`.)

One little caveat: I applied the same fix to the `if (!MAC && directoriesOnly)` code branch. As far as I can tell, this only applies to the `user-directory` primitive on Windows. I'd be grateful if someone with a Windows machine could test that. Short of that, it wouldn't be a big deal to remove this line.

That being said, the whole thing is a mess, and uses a bunch of different dialog classes:

OS | Choose what? | Class
---|---|---
Linux | file | `javax.swing.JFileChooser`
Linux | dir | `javax.swing.JFileChooser`
Win | file | `java.awt.FileDialog`
Win | dir | `javax.swing.JFileChooser`
Mac | file | `java.awt.FileDialog`
Mac | dir | `net.roydesign.ui.FolderDialog`

As @fstonedahl says in an old comment:
```
// I suspect my Linux-specific code could replace all the Mac/Windows code below,
// but that code already seems strangely more complicated than expected, so I decided
// not to mess with it.  Probably it's just left-over cruft from a pre-JFileChooser era,
// but I'm not sure.
```

I suspect he's right. I'd even go as far as replacing the whole `FileDialog.java` class for `6.x` by what would end up being only a few lines of Scala code using `JFileChooser`. It would help with #726, get rid of the `net.roydesign.ui` dependency, and possibly other things.

But maybe we shouldn't mess with it. Thoughts? Historical considerations?