### PR TITLE
Manage original and zoomed font separately in OutputWidget

### DIFF
--- a/src/main/org/nlogo/window/OutputWidget.scala
+++ b/src/main/org/nlogo/window/OutputWidget.scala
@@ -21,8 +21,15 @@ class OutputWidget extends SingleErrorWidget with CommandCenterInterface with
   }, java.awt.BorderLayout.CENTER)
 
   def propertySet = Properties.output
-  def fontSize = outputArea.fontSize
-  def fontSize(fontSize:Int) = outputArea.fontSize(fontSize)
+
+  originalFont = outputArea.getFont
+  def fontSize = originalFont.getSize
+  def fontSize_=(newSize: Int): Unit = {
+    val zoomDiff = outputArea.fontSize - fontSize
+    outputArea.fontSize(newSize + zoomDiff)
+    originalFont = originalFont.deriveFont(newSize.toFloat)
+  }
+
   override def classDisplayName = I18N.gui.get("tabs.run.widgets.output")
   override def zoomSubcomponents = true
   override def exportable = true


### PR DESCRIPTION
This is intended to fix #802, as `fontSize` (called by the `save` method) now returns the original font size.

The general logic is lifted from: https://github.com/NetLogo/NetLogo/blob/5.x/src/main/org/nlogo/widget/NoteWidget.scala#L43

Things are simpler here, though, because changing the font size doesn't change the size of the widget.

There is no test coverage, as it is generally absent for widgets and I'm not even sure what it would look like in this case. Suggestions welcome, though.

@frankduncan, review? @SethTisue, I'd be grateful if you could take a quick look as well.