### PR TITLE
Bugfix: close url classloader of extension on extension manager reset.

### DIFF
--- a/src/main/org/nlogo/workspace/ExtensionManager.java
+++ b/src/main/org/nlogo/workspace/ExtensionManager.java
@@ -9,6 +9,7 @@ import org.nlogo.api.ErrorSource;
 import org.nlogo.api.ExtensionException;
 import org.nlogo.api.Primitive;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -635,6 +636,14 @@ public strictfp class ExtensionManager
         // and continue with the operation ev 7/3/08
         ex.printStackTrace();
       }
+
+      try {
+        jc.jarClassLoader.close();
+      } catch (IOException ex) {
+        System.err.println(ex);
+        ex.printStackTrace();
+      }
+
       jc.loaded = false;
       jc.live = false;
       jc.jarClassLoader = null;


### PR DESCRIPTION
In OpenMOLE some users are complaining about a file descriptor leak when using extensions with NetLogo Headless. After investigation it seems that the URL class loader of the extension manager are never closed.

From oracle documentation, is seems that closing this class closes also files opened by the classloader:
https://docs.oracle.com/javase/7/docs/api/java/net/URLClassLoader.html#close%28%29

This patch is an attempt to fix this issue.
