### PR TITLE
Show line numbers in the editor. closes #217

### DIFF
--- a/dist/docs/interface.html.mustache
+++ b/dist/docs/interface.html.mustache
@@ -392,6 +392,16 @@
             &nbsp;
           <td class="nameCenter">
         <p>
+            Show Line Numbers
+          <td class="descriptionRight">
+        <p>
+            Toggle whether the line numbers are shown in code tabs.
+          <tr>
+        <td class="emptyLeft">
+        <p>
+            &nbsp;
+          <td class="nameCenter">
+        <p>
             Shift Left /
             <br>
             Shift Right
@@ -716,13 +726,13 @@
         <p>
             Opens the NetLogo Users Group site in a web browser.
           <tr>
-        <td style='vertical-align: top; border-top:none;border-left:double windowtext 4.5pt; border-bottom:double windowtext 4.5pt;border-right:solid windowtext .5pt; padding:0in 5.4pt 0in 5.4pt'>
+        <td style="emptyLeft">
         <p>
             &nbsp;
-          <td style='vertical-align: top; border-top:none;border-left: none;border-bottom:double windowtext 4.5pt;border-right:solid windowtext .5pt; padding:0in 5.4pt 0in 5.4pt'>
+          <td style="nameCenter">
         <p>
             Donate
-          <td style='vertical-align: top; border-top:none;border-left: none;border-bottom:double windowtext 4.5pt;border-right:double windowtext 4.5pt; padding:0in 5.4pt 0in 5.4pt'>
+          <td style="descriptionRight">
         <p>
             Opens the NetLogo donation page in a web browser.
           </table>

--- a/dist/i18n/GUI_Strings_en.txt
+++ b/dist/i18n/GUI_Strings_en.txt
@@ -64,6 +64,7 @@ menu.edit.redo = Redo
 menu.edit.selectAll = Select All
 menu.edit.find = Find...
 menu.edit.findNext = Find Next
+menu.edit.showLineNumbers = Show Line Numbers
 menu.edit.shiftLeft = Shift Left
 menu.edit.shiftRight = Shift Right
 menu.edit.comment = Comment

--- a/src/main/org/nlogo/app/App.scala
+++ b/src/main/org/nlogo/app/App.scala
@@ -381,7 +381,7 @@ class App extends
     pico.addComponent(tabs.interfaceTab.getInterfacePanel)
     frame.getContentPane.add(tabs, java.awt.BorderLayout.CENTER)
 
-    frame.addLinkComponent(new CompilerManager(workspace, tabs.proceduresTab))
+    frame.addLinkComponent(new CompilerManager(workspace, tabs.codeTab))
     frame.addLinkComponent(listenerManager)
 
     org.nlogo.util.Exceptions.setHandler(this)
@@ -875,7 +875,7 @@ class App extends
    * Returns the contents of the Code tab.
    * @return contents of Code tab
    */
-  def getProcedures: String = dispatchThreadOrBust(tabs.proceduresTab.innerSource)
+  def getProcedures: String = dispatchThreadOrBust(tabs.codeTab.innerSource)
 
   /**
    * Replaces the contents of the Code tab.
@@ -883,7 +883,7 @@ class App extends
    * @param source new contents
    * @see #compile
    */
-  def setProcedures(source:String) { dispatchThreadOrBust(tabs.proceduresTab.innerSource(source)) }
+  def setProcedures(source:String) { dispatchThreadOrBust(tabs.codeTab.innerSource(source)) }
 
   /**
    * Recompiles the model.  Useful after calling

--- a/src/main/org/nlogo/app/CodeTab.scala
+++ b/src/main/org/nlogo/app/CodeTab.scala
@@ -13,7 +13,7 @@ import java.awt.print.PageFormat
 import javax.swing.{JButton, ImageIcon, AbstractAction, Action, ScrollPaneConstants, JScrollPane, BorderFactory, JPanel}
 import org.nlogo.api.I18N
 
-class ProceduresTab(val workspace: AbstractWorkspace) extends JPanel
+class CodeTab(val workspace: AbstractWorkspace) extends JPanel
   with org.nlogo.window.ProceduresInterface
   with ProceduresMenuTarget
   with Events.SwitchedTabsEvent.Handler
@@ -57,10 +57,10 @@ class ProceduresTab(val workspace: AbstractWorkspace) extends JPanel
 
   private class CompileAction extends AbstractAction(I18N.gui.get("tabs.code.checkButton")) {
     putValue(Action.SMALL_ICON,
-      new ImageIcon(classOf[ProceduresTab].getResource(
+      new ImageIcon(classOf[CodeTab].getResource(
         "/images/check.gif")))
     def actionPerformed(e: ActionEvent) {
-      new org.nlogo.window.Events.CompileAllEvent().raise(ProceduresTab.this)
+      new org.nlogo.window.Events.CompileAllEvent().raise(CodeTab.this)
     }
   }
 
@@ -69,7 +69,7 @@ class ProceduresTab(val workspace: AbstractWorkspace) extends JPanel
       add(new JButton(org.nlogo.app.FindDialog.FIND_ACTION))
       add(new JButton(compileAction))
       add(new org.nlogo.swing.ToolBar.Separator())
-      add(new ProceduresMenu(ProceduresTab.this))
+      add(new ProceduresMenu(CodeTab.this))
     }
   }
 

--- a/src/main/org/nlogo/app/CodeTab.scala
+++ b/src/main/org/nlogo/app/CodeTab.scala
@@ -34,6 +34,10 @@ class CodeTab(val workspace: AbstractWorkspace) extends JPanel
   val errorLabel = new EditorAreaErrorLabel(text)
   val lineNumbers = new LineNumbersBar(text)
   val toolBar = getToolBar
+  val scrollableEditor = new JScrollPane(
+    text,
+    ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS,
+    ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED)
   def compiler = workspace
   def program = workspace.world.program
 
@@ -41,11 +45,6 @@ class CodeTab(val workspace: AbstractWorkspace) extends JPanel
     setIndenter(false)
     setLayout(new BorderLayout)
     add(toolBar, BorderLayout.NORTH)
-    val scrollableEditor = new JScrollPane(
-      text,
-      ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS,
-      ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED)
-    scrollableEditor.setRowHeaderView(lineNumbers)
     val codePanel = new JPanel(new BorderLayout) {
       add(scrollableEditor, BorderLayout.CENTER)
       add(errorLabel, BorderLayout.NORTH)
@@ -154,4 +153,7 @@ class CodeTab(val workspace: AbstractWorkspace) extends JPanel
     if(isSmart) text.setIndenter(new SmartIndenter(new EditorAreaWrapper(text), workspace))
     else text.setIndenter(new org.nlogo.editor.DumbIndenter(text))
   }
+
+  def lineNumbersVisible = scrollableEditor.getRowHeader != null && scrollableEditor.getRowHeader.getView != null
+  def lineNumbersVisible_=(visible: Boolean) = scrollableEditor.setRowHeaderView(if(visible) lineNumbers else null)
 }

--- a/src/main/org/nlogo/app/IncludesMenu.scala
+++ b/src/main/org/nlogo/app/IncludesMenu.scala
@@ -2,7 +2,7 @@
 
 package org.nlogo.app
 
-class IncludesMenu(target: ProceduresTab)
+class IncludesMenu(target: CodeTab)
 extends org.nlogo.swing.ToolBarMenu("Includes")
 with org.nlogo.window.Events.CompiledEvent.Handler
 {
@@ -13,7 +13,7 @@ with org.nlogo.window.Events.CompiledEvent.Handler
   private var includesTable: Map[String, String] = null
 
   def handle(e: org.nlogo.window.Events.CompiledEvent) {
-    if(e.sourceOwner.isInstanceOf[ProceduresTab])
+    if(e.sourceOwner.isInstanceOf[CodeTab])
       updateVisibility()
   }
 

--- a/src/main/org/nlogo/app/MainCodeTab.scala
+++ b/src/main/org/nlogo/app/MainCodeTab.scala
@@ -8,8 +8,8 @@ import org.nlogo.api.{I18N, ModelSection}
 // This is THE Code tab.  Certain settings and things that are only accessible here.
 // Other Code tabs come and go.
 
-class MainProceduresTab(workspace: AbstractWorkspace)
-extends ProceduresTab(workspace)
+class MainCodeTab(workspace: AbstractWorkspace)
+extends CodeTab(workspace)
 with org.nlogo.window.Events.LoadSectionEvent.Handler
 {
 
@@ -20,7 +20,7 @@ with org.nlogo.window.Events.LoadSectionEvent.Handler
     def actionPerformed(e: java.awt.event.ActionEvent) {
       setIndenter(tabbing.isSelected)
       new org.nlogo.app.Events.IndenterChangedEvent(tabbing.isSelected)
-        .raise(MainProceduresTab.this)
+        .raise(MainCodeTab.this)
     }
   }
 
@@ -33,10 +33,10 @@ with org.nlogo.window.Events.LoadSectionEvent.Handler
           org.nlogo.app.FindDialog.FIND_ACTION))
         add(new javax.swing.JButton(compileAction))
         add(new org.nlogo.swing.ToolBar.Separator)
-        add(new ProceduresMenu(MainProceduresTab.this))
+        add(new ProceduresMenu(MainCodeTab.this))
         // we add this here, however, unless there are includes it will not be displayed, as it sets
         // it's preferred size to 0x0 -- CLB
-        add(new IncludesMenu(MainProceduresTab.this))
+        add(new IncludesMenu(MainCodeTab.this))
         // turning auto-indent checkbox back on
         add(new org.nlogo.swing.ToolBar.Separator)
         tabbing = new javax.swing.JCheckBox(smartTabAction)

--- a/src/main/org/nlogo/app/ModelSaver.scala
+++ b/src/main/org/nlogo/app/ModelSaver.scala
@@ -22,7 +22,7 @@ class ModelSaver(app: App) {
 
     // procedures
     section {
-      buf ++= app.tabs.proceduresTab.innerSource
+      buf ++= app.tabs.codeTab.innerSource
       if(buf.nonEmpty && buf.last != '\n')
         buf += '\n'
     }

--- a/src/main/org/nlogo/app/ProceduresTab.scala
+++ b/src/main/org/nlogo/app/ProceduresTab.scala
@@ -3,6 +3,7 @@
 package org.nlogo.app
 
 import org.nlogo.agent.Observer
+import org.nlogo.editor.LineNumbersBar
 import org.nlogo.window.EditorAreaErrorLabel
 import org.nlogo.workspace.AbstractWorkspace
 
@@ -31,6 +32,7 @@ class ProceduresTab(val workspace: AbstractWorkspace) extends JPanel
   override def zoomTarget = text
 
   val errorLabel = new EditorAreaErrorLabel(text)
+  val lineNumbers = new LineNumbersBar(text)
   val toolBar = getToolBar
   def compiler = workspace
   def program = workspace.world.program
@@ -39,12 +41,13 @@ class ProceduresTab(val workspace: AbstractWorkspace) extends JPanel
     setIndenter(false)
     setLayout(new BorderLayout)
     add(toolBar, BorderLayout.NORTH)
+    val scrollableEditor = new JScrollPane(
+      text,
+      ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS,
+      ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED)
+    scrollableEditor.setRowHeaderView(lineNumbers)
     val codePanel = new JPanel(new BorderLayout) {
-      add(new JScrollPane(
-        text,
-        ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS,
-        ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED),
-        BorderLayout.CENTER)
+      add(scrollableEditor, BorderLayout.CENTER)
       add(errorLabel, BorderLayout.NORTH)
     }
     add(codePanel, BorderLayout.CENTER)
@@ -110,6 +113,7 @@ class ProceduresTab(val workspace: AbstractWorkspace) extends JPanel
     if(originalFontSize == -1)
       originalFontSize = text.getFont.getSize
     text.setFont(text.getFont.deriveFont(StrictMath.ceil(originalFontSize * zoomFactor).toFloat))
+    lineNumbers.setFont(text.getFont)
     errorLabel.zoom(zoomFactor)
   }
 

--- a/src/main/org/nlogo/app/Tabs.scala
+++ b/src/main/org/nlogo/app/Tabs.scala
@@ -165,6 +165,9 @@ class Tabs(val workspace: GUIWorkspace,
     removeMenuItem(index)
   }
 
+  def forAllCodeTabs(fn: CodeTab => Unit) =
+    getComponents collect { case tab: CodeTab => tab } foreach (fn)
+
   def removeMenuItem(index: Int) {
     // first remove all the menu items after this one...
     for(i <- tabsMenu.getItemCount() - 1 to index by -1) tabsMenu.remove(i)

--- a/src/main/org/nlogo/app/TemporaryCodeTab.scala
+++ b/src/main/org/nlogo/app/TemporaryCodeTab.scala
@@ -7,15 +7,15 @@ import org.nlogo.awt.UserCancelException
 import org.nlogo.workspace.AbstractWorkspace
 import org.nlogo.api.{I18N, FileIO, LocalFile}
 
-object TemporaryProceduresTab {
+object TemporaryCodeTab {
   val NewFile = "New File"
 }
-class TemporaryProceduresTab(workspace: AbstractWorkspace,
+class TemporaryCodeTab(workspace: AbstractWorkspace,
                              tabs: Tabs,
                              var filename: String,
                              fileMustExist: Boolean,
                              smartIndent: Boolean)
-extends ProceduresTab(workspace)
+extends CodeTab(workspace)
 with org.nlogo.app.Events.IndenterChangedEvent.Handler
 with org.nlogo.window.Events.LoadBeginEvent.Handler
 with org.nlogo.window.Events.AboutToQuitEvent.Handler
@@ -33,7 +33,7 @@ with org.nlogo.window.Events.AboutToQuitEvent.Handler
         add(new org.nlogo.swing.ToolBar.Separator)
         add(new javax.swing.JButton(new FileCloseAction))
         add(new org.nlogo.swing.ToolBar.Separator)
-        add(new ProceduresMenu(TemporaryProceduresTab.this))
+        add(new ProceduresMenu(TemporaryCodeTab.this))
         add(includesMenu)
       }
     }
@@ -44,7 +44,7 @@ with org.nlogo.window.Events.AboutToQuitEvent.Handler
   def isDirty = _dirty
 
   private def load(fileMustExist: Boolean) {
-    if(filename != TemporaryProceduresTab.NewFile) {
+    if(filename != TemporaryCodeTab.NewFile) {
       try {
         val sourceFile = new LocalFile(filename)
         val origSource = sourceFile.readFile()
@@ -66,7 +66,7 @@ with org.nlogo.window.Events.AboutToQuitEvent.Handler
     if((e.sourceOwner.isInstanceOf[org.nlogo.window.ExternalFileInterface] &&
         e.sourceOwner.asInstanceOf[org.nlogo.window.ExternalFileInterface].getFileName == filename)
         // if the Code tab compiles then get rid of the error ev 7/26/07
-        || (e.sourceOwner.isInstanceOf[ProceduresTab] && e.error == null))
+        || (e.sourceOwner.isInstanceOf[CodeTab] && e.error == null))
       errorLabel.setError(e.error, e.sourceOwner.headerSource.size)
   }
 
@@ -99,7 +99,7 @@ with org.nlogo.window.Events.AboutToQuitEvent.Handler
 
   @throws(classOf[UserCancelException])
   def save() {
-    if(filename == TemporaryProceduresTab.NewFile) {
+    if(filename == TemporaryCodeTab.NewFile) {
       filename = userChooseSavePath
       tabs.saveTemporaryFile(this, filename)
       dirty()

--- a/src/main/org/nlogo/app/TemporaryCodeTab.scala
+++ b/src/main/org/nlogo/app/TemporaryCodeTab.scala
@@ -24,6 +24,7 @@ with org.nlogo.window.Events.AboutToQuitEvent.Handler
   val includesMenu = new IncludesMenu(this)
   load(fileMustExist)
   setIndenter(smartIndent)
+  lineNumbersVisible = tabs.codeTab.lineNumbersVisible
 
   override def getToolBar =
     new org.nlogo.swing.ToolBar() {

--- a/src/main/org/nlogo/app/previewcommands/EditorPanel.scala
+++ b/src/main/org/nlogo/app/previewcommands/EditorPanel.scala
@@ -13,7 +13,7 @@ import org.nlogo.api.PreviewCommands.Compilable
 import org.nlogo.api.PreviewCommands.Custom
 import org.nlogo.api.PreviewCommands.Default
 import org.nlogo.api.PreviewCommands.Manual
-import org.nlogo.app.ProceduresTab
+import org.nlogo.app.CodeTab
 import org.nlogo.awt.Fonts.platformMonospacedFont
 import org.nlogo.swing.HasPropertyChangeSupport
 import org.nlogo.util.Implicits.RichString
@@ -36,7 +36,7 @@ class EditorPanel(colorizer: EditorColorizer) extends JPanel {
   val comboBox = new ComboBox
   val compileButton = new JButton(
     I18N.gui.get("tabs.code.checkButton"),
-    new ImageIcon(classOf[ProceduresTab].getResource("/images/check.gif"))
+    new ImageIcon(classOf[CodeTab].getResource("/images/check.gif"))
   )
 
   private var dirty = false

--- a/src/main/org/nlogo/editor/LineNumbersBar.scala
+++ b/src/main/org/nlogo/editor/LineNumbersBar.scala
@@ -8,20 +8,25 @@ import javax.swing.event.{ DocumentEvent, DocumentListener }
 import javax.swing.text.DefaultCaret
 
 class LineNumbersBar(editor: EditorArea[_]) extends JTextPane with DocumentListener {
+  var previousLastLineNumber = -1
+
   updateNumbers()
   setEnabled(false)
   setBackground(new Color(240, 240, 240))
+  setBorder(editor.getBorder)
   getCaret.asInstanceOf[DefaultCaret].setUpdatePolicy(DefaultCaret.NEVER_UPDATE)
   editor.getDocument.addDocumentListener(this)
 
   def updateNumbers() = {
-    val lastLineNumber = editor.getText().filter(_=='\n').length + 1
-    setText(1 to lastLineNumber mkString("\n"))
+    val lastLineNumber = editor.getText().count(_=='\n') + 1
+    if(lastLineNumber != previousLastLineNumber) {
+      setText(1 to lastLineNumber mkString("\n"))
+      previousLastLineNumber = lastLineNumber
+    }
   }
 
   override def getPreferredSize = new Dimension(super.getPreferredSize.width, editor.getPreferredSize.height)
   override def getFont = editor.getFont
-  override def getFontMetrics(f: Font) = editor.getFontMetrics(f)
 
   def insertUpdate(e: DocumentEvent) = updateNumbers()
   def removeUpdate(e: DocumentEvent) = updateNumbers()

--- a/src/main/org/nlogo/editor/LineNumbersBar.scala
+++ b/src/main/org/nlogo/editor/LineNumbersBar.scala
@@ -2,13 +2,14 @@
 
 package org.nlogo.editor
 
-import java.awt.Dimension
+import java.awt.{ Color, Dimension }
 import javax.swing.JTextPane
 import javax.swing.event.{ DocumentEvent, DocumentListener }
 
 class LineNumbersBar(editor: EditorArea[_]) extends JTextPane with DocumentListener {
   updateNumbers()
   setEnabled(false)
+  setBackground(new Color(240, 240, 240))
   editor.getDocument.addDocumentListener(this)
 
   def updateNumbers() = {

--- a/src/main/org/nlogo/editor/LineNumbersBar.scala
+++ b/src/main/org/nlogo/editor/LineNumbersBar.scala
@@ -2,14 +2,16 @@
 
 package org.nlogo.editor
 
-import java.awt.{ Color, Dimension }
+import java.awt.{ Color, Dimension, Font }
 import javax.swing.JTextPane
 import javax.swing.event.{ DocumentEvent, DocumentListener }
+import javax.swing.text.DefaultCaret
 
 class LineNumbersBar(editor: EditorArea[_]) extends JTextPane with DocumentListener {
   updateNumbers()
   setEnabled(false)
   setBackground(new Color(240, 240, 240))
+  getCaret.asInstanceOf[DefaultCaret].setUpdatePolicy(DefaultCaret.NEVER_UPDATE)
   editor.getDocument.addDocumentListener(this)
 
   def updateNumbers() = {
@@ -19,6 +21,7 @@ class LineNumbersBar(editor: EditorArea[_]) extends JTextPane with DocumentListe
 
   override def getPreferredSize = new Dimension(super.getPreferredSize.width, editor.getPreferredSize.height)
   override def getFont = editor.getFont
+  override def getFontMetrics(f: Font) = editor.getFontMetrics(f)
 
   def insertUpdate(e: DocumentEvent) = updateNumbers()
   def removeUpdate(e: DocumentEvent) = updateNumbers()

--- a/src/main/org/nlogo/editor/LineNumbersBar.scala
+++ b/src/main/org/nlogo/editor/LineNumbersBar.scala
@@ -1,0 +1,25 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.editor
+
+import java.awt.Dimension
+import javax.swing.JTextPane
+import javax.swing.event.{ DocumentEvent, DocumentListener }
+
+class LineNumbersBar(editor: EditorArea[_]) extends JTextPane with DocumentListener {
+  updateNumbers()
+  setEnabled(false)
+  editor.getDocument.addDocumentListener(this)
+
+  def updateNumbers() = {
+    val lastLineNumber = editor.getText().filter(_=='\n').length + 1
+    setText(1 to lastLineNumber mkString("\n"))
+  }
+
+  override def getPreferredSize = new Dimension(super.getPreferredSize.width, editor.getPreferredSize.height)
+  override def getFont = editor.getFont
+
+  def insertUpdate(e: DocumentEvent) = updateNumbers()
+  def removeUpdate(e: DocumentEvent) = updateNumbers()
+  def changedUpdate(e: DocumentEvent) = {}
+}


### PR DESCRIPTION
Note that it doesn't work with zooming, thus if you zoom in and back out it will ruin the alignment between the line numbers and the actual code lines.

Other than that, I think it's quite cool.

A possible enhancement would be adding a checkbox to show/hide the bar.
This is a very simple thing to add, so just tell me if it's desirable.