### PR TITLE
remember output type preference in BehaviorSpace

### DIFF
--- a/src/main/org/nlogo/lab/gui/RunOptionsDialog.scala
+++ b/src/main/org/nlogo/lab/gui/RunOptionsDialog.scala
@@ -7,19 +7,31 @@ import org.nlogo.awt.UserCancelException
 import org.nlogo.window.EditDialogFactoryInterface
 import Supervisor.RunOptions
 import collection.JavaConverters._
+import java.util.prefs.Preferences
 
 class RunOptionsDialog(parent: java.awt.Dialog,
                        dialogFactory: EditDialogFactoryInterface)
 {
+  object Prefs {
+    private val prefs = Preferences.userNodeForPackage(RunOptionsDialog.this.getClass)
+    def spreadsheet = prefs.getBoolean("spreadsheet", true)
+    def table = prefs.getBoolean("table", false)
+    def updateFrom(runOptions: RunOptions): Unit = {
+      prefs.putBoolean("spreadsheet", runOptions.spreadsheet)
+      prefs.putBoolean("table", runOptions.table)
+    }
+  }
   def get = {
     val editable = new EditableRunOptions
     if(dialogFactory.canceled(parent, editable))
       throw new UserCancelException
-    editable.get
+    val runOptions = editable.get
+    Prefs.updateFrom(runOptions)
+    runOptions
   }
   class EditableRunOptions extends Editable {
-    var spreadsheet = true
-    var table = false
+    var spreadsheet = Prefs.spreadsheet
+    var table = Prefs.table
     var threadCount = Runtime.getRuntime.availableProcessors
     val classDisplayName = "Run options"
     val propertySet =


### PR DESCRIPTION
To close #768.

Well, that was hanging low enough. The mechanism used here is basically the same as the one used in https://github.com/NetLogo/NetLogo/blob/5.x/src/main/org/nlogo/app/RecentFilesMenu.scala, so I expect it will work just as well.

I opened the PR against `5.x` but it should be seamlessly mergeable in `6.x`.

@frankduncan, can you give it a quick look?