### PR TITLE
add Online Models dialog

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,6 +75,8 @@ NativeLibs.nativeLibsTask
 
 moduleConfigurations += ModuleConfiguration("javax.media", JavaNet2Repository)
 
+resolvers += "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/"
+
 libraryDependencies ++= Seq(
   "log4j" % "log4j" % "1.2.17",
   "javax.media" % "jmf" % "2.1.1e",
@@ -88,6 +90,8 @@ libraryDependencies ++= Seq(
   "org.jogamp.gluegen" % "gluegen-rt-main" % "2.1.5-01", // from "http://ccl.northwestern.edu/devel/gluegen-rt-2.1.5.jar",
   "org.apache.httpcomponents" % "httpclient" % "4.2",
   "org.apache.httpcomponents" % "httpmime" % "4.2",
+  "com.typesafe.play" %% "play-json" % "2.3.8",
+  "com.typesafe.play" %% "play-ws" % "2.3.8",
   "com.googlecode.json-simple" % "json-simple" % "1.1.1"
 )
 

--- a/project/Running.scala
+++ b/project/Running.scala
@@ -11,7 +11,10 @@ object Running {
       "-XX:MaxPermSize=128m",
       "-Xmx1024m",
       "-Dfile.encoding=UTF-8",
-      "-Djava.ext.dirs=",
+      // sunjce_provider.jar is needed for https connection to GitHub.
+      // but surely there was a reason to clear java.ext.dirs
+      // so this should NOT be merged like this - NP 2014-05-04.
+      // "-Djava.ext.dirs=",
       "-Dapple.awt.graphics.UseQuartz=true") ++
     (if(System.getProperty("os.name").startsWith("Mac"))
       Seq("-Xdock:name=NetLogo")

--- a/src/main/org/nlogo/app/App.scala
+++ b/src/main/org/nlogo/app/App.scala
@@ -149,6 +149,9 @@ object App{
           () => pico.getComponent(classOf[App]).tabs.setSelectedComponent(
             pico.getComponent(classOf[App]).tabs.reviewTab))))
     pico.addComponent(classOf[AgentMonitorManager])
+    pico.add(classOf[GitHubModelsDialogInterface],
+      "org.nlogo.app.github.ModelsDialog",
+      Array[Parameter](new ComponentParameter(classOf[AppFrame])))
     app = pico.getComponent(classOf[App])
     // It's pretty silly, but in order for the splash screen to show up
     // for more than a fraction of a second, we want to initialize as
@@ -298,6 +301,7 @@ class App extends
   var labManager:LabManagerInterface = null
   private val listenerManager = new NetLogoListenerManager
   lazy val modelingCommons = pico.getComponent(classOf[ModelingCommonsInterface])
+  lazy val gitHubModelsDialog = pico.getComponent(classOf[GitHubModelsDialogInterface])
   private val ImportWorldURLProp = "netlogo.world_state_url"
   private val ImportRawWorldURLProp = "netlogo.raw_world_state_url"
 

--- a/src/main/org/nlogo/app/FileMenu.scala
+++ b/src/main/org/nlogo/app/FileMenu.scala
@@ -3,12 +3,10 @@
 package org.nlogo.app
 
 import java.io.IOException
-
 import org.nlogo.api, api.{ I18N, ModelReader, ModelSection, ModelType }
 import org.nlogo.api.ModelReader.{ modelSuffix, emptyModelPath }
 import org.nlogo.awt.UserCancelException
 import org.nlogo.window.InvalidVersionException
-
 import scala.annotation.{strictfp, switch}
 
 /*
@@ -26,6 +24,7 @@ import scala.annotation.{strictfp, switch}
   addMenuItem('N', new NewAction)
   addMenuItem('O', new OpenAction)
   addMenuItem('M', new ModelsLibraryAction)
+  addMenuItem('G', new GitHubModelsAction)
   add(new RecentFilesMenu(app, this))
   addSeparator()
   addMenuItem('S', new SaveAction)
@@ -112,6 +111,14 @@ import scala.annotation.{strictfp, switch}
       val source = ModelsLibraryDialog.open(org.nlogo.awt.Hierarchy.getFrame(FileMenu.this))
       val modelPath = ModelsLibraryDialog.getModelPath
       openFromSource(source, modelPath, "Loading...", ModelType.Library)
+    }
+  }
+
+  private class GitHubModelsAction extends FileMenuAction("GitHub Models...") {
+    def action() {
+      offerSave()
+      for (source <- app.gitHubModelsDialog.getModelSource())
+        openFromSource(source, null, "Loading...", ModelType.Library)
     }
   }
 

--- a/src/main/org/nlogo/app/github/ApiClient.scala
+++ b/src/main/org/nlogo/app/github/ApiClient.scala
@@ -1,0 +1,39 @@
+package org.nlogo.app.github
+
+import scala.concurrent.Future
+
+import org.apache.commons.codec.binary.Base64
+
+import com.ning.http.client.AsyncHttpClientConfig
+
+import play.api.libs.ws.WSAuthScheme
+import play.api.libs.ws.WSResponse
+import play.api.libs.ws.ning.NingWSClient
+
+object ApiClient {
+  implicit class RichWSResponse(r: WSResponse) {
+    def content = new String(Base64.decodeBase64((r.json \ "content").as[String]), "UTF-8")
+    def nextPageUrl: Option[String] = r.header("Link").flatMap {
+      _.split(", ") // separate the links
+        .map(_.split("; ")) // split each one between url and rel
+        .find(_.last == "rel=\"next\"") // find the link to the next page
+        .map(_.head.tail.init) // and keep the url with the first ("<") and last (">") chars removed
+    }
+  }
+}
+
+class ApiClient(user: () => String, password: () => String) {
+
+  // TODO: close client when quitting NetLogo
+  val client = new NingWSClient(new AsyncHttpClientConfig.Builder().build())
+
+  def get(uri: String, parameters: (String, String)*): Future[WSResponse] = {
+    client
+      .url(uri.toString)
+      .withFollowRedirects(true)
+      .withHeaders("Accept" -> "application/vnd.github.v3+json")
+      .withAuth(user(), password(), WSAuthScheme.BASIC)
+      .withQueryString(parameters: _*)
+      .get
+  }
+}

--- a/src/main/org/nlogo/app/github/ModelsDialog.scala
+++ b/src/main/org/nlogo/app/github/ModelsDialog.scala
@@ -1,0 +1,155 @@
+package org.nlogo.app.github
+
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.awt.Frame
+import java.awt.event.ActionEvent
+import java.awt.event.WindowAdapter
+import java.awt.event.WindowEvent
+import java.util.prefs.Preferences
+
+import scala.math.max
+
+import org.nlogo.awt.Positioning
+import org.nlogo.swing.Implicits.swingExecutionContext
+import org.nlogo.swing.Utils.addEscKeyAction
+import org.nlogo.window.GitHubModelsDialogInterface
+
+import javax.swing.AbstractAction
+import javax.swing.JButton
+import javax.swing.JDialog
+import javax.swing.JEditorPane
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JPasswordField
+import javax.swing.JScrollPane
+import javax.swing.JSplitPane
+import javax.swing.JSplitPane.HORIZONTAL_SPLIT
+import javax.swing.JTextField
+import javax.swing.JTree
+import javax.swing.WindowConstants.DO_NOTHING_ON_CLOSE
+import javax.swing.event.TreeSelectionEvent
+import javax.swing.event.TreeSelectionListener
+import javax.swing.tree.DefaultMutableTreeNode
+import javax.swing.tree.TreeSelectionModel.SINGLE_TREE_SELECTION
+
+class ModelsDialog(parent: Frame)
+  extends JDialog(parent, "Online Models from GitHub", true)
+  with TreeSelectionListener
+  with GitHubModelsDialogInterface {
+
+  def getModelSource(): Option[String] = {
+    tree.setSelectionRow(0)
+    setVisible(true)
+    modelSource
+  }
+
+  val prefs = Preferences.userNodeForPackage(classOf[ModelsDialog])
+  private var modelSource: Option[String] = None
+
+  setLayout(new BorderLayout)
+
+  val openAction = new AbstractAction("Open") {
+    setEnabled(false)
+    def actionPerformed(e: ActionEvent) {
+      setVisible(false)
+    }
+  }
+  val openButton = new JButton(openAction)
+  val cancelAction = new AbstractAction("Cancel") {
+    def actionPerformed(e: ActionEvent) {
+      modelSource = None
+      setVisible(false)
+    }
+  }
+  val cancelButton = new JButton(cancelAction)
+  val usernameField = new JTextField(15) {
+    setText(prefs.get("username", ""))
+  }
+  val passwordField = new JPasswordField(15)
+  add(new JPanel {
+    setLayout(new BorderLayout)
+    add(new JPanel {
+      add(new JLabel("GitHub Username:"))
+      add(usernameField)
+      add(new JLabel("Password:"))
+      add(passwordField)
+      add(new JButton(new AbstractAction("(Re)load from GitHub") {
+        def actionPerformed(e: ActionEvent) {
+          prefs.put("username", usernameField.getText)
+          tree.setModel(new TreeModel(client))
+        }
+      }))
+    }, BorderLayout.LINE_START)
+    add(new JPanel {
+      add(openButton)
+      add(cancelButton)
+    }, BorderLayout.LINE_END)
+  }, BorderLayout.PAGE_END)
+
+  def valueChanged(e: TreeSelectionEvent): Unit = {
+    def update(description: String, m: Option[String]): Unit = {
+      htmlPane.setText(description)
+      htmlPane.setCaretPosition(0)
+      modelSource = m
+      openButton.setEnabled(modelSource.isDefined)
+    }
+    val tree = e.getSource.asInstanceOf[JTree]
+    tree.getLastSelectedPathComponent match {
+      case m: ModelNode =>
+        if (!m.source.isCompleted) update(m.info, None)
+        m.source.onSuccess {
+          case source if m eq tree.getLastSelectedPathComponent =>
+            update(m.info, Some(source))
+        }
+      case r: RepoNode =>
+        r.addChildren // trigger the lazy future
+        if (!r.readme.isCompleted) update(r.info, None)
+        r.readme.onSuccess {
+          case source if r eq tree.getLastSelectedPathComponent =>
+            update(r.info, None)
+        }
+      case n: Node => update(n.info, None)
+      case _ => // our GitHub tree is not loaded; do nothing
+    }
+  }
+
+  addEscKeyAction(this, cancelAction)
+  setDefaultCloseOperation(DO_NOTHING_ON_CLOSE)
+  addWindowListener(new WindowAdapter() {
+    override def windowClosing(e: WindowEvent) {
+      cancelAction.actionPerformed(null)
+    }
+  })
+
+  val client = new ApiClient(
+    () => usernameField.getText,
+    () => passwordField.getPassword.mkString)
+
+  implicit class RichDimension(d: Dimension) {
+    def orAtLeast(width: Int, height: Int) =
+      new Dimension(max(d.width, width), max(d.height, height))
+  }
+  val tree = new JTree(new DefaultMutableTreeNode) {
+    override def getPreferredSize = super.getPreferredSize.orAtLeast(300, 500)
+    setRootVisible(false)
+    getSelectionModel.setSelectionMode(SINGLE_TREE_SELECTION)
+  }
+  tree.addTreeSelectionListener(this)
+
+  val htmlPane = new JEditorPane() {
+    override def getPreferredSize = super.getPreferredSize.orAtLeast(500, 500)
+    setContentType("text/html")
+    setEditable(false)
+  }
+
+  val splitPane = new JSplitPane(HORIZONTAL_SPLIT) {
+    setTopComponent(new JScrollPane(tree))
+    setBottomComponent(new JScrollPane(htmlPane))
+    setDividerLocation(0.5)
+  }
+
+  add(splitPane, BorderLayout.CENTER)
+  pack()
+  Positioning.center(this, parent)
+}

--- a/src/main/org/nlogo/app/github/TreeModel.scala
+++ b/src/main/org/nlogo/app/github/TreeModel.scala
@@ -1,0 +1,177 @@
+package org.nlogo.app.github
+
+import java.util.regex.Pattern
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters.enumerationAsScalaIteratorConverter
+import scala.collection.mutable
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.Success
+
+import org.nlogo.api.ModelReader.SEPARATOR
+import org.nlogo.app.InfoFormatter
+import org.nlogo.app.github.ApiClient.RichWSResponse
+import org.nlogo.swing.Implicits.swingExecutionContext
+
+import javax.swing.tree.DefaultMutableTreeNode
+import javax.swing.tree.DefaultTreeModel
+import javax.swing.tree.MutableTreeNode
+import javax.swing.tree.TreeNode
+import play.api.libs.functional.syntax.functionalCanBuildApplicative
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.JsArray
+import play.api.libs.json.JsPath
+import play.api.libs.json.Reads
+import play.api.libs.ws.WSResponse
+
+object TreeModel {
+  val fileExtensions = Seq(".nlogo", ".nlogo3d")
+}
+
+class TreeModel(val client: ApiClient) extends DefaultTreeModel(new DefaultMutableTreeNode) {
+  private val _root = new Root(this)
+  setRoot(_root)
+  _root.addChildren // trigger the lazy future
+}
+
+trait CanAddChildren {
+  self: MutableTreeNode =>
+  val treeModel: TreeModel
+  protected def _addChildren: Future[Unit]
+  lazy val addChildren = Promise[Unit].completeWith(_addChildren)
+  def insertSorted(node: MutableTreeNode, f: (TreeNode) => String): Unit = {
+    val index = (0 until getChildCount)
+      .find(i => f(getChildAt(i)).toUpperCase > f(node).toUpperCase)
+      .getOrElse(getChildCount)
+    treeModel.insertNodeInto(node, this, index)
+  }
+}
+
+trait Node extends DefaultMutableTreeNode {
+  val treeModel: TreeModel
+  val path: String
+  def parentPath = path.split("/").init.mkString("/")
+  def info: String
+}
+
+class Root(override val treeModel: TreeModel) extends DefaultMutableTreeNode("") with CanAddChildren {
+  override def isLeaf = false
+  implicit val repoReads: Reads[RepoNode] = (
+    (JsPath \ "full_name").read[String] and
+    (JsPath \ "description").readNullable[String] and
+    (JsPath \ "url").read[String] and
+    (JsPath \ "default_branch").read[String]
+  )(new RepoNode(treeModel, _, _, _, _))
+  override def _addChildren = {
+    def process(r: WSResponse): Future[Unit] = {
+      val processNextPage: Option[Future[Unit]] =
+        r.nextPageUrl.map { nextUrl =>
+          treeModel.client.get(nextUrl).flatMap(process)
+        }
+      for {
+        item <- (r.json \ "items").as[JsArray].value
+        repo <- item.validate[RepoNode].asOpt
+      } insertSorted(repo, _.asInstanceOf[RepoNode].fullName)
+      processNextPage.getOrElse(Future(()))
+    }
+    treeModel.client.get(
+      "https://api.github.com/search/repositories",
+      "q" -> "language:NetLogo",
+      "per_page" -> "100"
+    ).flatMap(process)
+  }
+}
+
+class RepoNode(
+  override val treeModel: TreeModel,
+  val fullName: String,
+  val description: Option[String],
+  val url: String,
+  val defaultBranch: String)
+  extends Node with CanAddChildren {
+  val path = "\\"
+  lazy val readme: Future[String] =
+    treeModel.client.get(url + "/readme").map(_.content)
+  override def info: String =
+    description.map("<p>" + _ + "</p>").getOrElse("") +
+      (readme.value match {
+        case Some(Success(readme)) => InfoFormatter(readme)
+        case _ => ""
+      })
+  override def toString = fullName
+  override def isLeaf = false
+  implicit val folderReads: Reads[FolderNode] = (
+    (JsPath \ "path").read[String] and
+    (JsPath \ "sha").read[String] and
+    (JsPath \ "url").read[String]
+  )(new FolderNode(treeModel, _, _, _))
+  implicit val modelReads: Reads[ModelNode] = (
+    (JsPath \ "path").read[String] and
+    (JsPath \ "sha").read[String] and
+    (JsPath \ "url").read[String]
+  )(new ModelNode(treeModel, _, _, _))
+
+  override def _addChildren = {
+    treeModel.client.get(s"${url}/branches/${defaultBranch}").flatMap { r =>
+      val treeUrl = (r.json \ "commit" \ "commit" \ "tree" \ "url").as[String]
+      val map = mutable.Map[String, Node]()
+      def parent(n: Node) = map.getOrElse(n.parentPath, this)
+      treeModel.client.get(treeUrl, "recursive" -> "1").map { r =>
+        for {
+          v <- (r.json \ "tree").as[JsArray].value
+          n <- (v \ "type").as[String] match {
+            case "tree" => v.validate[FolderNode].asOpt
+            case "blob" if (
+              TreeModel.fileExtensions.exists(((v \ "path").as[String]).endsWith)
+            ) => v.validate[ModelNode].asOpt
+            case _ => None
+          }
+        } {
+          parent(n).add(n)
+          map += n.path -> n
+        }
+        @tailrec def prune(): Unit = {
+          val nodesToPrune = depthFirstEnumeration.asScala
+            .collect { case f: FolderNode if f.getChildCount == 0 => f }
+          if (nodesToPrune.nonEmpty) {
+            nodesToPrune.foreach { n => parent(n).remove(n) }
+            prune()
+          }
+        }
+        prune()
+        treeModel.nodesWereInserted(this, (0 until getChildCount).toArray)
+      }
+    }
+  }
+
+}
+
+class ModelNode(
+  override val treeModel: TreeModel,
+  val path: String,
+  val sha: String,
+  val url: String)
+  extends Node {
+  override val toString =
+    TreeModel.fileExtensions.foldLeft(path.split("/").last)(_.stripSuffix(_))
+  override def isLeaf = true
+  lazy val source: Future[String] = treeModel.client.get(url).map(_.content)
+  override def info: String = source.value match {
+    case Some(Success(source)) =>
+      val info = source.split(Pattern.quote(SEPARATOR))(2)
+      InfoFormatter(info)
+    case _ => "Loading..."
+  }
+}
+
+class FolderNode(
+  override val treeModel: TreeModel,
+  val path: String,
+  val sha: String,
+  val url: String)
+  extends Node {
+  override val toString = path.split("/").last
+  override def isLeaf = false
+  override def info = path
+}

--- a/src/main/org/nlogo/swing/Implicits.scala
+++ b/src/main/org/nlogo/swing/Implicits.scala
@@ -6,7 +6,9 @@ import javax.swing.event.DocumentListener
 import javax.swing._
 import java.awt.event._
 import java.awt.{Container, Component}
+import java.util.concurrent.Executor
 import language.implicitConversions
+import scala.concurrent.ExecutionContext
 
 object Implicits {
   implicit def thunk2runnable(fn: () => Unit): Runnable =
@@ -33,6 +35,11 @@ object Implicits {
 
   implicit def EnrichComboBox[T](combo: JComboBox[T]) = RichJComboBox[T](combo)
   implicit def EnrichContainer(c:Container) = new RichComponent(c)
+
+  implicit val swingExecutionContext: ExecutionContext =
+    ExecutionContext.fromExecutor(new Executor {
+      def execute(command: Runnable): Unit = SwingUtilities invokeLater command
+    })
 }
 
 object RichJButton{

--- a/src/main/org/nlogo/window/GitHubModelsDialogInterface.scala
+++ b/src/main/org/nlogo/window/GitHubModelsDialogInterface.scala
@@ -1,0 +1,5 @@
+package org.nlogo.window
+
+trait GitHubModelsDialogInterface {
+  def getModelSource(): Option[String]
+}


### PR DESCRIPTION
(This is emphatically just a prototype. This pull request should not get merged.)

## What is it?

A tool to browse GitHub for NetLogo models and load them directly in NetLogo. The idea stems from a chat with @frankduncan so he gets credit for it (but flaws in execution are mine alone).

Here is a screenshot:

![screenshot from 2015-05-05 21 24 52](https://cloud.githubusercontent.com/assets/908754/7486138/4f080150-f36e-11e4-89af-5355e11a350a.png)

- The left panel is a tree, just like in the model library dialog. Top nodes are repos, and you have their directory structure under them, showing only folders with NetLogo files.

- The right panel shows the readme if a repository node is selected or the info tab content if a model is selected. We could conceivably generate and add preview images.

To use it, bring it up from the **File** menu (or <kbd>Ctrl</kbd>+<kbd>g</kbd>) enter your GitHub username/password and click **(Re)Load from GitHub**.

It shows every GitHub repo that _you_ have access to, i.e. all public repos + your private repos.

Click **Open** to load the selected model (double-clicking doesn't work yet).

## What's currently wrong with it?

- The code is really messy, mixing up GUI and GitHub api querying stuff.

- There is almost no error handling. If something goes wrong with a request, things just won't load.

- Support files (e.g., data, images, .nls files, etc.) are not downloaded.

- Of course, if a model needs an unbundled extension, it doesn't get downloaded either.

- Nothing is currently cached on disk between sessions (this is bad for speed and api rate limit).

- Everything (i.e., every model file, once the info tab is displayed) stays in memory for the whole session.

- The user currently needs to log into GitHub using username/password (the password is not stored). It's probably possible to make life easier for the user using OAuth tokens or something; I'm not very familiar with this stuff. There is no way around the fact that GitHub requires authentification, though. Anonymous API queries are limited to 60/hour (https://developer.github.com/v3/#rate-limiting) which is not nearly enough.

- Need to find a workaround for https://github.com/NetLogo/NetLogo/commit/d7b654f9e282251db5b1a66f5767a50a5ea9222b.

Whether or not an improved version of this should get integrated into NetLogo is an open question. We could also make it a plugin at first.

That being said, I already had a lot of fun just browsing the tree and looking at people's models!

Comments welcome.
