### PR TITLE
ClassCastException when using turtle-only primitive inside reporter task

### DIFF
--- a/src/main/org/nlogo/compiler/AgentTypeChecker.scala
+++ b/src/main/org/nlogo/compiler/AgentTypeChecker.scala
@@ -105,13 +105,15 @@ private class AgentTypeChecker(defs: Seq[ProcedureDefinition]) {
     override def visitReporterApp(app: ReporterApp) {
       val r = app.reporter
       usableBy = typeCheck(currentProcedure, r, usableBy)
-      if(r.isInstanceOf[_task] || r.isInstanceOf[_reportertask])
+      if(r.isInstanceOf[_task])
         app.args.head.accept(new AgentTypeCheckerVisitor(currentProcedure, "OTPL"))
       else if(r.syntax.blockAgentClassString != null)
         chooseVisitorAndContinue(r.syntax.blockAgentClassString, app.args)
       else
         super.visitReporterApp(app)
-      r.agentClassString = usableBy
+
+      if (! r.isInstanceOf[_task])
+        r.agentClassString = usableBy
     }
 
     private def chooseVisitorAndContinue(blockAgentClassString: String, exps: Seq[Expression]) {

--- a/src/test/org/nlogo/compiler/AgentTypeCheckerTests.scala
+++ b/src/test/org/nlogo/compiler/AgentTypeCheckerTests.scala
@@ -129,4 +129,22 @@ class AgentTypeCheckerTests extends FunSuite {
     testError("to foo ask turtles [ ___foo ] end",
       "You can't use __magic-open in a turtle context, because __magic-open is observer-only.")
   }
+
+  // the next tests check correctness of task type-checking
+  test("map") {
+    val foo = compile("to foo print map [ my-links ] [ 1 2 3 ] end", false).head
+    val reporterTask = foo.statements.head
+      .args.head.asInstanceOf[ReporterApp]
+      .args.head.asInstanceOf[ReporterApp]
+    expect(reporterTask.reporter.agentClassString)("-T--")
+  }
+  test("tasks type-check properly") {
+    val foo = compile("to foo ask turtles [ let bar task [ print 1 ] ] end", false).head
+    expect(foo.procedure.usableBy)("OTPL")
+    val barTask = foo.statements.head.args(1).asInstanceOf[CommandBlock]
+    .statements.head.args(1).asInstanceOf[ReporterApp]
+    expect("OTPL")(barTask.reporter.agentClassString)
+    val cmdTask = barTask.args(0).asInstanceOf[ReporterApp]
+    expect(cmdTask.reporter.agentClassString)("OTPL")
+  }
 }

--- a/src/test/org/nlogo/util/UtilsTests.scala
+++ b/src/test/org/nlogo/util/UtilsTests.scala
@@ -14,7 +14,7 @@ class UtilsTests extends FunSuite {
     assert(Utils.getStackTrace(new Throwable).filter(_!='\r').take(expected.size) === expected)
   }
   test("getResourceLines") {
-    val expected = "NetLogo author: Uri Wilensky\n"
+    val expected = "\nNetLogo author: Uri Wilensky\n"
     assert(Utils.getResourceAsString("/system/about.txt").take(expected.size) ===
       expected)
   }

--- a/test/reporters/Version.txt
+++ b/test/reporters/Version.txt
@@ -1,5 +1,5 @@
 Version_2D
-  substring netlogo-version 0 3 => "5.2"
+  substring netlogo-version 0 3 => "5.3"
 
 Version_3D
-  substring netlogo-version 0 6 => "3D 5.2"
+  substring netlogo-version 0 6 => "3D 5.3"


### PR DESCRIPTION
Example:
```
print map [ my-links ] [ 1 2 3 ]
```
It broke between 5.2.0 and 5.2.1.

5.2.0 gives the correct error message:
```
ERROR: You can't use my-links in an observer context, because my-links is turtle-only.
```
Possibly related to #888. Possibly related to https://github.com/NetLogo/NetLogo/commit/2e8128becc9e4e1a7c08c6ee263690c3ee279cd3#diff-535578908f1ea36d8e13a03b3c7b328aR108 and/or a5e00b14374f4e8b5e1859cdfaf23371595390f4.

Here is the exception:
```
error (ClassCastException)
 while observer running PRINT
  called by Command Center

NetLogo is unable to supply you with more details about this error.  Please report the problem
at https://github.com/NetLogo/NetLogo/issues, or to bugs@ccl.northwestern.edu, and paste the
contents of this window into your report.

java.lang.ClassCastException: org.nlogo.agent.Observer cannot be cast to org.nlogo.agent.Turtle
 at org.nlogo.prim._mylinks.report(_mylinks.java:39)
 at org.nlogo.nvm.ReporterTask.report(Task.scala:53)
 at org.nlogo.prim.etc._map.report(_map.scala:48)
 at org.nlogo.prim.etc._map.report(_map.scala:8)
 at org.nlogo.prim.etc._print.perform(_print.scala:13)
 at org.nlogo.nvm.Context.stepConcurrent(Context.java:91)
 at org.nlogo.nvm.ConcurrentJob.step(ConcurrentJob.java:82)
 at org.nlogo.job.JobThread.org$nlogo$job$JobThread$$runPrimaryJobs(JobThread.scala:143)
 at org.nlogo.job.JobThread$$anonfun$run$1.apply$mcV$sp(JobThread.scala:78)
 at org.nlogo.job.JobThread$$anonfun$run$1.apply(JobThread.scala:76)
 at org.nlogo.job.JobThread$$anonfun$run$1.apply(JobThread.scala:76)
 at scala.util.control.Exception$Catch.apply(Exception.scala:88)
 at org.nlogo.util.Exceptions$.handling(Exceptions.scala:41)
 at org.nlogo.job.JobThread.run(JobThread.scala:75)

NetLogo 5.2.2-RC2
main: org.nlogo.app.AppFrame
thread: JobThread
Java HotSpot(TM) 64-Bit Server VM 1.8.0_66 (Oracle Corporation; 1.8.0_66-b17)
operating system: Linux 4.2.0-19-generic (amd64 processor)
Scala version 2.9.2
JOGL: (3D View not initialized)
OpenGL Graphics: (3D View not initialized)
model: Untitled

02:30:54.549 RuntimeErrorEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
02:30:54.548 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
02:30:54.547 AddJobEvent (org.nlogo.app.CommandLine) AWT-EventQueue-0
02:30:54.547 OutputEvent (org.nlogo.app.CommandLine) AWT-EventQueue-0
02:30:54.547 CompiledEvent (org.nlogo.window.CompilerManager) AWT-EventQueue-0
02:30:54.545 CompileMoreSourceEvent (org.nlogo.app.CommandLine) AWT-EventQueue-0
02:30:54.388 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
02:30:54.188 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
02:30:53.987 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
02:30:53.787 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
```