### PR TITLE
strip trailing whitespace when saving

### DIFF
--- a/src/main/org/nlogo/app/ModelSaver.scala
+++ b/src/main/org/nlogo/app/ModelSaver.scala
@@ -89,7 +89,9 @@ class ModelSaver(app: App) {
       buf ++= (if(app.tabs.workspace.snapOn) "1\n" else "0\n")
     }
 
-    buf.toString
+    buf.lines
+      .map(_.replaceAll("\\s+$", "")) // strips trailing whitespace at the end of each line
+      .mkString("", "\n", "\n") // and build the string with a new line at end of file
   }
 
 }


### PR DESCRIPTION
To close #725.

I checked all sections of the model file format for potential problems:

- procedures: NetLogo code - OK
- widgets: our custom widget format - OK
- info: markdown, but OK (see https://github.com/NetLogo/NetLogo/issues/725#issuecomment-77230428)
- turtle shapes: custom format - OK
- version: custom format - OK
- preview commands: NetLogo code - OK
- system dynamics modeler: JHotDraw format, already explicitely stripped - OK
- BehaviorSpace: XML - OK
- reserved for HubNet client: our custom widget format - OK
- link shapes: custom format - OK
- interface tab settings: custom format - OK

I also ran `test:run-main org.nlogo.tools.ModelResaver` on a branch of the models library (https://github.com/NetLogo/models/tree/strip-trailing-whitespace). Unit tests for for `5.x.` (including `TestCompileAll`) still pass with that.

Anything else I should check before we merge this?