### PR TITLE
(WIP) Support 3D rendering in headless mode

### DIFF
--- a/src/main/org/nlogo/api/RendererInterface.scala
+++ b/src/main/org/nlogo/api/RendererInterface.scala
@@ -2,17 +2,20 @@
 
 package org.nlogo.api
 
-trait RendererInterface {
+trait HeadlessRendererInterface {
   def trailDrawer: TrailDrawerInterface
   def changeTopology(wrapX: Boolean, wrapY: Boolean)
+  def resetCache(patchSize: Double)
+  def exportView(settings: ViewSettings): java.awt.image.BufferedImage
+  def exportView(g: java.awt.Graphics2D, settings: ViewSettings)
+  def renderLabelsAsRectangles_=(b: Boolean)
+}
+
+trait RendererInterface extends HeadlessRendererInterface {
   def paint(g: GraphicsInterface, settings: ViewSettings)
   def paint(g: java.awt.Graphics2D, settings: ViewSettings)
-  def resetCache(patchSize: Double)
   def graphicsX(xcor: Double, patchSize: Double, viewOffsetX: Double): Double
   def graphicsY(ycor: Double, patchSize: Double, viewOffsetY: Double): Double
   def outlineAgent(agent: Agent)
-  def exportView(g: java.awt.Graphics2D, settings: ViewSettings)
-  def exportView(settings: ViewSettings): java.awt.image.BufferedImage
   def prepareToPaint(settings: ViewSettings, width: Int, height: Int)
-  def renderLabelsAsRectangles_=(b: Boolean)
 }

--- a/src/main/org/nlogo/gl/render/Headless3DRenderer.scala
+++ b/src/main/org/nlogo/gl/render/Headless3DRenderer.scala
@@ -1,0 +1,71 @@
+package org.nlogo.gl.render
+
+import java.awt.Graphics2D
+import java.awt.image.BufferedImage
+import org.nlogo.api.HeadlessRendererInterface
+import org.nlogo.api.TrailDrawerInterface
+import org.nlogo.api.ViewSettings
+import org.nlogo.api.World
+import javax.media.opengl.GLCanvas
+import javax.media.opengl.GLCapabilities
+import javax.media.opengl.GLPbuffer
+import javax.media.opengl.GLDrawableFactory
+import org.nlogo.api.Perspective
+import com.sun.opengl.util.Screenshot
+
+object Headless3DViewSettings extends ViewSettings with GLViewSettings {
+  val wireframeOn = true
+  val fontSize: Int = 10
+  val patchSize: Double = 13
+  val viewWidth: Double = 400
+  val viewHeight: Double = 400
+  val viewOffsetX: Double = 0
+  val viewOffsetY: Double = 0
+  val drawSpotlight: Boolean = false
+  val renderPerspective: Boolean = false
+  val isHeadless: Boolean = true
+  val perspective: Perspective = Perspective.Observe
+}
+
+class Headless3DRenderer(
+  world: World,
+  val trailDrawer: TrailDrawerInterface)
+  extends Renderer3D(world, Headless3DViewSettings, trailDrawer, Headless3DViewSettings)
+  with HeadlessRendererInterface {
+
+  def renderLabelsAsRectangles_=(b: Boolean): Unit = () // ignore the value
+  def resetCache(patchSize: Double): Unit = () // do nothing
+  def changeTopology(wrapX: Boolean, wrapY: Boolean): Unit = () // do nothing
+
+  def exportView(g: Graphics2D, settings: ViewSettings): Unit =
+    throw new UnsupportedOperationException // TODO
+
+  def exportView(settings: ViewSettings): BufferedImage = {
+    val capabilities = new GLCapabilities
+    capabilities.setSampleBuffers(true)
+    capabilities.setNumSamples(4)
+    capabilities.setStencilBits(1)
+    val width = Headless3DViewSettings.viewWidth.toInt
+    val height = Headless3DViewSettings.viewHeight.toInt
+    val buffer = GLDrawableFactory.getFactory
+      .createGLPbuffer(capabilities, null, width, height, null)
+    val exporter = createExportRenderer()
+    buffer.addGLEventListener(exporter)
+    buffer.display()
+    buffer.removeGLEventListener(exporter)
+    println("before make current")
+    buffer.getContext.makeCurrent()
+    val bufferedImage = Screenshot.readToBufferedImage(width, height)
+    buffer.destroy()
+//    val bufferedImage = new BufferedImage(
+//      buffer.getWidth, buffer.getHeight,
+//      BufferedImage.TYPE_INT_ARGB
+//    )
+//    bufferedImage.setRGB(
+//      0, 0, buffer.getWidth, buffer.getHeight,
+//      exporter.pixelInts, 0, buffer.getWidth
+//    )
+    bufferedImage
+
+  }
+}

--- a/src/main/org/nlogo/headless/ChecksumsAndPreviews.scala
+++ b/src/main/org/nlogo/headless/ChecksumsAndPreviews.scala
@@ -45,7 +45,7 @@ object ChecksumsAndPreviews {
       List("HUBNET", "/GOGO/", "/CODE EXAMPLES/SOUND/")
         .forall(!path.toUpperCase.containsSlice(_))
     def remake(path: String) {
-      val previewPath = path.replaceFirst("\\.nlogo$", ".png")
+      val previewPath = path.replaceFirst("\\.nlogo(3d)?$", ".png")
       val workspace = HeadlessWorkspace.newInstance
       try {
         // we set the random seed before opening the model, so that the random-seed will affect the
@@ -57,6 +57,7 @@ object ChecksumsAndPreviews {
         else {
           println("making preview for: " + path)
           workspace.command(workspace.previewCommands)
+          println(previewPath)
           workspace.exportView(previewPath, "PNG")
         }
       }


### PR DESCRIPTION
I started tinkering on this a couple of weeks ago after a chat with Seth made me realize that the 3D view currently cannot be exported from headless mode.

I would very much like to have that working in order to automatically generate the preview images for 3D models. It would also improve regression testing for NetLogo 3D.

My efforts so far have failed, and then I had to move on to other stuff. I'll give it a another try when/if time permits, but I wanted to at least have the work in progress out there in the meanwhile.
