### PR TITLE
Mark the birth version of primitives

### DIFF
--- a/dist/docs/3d.html.mustache
+++ b/dist/docs/3d.html.mustache
@@ -606,7 +606,7 @@ if (distancexyz 0 0 0) &lt; 10
       </div>
     <div class="dict_entry" id="link-pitch">
       <h3>
-        <a>link-pitch<span class="since">4.0</span></a>
+        <a>link-pitch<span class="since">4.0.2</span></a>
       </h3>
       <h4>
         <span class="prim_example">link-pitch</span>

--- a/dist/docs/3d.html.mustache
+++ b/dist/docs/3d.html.mustache
@@ -606,7 +606,7 @@ if (distancexyz 0 0 0) &lt; 10
       </div>
     <div class="dict_entry" id="link-pitch">
       <h3>
-        <a>link-pitch</a>
+        <a>link-pitch<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">link-pitch</span>

--- a/dist/docs/3d.html.mustache
+++ b/dist/docs/3d.html.mustache
@@ -522,8 +522,8 @@ ask turtles at-points [[2 4 0] [1 2 1] [10 15 10]]
     </div>
     <div class="dict_entry" id="distance-3d">
       <h3>
-        <a>distancexyz</a>
-        <a>distancexyz-nowrap</a>
+        <a>distancexyz<span class="since">3.1</span></a>
+        <a>distancexyz-nowrap<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">distancexyz <i>xcor</i> <i>ycor</i> <i>zcor</i></span>
@@ -552,7 +552,7 @@ if (distancexyz 0 0 0) &lt; 10
     </div>
     <div class="dict_entry" id="dz">
       <h3>
-        <a>dz</a>
+        <a>dz<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">dz</span>
@@ -637,8 +637,8 @@ ask link 0 1 [ print link-pitch ]
       </div>
     <div class="dict_entry" id="min-max-pzcor">
       <h3>
-        <a>max-pzcor</a>
-        <a>min-pzcor</a>
+        <a>max-pzcor<span class="since">3.1</span></a>
+        <a>min-pzcor<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">max-pzcor</span>
@@ -662,7 +662,7 @@ ask link 0 1 [ print link-pitch ]
     <div class="dict_entry" id="neighbors-3d">
       <h3>
         <a>neighbors</a>
-        <a>neighbors6</a>
+        <a>neighbors6<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">neighbors</span>
@@ -766,7 +766,7 @@ ask patch-at 1 -1 1 [ set pcolor green ]
     </div>
     <div class="dict_entry" id="patch-at-heading-pitch-and-distance">
       <h3>
-        <a>patch-at-heading-pitch-and-distance</a>
+        <a>patch-at-heading-pitch-and-distance<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">patch-at-heading-pitch-and-distance <i>heading</i> <i>pitch</i> <i>distance</i></span>
@@ -837,7 +837,7 @@ set heading heading + 10 ;; same effect as &quot;tilt-up 10&quot;
       </div>
     <div class="dict_entry" id="random-pzcor">
       <h3>
-        <a>random-pzcor</a>
+        <a>random-pzcor<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">random-pzcor</span>
@@ -856,7 +856,7 @@ ask turtles [
       </div>
     <div class="dict_entry" id="random-zcor">
       <h3>
-        <a>random-zcor</a>
+        <a>random-zcor<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">random-zcor</span>
@@ -920,7 +920,7 @@ set roll roll + 10 ;; same effect as &quot;roll-right 10&quot;
       </div>
     <div class="dict_entry" id="roll-left">
       <h3>
-        <a>roll-left</a>
+        <a>roll-left<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">roll-left <i>number</i></span>
@@ -932,7 +932,7 @@ set roll roll + 10 ;; same effect as &quot;roll-right 10&quot;
       </div>
     <div class="dict_entry" id="roll-right">
       <h3>
-        <a>roll-right</a>
+        <a>roll-right<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">roll-right <i>number</i></span>
@@ -944,7 +944,7 @@ set roll roll + 10 ;; same effect as &quot;roll-right 10&quot;
       </div>
     <div class="dict_entry" id="setxyz">
       <h3>
-        <a>setxyz</a>
+        <a>setxyz<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">setxyz <i>x y z</i></span>
@@ -983,8 +983,8 @@ setxyz 0 0 0
       </div>
     <div class="dict_entry" id="towards-pitch-cmd">
       <h3>
-        <a>towards-pitch</a>
-        <a>towards-pitch-nowrap</a>
+        <a>towards-pitch<span class="since">3.1</span></a>
+        <a>towards-pitch-nowrap<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">towards-pitch <i>agent</i></span>
@@ -1008,8 +1008,8 @@ setxyz 0 0 0
       </div>
     <div class="dict_entry" id="towards-pitch-xyz-cmd">
       <h3>
-        <a>towards-pitch-xyz</a>
-        <a>towards-pitch-xyz-nowrap</a>
+        <a>towards-pitch-xyz<span class="since">3.1</span></a>
+        <a>towards-pitch-xyz-nowrap<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">towards-pitch-xyz <i>x</i> <i>y</i> <i>z</i></span>
@@ -1056,7 +1056,7 @@ show [count turtles-at 0 0 0] of turtle 0
     </div>
     <div class="dict_entry" id="world-depth">
       <h3>
-        <a>world-depth</a>
+        <a>world-depth<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">world-depth</span>

--- a/dist/docs/3d.html.mustache
+++ b/dist/docs/3d.html.mustache
@@ -572,7 +572,7 @@ if (distancexyz 0 0 0) &lt; 10
     <div class="dict_entry" id="face-3d">
       <h3>
         <a>face</a>
-        <a>facexyz</a>
+        <a>facexyz<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">face <i>agent</i></span>
@@ -685,10 +685,10 @@ ask neighbors6 [ set pcolor red ]
     </div>
     <div class="dict_entry" id="orbit-cmds">
       <h3>
-        <a>orbit-down</a>
-        <a>orbit-left</a>
-        <a>orbit-right</a>
-        <a>orbit-up</a>
+        <a>orbit-down<span class="since">4.0</span></a>
+        <a>orbit-left<span class="since">4.0</span></a>
+        <a>orbit-right<span class="since">4.0</span></a>
+        <a>orbit-up<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">orbit-down <i>number</i></span>
@@ -727,7 +727,7 @@ ask neighbors6 [ set pcolor red ]
       <p>
         See also <a href="#setxyz">setxyz</a>
       <h3>
-        <a id="patch">patch</a>
+        <a id="patch">patch<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">patch <i>pxcor</i> <i>pycor</i> <i>pzcor</i></span>
@@ -747,7 +747,7 @@ ask (patch 3 -4 2) [ set pcolor green ]
       </div>
     <div class="dict_entry" id="patch-at">
       <h3>
-        <a>patch-at</a>
+        <a>patch-at<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">patch-at <i>dx</i> <i>dy</i> <i>dz</i></span>
@@ -967,8 +967,8 @@ setxyz 0 0 0
     </div>
     <div class="dict_entry" id="tilt-cmds">
       <h3>
-        <a>tilt-down</a>
-        <a>tilt-up</a>
+        <a>tilt-down<span class="since">4.0</span></a>
+        <a>tilt-up<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">tilt-down <i>number</i></span>
@@ -1033,7 +1033,7 @@ setxyz 0 0 0
       </div>
     <div class="dict_entry" id="turtles-at breeds-at">
       <h3>
-        <a>turtles-at</a>
+        <a>turtles-at<span class="since">4.0</span></a>
         <a>&lt;breeds&gt;-at</a>
       </h3>
       <h4>
@@ -1089,7 +1089,7 @@ show [count turtles-at 0 0 0] of turtle 0
       </div>
     <div class="dict_entry" id="zoom">
       <h3>
-        <a>zoom</a>
+        <a>zoom<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">zoom <i>number</i></span>

--- a/dist/docs/dictionary.html.mustache
+++ b/dist/docs/dictionary.html.mustache
@@ -2331,7 +2331,7 @@ every 2 [ set index index + 1 ]
         <a>export-interface</a>
         <a>export-output<span class="since">1.0</span></a>
         <a>export-plot<span class="since">1.0</span></a>
-        <a>export-all-plots</a>
+        <a>export-all-plots<span class="since">1.2.1</span></a>
         <a>export-world<span class="since">1.0</span></a>
       </h3>
       <h4>
@@ -3273,7 +3273,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-enter-message">
       <h3>
-        <a>hubnet-enter-message?</a>
+        <a>hubnet-enter-message?<span class="since">1.2.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-enter-message?</span>
@@ -3288,7 +3288,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-exit-message">
       <h3>
-        <a>hubnet-exit-message?</a>
+        <a>hubnet-exit-message?<span class="since">1.2.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-exit-message?</span>
@@ -3925,20 +3925,20 @@ show int -3.5
     </div>
     <div class="dict_entry" id="is-of-type">
       <h3>
-        <a>is-agent?</a>
-        <a>is-agentset?</a>
-        <a>is-boolean?</a>
+        <a>is-agent?<span class="since">1.2.1</span></a>
+        <a>is-agentset?<span class="since">1.2.1</span></a>
+        <a>is-boolean?<span class="since">1.2.1</span></a>
         <a>is-command-task?</a>
         <a>is-directed-link?</a>
         <a>is-link?</a>
         <a>is-link-set?</a>
         <a>is-list?<span class="since">1.0</span></a>
-        <a>is-number?</a>
-        <a>is-patch?</a>
+        <a>is-number?<span class="since">1.2.1</span></a>
+        <a>is-patch?<span class="since">1.2.1</span></a>
         <a>is-patch-set?</a>
         <a>is-reporter-task?</a>
         <a>is-string?<span class="since">1.0</span></a>
-        <a>is-turtle?</a>
+        <a>is-turtle?<span class="since">1.2.1</span></a>
         <a>is-turtle-set?</a>
         <a>is-undirected-link?</a>
       </h3>
@@ -6237,10 +6237,10 @@ show random-float 2.5
     </div>
     <div class="dict_entry" id="random-reporters">
       <h3>
-        <a>random-exponential</a>
+        <a>random-exponential<span class="since">1.2.1</span></a>
         <a>random-gamma</a>
-        <a>random-normal</a>
-        <a>random-poisson</a>
+        <a>random-normal<span class="since">1.2.1</span></a>
+        <a>random-poisson<span class="since">1.2.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">random-exponential <i>mean</i></span>
@@ -6452,7 +6452,7 @@ show evaluate-polynomial [3 2 1] 4
     </div>
     <div class="dict_entry" id="remainder">
       <h3>
-        <a>remainder</a>
+        <a>remainder<span class="since">1.2.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">remainder <i>number1</i> <i>number2</i></span>

--- a/dist/docs/dictionary.html.mustache
+++ b/dist/docs/dictionary.html.mustache
@@ -865,7 +865,7 @@ show abs 5
       </div>
     <div class="dict_entry" id="all">
       <h3>
-        <a>all?</a>
+        <a>all?<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">all? <i>agentset</i> [<i>reporter</i>]</span>
@@ -930,7 +930,7 @@ if any? turtles with [color = red]
       </div>
     <div class="dict_entry" id="approximate-hsb">
       <h3>
-        <a>approximate-hsb</a>
+        <a>approximate-hsb<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">approximate-hsb <i>hue saturation brightness</i></span>
@@ -956,7 +956,7 @@ show approximate-hsb 180 57.143 76.863
       </div>
     <div class="dict_entry" id="approximate-rgb">
       <h3>
-        <a>approximate-rgb</a>
+        <a>approximate-rgb<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">approximate-rgb <i>red green blue</i></span>
@@ -1079,7 +1079,7 @@ ask turtle 4 [ rt 90 ]
       </div>
     <div class="dict_entry" id="ask-concurrent">
       <h3>
-        <a>ask-concurrent</a>
+        <a>ask-concurrent<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">ask-concurrent <i>agentset</i> [<i>commands</i>]</span>
@@ -1225,7 +1225,7 @@ end
       </div>
     <div class="dict_entry" id="base-colors">
       <h3>
-        <a>base-colors</a>
+        <a>base-colors<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">base-colors</span>
@@ -1291,7 +1291,7 @@ repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
       </div>
     <div class="dict_entry" id="both-ends">
       <h3>
-        <a>both-ends</a>
+        <a>both-ends<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">both-ends</span>
@@ -1537,7 +1537,7 @@ show ceiling -4.5
       </div>
     <div class="dict_entry" id="clear-links">
       <h3>
-        <a>clear-links</a>
+        <a>clear-links<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">clear-links</span>
@@ -1685,8 +1685,8 @@ show count patches with [pcolor = red]
     </div>
     <div class="dict_entry" id="create-ordered-turtles">
       <h3>
-        <a>create-ordered-turtles</a>
-        <a>cro</a>
+        <a>create-ordered-turtles<span class="since">4.0</span></a>
+        <a>cro<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">create-ordered-turtles <i>number</i></span>
@@ -1719,12 +1719,12 @@ cro 100 [ fd 10 ]  ;; makes an evenly spaced circle
         <a>create-&lt;breeds&gt;-from</a>
         <a>create-&lt;breed&gt;-with</a>
         <a>create-&lt;breeds&gt;-with</a>
-        <a>create-link-to</a>
-        <a>create-links-to</a>
-        <a>create-link-from</a>
-        <a>create-links-from</a>
-        <a>create-link-with</a>
-        <a>create-links-with</a>
+        <a>create-link-to<span class="since">4.0</span></a>
+        <a>create-links-to<span class="since">4.0</span></a>
+        <a>create-link-from<span class="since">4.0</span></a>
+        <a>create-links-from<span class="since">4.0</span></a>
+        <a>create-link-with<span class="since">4.0</span></a>
+        <a>create-links-with<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">create-&lt;breed&gt;-to <i>turtle</i></span>
@@ -2210,7 +2210,7 @@ if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
       </div>
     <div class="dict_entry" id="end1">
       <h3>
-        <a>end1</a>
+        <a>end1<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">end1</span>
@@ -2231,7 +2231,7 @@ ask links
     </div>
     <div class="dict_entry" id="end2">
       <h3>
-        <a>end2</a>
+        <a>end2<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">end2</span>
@@ -2596,7 +2596,7 @@ print file-at-end?
       </div>
     <div class="dict_entry" id="file-flush">
       <h3>
-        <a>file-flush</a>
+        <a>file-flush<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">file-flush</span>
@@ -3106,7 +3106,7 @@ set hidden? not hidden?
     </div>
     <div class="dict_entry" id="hide-link">
       <h3>
-        <a>hide-link</a>
+        <a>hide-link<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">hide-link</span>
@@ -3701,7 +3701,7 @@ show reduce [ifelse-value (?1 &gt; ?2) [?1] [?2]]
       </div>
     <div class="dict_entry" id="import-pcolors-rgb">
       <h3>
-        <a>import-pcolors-rgb</a>
+        <a>import-pcolors-rgb<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">import-pcolors-rgb <i>filename</i></span>
@@ -3788,7 +3788,7 @@ ask turtles
     <div class="dict_entry" id="in-link-neighbor">
       <h3>
         <a>in-&lt;breed&gt;-neighbor?</a>
-        <a>in-link-neighbor?</a>
+        <a>in-link-neighbor?<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">in-&lt;breed&gt;-neighbor? <i>agent</i></span>
@@ -3814,7 +3814,7 @@ ask turtle 1 [
     <div class="dict_entry" id="in-link-neighbors">
       <h3>
         <a>in-&lt;breed&gt;-neighbors</a>
-        <a>in-link-neighbors</a>
+        <a>in-link-neighbors<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">in-&lt;breed&gt;-neighbors</span>
@@ -3833,7 +3833,7 @@ ask turtle 1 [ ask in-link-neighbors [ set color blue ] ] ;; turtle 0 turns blue
     <div class="dict_entry" id="in-link-from">
       <h3>
         <a>in-&lt;breed&gt;-from</a>
-        <a>in-link-from</a>
+        <a>in-link-from<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">in-&lt;breed&gt;-from <i>turtle</i></span>
@@ -3929,18 +3929,18 @@ show int -3.5
         <a>is-agentset?<span class="since">1.2.1</span></a>
         <a>is-boolean?<span class="since">1.2.1</span></a>
         <a>is-command-task?</a>
-        <a>is-directed-link?</a>
-        <a>is-link?</a>
-        <a>is-link-set?</a>
+        <a>is-directed-link?<span class="since">4.0</span></a>
+        <a>is-link?<span class="since">4.0</span></a>
+        <a>is-link-set?<span class="since">4.0</span></a>
         <a>is-list?<span class="since">1.0</span></a>
         <a>is-number?<span class="since">1.2.1</span></a>
         <a>is-patch?<span class="since">1.2.1</span></a>
-        <a>is-patch-set?</a>
+        <a>is-patch-set?<span class="since">4.0</span></a>
         <a>is-reporter-task?</a>
         <a>is-string?<span class="since">1.0</span></a>
         <a>is-turtle?<span class="since">1.2.1</span></a>
-        <a>is-turtle-set?</a>
-        <a>is-undirected-link?</a>
+        <a>is-turtle-set?<span class="since">4.0</span></a>
+        <a>is-undirected-link?<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">is-agent? <i>value</i></span>
@@ -4081,7 +4081,7 @@ ask turtles [ set label-color red ]
       </div>
     <div class="dict_entry" id="layout-circle">
       <h3>
-        <a>layout-circle</a>
+        <a>layout-circle<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">layout-circle <i>agentset</i> <i>radius</i></span>
@@ -4110,7 +4110,7 @@ layout-circle sort-by [[size] of ?1 &lt; [size] of ?2] turtles 10
     </div>
     <div class="dict_entry" id="layout-radial">
       <h3>
-        <a>layout-radial</a>
+        <a>layout-radial<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">layout-radial <i>turtle-set</i> <i>link-set</i> <i>root-agent</i></span>
@@ -4147,7 +4147,7 @@ end
     </div>
     <div class="dict_entry" id="layout-spring">
       <h3>
-        <a>layout-spring</a>
+        <a>layout-spring<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">layout-spring <i>turtle-set</i> <i>link-set</i>
@@ -4201,7 +4201,7 @@ end
     </div>
     <div class="dict_entry" id="layout-tutte">
       <h3>
-        <a>layout-tutte</a>
+        <a>layout-tutte<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">layout-tutte <i>turtle-set</i> <i>link-set</i> <i>radius</i></span>
@@ -4293,7 +4293,7 @@ if prey != nobody
     </div>
     <div class="dict_entry" id="link">
       <h3>
-        <a>link</a>
+        <a>link<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">link <i>end1</i> <i>end2</i> &lt;breed&gt; <i>end1</i> <i>end2</i></span>
@@ -4314,7 +4314,7 @@ ask directed-link 0 1 [ set color red ]
       </div>
     <div class="dict_entry" id="link-heading">
       <h3>
-        <a>link-heading</a>
+        <a>link-heading<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">link-heading</span>
@@ -4333,7 +4333,7 @@ ask link 0 1 [ print link-heading ]
       </div>
     <div class="dict_entry" id="link-length">
       <h3>
-        <a>link-length</a>
+        <a>link-length<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">link-length</span>
@@ -4350,7 +4350,7 @@ ask link 0 1 [ print link-length ]
       </div>
     <div class="dict_entry" id="link-set">
       <h3>
-        <a>link-set</a>
+        <a>link-set<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">link-set <i>value</i></span>
@@ -4369,7 +4369,7 @@ link-set [my-links] of nodes with [color = red]
       </div>
     <div class="dict_entry" id="link-shapes">
       <h3>
-        <a>link-shapes</a>
+        <a>link-shapes<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">link-shapes</span>
@@ -4387,7 +4387,7 @@ show link-shapes
     </div>
     <div class="dict_entry" id="links">
       <h3>
-        <a>links</a>
+        <a>links<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">links</span>
@@ -4572,7 +4572,7 @@ show max (list a b c)
       </div>
       <div class="dict_entry" id="max-n-of">
         <h3>
-          <a>max-n-of</a>
+          <a>max-n-of<span class="since">4.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">max-n-of <i>number</i> <i>agentset</i> [<i>reporter</i>]</span>
@@ -4733,7 +4733,7 @@ show min (list a b c)
       </div>
       <div class="dict_entry" id="min-n-of">
         <h3>
-          <a>min-n-of</a>
+          <a>min-n-of<span class="since">4.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">min-n-of <i>number</i> <i>agentset</i> [<i>reporter</i>]</span>
@@ -4908,7 +4908,7 @@ if mouse-down?
       </div>
       <div class="dict_entry" id="move-to">
         <h3>
-          <a>move-to</a>
+          <a>move-to<span class="since">4.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">move-to <i>agent</i></span>
@@ -5032,7 +5032,7 @@ print movie-status
       <div class="dict_entry" id="my-links">
         <h3>
           <a>my-&lt;breeds&gt;</a>
-          <a>my-links</a>
+          <a>my-links<span class="since">4.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">my-&lt;breeds&gt;</span>
@@ -5060,7 +5060,7 @@ end
       <div class="dict_entry" id="my-in-links">
         <h3>
           <a>my-in-&lt;breeds&gt;</a>
-          <a>my-in-links</a>
+          <a>my-in-links<span class="since">4.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">my-in-&lt;breeds&gt;</span>
@@ -5086,7 +5086,7 @@ ask turtle 1
       <div class="dict_entry" id="my-out-links">
         <h3>
           <a>my-out-&lt;breeds&gt;</a>
-          <a>my-out-links</a>
+          <a>my-out-links<span class="since">4.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">my-out-&lt;breeds&gt;</span>
@@ -5228,7 +5228,7 @@ ask neighbors4 [ set pcolor red ]
       <div class="dict_entry" id="link-neighbors">
         <h3>
           <a>&lt;breed&gt;-neighbors</a>
-          <a>link-neighbors</a>
+          <a>link-neighbors<span class="since">4.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">&lt;breed&gt;-neighbors</span>
@@ -5255,7 +5255,7 @@ end
       <div class="dict_entry" id="link-neighbor">
         <h3>
           <a>&lt;breed&gt;-neighbor?</a>
-          <a>link-neighbor?</a>
+          <a>link-neighbor?<span class="since">4.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">&lt;breed&gt;-neighbor? <i>turtle</i></span>
@@ -5281,7 +5281,7 @@ ask turtle 1
     </div>
     <div class="dict_entry" id="netlogo-applet">
       <h3>
-        <a>netlogo-applet?</a>
+        <a>netlogo-applet?<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">netlogo-applet?</span>
@@ -5384,7 +5384,7 @@ if target != nobody
     </div>
     <div class="dict_entry" id="no-links">
       <h3>
-        <a>no-links</a>
+        <a>no-links<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">no-links</span>
@@ -5394,7 +5394,7 @@ if target != nobody
     </div>
     <div class="dict_entry" id="no-patches">
       <h3>
-        <a>no-patches</a>
+        <a>no-patches<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">no-patches</span>
@@ -5417,7 +5417,7 @@ if not any? turtles [ crt 10 ]
     </div>
     <div class="dict_entry" id="no-turtles">
       <h3>
-        <a>no-turtles</a>
+        <a>no-turtles<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">no-turtles</span>
@@ -5432,7 +5432,7 @@ if not any? turtles [ crt 10 ]
     <div id="O">
     <div class="dict_entry" id="of">
       <h3>
-        <a>of</a>
+        <a>of<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">[<i>reporter</i>] of <i>agent</i></span>
@@ -5512,7 +5512,7 @@ if (pxcor &gt; 0) or (pycor &gt; 0) [ set pcolor red ]
     </div>
     <div class="dict_entry" id="other">
       <h3>
-        <a>other</a>
+        <a>other<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">other <i>agentset</i></span>
@@ -5530,7 +5530,7 @@ show count other turtles-here
     </div>
     <div class="dict_entry" id="other-end">
       <h3>
-        <a>other-end</a>
+        <a>other-end<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">other-end</span>
@@ -5558,7 +5558,7 @@ ask link 0 1 [ ask turtle 0 [ show other-end ] ] ;; prints turtle 1
     <div class="dict_entry" id="out-link-neighbor">
       <h3>
         <a>out-&lt;breed&gt;-neighbor?</a>
-        <a>out-link-neighbor?</a>
+        <a>out-link-neighbor?<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">out-&lt;breed&gt;-neighbor? <i>turtle</i></span>
@@ -5584,7 +5584,7 @@ ask turtle 1 [
     <div class="dict_entry" id="out-link-neighbors">
       <h3>
         <a>out-&lt;breed&gt;-neighbors</a>
-        <a>out-link-neighbors</a>
+        <a>out-link-neighbors<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">out-&lt;breed&gt;-neighbors</span>
@@ -5612,7 +5612,7 @@ end
     <div class="dict_entry" id="out-link-to">
       <h3>
         <a>out-&lt;breed&gt;-to</a>
-        <a>out-link-to</a>
+        <a>out-link-to<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">out-&lt;breed&gt;-to <i>turtle</i></span>
@@ -5805,7 +5805,7 @@ ask patch-right-and-ahead 30 1 [ set pcolor green ]
       </div>
     <div class="dict_entry" id="patch-set">
       <h3>
-        <a>patch-set</a>
+        <a>patch-set<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">patch-set <i>value1</i></span>
@@ -6014,7 +6014,7 @@ patch-set [neighbors] of turtles
       </div>
     <div class="dict_entry" id="plot-pen-exists">
       <h3>
-        <a>plot-pen-exists?</a>
+        <a>plot-pen-exists?<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">plot-pen-exists? <i>string</i></span>
@@ -6606,7 +6606,7 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
       </div>
     <div class="dict_entry" id="reset-ticks">
       <h3>
-        <a>reset-ticks</a>
+        <a>reset-ticks<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">reset-ticks</span>
@@ -7300,7 +7300,7 @@ ask turtles [ set shape one-of shapes ]
       </div>
     <div class="dict_entry" id="show-link">
       <h3>
-        <a>show-link</a>
+        <a>show-link<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">show-link</span>
@@ -7762,7 +7762,7 @@ show sum [energy] of turtles
       </div>
     <div class="dict_entry" id="tick">
       <h3>
-        <a>tick</a>
+        <a>tick<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">tick</span>
@@ -7780,7 +7780,7 @@ show sum [energy] of turtles
       </div>
     <div class="dict_entry" id="tick-advance">
       <h3>
-        <a>tick-advance</a>
+        <a>tick-advance<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">tick-advance <i>number</i></span>
@@ -7807,7 +7807,7 @@ show sum [energy] of turtles
       </div>
     <div class="dict_entry" id="ticks">
       <h3>
-        <a>ticks</a>
+        <a>ticks<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">ticks</span>
@@ -7828,7 +7828,7 @@ show sum [energy] of turtles
       </div>
     <div class="dict_entry" id="tie">
       <h3>
-        <a>tie</a>
+        <a>tie<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">tie</span>
@@ -8011,7 +8011,7 @@ ask turtle 5 [ set color red ]
     </div>
     <div class="dict_entry" id="turtle-set">
       <h3>
-        <a>turtle-set</a>
+        <a>turtle-set<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">turtle-set <i>value1</i></span>
@@ -8225,7 +8225,7 @@ ask turtle 0 [ show sort my-links ]
       </div>
     <div class="dict_entry" id="untie">
       <h3>
-        <a>untie</a>
+        <a>untie<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">untie</span>
@@ -8600,7 +8600,7 @@ show count patches with [pcolor = red]
     <div class="dict_entry" id="link-with">
       <h3>
         <a>&lt;breed&gt;-with</a>
-        <a>link-with</a>
+        <a>link-with<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">&lt;breed&gt;-with <i>turtle</i></span>
@@ -8660,7 +8660,7 @@ show count patches with-min [pycor]
       </div>
     <div class="dict_entry" id="with-local-randomness">
       <h3>
-        <a>with-local-randomness</a>
+        <a>with-local-randomness<span class="since">4.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">with-local-randomness [ <i>commands</i> ]</span>

--- a/dist/docs/dictionary.html.mustache
+++ b/dist/docs/dictionary.html.mustache
@@ -1514,8 +1514,8 @@ show ceiling -4.5
       </div>
     <div class="dict_entry" id="clear-drawing">
       <h3>
-        <a>clear-drawing</a>
-        <a>cd</a>
+        <a>clear-drawing<span class="since">3.0</span></a>
+        <a>cd<span class="since">3.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">clear-drawing</span>
@@ -1887,7 +1887,7 @@ end
     <div id="D">
     <div class="dict_entry" id="date-and-time">
       <h3>
-        <a>date-and-time</a>
+        <a>date-and-time<span class="since">3.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">date-and-time</span>
@@ -2327,7 +2327,7 @@ every 2 [ set index index + 1 ]
       </div>
     <div class="dict_entry" id="export-cmds">
       <h3>
-        <a>export-view</a>
+        <a>export-view<span class="since">3.0</span></a>
         <a>export-interface<span class="since">2.0</span></a>
         <a>export-output<span class="since">1.0</span></a>
         <a>export-plot<span class="since">1.0</span></a>
@@ -2473,7 +2473,7 @@ show extract-rgb cyan
     <div id="F">
     <div class="dict_entry" id="face">
       <h3>
-        <a>face</a>
+        <a>face<span class="since">3.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">face <i>agent</i></span>
@@ -2491,7 +2491,7 @@ show extract-rgb cyan
       </div>
     <div class="dict_entry" id="facexy">
       <h3>
-        <a>facexy</a>
+        <a>facexy<span class="since">3.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">facexy <i>number</i> <i>number</i></span>
@@ -2890,7 +2890,7 @@ show floor -4.5
       </div>
     <div class="dict_entry" id="follow">
       <h3>
-        <a>follow</a>
+        <a>follow<span class="since">3.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">follow <i>turtle</i></span>
@@ -2904,7 +2904,7 @@ show floor -4.5
       </div>
     <div class="dict_entry" id="follow-me">
       <h3>
-        <a>follow-me</a>
+        <a>follow-me<span class="since">3.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">follow-me</span>
@@ -3650,7 +3650,7 @@ show reduce [ifelse-value (?1 &gt; ?2) [?1] [?2]]
       </div>
     <div class="dict_entry" id="import-drawing">
       <h3>
-        <a>import-drawing</a>
+        <a>import-drawing<span class="since">3.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">import-drawing <i>filename</i></span>
@@ -3673,7 +3673,7 @@ show reduce [ifelse-value (?1 &gt; ?2) [?1] [?2]]
       </div>
     <div class="dict_entry" id="import-pcolors">
       <h3>
-        <a>import-pcolors</a>
+        <a>import-pcolors<span class="since">3.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">import-pcolors <i>filename</i></span>
@@ -3758,7 +3758,7 @@ show reduce [ifelse-value (?1 &gt; ?2) [?1] [?2]]
       </div>
     <div class="dict_entry" id="in-cone">
       <h3>
-        <a>in-cone</a>
+        <a>in-cone<span class="since">3.0</span></a>
       </h3>
       <h4>
         <span class="prim_example"><i>agentset</i> in-cone <i>distance</i> <i>angle</i></span>
@@ -4874,7 +4874,7 @@ show modes [pxcor] of turtles
         </div>
       <div class="dict_entry" id="mouse-inside">
         <h3>
-          <a>mouse-inside?</a>
+          <a>mouse-inside?<span class="since">3.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">mouse-inside?</span>
@@ -4957,7 +4957,7 @@ move-to max-one-of turtles [size]
         </div>
       <div class="dict_entry" id="movie-grab-view">
         <h3>
-          <a>movie-grab-view</a>
+          <a>movie-grab-view<span class="since">3.0</span></a>
           <a>movie-grab-interface<span class="since">2.1</span></a>
         </h3>
         <h4>
@@ -5291,7 +5291,7 @@ ask turtle 1
       </div>
     <div class="dict_entry" id="netlogo-version">
       <h3>
-        <a>netlogo-version</a>
+        <a>netlogo-version<span class="since">3.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">netlogo-version</span>
@@ -5316,7 +5316,7 @@ show netlogo-version
       </div>
     <div class="dict_entry" id="new-seed">
       <h3>
-        <a>new-seed</a>
+        <a>new-seed<span class="since">3.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">new-seed</span>
@@ -5898,8 +5898,8 @@ patch-set [neighbors] of turtles
       <h3>
         <a>pen-down<span class="since">1.0</span></a>
         <a>pd<span class="since">1.0</span></a>
-        <a>pen-erase</a>
-        <a>pe</a>
+        <a>pen-erase<span class="since">3.0</span></a>
+        <a>pe<span class="since">3.0</span></a>
         <a>pen-up<span class="since">1.0</span></a>
         <a>pu<span class="since">1.0</span></a>
       </h3>
@@ -6589,8 +6589,8 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
       </div>
     <div class="dict_entry" id="reset-perspective">
       <h3>
-        <a>reset-perspective</a>
-        <a>rp</a>
+        <a>reset-perspective<span class="since">3.0</span></a>
+        <a>rp<span class="since">3.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">reset-perspective</span>
@@ -6688,7 +6688,7 @@ show reverse &quot;live&quot;
       </div>
     <div class="dict_entry" id="ride">
       <h3>
-        <a>ride</a>
+        <a>ride<span class="since">3.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">ride <i>turtle</i></span>
@@ -6707,7 +6707,7 @@ show reverse &quot;live&quot;
       </div>
     <div class="dict_entry" id="ride-me">
       <h3>
-        <a>ride-me</a>
+        <a>ride-me<span class="since">3.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">ride-me</span>
@@ -7630,7 +7630,7 @@ ask sheep [ stop-inspecting self ]
     </div>
     <div class="dict_entry" id="subject">
       <h3>
-        <a>subject</a>
+        <a>subject<span class="since">3.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">subject</span>
@@ -8483,7 +8483,7 @@ repeat 10 [ fd 1 wait 0.5 ]
       </div>
     <div class="dict_entry" id="watch">
       <h3>
-        <a>watch</a>
+        <a>watch<span class="since">3.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">watch <i>agent</i></span>
@@ -8497,7 +8497,7 @@ repeat 10 [ fd 1 wait 0.5 ]
       </div>
     <div class="dict_entry" id="watch-me">
       <h3>
-        <a>watch-me</a>
+        <a>watch-me<span class="since">3.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">watch-me</span>

--- a/dist/docs/dictionary.html.mustache
+++ b/dist/docs/dictionary.html.mustache
@@ -1266,7 +1266,7 @@ repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
       </div>
     <div class="dict_entry" id="behaviorspace-experiment-name">
       <h3>
-        <a>behaviorspace-experiment-name</a>
+        <a>behaviorspace-experiment-name<span class="since">5.2</span></a>
       </h3>
       <h4>
         <span class="prim_example">behaviorspace-experiment-name</span>
@@ -5306,7 +5306,7 @@ show netlogo-version
     </div>
     <div class="dict_entry" id="netlogo-web">
       <h3>
-        <a>netlogo-web?</a>
+        <a>netlogo-web?<span class="since">5.2</span></a>
       </h3>
       <h4>
         <span class="prim_example">netlogo-web?</span>
@@ -7599,7 +7599,7 @@ if not any? turtles [ stop ]
       </div>
     <div class="dict_entry" id="stop-inspecting">
       <h3>
-        <a>stop-inspecting</a>
+        <a>stop-inspecting<span class="since">5.2</span></a>
       </h3>
       <h4>
         <span class="prim_example">stop-inspecting <i>agent</i></span>
@@ -7619,7 +7619,7 @@ ask sheep [ stop-inspecting self ]
     </div>
     <div class="dict_entry" id="stop-inspecting-dead-agents">
       <h3>
-        <a>stop-inspecting-dead-agents</a>
+        <a>stop-inspecting-dead-agents<span class="since">5.2</span></a>
       </h3>
       <h4>
         <span class="prim_example">stop-inspecting-dead-agents</span>

--- a/dist/docs/dictionary.html.mustache
+++ b/dist/docs/dictionary.html.mustache
@@ -1429,7 +1429,7 @@ show but-last &quot;string&quot;
     <div id="C">
     <div class="dict_entry" id="can-move">
       <h3>
-        <a>can-move?</a>
+        <a>can-move?<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">can-move? <i>distance</i></span>
@@ -4617,8 +4617,8 @@ show max-one-of patches [count turtles-here]
         </div>
       <div class="dict_entry" id="max-pcor">
         <h3>
-          <a>max-pxcor</a>
-          <a>max-pycor</a>
+          <a>max-pxcor<span class="since">3.1</span></a>
+          <a>max-pycor<span class="since">3.1</span></a>
         </h3>
         <h4>
           <span class="prim_example">max-pxcor</span>
@@ -4779,8 +4779,8 @@ show min-one-of turtles [xcor + ycor]
         </div>
       <div class="dict_entry" id="min-pcor">
         <h3>
-          <a>min-pxcor</a>
-          <a>min-pycor</a>
+          <a>min-pxcor<span class="since">3.1</span></a>
+          <a>min-pycor<span class="since">3.1</span></a>
         </h3>
         <h4>
           <span class="prim_example">min-pxcor</span>
@@ -5152,7 +5152,7 @@ ask turtles
       <div id="N">
       <div class="dict_entry" id="n-of">
         <h3>
-          <a>n-of</a>
+          <a>n-of<span class="since">3.1</span></a>
         </h3>
         <h4>
           <span class="prim_example">n-of <i>size</i> <i>agentset</i></span>
@@ -6283,8 +6283,8 @@ show random-poisson 3.4
     </div>
     <div class="dict_entry" id="random-pcor">
       <h3>
-        <a>random-pxcor</a>
-        <a>random-pycor</a>
+        <a>random-pxcor<span class="since">3.1</span></a>
+        <a>random-pycor<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">random-pxcor</span>
@@ -6333,8 +6333,8 @@ show random 100
     </div>
     <div class="dict_entry" id="random-cor">
       <h3>
-        <a>random-xcor</a>
-        <a>random-ycor</a>
+        <a>random-xcor<span class="since">3.1</span></a>
+        <a>random-ycor<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">random-xcor</span>
@@ -7518,7 +7518,7 @@ sprout-sheep 1 [ set color black ]
       </div>
     <div class="dict_entry" id="stamperase">
       <h3>
-        <a>stamp-erase</a>
+        <a>stamp-erase<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">stamp-erase</span>
@@ -8300,7 +8300,7 @@ if [<i>patch-variable</i>] of p &gt; <i>patch-variable</i> [
       </div>
     <div class="dict_entry" id="user-directory">
       <h3>
-        <a>user-directory</a>
+        <a>user-directory<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">user-directory</span>
@@ -8318,7 +8318,7 @@ set-current-directory user-directory
     </div>
     <div class="dict_entry" id="user-file">
       <h3>
-        <a>user-file</a>
+        <a>user-file<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">user-file</span>
@@ -8336,7 +8336,7 @@ file-open user-file
     </div>
     <div class="dict_entry" id="user-new-file">
       <h3>
-        <a>user-new-file</a>
+        <a>user-new-file<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">user-new-file</span>
@@ -8392,7 +8392,7 @@ user-message (word &quot;There are &quot; count turtles &quot; turtles.&quot;)
     </div>
     <div class="dict_entry" id="user-one-of">
       <h3>
-        <a>user-one-of</a>
+        <a>user-one-of<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">user-one-of <i>value</i> <i>list-of-choices</i></span>
@@ -8749,8 +8749,8 @@ show (word &quot;a&quot; &quot;b&quot; &quot;c&quot; 1 23)
     </div>
     <div class="dict_entry" id="world-dim">
       <h3>
-        <a>world-width</a>
-        <a>world-height</a>
+        <a>world-width<span class="since">3.1</span></a>
+        <a>world-height<span class="since">3.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">world-width</span>

--- a/dist/docs/dictionary.html.mustache
+++ b/dist/docs/dictionary.html.mustache
@@ -1278,7 +1278,7 @@ repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
       </div>
     <div class="dict_entry" id="behaviorspace-run-number">
       <h3>
-        <a>behaviorspace-run-number</a>
+        <a>behaviorspace-run-number<span class="since">4.1.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">behaviorspace-run-number</span>

--- a/dist/docs/dictionary.html.mustache
+++ b/dist/docs/dictionary.html.mustache
@@ -3218,7 +3218,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-broadcast-clear-output">
       <h3>
-        <a>hubnet-broadcast-clear-output</a>
+        <a>hubnet-broadcast-clear-output<span class="since">4.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-broadcast-clear-output</span>
@@ -3230,7 +3230,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-broadcast-message">
       <h3>
-        <a>hubnet-broadcast-message</a>
+        <a>hubnet-broadcast-message<span class="since">4.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-broadcast-message <i>value</i></span>
@@ -3244,8 +3244,8 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-clear-override">
       <h3>
-        <a>hubnet-clear-override</a>
-        <a>hubnet-clear-overrides</a>
+        <a>hubnet-clear-override<span class="since">4.1</span></a>
+        <a>hubnet-clear-overrides<span class="since">4.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-clear-override <i>client</i> <i>agent-or-set</i> <i>variable-name</i></span>
@@ -3413,7 +3413,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-reset-perspective">
       <h3>
-        <a>hubnet-reset-perspective</a>
+        <a>hubnet-reset-perspective<span class="since">4.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-reset-perspective <i>tag-name</i></span>
@@ -3452,7 +3452,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-send-clear-output">
       <h3>
-        <a>hubnet-send-clear-output</a>
+        <a>hubnet-send-clear-output<span class="since">4.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-send-clear-output <i>string</i></span>
@@ -3470,7 +3470,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-send-follow">
       <h3>
-        <a>hubnet-send-follow</a>
+        <a>hubnet-send-follow<span class="since">4.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-send-follow <i>client-name agent radius</i></span>
@@ -3485,7 +3485,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-send-message">
       <h3>
-        <a>hubnet-send-message</a>
+        <a>hubnet-send-message<span class="since">4.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-send-message <i>string</i> <i>value</i></span>
@@ -3498,7 +3498,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-send-override">
       <h3>
-        <a>hubnet-send-override</a>
+        <a>hubnet-send-override<span class="since">4.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-send-override <i>client-name agent-or-set variable-name</i></span>
@@ -3526,7 +3526,7 @@ ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
       </div>
     <div class="dict_entry" id="hubnet-send-watch">
       <h3>
-        <a>hubnet-send-watch</a>
+        <a>hubnet-send-watch<span class="since">4.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-send-watch <i>client-name agent</i></span>
@@ -5831,7 +5831,7 @@ patch-set [neighbors] of turtles
       </div>
     <div class="dict_entry" id="patch-size">
       <h3>
-        <a>patch-size</a>
+        <a>patch-size<span class="since">4.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">patch-size</span>
@@ -6636,7 +6636,7 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
       </div>
     <div class="dict_entry" id="resize-world">
       <h3>
-        <a>resize-world</a>
+        <a>resize-world<span class="since">4.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">resize-world <i>min-pxcor</i> <i>max-pxcor</i> <i>min-pycor</i> <i>max-pycor</i></span>
@@ -7070,7 +7070,7 @@ ask cats [ set breed dogs ]
       </div>
     <div class="dict_entry" id="set-patch-size">
       <h3>
-        <a>set-patch-size</a>
+        <a>set-patch-size<span class="since">4.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">set-patch-size <i>size</i></span>

--- a/dist/docs/dictionary.html.mustache
+++ b/dist/docs/dictionary.html.mustache
@@ -853,7 +853,7 @@ show abs 5
     </div>
     <div class="dict_entry" id="acos">
       <h3>
-        <a>acos</a>
+        <a>acos<span class="since">1.3</span></a>
       </h3>
       <h4>
         <span class="prim_example">acos <i>number</i></span>
@@ -1039,7 +1039,7 @@ show 5 * (6 + 6) / 3
     </div>
     <div class="dict_entry" id="asin">
       <h3>
-        <a>asin</a>
+        <a>asin<span class="since">1.3</span></a>
       </h3>
       <h4>
         <span class="prim_example">asin <i>number</i></span>
@@ -2835,7 +2835,7 @@ ask turtles
       </div>
     <div class="dict_entry" id="filter">
       <h3>
-        <a>filter</a>
+        <a>filter<span class="since">1.3</span></a>
       </h3>
       <h4>
         <span class="prim_example">filter <i>reporter-task</i> <i>list</i></span>
@@ -2917,7 +2917,7 @@ show floor -4.5
       </div>
     <div class="dict_entry" id="foreach">
       <h3>
-        <a>foreach</a>
+        <a>foreach<span class="since">1.3</span></a>
       </h3>
       <h4>
         <span class="prim_example">foreach <i>list</i> <i>command-task</i></span>
@@ -4519,7 +4519,7 @@ set mylist lput 42 mylist
       <div id="M">
       <div class="dict_entry" id="map">
         <h3>
-          <a>map</a>
+          <a>map<span class="since">1.3</span></a>
         </h3>
         <h4>
           <span class="prim_example">map <i>reporter-task</i> <i>list</i></span>
@@ -6383,7 +6383,7 @@ crt read-from-string user-input &quot;Make how many turtles?&quot;
     </div>
     <div class="dict_entry" id="reduce">
       <h3>
-        <a>reduce</a>
+        <a>reduce<span class="since">1.3</span></a>
       </h3>
       <h4>
         <span class="prim_example">reduce <i>reporter-task</i> <i>list</i></span>
@@ -6768,8 +6768,8 @@ show round -4.5
       </div>
     <div class="dict_entry" id="run">
       <h3>
-        <a>run</a>
-        <a>runresult</a>
+        <a>run<span class="since">1.3</span></a>
+        <a>runresult<span class="since">1.3</span></a>
       </h3>
       <h4>
         <span class="prim_example">run <i>command-task</i></span>
@@ -6848,7 +6848,7 @@ ask turtles [ set color scale-color red age 0 50 ]
     </div>
     <div class="dict_entry" id="self">
       <h3>
-        <a>self</a>
+        <a>self<span class="since">1.3</span></a>
       </h3>
       <h4>
         <span class="prim_example">self</span>
@@ -7404,7 +7404,7 @@ foreach sort patches [
       </div>
     <div class="dict_entry" id="sort-by">
       <h3>
-        <a>sort-by</a>
+        <a>sort-by<span class="since">1.3</span></a>
       </h3>
       <h4>
         <span class="prim_example">sort-by <i>reporter-task</i> <i>list</i></span>

--- a/dist/docs/dictionary.html.mustache
+++ b/dist/docs/dictionary.html.mustache
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="netlogo.css" type="text/css">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <style type="text/css">
-p { margin-left: 1.5em ; }
+    p  { margin-left: 1.5em ; }
     h3 { font-size: 115% ; }
     h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
     </style>
@@ -837,7 +837,7 @@ Go figure! - ST 12/2/04
     <div id="A">
     <div class="dict_entry" id="abs">
       <h3>
-        <a>abs</a>
+        <a>abs<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">abs <i>number</i></span>
@@ -888,7 +888,7 @@ if all? turtles [color = red]
       </div>
     <div class="dict_entry" id="and">
       <h3>
-        <a>and</a>
+        <a>and<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example"><i>condition1</i> and <i>condition2</i></span>
@@ -984,17 +984,17 @@ show approximate-rgb 0 255 255
     <div class="dict_entry" id="Symbols">
       <h3>
         <a>Arithmetic Operators</a>
-        <a>+</a>
-        <a>*</a>
-        <a>-</a>
-        <a>/</a>
-        <a>^</a>
-        <a>&lt;</a>
-        <a>&gt;</a>
-        <a>=</a>
-        <a>!=</a>
-        <a>&lt;=</a>
-        <a>&gt;=</a>
+        <a>+<span class="since">1.0</span></a>
+        <a>*<span class="since">1.0</span></a>
+        <a>-<span class="since">1.0</span></a>
+        <a>/<span class="since">1.0</span></a>
+        <a>^<span class="since">1.0</span></a>
+        <a>&lt;<span class="since">1.0</span></a>
+        <a>&gt;<span class="since">1.0</span></a>
+        <a>=<span class="since">1.0</span></a>
+        <a>!=<span class="since">1.0</span></a>
+        <a>&lt;=<span class="since">1.0</span></a>
+        <a>&gt;=<span class="since">1.0</span></a>
       </h3>
       <p>
         All of these operators take two inputs, and all act as &quot;infix
@@ -1051,7 +1051,7 @@ show 5 * (6 + 6) / 3
       </div>
     <div class="dict_entry" id="ask">
       <h3>
-        <a>ask</a>
+        <a>ask<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">ask <i>agentset</i> [<i>commands</i>]</span>
@@ -1100,7 +1100,7 @@ ask turtle 4 [ rt 90 ]
       </div>
     <div class="dict_entry" id="at-points">
       <h3>
-        <a>at-points</a>
+        <a>at-points<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example"><i>agentset</i> at-points [[<i>x1 y1</i>] [<i>x2 y2</i>] ...]</span>
@@ -1127,7 +1127,7 @@ ask turtles at-points [[2 4] [1 2] [10 15]]
     </div>
     <div class="dict_entry" id="atan">
       <h3>
-        <a>atan</a>
+        <a>atan<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">atan <i>x y</i></span>
@@ -1168,7 +1168,7 @@ end
     </div>
     <div class="dict_entry" id="autoplot">
       <h3>
-        <a>autoplot?</a>
+        <a>autoplot?<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">autoplot?</span>
@@ -1179,8 +1179,8 @@ end
       </div>
     <div class="dict_entry" id="auto-plot-status">
       <h3>
-        <a>auto-plot-off</a>
-        <a>auto-plot-on</a>
+        <a>auto-plot-off<span class="since">1.0</span></a>
+        <a>auto-plot-on<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">auto-plot-off</span>
@@ -1201,8 +1201,8 @@ end
     <div id="B">
     <div class="dict_entry" id="back">
       <h3>
-        <a>back</a>
-        <a>bk</a>
+        <a>back<span class="since">1.0</span></a>
+        <a>bk<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">back <i>number</i></span>
@@ -1390,12 +1390,12 @@ show turtle 51
       </div>
     <div class="dict_entry" id="but-first-and-last">
       <h3>
-        <a>but-first</a>
-        <a>butfirst</a>
-        <a>bf</a>
-        <a>but-last</a>
-        <a>butlast</a>
-        <a>bl</a>
+        <a>but-first<span class="since">1.0</span></a>
+        <a>butfirst<span class="since">1.0</span></a>
+        <a>bf<span class="since">1.0</span></a>
+        <a>but-last<span class="since">1.0</span></a>
+        <a>butlast<span class="since">1.0</span></a>
+        <a>bl<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">but-first <i>list</i></span>
@@ -1469,7 +1469,7 @@ observer&gt; carefully [ print one-of [] ] [ print error-message ]
     </div>
     <div class="dict_entry" id="ceiling">
       <h3>
-        <a>ceiling</a>
+        <a>ceiling<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">ceiling <i>number</i></span>
@@ -1489,8 +1489,8 @@ show ceiling -4.5
       </div>
     <div class="dict_entry" id="clear-all">
       <h3>
-        <a>clear-all</a>
-        <a>ca</a>
+        <a>clear-all<span class="since">1.0</span></a>
+        <a>ca<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">clear-all</span>
@@ -1503,7 +1503,7 @@ show ceiling -4.5
       </div>
     <div class="dict_entry" id="clear-all-plots">
       <h3>
-        <a>clear-all-plots</a>
+        <a>clear-all-plots<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">clear-all-plots</span>
@@ -1526,7 +1526,7 @@ show ceiling -4.5
       </div>
     <div class="dict_entry" id="clear-globals">
       <h3>
-        <a>clear-globals</a>
+        <a>clear-globals<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">clear-globals</span>
@@ -1550,7 +1550,7 @@ show ceiling -4.5
       </div>
     <div class="dict_entry" id="clear-output">
       <h3>
-        <a>clear-output</a>
+        <a>clear-output<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">clear-output</span>
@@ -1562,8 +1562,8 @@ show ceiling -4.5
       </div>
     <div class="dict_entry" id="clear-patches">
       <h3>
-        <a>clear-patches</a>
-        <a>cp</a>
+        <a>clear-patches<span class="since">1.0</span></a>
+        <a>cp<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">clear-patches</span>
@@ -1619,8 +1619,8 @@ show ceiling -4.5
       </div>
     <div class="dict_entry" id="clear-turtles">
       <h3>
-        <a>clear-turtles</a>
-        <a>ct</a>
+        <a>clear-turtles<span class="since">1.0</span></a>
+        <a>ct<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">clear-turtles</span>
@@ -1654,7 +1654,7 @@ show ceiling -4.5
       </div>
     <div class="dict_entry" id="cos">
       <h3>
-        <a>cos</a>
+        <a>cos<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">cos <i>number</i></span>
@@ -1669,7 +1669,7 @@ show cos 180
     </div>
     <div class="dict_entry" id="count">
       <h3>
-        <a>count</a>
+        <a>count<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">count <i>agentset</i></span>
@@ -1812,8 +1812,8 @@ end
     </div>
     <div class="dict_entry" id="create-turtles">
       <h3>
-        <a>create-turtles</a>
-        <a>crt</a>
+        <a>create-turtles<span class="since">1.0</span></a>
+        <a>crt<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">create-turtles <i>number</i></span>
@@ -1906,7 +1906,7 @@ show date-and-time
     </div>
     <div class="dict_entry" id="die">
       <h3>
-        <a>die</a>
+        <a>die<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">die</span>
@@ -1943,7 +1943,7 @@ ask links with [color = blue] [ die ]
       </div>
     <div class="dict_entry" id="diffuse">
       <h3>
-        <a>diffuse</a>
+        <a>diffuse<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">diffuse <i>patch-variable</i> <i>number</i></span>
@@ -1971,7 +1971,7 @@ diffuse chemical 0.5
     </div>
     <div class="dict_entry" id="diffuse4">
       <h3>
-        <a>diffuse4</a>
+        <a>diffuse4<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">diffuse4 <i>patch-variable</i> <i>number</i></span>
@@ -2036,7 +2036,7 @@ ask turtle 0 [ show one-of my-out-links ]
       </div>
     <div class="dict_entry" id="display">
       <h3>
-        <a>display</a>
+        <a>display<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">display</span>
@@ -2077,7 +2077,7 @@ ask turtles [ set color blue]
       </div>
     <div class="dict_entry" id="distance">
       <h3>
-        <a>distance</a>
+        <a>distance<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">distance <i>agent</i></span>
@@ -2097,7 +2097,7 @@ ask turtles [ show max-one-of turtles [distance myself] ]
     </div>
     <div class="dict_entry" id="distancexy">
       <h3>
-        <a>distancexy</a>
+        <a>distancexy<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">distancexy <i>xcor</i> <i>ycor</i></span>
@@ -2120,8 +2120,8 @@ if (distancexy 0 0) &gt; 10
     </div>
     <div class="dict_entry" id="downhill">
       <h3>
-        <a>downhill</a>
-        <a>downhill4</a>
+        <a>downhill<span class="since">1.0</span></a>
+        <a>downhill4<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">downhill <i>patch-variable</i></span>
@@ -2156,8 +2156,8 @@ if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
       </div>
     <div class="dict_entry" id="dxy">
       <h3>
-        <a>dx</a>
-        <a>dy</a>
+        <a>dx<span class="since">1.0</span></a>
+        <a>dy<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">dx</span>
@@ -2186,7 +2186,7 @@ if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
     <div id="E">
     <div class="dict_entry" id="empty">
       <h3>
-        <a>empty?</a>
+        <a>empty?<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">empty? <i>list</i></span>
@@ -2283,7 +2283,7 @@ ask links
       </div>
     <div class="dict_entry" id="every">
       <h3>
-        <a>every</a>
+        <a>every<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">every <i>number</i> [ <i>commands</i> ]</span>
@@ -2315,7 +2315,7 @@ every 2 [ set index index + 1 ]
       </div>
     <div class="dict_entry" id="exp">
       <h3>
-        <a>exp</a>
+        <a>exp<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">exp <i>number</i></span>
@@ -2329,10 +2329,10 @@ every 2 [ set index index + 1 ]
       <h3>
         <a>export-view</a>
         <a>export-interface</a>
-        <a>export-output</a>
-        <a>export-plot</a>
+        <a>export-output<span class="since">1.0</span></a>
+        <a>export-plot<span class="since">1.0</span></a>
         <a>export-all-plots</a>
-        <a>export-world</a>
+        <a>export-world<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">export-view <i>filename</i></span>
@@ -2425,7 +2425,7 @@ export-world (word &quot;results &quot; random-float 1.0 &quot;.csv&quot;)
       </div>
     <div class="dict_entry" id="extract-hsb">
       <h3>
-        <a>extract-hsb</a>
+        <a>extract-hsb<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">extract-hsb <i>color</i></span>
@@ -2447,7 +2447,7 @@ show extract-hsb cyan
       </div>
     <div class="dict_entry" id="extract-rgb">
       <h3>
-        <a>extract-rgb</a>
+        <a>extract-rgb<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">extract-rgb <i>color</i></span>
@@ -2858,7 +2858,7 @@ show filter [first ? != &quot;t&quot;] [&quot;hi&quot; &quot;there&quot; &quot;e
       </div>
     <div class="dict_entry" id="first">
       <h3>
-        <a>first</a>
+        <a>first<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">first <i>list</i></span>
@@ -2872,7 +2872,7 @@ show filter [first ? != &quot;t&quot;] [&quot;hi&quot; &quot;there&quot; &quot;e
       </div>
     <div class="dict_entry" id="floor">
       <h3>
-        <a>floor</a>
+        <a>floor<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">floor <i>number</i></span>
@@ -2957,8 +2957,8 @@ foreach [1.1 2.2 2.6] [ show (word ? &quot; -&gt; &quot; round ?) ]
       </div>
     <div class="dict_entry" id="forward">
       <h3>
-        <a>forward</a>
-        <a>fd</a>
+        <a>forward<span class="since">1.0</span></a>
+        <a>fd<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">forward <i>number</i></span>
@@ -2980,7 +2980,7 @@ foreach [1.1 2.2 2.6] [ show (word ? &quot; -&gt; &quot; round ?) ]
       </div>
     <div class="dict_entry" id="fput">
       <h3>
-        <a>fput</a>
+        <a>fput<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">fput <i>item list</i></span>
@@ -3024,7 +3024,7 @@ set mylist fput 2 mylist
     <div id="H">
     <div class="dict_entry" id="hatch">
       <h3>
-        <a>hatch</a>
+        <a>hatch<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">hatch <i>number</i> [ <i>commands</i> ]</span>
@@ -3122,8 +3122,8 @@ set hidden? not hidden?
       </div>
     <div class="dict_entry" id="hide-turtle">
       <h3>
-        <a>hide-turtle</a>
-        <a>ht</a>
+        <a>hide-turtle<span class="since">1.0</span></a>
+        <a>ht<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">hide-turtle</span>
@@ -3139,7 +3139,7 @@ set hidden? not hidden?
       </div>
     <div class="dict_entry" id="histogram">
       <h3>
-        <a>histogram</a>
+        <a>histogram<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">histogram <i>list</i></span>
@@ -3177,7 +3177,7 @@ histogram [color] of turtles
     </div>
     <div class="dict_entry" id="home">
       <h3>
-        <a>home</a>
+        <a>home<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">home</span>
@@ -3189,7 +3189,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hsb">
       <h3>
-        <a>hsb</a>
+        <a>hsb<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">hsb <i>hue saturation brightness</i></span>
@@ -3566,7 +3566,7 @@ hubnet-set-client-interface &quot;COMPUTER&quot; []
     <div id="I">
     <div class="dict_entry" id="if">
       <h3>
-        <a>if</a>
+        <a>if<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">if <i>condition</i> [ <i>commands</i> ]</span>
@@ -3588,7 +3588,7 @@ if xcor &gt; 0[ set color blue ]
       </div>
     <div class="dict_entry" id="ifelse">
       <h3>
-        <a>ifelse</a>
+        <a>ifelse<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">ifelse <i>reporter</i> [ <i>commands1</i> ] [ <i>commands2</i> ]</span>
@@ -3722,7 +3722,7 @@ show reduce [ifelse-value (?1 &gt; ?2) [?1] [?2]]
       </div>
     <div class="dict_entry" id="import-world">
       <h3>
-        <a>import-world</a>
+        <a>import-world<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">import-world <i>filename</i></span>
@@ -3867,7 +3867,7 @@ ask turtle 0 [ show in-link-from turtle 1 ] ;; shows nobody
       </div>
     <div class="dict_entry" id="in-radius">
       <h3>
-        <a>in-radius</a>
+        <a>in-radius<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example"><i>agentset</i> in-radius <i>number</i></span>
@@ -3908,7 +3908,7 @@ inspect one-of sheep
     </div>
     <div class="dict_entry" id="int">
       <h3>
-        <a>int</a>
+        <a>int<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">int <i>number</i></span>
@@ -3932,12 +3932,12 @@ show int -3.5
         <a>is-directed-link?</a>
         <a>is-link?</a>
         <a>is-link-set?</a>
-        <a>is-list?</a>
+        <a>is-list?<span class="since">1.0</span></a>
         <a>is-number?</a>
         <a>is-patch?</a>
         <a>is-patch-set?</a>
         <a>is-reporter-task?</a>
-        <a>is-string?</a>
+        <a>is-string?<span class="since">1.0</span></a>
         <a>is-turtle?</a>
         <a>is-turtle-set?</a>
         <a>is-undirected-link?</a>
@@ -3966,7 +3966,7 @@ show int -3.5
       </div>
     <div class="dict_entry" id="item">
       <h3>
-        <a>item</a>
+        <a>item<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">item <i>index list</i></span>
@@ -3996,7 +3996,7 @@ show item 3 &quot;my-shoe&quot;
     <div id="J">
     <div class="dict_entry" id="jump">
       <h3>
-        <a>jump</a>
+        <a>jump<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">jump <i>number</i></span>
@@ -4067,7 +4067,7 @@ ask turtles [ set label-color red ]
     </div>
     <div class="dict_entry" id="last">
       <h3>
-        <a>last</a>
+        <a>last<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">last <i>list</i></span>
@@ -4247,8 +4247,8 @@ end
     </div>
     <div class="dict_entry" id="left">
       <h3>
-        <a>left</a>
-        <a>lt</a>
+        <a>left<span class="since">1.0</span></a>
+        <a>lt<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">left <i>number</i></span>
@@ -4260,7 +4260,7 @@ end
       </div>
     <div class="dict_entry" id="length">
       <h3>
-        <a>length</a>
+        <a>length<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">length <i>list</i></span>
@@ -4425,7 +4425,7 @@ streets-own [cars bikes]
 </pre>
       <div class="dict_entry" id="list">
         <h3>
-          <a>list</a>
+          <a>list<span class="since">1.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">list <i>value1</i> <i>value2</i></span>
@@ -4445,7 +4445,7 @@ show (list (random 10) 1 2 3 (random 10))
       </div>
       <div class="dict_entry" id="ln">
         <h3>
-          <a>ln</a>
+          <a>ln<span class="since">1.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">ln <i>number</i></span>
@@ -4458,7 +4458,7 @@ show (list (random 10) 1 2 3 (random 10))
         </div>
       <div class="dict_entry" id="log">
         <h3>
-          <a>log</a>
+          <a>log<span class="since">1.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">log <i>number</i> <i>base</i></span>
@@ -4474,7 +4474,7 @@ show log 64 2
         </div>
       <div class="dict_entry" id="loop">
         <h3>
-          <a>loop</a>
+          <a>loop<span class="since">1.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">loop [ <i>commands</i> ]</span>
@@ -4499,7 +4499,7 @@ end</pre>
         </div>
       <div class="dict_entry" id="lput">
         <h3>
-          <a>lput</a>
+          <a>lput<span class="since">1.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">lput <i>value list</i></span>
@@ -4552,7 +4552,7 @@ show (map [?1 + ?2 = ?3] [1 2 3] [2 4 6] [3 5 9])
         </div>
       <div class="dict_entry" id="max">
         <h3>
-          <a>max</a>
+          <a>max<span class="since">1.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">max <i>list</i></span>
@@ -4598,7 +4598,7 @@ show max-n-of 5 patches with [pycor = 0] [pxcor]
         </div>
       <div class="dict_entry" id="max-one-of">
         <h3>
-          <a>max-one-of</a>
+          <a>max-one-of<span class="since">1.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">max-one-of <i>agentset</i> [<i>reporter</i>]</span>
@@ -4646,7 +4646,7 @@ crt 100 [ setxy random-float max-pxcor
         </div>
       <div class="dict_entry" id="mean">
         <h3>
-          <a>mean</a>
+          <a>mean<span class="since">1.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">mean <i>list</i></span>
@@ -4662,7 +4662,7 @@ show mean [xcor] of turtles
       </div>
       <div class="dict_entry" id="median">
         <h3>
-          <a>median</a>
+          <a>median<span class="since">1.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">median <i>list</i></span>
@@ -4680,7 +4680,7 @@ show median [xcor] of turtles
       </div>
       <div class="dict_entry" id="member">
         <h3>
-          <a>member?</a>
+          <a>member?<span class="since">1.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">member? <i>value list</i></span>
@@ -4714,7 +4714,7 @@ show member? turtle 0 patches
         </div>
       <div class="dict_entry" id="min">
         <h3>
-          <a>min</a>
+          <a>min<span class="since">1.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">min <i>list</i></span>
@@ -4759,7 +4759,7 @@ show min-n-of 5 patches with [pycor = 0] [pxcor]
         </div>
       <div class="dict_entry" id="min-one-of">
         <h3>
-          <a>min-one-of</a>
+          <a>min-one-of<span class="since">1.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">min-one-of <i>agentset</i> [<i>reporter</i>]</span>
@@ -4808,7 +4808,7 @@ crt 100 [ setxy random-float min-pxcor
         </div>
       <div class="dict_entry" id="mod">
         <h3>
-          <a>mod</a>
+          <a>mod<span class="since">1.0</span></a>
         </h3>
         <h4>
           <span class="prim_example"><i>number1</i> mod <i>number2</i></span>
@@ -4861,7 +4861,7 @@ show modes [pxcor] of turtles
       </div>
       <div class="dict_entry" id="mouse-down">
         <h3>
-          <a>mouse-down?</a>
+          <a>mouse-down?<span class="since">1.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">mouse-down?</span>
@@ -4885,8 +4885,8 @@ show modes [pxcor] of turtles
         </div>
       <div class="dict_entry" id="mouse-cor">
         <h3>
-          <a>mouse-xcor</a>
-          <a>mouse-ycor</a>
+          <a>mouse-xcor<span class="since">1.0</span></a>
+          <a>mouse-ycor<span class="since">1.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">mouse-xcor</span>
@@ -5111,7 +5111,7 @@ ask turtle 1
       </div>
       <div class="dict_entry" id="myself">
         <h3>
-          <a>myself</a>
+          <a>myself<span class="since">1.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">myself</span>
@@ -5336,7 +5336,7 @@ show netlogo-version
       </div>
     <div class="dict_entry" id="no-display">
       <h3>
-        <a>no-display</a>
+        <a>no-display<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">no-display</span>
@@ -5404,7 +5404,7 @@ if target != nobody
     </div>
     <div class="dict_entry" id="not">
       <h3>
-        <a>not</a>
+        <a>not<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">not <i>boolean</i></span>
@@ -5465,7 +5465,7 @@ show sort [who * who] of turtles
     </div>
     <div class="dict_entry" id="one-of">
       <h3>
-        <a>one-of</a>
+        <a>one-of<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">one-of <i>agentset</i></span>
@@ -5494,7 +5494,7 @@ show one-of mylist
       </div>
     <div class="dict_entry" id="or">
       <h3>
-        <a>or</a>
+        <a>or<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example"><i>boolean1</i> or <i>boolean2</i></span>
@@ -5663,7 +5663,7 @@ ask turtle 1
     <div id="P">
     <div class="dict_entry" id="patch">
       <h3>
-        <a>patch</a>
+        <a>patch<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">patch <i>xcor</i> <i>ycor</i></span>
@@ -5718,7 +5718,7 @@ ask patch-ahead 1 [ set pcolor green ]
       </div>
     <div class="dict_entry" id="patch-at">
       <h3>
-        <a>patch-at</a>
+        <a>patch-at<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">patch-at <i>dx</i> <i>dy</i></span>
@@ -5762,7 +5762,7 @@ ask patch-at-heading-and-distance -90 1 [ set pcolor green ]
       </div>
     <div class="dict_entry" id="patch-here">
       <h3>
-        <a>patch-here</a>
+        <a>patch-here<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">patch-here</span>
@@ -5844,7 +5844,7 @@ patch-set [neighbors] of turtles
       </div>
     <div class="dict_entry" id="patches">
       <h3>
-        <a>patches</a>
+        <a>patches<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">patches</span>
@@ -5896,12 +5896,12 @@ patch-set [neighbors] of turtles
       </div>
     <div class="dict_entry" id="pen-switch-status">
       <h3>
-        <a>pen-down</a>
-        <a>pd</a>
+        <a>pen-down<span class="since">1.0</span></a>
+        <a>pd<span class="since">1.0</span></a>
         <a>pen-erase</a>
         <a>pe</a>
-        <a>pen-up</a>
-        <a>pu</a>
+        <a>pen-up<span class="since">1.0</span></a>
+        <a>pu<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">pen-down</span>
@@ -5991,7 +5991,7 @@ patch-set [neighbors] of turtles
       </div>
     <div class="dict_entry" id="plot">
       <h3>
-        <a>plot</a>
+        <a>plot<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">plot <i>number</i></span>
@@ -6004,7 +6004,7 @@ patch-set [neighbors] of turtles
       </div>
     <div class="dict_entry" id="plot-name">
       <h3>
-        <a>plot-name</a>
+        <a>plot-name<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">plot-name</span>
@@ -6025,8 +6025,8 @@ patch-set [neighbors] of turtles
       </div>
     <div class="dict_entry" id="plot-pen-switch-status">
       <h3>
-        <a>plot-pen-down</a>
-        <a>plot-pen-up</a>
+        <a>plot-pen-down<span class="since">1.0</span></a>
+        <a>plot-pen-up<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">plot-pen-down</span>
@@ -6038,7 +6038,7 @@ patch-set [neighbors] of turtles
       </div>
     <div class="dict_entry" id="plot-pen-reset">
       <h3>
-        <a>plot-pen-reset</a>
+        <a>plot-pen-reset<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">plot-pen-reset</span>
@@ -6051,7 +6051,7 @@ patch-set [neighbors] of turtles
       </div>
     <div class="dict_entry" id="plotxy">
       <h3>
-        <a>plotxy</a>
+        <a>plotxy<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">plotxy <i>number1 number2</i></span>
@@ -6063,10 +6063,10 @@ patch-set [neighbors] of turtles
       </div>
     <div class="dict_entry" id="plot-cor-max-or-min">
       <h3>
-        <a>plot-x-min</a>
-        <a>plot-x-max</a>
-        <a>plot-y-min</a>
-        <a>plot-y-max</a>
+        <a>plot-x-min<span class="since">1.0</span></a>
+        <a>plot-x-max<span class="since">1.0</span></a>
+        <a>plot-y-min<span class="since">1.0</span></a>
+        <a>plot-y-max<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">plot-x-min</span>
@@ -6084,7 +6084,7 @@ patch-set [neighbors] of turtles
       </div>
     <div class="dict_entry" id="position">
       <h3>
-        <a>position</a>
+        <a>position<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">position <i>item</i> <i>list</i></span>
@@ -6113,7 +6113,7 @@ show position &quot;in&quot; &quot;string&quot;
       </div>
     <div class="dict_entry" id="precision">
       <h3>
-        <a>precision</a>
+        <a>precision<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">precision <i>number places</i></span>
@@ -6134,7 +6134,7 @@ show precision 3834 -3
       </div>
     <div class="dict_entry" id="print">
       <h3>
-        <a>print</a>
+        <a>print<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">print <i>value</i></span>
@@ -6180,7 +6180,7 @@ show precision 3834 -3
     <div id="R">
     <div class="dict_entry" id="random">
       <h3>
-        <a>random</a>
+        <a>random<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">random <i>number</i></span>
@@ -6304,7 +6304,7 @@ ask turtles [
       </div>
     <div class="dict_entry" id="random-seed">
       <h3>
-        <a>random-seed</a>
+        <a>random-seed<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">random-seed <i>number</i></span>
@@ -6475,7 +6475,7 @@ show remainder -8 3
       </div>
     <div class="dict_entry" id="remove">
       <h3>
-        <a>remove</a>
+        <a>remove<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">remove <i>item</i> <i>list</i></span>
@@ -6497,7 +6497,7 @@ show remove &quot;to&quot; &quot;phototonic&quot;
     </div>
     <div class="dict_entry" id="remove-duplicates">
       <h3>
-        <a>remove-duplicates</a>
+        <a>remove-duplicates<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">remove-duplicates <i>list</i></span>
@@ -6538,7 +6538,7 @@ show remove-item 2 &quot;string&quot;
     </div>
     <div class="dict_entry" id="repeat">
       <h3>
-        <a>repeat</a>
+        <a>repeat<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">repeat <i>number</i> [ <i>commands</i> ]</span>
@@ -6554,7 +6554,7 @@ show remove-item 2 &quot;string&quot;
     </div>
     <div class="dict_entry" id="replace-item">
       <h3>
-        <a>replace-item</a>
+        <a>replace-item<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">replace-item <i>index list value</i></span>
@@ -6577,7 +6577,7 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
     </div>
     <div class="dict_entry" id="report">
       <h3>
-        <a>report</a>
+        <a>report<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">report <i>value</i></span>
@@ -6622,7 +6622,7 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
       </div>
     <div class="dict_entry" id="reset-timer">
       <h3>
-        <a>reset-timer</a>
+        <a>reset-timer<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">reset-timer</span>
@@ -6656,7 +6656,7 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
       </div>
     <div class="dict_entry" id="reverse">
       <h3>
-        <a>reverse</a>
+        <a>reverse<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">reverse <i>list</i></span>
@@ -6675,7 +6675,7 @@ show reverse &quot;live&quot;
     </div>
     <div class="dict_entry" id="rgb">
       <h3>
-        <a>rgb</a>
+        <a>rgb<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">rgb <i>red green blue</i></span>
@@ -6720,8 +6720,8 @@ show reverse &quot;live&quot;
       </div>
     <div class="dict_entry" id="right">
       <h3>
-        <a>right</a>
-        <a>rt</a>
+        <a>right<span class="since">1.0</span></a>
+        <a>rt<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">right <i>number</i></span>
@@ -6733,7 +6733,7 @@ show reverse &quot;live&quot;
       </div>
     <div class="dict_entry" id="round">
       <h3>
-        <a>round</a>
+        <a>round<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">round <i>number</i></span>
@@ -6819,7 +6819,7 @@ show (runresult task [ ?1 + ?2 ] 10 5)
     <div id="S">
     <div class="dict_entry" id="scale-color">
       <h3>
-        <a>scale-color</a>
+        <a>scale-color<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">scale-color <i>color number range1 range2</i></span>
@@ -6885,8 +6885,8 @@ ask turtles [ set color scale-color red age 0 50 ]
       </div>
     <div class="dict_entry" id="sentence">
       <h3>
-        <a>sentence</a>
-        <a>se</a>
+        <a>sentence<span class="since">1.0</span></a>
+        <a>se<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">sentence <i>value1</i> <i>value2</i></span>
@@ -6913,7 +6913,7 @@ show (sentence [1 2] 3 [4 5] (3 + 3) 7)
     </div>
     <div class="dict_entry" id="set">
       <h3>
-        <a>set</a>
+        <a>set<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">set <i>variable</i> <i>value</i></span>
@@ -6965,7 +6965,7 @@ file-open &quot;my-file.txt&quot;
     </div>
     <div class="dict_entry" id="set-current-plot">
       <h3>
-        <a>set-current-plot</a>
+        <a>set-current-plot<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">set-current-plot <i>plotname</i></span>
@@ -6976,7 +6976,7 @@ file-open &quot;my-file.txt&quot;
       </div>
     <div class="dict_entry" id="set-current-plot-pen">
       <h3>
-        <a>set-current-plot-pen</a>
+        <a>set-current-plot-pen<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">set-current-plot-pen <i>penname</i></span>
@@ -6988,7 +6988,7 @@ file-open &quot;my-file.txt&quot;
       </div>
     <div class="dict_entry" id="set-default-shape">
       <h3>
-        <a>set-default-shape</a>
+        <a>set-default-shape<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">set-default-shape turtles <i>string</i></span>
@@ -7034,7 +7034,7 @@ ask cats [ set breed dogs ]
       </div>
     <div class="dict_entry" id="set-histogram-num-bars">
       <h3>
-        <a>set-histogram-num-bars</a>
+        <a>set-histogram-num-bars<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">set-histogram-num-bars <i>number</i></span>
@@ -7084,7 +7084,7 @@ ask cats [ set breed dogs ]
       </div>
     <div class="dict_entry" id="set-plot-pen-color">
       <h3>
-        <a>set-plot-pen-color</a>
+        <a>set-plot-pen-color<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">set-plot-pen-color <i>number</i></span>
@@ -7094,7 +7094,7 @@ ask cats [ set breed dogs ]
       </div>
     <div class="dict_entry" id="set-plot-pen-interval">
       <h3>
-        <a>set-plot-pen-interval</a>
+        <a>set-plot-pen-interval<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">set-plot-pen-interval <i>number</i></span>
@@ -7106,7 +7106,7 @@ ask cats [ set breed dogs ]
       </div>
     <div class="dict_entry" id="set-plot-pen-mode">
       <h3>
-        <a>set-plot-pen-mode</a>
+        <a>set-plot-pen-mode<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">set-plot-pen-mode <i>number</i></span>
@@ -7148,8 +7148,8 @@ ask cats [ set breed dogs ]
       </div>
     <div class="dict_entry" id="set-plot--range">
       <h3>
-        <a>set-plot-x-range</a>
-        <a>set-plot-y-range</a>
+        <a>set-plot-x-range<span class="since">1.0</span></a>
+        <a>set-plot-y-range<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">set-plot-x-range <i>min max</i></span>
@@ -7165,7 +7165,7 @@ ask cats [ set breed dogs ]
       </div>
     <div class="dict_entry" id="setxy">
       <h3>
-        <a>setxy</a>
+        <a>setxy<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">setxy <i>x y</i></span>
@@ -7198,7 +7198,7 @@ setxy random-pxcor random-pycor
       </div>
     <div class="dict_entry" id="shade-of">
       <h3>
-        <a>shade-of?</a>
+        <a>shade-of?<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">shade-of? <i>color1</i> <i>color2</i></span>
@@ -7265,7 +7265,7 @@ ask turtles [ set shape one-of shapes ]
     </div>
     <div class="dict_entry" id="show">
       <h3>
-        <a>show</a>
+        <a>show<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">show <i>value</i></span>
@@ -7283,8 +7283,8 @@ ask turtles [ set shape one-of shapes ]
       </div>
     <div class="dict_entry" id="show-turtle">
       <h3>
-        <a>show-turtle</a>
-        <a>st</a>
+        <a>show-turtle<span class="since">1.0</span></a>
+        <a>st<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">show-turtle</span>
@@ -7333,7 +7333,7 @@ show shuffle [1 2 3 4 5]
     </div>
     <div class="dict_entry" id="sin">
       <h3>
-        <a>sin</a>
+        <a>sin<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">sin <i>number</i></span>
@@ -7362,7 +7362,7 @@ show sin 270
       </div>
     <div class="dict_entry" id="sort">
       <h3>
-        <a>sort</a>
+        <a>sort<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">sort <i>list</i></span>
@@ -7465,7 +7465,7 @@ foreach sort-on [size] turtles
       </div>
     <div class="dict_entry" id="sprout">
       <h3>
-        <a>sprout</a>
+        <a>sprout<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">sprout <i>number</i> [ <i>commands</i> ]</span>
@@ -7493,7 +7493,7 @@ sprout-sheep 1 [ set color black ]
       </div>
     <div class="dict_entry" id="sqrt">
       <h3>
-        <a>sqrt</a>
+        <a>sqrt<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">sqrt <i>number</i></span>
@@ -7503,7 +7503,7 @@ sprout-sheep 1 [ set color black ]
       </div>
     <div class="dict_entry" id="stamp">
       <h3>
-        <a>stamp</a>
+        <a>stamp<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">stamp</span>
@@ -7533,7 +7533,7 @@ sprout-sheep 1 [ set color black ]
       </div>
     <div class="dict_entry" id="standard-deviation">
       <h3>
-        <a>standard-deviation</a>
+        <a>standard-deviation<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">standard-deviation <i>list</i></span>
@@ -7575,7 +7575,7 @@ end
       </div>
     <div class="dict_entry" id="stop">
       <h3>
-        <a>stop</a>
+        <a>stop<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">stop</span>
@@ -7645,7 +7645,7 @@ ask sheep [ stop-inspecting self ]
     <div class="dict_entry" id="subliststring">
       <h3>
         <a>sublist</a>
-        <a>substring</a>
+        <a>substring<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">sublist <i>list position1 position2</i></span>
@@ -7699,7 +7699,7 @@ show subtract-headings 0 180
     </div>
     <div class="dict_entry" id="sum">
       <h3>
-        <a>sum</a>
+        <a>sum<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">sum <i>list</i></span>
@@ -7719,7 +7719,7 @@ show sum [energy] of turtles
     <div id="T">
     <div class="dict_entry" id="tan">
       <h3>
-        <a>tan</a>
+        <a>tan<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">tan <i>number</i></span>
@@ -7881,7 +7881,7 @@ show sum [energy] of turtles
       </div>
     <div class="dict_entry" id="timer">
       <h3>
-        <a>timer</a>
+        <a>timer<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">timer</span>
@@ -7951,7 +7951,7 @@ end
     </div>
     <div class="dict_entry" id="towards">
       <h3>
-        <a>towards</a>
+        <a>towards<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">towards <i>agent</i></span>
@@ -7975,7 +7975,7 @@ set heading towards turtle 1
       </div>
     <div class="dict_entry" id="towardsxy">
       <h3>
-        <a>towardsxy</a>
+        <a>towardsxy<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">towardsxy <i>x</i> <i>y</i></span>
@@ -7996,7 +7996,7 @@ set heading towards turtle 1
       </div>
     <div class="dict_entry" id="turtle">
       <h3>
-        <a>turtle</a>
+        <a>turtle<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">turtle <i>number</i> &lt;breed&gt; <i>number</i></span>
@@ -8033,7 +8033,7 @@ turtle-set self
       </div>
     <div class="dict_entry" id="turtles">
       <h3>
-        <a>turtles</a>
+        <a>turtles<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">turtles</span>
@@ -8047,7 +8047,7 @@ show count turtles
     </div>
     <div class="dict_entry" id="turtles-at">
       <h3>
-        <a>turtles-at</a>
+        <a>turtles-at<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">turtles-at <i>dx</i> <i>dy</i></span>
@@ -8069,7 +8069,7 @@ show count [turtles-at 1 1] of patch 1 2
       </div>
     <div class="dict_entry" id="turtles-here">
       <h3>
-        <a>turtles-here</a>
+        <a>turtles-here<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">turtles-here</span>
@@ -8156,7 +8156,7 @@ dogs-own [hair puppies]
       </div>
     <div class="dict_entry" id="type">
       <h3>
-        <a>type</a>
+        <a>type<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">type <i>value</i></span>
@@ -8264,8 +8264,8 @@ ask turtle 0 [ show sort my-links ]
       </div>
     <div class="dict_entry" id="uphill">
       <h3>
-        <a>uphill</a>
-        <a>uphill4</a>
+        <a>uphill<span class="since">1.0</span></a>
+        <a>uphill4<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">uphill <i>patch-variable</i></span>
@@ -8434,7 +8434,7 @@ if user-yes-or-no? &quot;Set up the model?&quot;
     <div id="V">
     <div class="dict_entry" id="variance">
       <h3>
-        <a>variance</a>
+        <a>variance<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">variance <i>list</i></span>
@@ -8462,7 +8462,7 @@ show variance [2 7 4 3 5]
     <div id="W">
     <div class="dict_entry" id="wait">
       <h3>
-        <a>wait</a>
+        <a>wait<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">wait <i>number</i></span>
@@ -8510,7 +8510,7 @@ repeat 10 [ fd 1 wait 0.5 ]
       </div>
     <div class="dict_entry" id="while">
       <h3>
-        <a>while</a>
+        <a>while<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">while [<i>reporter</i>] [ <i>commands</i> ]</span>
@@ -8581,7 +8581,7 @@ ask turtles [ print who ]
       </div>
     <div class="dict_entry" id="with">
       <h3>
-        <a>with</a>
+        <a>with<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example"><i>agentset</i> with [<i>reporter</i>]</span>
@@ -8722,7 +8722,7 @@ print n-values 10 [random 10]
       </div>
     <div class="dict_entry" id="word">
       <h3>
-        <a>word</a>
+        <a>word<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">word <i>value1</i> <i>value2</i></span>
@@ -8768,7 +8768,7 @@ show (word &quot;a&quot; &quot;b&quot; &quot;c&quot; 1 23)
       </div>
     <div class="dict_entry" id="wrap-color">
       <h3>
-        <a>wrap-color</a>
+        <a>wrap-color<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">wrap-color <i>number</i></span>
@@ -8842,7 +8842,7 @@ write &quot;hello world&quot;
       </div>
     <div class="dict_entry" id="xor">
       <h3>
-        <a>xor</a>
+        <a>xor<span class="since">1.0</span></a>
       </h3>
       <h4>
         <span class="prim_example"><i>boolean1</i> xor <i>boolean2</i></span>

--- a/dist/docs/dictionary.html.mustache
+++ b/dist/docs/dictionary.html.mustache
@@ -1602,7 +1602,7 @@ show ceiling -4.5
       </div>
     <div class="dict_entry" id="clear-ticks">
       <h3>
-        <a>clear-ticks</a>
+        <a>clear-ticks<span class="since">5.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">clear-ticks</span>
@@ -2252,7 +2252,7 @@ ask links
     </div>
     <div class="dict_entry" id="error">
       <h3>
-        <a>error</a>
+        <a>error<span class="since">5.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">error <i>value</i></span>
@@ -3262,7 +3262,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-clients-list">
       <h3>
-        <a>hubnet-clients-list</a>
+        <a>hubnet-clients-list<span class="since">5.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-clients-list</span>
@@ -3318,7 +3318,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-kick-client">
       <h3>
-        <a>hubnet-kick-client</a>
+        <a>hubnet-kick-client<span class="since">5.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-kick-client <i>client-name</i></span>
@@ -3330,7 +3330,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-kick-all-clients">
       <h3>
-        <a>hubnet-kick-all-clients</a>
+        <a>hubnet-kick-all-clients<span class="since">5.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-kick-all-clients</span>
@@ -3928,7 +3928,7 @@ show int -3.5
         <a>is-agent?<span class="since">1.2.1</span></a>
         <a>is-agentset?<span class="since">1.2.1</span></a>
         <a>is-boolean?<span class="since">1.2.1</span></a>
-        <a>is-command-task?</a>
+        <a>is-command-task?<span class="since">5.0</span></a>
         <a>is-directed-link?<span class="since">4.0</span></a>
         <a>is-link?<span class="since">4.0</span></a>
         <a>is-link-set?<span class="since">4.0</span></a>
@@ -3936,7 +3936,7 @@ show int -3.5
         <a>is-number?<span class="since">1.2.1</span></a>
         <a>is-patch?<span class="since">1.2.1</span></a>
         <a>is-patch-set?<span class="since">4.0</span></a>
-        <a>is-reporter-task?</a>
+        <a>is-reporter-task?<span class="since">5.0</span></a>
         <a>is-string?<span class="since">1.0</span></a>
         <a>is-turtle?<span class="since">1.2.1</span></a>
         <a>is-turtle-set?<span class="since">4.0</span></a>
@@ -7128,7 +7128,7 @@ ask cats [ set breed dogs ]
       </div>
     <div class="dict_entry" id="setup-plots">
       <h3>
-        <a>setup-plots</a>
+        <a>setup-plots<span class="since">5.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">setup-plots</span>
@@ -7438,7 +7438,7 @@ show sort-by [length ?1 &lt; length ?2] [&quot;Grumpy&quot; &quot;Doc&quot; &quo
       </div>
     <div class="dict_entry" id="sort-on">
       <h3>
-        <a>sort-on</a>
+        <a>sort-on<span class="since">5.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">sort-on [<i>reporter</i>] <i>agentset</i></span>
@@ -7730,7 +7730,7 @@ show sum [energy] of turtles
       </div>
     <div class="dict_entry" id="task">
       <h3>
-        <a>task</a>
+        <a>task<span class="since">5.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">task [ <i>commands</i> ]</span>
@@ -8244,7 +8244,7 @@ ask turtle 0 [ show sort my-links ]
       </div>
     <div class="dict_entry" id="update-plots">
       <h3>
-        <a>update-plots</a>
+        <a>update-plots<span class="since">5.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">update-plots</span>

--- a/dist/docs/dictionary.html.mustache
+++ b/dist/docs/dictionary.html.mustache
@@ -907,7 +907,7 @@ if (pxcor &gt; 0) and (pycor &gt; 0)
     </div>
     <div class="dict_entry" id="any">
       <h3>
-        <a>any?</a>
+        <a>any?<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">any? <i>agentset</i></span>
@@ -2328,7 +2328,7 @@ every 2 [ set index index + 1 ]
     <div class="dict_entry" id="export-cmds">
       <h3>
         <a>export-view</a>
-        <a>export-interface</a>
+        <a>export-interface<span class="since">2.0</span></a>
         <a>export-output<span class="since">1.0</span></a>
         <a>export-plot<span class="since">1.0</span></a>
         <a>export-all-plots<span class="since">1.2.1</span></a>
@@ -2509,7 +2509,7 @@ show extract-rgb cyan
       </div>
     <div class="dict_entry" id="file-at-end">
       <h3>
-        <a>file-at-end?</a>
+        <a>file-at-end?<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">file-at-end?</span>
@@ -2531,7 +2531,7 @@ print file-at-end?
       </div>
     <div class="dict_entry" id="file-close">
       <h3>
-        <a>file-close</a>
+        <a>file-close<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">file-close</span>
@@ -2548,7 +2548,7 @@ print file-at-end?
       </div>
     <div class="dict_entry" id="file-close-all">
       <h3>
-        <a>file-close-all</a>
+        <a>file-close-all<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">file-close-all</span>
@@ -2561,7 +2561,7 @@ print file-at-end?
       </div>
     <div class="dict_entry" id="file-delete">
       <h3>
-        <a>file-delete</a>
+        <a>file-delete<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">file-delete <i>string</i></span>
@@ -2580,7 +2580,7 @@ print file-at-end?
       </div>
     <div class="dict_entry" id="file-exists">
       <h3>
-        <a>file-exists?</a>
+        <a>file-exists?<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">file-exists? <i>string</i></span>
@@ -2614,7 +2614,7 @@ print file-at-end?
       </div>
     <div class="dict_entry" id="file-open">
       <h3>
-        <a>file-open</a>
+        <a>file-open<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">file-open <i>string</i></span>
@@ -2663,7 +2663,7 @@ file-print &quot;Hello World&quot; ;; File is in writing mode
       </div>
     <div class="dict_entry" id="file-print">
       <h3>
-        <a>file-print</a>
+        <a>file-print<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">file-print <i>value</i></span>
@@ -2681,7 +2681,7 @@ file-print &quot;Hello World&quot; ;; File is in writing mode
       </div>
     <div class="dict_entry" id="file-read">
       <h3>
-        <a>file-read</a>
+        <a>file-read<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">file-read</span>
@@ -2716,7 +2716,7 @@ print length file-read
       </div>
     <div class="dict_entry" id="file-read-characters">
       <h3>
-        <a>file-read-characters</a>
+        <a>file-read-characters<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">file-read-characters <i>number</i></span>
@@ -2744,7 +2744,7 @@ print file-read-characters 5
       </div>
     <div class="dict_entry" id="file-read-line">
       <h3>
-        <a>file-read-line</a>
+        <a>file-read-line<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">file-read-line</span>
@@ -2769,7 +2769,7 @@ print file-read-line
       </div>
     <div class="dict_entry" id="file-show">
       <h3>
-        <a>file-show</a>
+        <a>file-show<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">file-show <i>value</i></span>
@@ -2788,7 +2788,7 @@ print file-read-line
       </div>
     <div class="dict_entry" id="file-type">
       <h3>
-        <a>file-type</a>
+        <a>file-type<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">file-type <i>value</i></span>
@@ -2808,7 +2808,7 @@ print file-read-line
       </div>
     <div class="dict_entry" id="file-write">
       <h3>
-        <a>file-write</a>
+        <a>file-write<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">file-write <i>value</i></span>
@@ -3616,7 +3616,7 @@ ask patches
       </div>
     <div class="dict_entry" id="ifelse-value">
       <h3>
-        <a>ifelse-value</a>
+        <a>ifelse-value<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">ifelse-value <i>reporter</i> [<i>reporter1</i>] [<i>reporter2</i>]</span>
@@ -4836,7 +4836,7 @@ show -8 mod 3
         </div>
       <div class="dict_entry" id="modes">
         <h3>
-          <a>modes</a>
+          <a>modes<span class="since">2.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">modes <i>list</i></span>
@@ -5178,7 +5178,7 @@ ask n-of 50 patches [ set pcolor green ]
         </div>
       <div class="dict_entry" id="n-values">
         <h3>
-          <a>n-values</a>
+          <a>n-values<span class="since">2.0</span></a>
         </h3>
         <h4>
           <span class="prim_example">n-values <i>size</i> <i>reporter-task</i></span>
@@ -5696,7 +5696,7 @@ show patch 18 19
       </div>
     <div class="dict_entry" id="patch-ahead">
       <h3>
-        <a>patch-ahead</a>
+        <a>patch-ahead<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">patch-ahead <i>distance</i></span>
@@ -5740,7 +5740,7 @@ ask patch-at 1 -1 [ set pcolor green ]
       </div>
     <div class="dict_entry" id="patch-at-heading-and-distance">
       <h3>
-        <a>patch-at-heading-and-distance</a>
+        <a>patch-at-heading-and-distance<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">patch-at-heading-and-distance <i>heading</i> <i>distance</i></span>
@@ -5776,8 +5776,8 @@ ask patch-at-heading-and-distance -90 1 [ set pcolor green ]
       </div>
     <div class="dict_entry" id="patch-lr-and-ahead">
       <h3>
-        <a>patch-left-and-ahead</a>
-        <a>patch-right-and-ahead</a>
+        <a>patch-left-and-ahead<span class="since">2.0</span></a>
+        <a>patch-right-and-ahead<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">patch-left-and-ahead <i>angle</i> <i>distance</i></span>
@@ -6211,7 +6211,7 @@ show random 3.5
       </div>
     <div class="dict_entry" id="random-float">
       <h3>
-        <a>random-float</a>
+        <a>random-float<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">random-float <i>number</i></span>
@@ -6238,7 +6238,7 @@ show random-float 2.5
     <div class="dict_entry" id="random-reporters">
       <h3>
         <a>random-exponential<span class="since">1.2.1</span></a>
-        <a>random-gamma</a>
+        <a>random-gamma<span class="since">2.0</span></a>
         <a>random-normal<span class="since">1.2.1</span></a>
         <a>random-poisson<span class="since">1.2.1</span></a>
       </h3>
@@ -6513,7 +6513,7 @@ set mylist remove-duplicates mylist
     </div>
     <div class="dict_entry" id="remove-item">
       <h3>
-        <a>remove-item</a>
+        <a>remove-item<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">remove-item <i>index</i> <i>list</i></span>
@@ -6935,7 +6935,7 @@ show (sentence [1 2] 3 [4 5] (3 + 3) 7)
     </div>
     <div class="dict_entry" id="set-current-directory">
       <h3>
-        <a>set-current-directory</a>
+        <a>set-current-directory<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">set-current-directory <i>string</i></span>
@@ -7316,7 +7316,7 @@ ask turtles [ set shape one-of shapes ]
       </div>
     <div class="dict_entry" id="shuffle">
       <h3>
-        <a>shuffle</a>
+        <a>shuffle<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">shuffle <i>list</i></span>
@@ -8097,7 +8097,7 @@ ask dogs [ show count cats-here ]
     </div>
     <div class="dict_entry" id="turtles-on">
       <h3>
-        <a>turtles-on</a>
+        <a>turtles-on<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">turtles-on <i>agent</i></span>
@@ -8412,7 +8412,7 @@ if &quot;yes&quot; = user-one-of &quot;Set up the model?&quot; [&quot;yes&quot; 
     </div>
     <div class="dict_entry" id="user-yes-or-no">
       <h3>
-        <a>user-yes-or-no?</a>
+        <a>user-yes-or-no?<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">user-yes-or-no? <i>value</i></span>
@@ -8793,7 +8793,7 @@ show wrap-color -10
     </div>
     <div class="dict_entry" id="write">
       <h3>
-        <a>write</a>
+        <a>write<span class="since">2.0</span></a>
       </h3>
       <h4>
         <span class="prim_example">write <i>value</i></span>

--- a/dist/docs/dictionary.html.mustache
+++ b/dist/docs/dictionary.html.mustache
@@ -1243,7 +1243,7 @@ ask turtles [ set color one-of remove gray base-colors ]
     </div>
     <div class="dict_entry" id="beep">
       <h3>
-        <a>beep</a>
+        <a>beep<span class="since">2.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">beep</span>
@@ -1447,7 +1447,7 @@ patch-ahead <i>distance</i> != nobody
     </div>
     <div class="dict_entry" id="carefully">
       <h3>
-        <a>carefully</a>
+        <a>carefully<span class="since">2.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">carefully [ <i>commands1</i> ] [ <i>commands2</i> ]</span>
@@ -2267,7 +2267,7 @@ ask links
       </div>
     <div class="dict_entry" id="error-message">
       <h3>
-        <a>error-message</a>
+        <a>error-message<span class="since">2.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">error-message</span>
@@ -4272,7 +4272,7 @@ end
       </div>
     <div class="dict_entry" id="let">
       <h3>
-        <a>let</a>
+        <a>let<span class="since">2.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">let <i>variable</i> <i>value</i></span>
@@ -4937,7 +4937,7 @@ move-to max-one-of turtles [size]
         </div>
       <div class="dict_entry" id="movie-cancel">
         <h3>
-          <a>movie-cancel</a>
+          <a>movie-cancel<span class="since">2.1</span></a>
         </h3>
         <h4>
           <span class="prim_example">movie-cancel</span>
@@ -4947,7 +4947,7 @@ move-to max-one-of turtles [size]
         </div>
       <div class="dict_entry" id="movie-close">
         <h3>
-          <a>movie-close</a>
+          <a>movie-close<span class="since">2.1</span></a>
         </h3>
         <h4>
           <span class="prim_example">movie-close</span>
@@ -4958,7 +4958,7 @@ move-to max-one-of turtles [size]
       <div class="dict_entry" id="movie-grab-view">
         <h3>
           <a>movie-grab-view</a>
-          <a>movie-grab-interface</a>
+          <a>movie-grab-interface<span class="since">2.1</span></a>
         </h3>
         <h4>
           <span class="prim_example">movie-grab-view</span>
@@ -4980,7 +4980,7 @@ movie-close
       </div>
       <div class="dict_entry" id="movie-set-frame-rate">
         <h3>
-          <a>movie-set-frame-rate</a>
+          <a>movie-set-frame-rate<span class="since">2.1</span></a>
         </h3>
         <h4>
           <span class="prim_example">movie-set-frame-rate <i>frame-rate</i></span>
@@ -4997,7 +4997,7 @@ movie-close
         </div>
       <div class="dict_entry" id="movie-start">
         <h3>
-          <a>movie-start</a>
+          <a>movie-start<span class="since">2.1</span></a>
         </h3>
         <h4>
           <span class="prim_example">movie-start <i>filename</i></span>
@@ -5011,7 +5011,7 @@ movie-close
         </div>
       <div class="dict_entry" id="movie-status">
         <h3>
-          <a>movie-status</a>
+          <a>movie-status<span class="since">2.1</span></a>
         </h3>
         <h4>
           <span class="prim_example">movie-status</span>
@@ -5638,10 +5638,10 @@ ask turtle 1
       </div>
     <div class="dict_entry" id="output-cmds">
       <h3>
-        <a>output-print</a>
-        <a>output-show</a>
-        <a>output-type</a>
-        <a>output-write</a>
+        <a>output-print<span class="since">2.1</span></a>
+        <a>output-show<span class="since">2.1</span></a>
+        <a>output-type<span class="since">2.1</span></a>
+        <a>output-write<span class="since">2.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">output-print <i>value</i></span>
@@ -7246,7 +7246,7 @@ ask links [ set shape &quot;link 1&quot; ]
       </div>
     <div class="dict_entry" id="shapes">
       <h3>
-        <a>shapes</a>
+        <a>shapes<span class="since">2.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">shapes</span>
@@ -7644,7 +7644,7 @@ ask sheep [ stop-inspecting self ]
       </div>
     <div class="dict_entry" id="subliststring">
       <h3>
-        <a>sublist</a>
+        <a>sublist<span class="since">2.1</span></a>
         <a>substring<span class="since">1.0</span></a>
       </h3>
       <h4>
@@ -7665,7 +7665,7 @@ show substring &quot;apartment&quot; 1 5
     </div>
     <div class="dict_entry" id="subtract-headings">
       <h3>
-        <a>subtract-headings</a>
+        <a>subtract-headings<span class="since">2.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">subtract-headings <i>heading1 heading2</i></span>
@@ -8622,7 +8622,7 @@ ask turtle 0 [
       </div>
     <div class="dict_entry" id="with-max">
       <h3>
-        <a>with-max</a>
+        <a>with-max<span class="since">2.1</span></a>
       </h3>
       <h4>
         <span class="prim_example"><i>agentset</i> with-max [<i>reporter</i>]</span>
@@ -8641,7 +8641,7 @@ show count patches with-max [pxcor]
       </div>
     <div class="dict_entry" id="with-min">
       <h3>
-        <a>with-min</a>
+        <a>with-min<span class="since">2.1</span></a>
       </h3>
       <h4>
         <span class="prim_example"><i>agentset</i> with-min [<i>reporter</i>]</span>

--- a/dist/docs/dictionary.html.mustache
+++ b/dist/docs/dictionary.html.mustache
@@ -3204,7 +3204,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-broadcast">
       <h3>
-        <a>hubnet-broadcast</a>
+        <a>hubnet-broadcast<span class="since">1.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-broadcast <i>tag-name value</i></span>
@@ -3303,7 +3303,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-fetch-message">
       <h3>
-        <a>hubnet-fetch-message</a>
+        <a>hubnet-fetch-message<span class="since">1.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-fetch-message</span>
@@ -3342,7 +3342,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-message">
       <h3>
-        <a>hubnet-message</a>
+        <a>hubnet-message<span class="since">1.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-message</span>
@@ -3355,7 +3355,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-message-source">
       <h3>
-        <a>hubnet-message-source</a>
+        <a>hubnet-message-source<span class="since">1.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-message-source</span>
@@ -3369,7 +3369,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-message-tag">
       <h3>
-        <a>hubnet-message-tag</a>
+        <a>hubnet-message-tag<span class="since">1.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-message-tag</span>
@@ -3385,7 +3385,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-message-waiting">
       <h3>
-        <a>hubnet-message-waiting?</a>
+        <a>hubnet-message-waiting?<span class="since">1.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-message-waiting?</span>
@@ -3399,7 +3399,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-reset">
       <h3>
-        <a>hubnet-reset</a>
+        <a>hubnet-reset<span class="since">1.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-reset</span>
@@ -3427,7 +3427,7 @@ histogram [color] of turtles
       </div>
     <div class="dict_entry" id="hubnet-send">
       <h3>
-        <a>hubnet-send</a>
+        <a>hubnet-send<span class="since">1.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-send <i>string tag-name value</i></span>
@@ -3540,7 +3540,7 @@ ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
       </div>
     <div class="dict_entry" id="hubnet-set-client-interface">
       <h3>
-        <a>hubnet-set-client-interface</a>
+        <a>hubnet-set-client-interface<span class="since">1.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">hubnet-set-client-interface <i>client-type</i> <i>client-info</i></span>
@@ -3889,7 +3889,7 @@ ask turtles
     </div>
     <div class="dict_entry" id="inspect">
       <h3>
-        <a>inspect</a>
+        <a>inspect<span class="since">1.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">inspect <i>agent</i></span>
@@ -5204,8 +5204,8 @@ show n-values 5 [? * ?]
         </div>
       <div class="dict_entry" id="neighbors">
         <h3>
-          <a>neighbors</a>
-          <a>neighbors4</a>
+          <a>neighbors<span class="since">1.1</span></a>
+          <a>neighbors4<span class="since">1.1</span></a>
         </h3>
         <h4>
           <span class="prim_example">neighbors</span>
@@ -6358,7 +6358,7 @@ ask turtles [
       </div>
     <div class="dict_entry" id="read-from-string">
       <h3>
-        <a>read-from-string</a>
+        <a>read-from-string<span class="since">1.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">read-from-string <i>string</i></span>
@@ -8361,7 +8361,7 @@ file-open user-new-file
       </div>
     <div class="dict_entry" id="user-input">
       <h3>
-        <a>user-input</a>
+        <a>user-input<span class="since">1.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">user-input <i>value</i></span>
@@ -8377,7 +8377,7 @@ show user-input &quot;What is your name?&quot;
     </div>
     <div class="dict_entry" id="user-message">
       <h3>
-        <a>user-message</a>
+        <a>user-message<span class="since">1.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">user-message <i>value</i></span>
@@ -8701,7 +8701,7 @@ print n-values 10 [random 10]
     </div>
     <div class="dict_entry" id="without-interruption">
       <h3>
-        <a>without-interruption</a>
+        <a>without-interruption<span class="since">1.1</span></a>
       </h3>
       <h4>
         <span class="prim_example">without-interruption [ <i>commands</i> ]</span>

--- a/dist/docs/netlogo.css
+++ b/dist/docs/netlogo.css
@@ -73,6 +73,18 @@ h4 {
 
 h3 > a {
   display: block;
+  clear: both;
+}
+
+.since:before {
+  content: "Since ";
+}
+
+.since {
+  padding: 2px 5px 0 5px;
+  background-color: rgba(0, 255, 0, 0.5);
+  font-style: italic;
+  float: right;
 }
 
 span.prim_example {


### PR DESCRIPTION
There are some issues with this (breeds related prims are not marked, for example), but it's a start.
The process was to diff each and every `tokens.txt` file since NetLogo 1.0 (except NetLogo 4.0, which its "Other" download doesn't include the NetLogo.jar. I assumed that new prims weren't added between 4.0 and 4.0.1), and mark the prims accordingly.
 - Most prims in `3d.html.mustache` that are shared with the normal prims are not marked due to the lack of change in `tokens.txt`.
 - I marked primitives according to their exact form, so for example, I didn't mark `any?` until it had the question mark.
 - Some prims were introduced in early versions, removed later, and then added back in. I did want to mark them as when they added back, but this didn't happen and instead they are marked as when they were first introduced.

Please eyeball it and provide bullets for what needs to be changed. Feedback will be very welcome!