### PR TITLE
Fix non-exhaustive pattern match

### DIFF
--- a/src/main/org/nlogo/workspace/ExtensionManager.scala
+++ b/src/main/org/nlogo/workspace/ExtensionManager.scala
@@ -220,12 +220,10 @@ class ExtensionManager(val workspace: ExtendableWorkspace, loader: ExtensionLoad
   }
 
   def replaceIdentifier(name: String): Primitive = {
-    val (primName, isRelevantJar) =
-      if (name.contains(':')) {
-        val Array(prefix, pname) = name.split(":")
-        (pname, { (jc: JarContainer) => prefix.toUpperCase == jc.normalizedName })
-      } else
-        (name,  { (jc: JarContainer) => jc.primManager.autoImportPrimitives })
+    val (primName, isRelevantJar) = name.split(":") match {
+      case Array(prefix, pname) => (pname, (jc: JarContainer) => prefix.toUpperCase == jc.normalizedName)
+      case _                    => (name,  (jc: JarContainer) => jc.primManager.autoImportPrimitives)
+    }
     jars.values.filter(liveJars.contains)
       .filter(isRelevantJar)
       .map(_.primManager.getPrimitive(primName)).headOption.orNull


### PR DESCRIPTION
To reproduce the problem, make sure you've built at least one extension in hexy. I'll use the `csv` extension, but it doesn't matter.

Open a new model, enter `extensions [ csv ]` in the code tab. Switch to the interface tab, and type "csv:". When you hit the ":", an exception will occur.