### PR TITLE
`link-neighbor?` wrong for directed, breeded links

### DIFF
--- a/src/main/org/nlogo/prim/_linkneighbor.java
+++ b/src/main/org/nlogo/prim/_linkneighbor.java
@@ -3,6 +3,7 @@
 package org.nlogo.prim;
 
 import org.nlogo.agent.AgentSet;
+import org.nlogo.agent.Link;
 import org.nlogo.agent.LinkManager;
 import org.nlogo.agent.Turtle;
 import org.nlogo.api.LogoException;
@@ -46,7 +47,7 @@ public final strictfp class _linkneighbor extends Reporter {
             : world.getLinkBreed(breedName);
     mustNotBeDirected(breed, context);
     LinkManager linkManager = world.linkManager;
-    return linkManager.findLinkFrom(parent, target, breed, true) != null
-        || linkManager.findLinkFrom(target, parent, breed, true) != null;
+    Link sharedLink = linkManager.findLinkEitherWay(parent, target, breed, true);
+    return sharedLink != null && ! sharedLink.isDirectedLink();
   }
 }

--- a/test/commands/Links.txt
+++ b/test/commands/Links.txt
@@ -136,6 +136,29 @@ LinkedTest3
   [link-neighbor? turtle 1] of turtle 0 => true
   [link-neighbor? turtle 0] of turtle 1 => true
 
+LinkNeighbor
+  O> crt 2
+  O> ask turtle 0 [create-directed-link-to turtle 1]
+  [link-neighbor? turtle 1] of turtle 0 => false
+  [link-neighbor? turtle 0] of turtle 1 => false
+
+LinkNeighbor2
+  O> crt 2
+  O> ask turtle 0 [create-undirected-link-with turtle 1]
+  [ link-neighbor? turtle 1 ] of turtle 0 => true
+  [ link-neighbor? turtle 0 ] of turtle 1 => true
+
+LinkNeighbor3
+  O> crt 2
+  O> ask turtle 0 [create-link-with turtle 1]
+  [ link-neighbor? turtle 1 ] of turtle 0 => true
+  [ link-neighbor? turtle 0 ] of turtle 1 => true
+
+LinkNeighbor4
+  O> crt 2
+  O> ask turtle 0 [create-link-to turtle 1]
+  [ link-neighbor? turtle 1 ] of turtle 0 => ERROR LINKS is a directed breed.
+
 NodeDies1
   O> create-nodes 2
   O> ask turtle 0 [create-link-to turtle 1]


### PR DESCRIPTION
To reproduce:

```
directed-link-breed [ directed-links directed-link ]

to test
  crt 2
  ask turtle 0 [
    create-directed-link-to turtle 1
    print link-neighbor? turtle 1
  ]
end
```

Running `test` prints `true` but should print `false`. According to the docs:

According to the docs:

> Reports true if there is an undirected link between turtle and the caller.

Note that it should print `true` if link is an undirected link breed. If the link breed is directed, unbreeded, it errors with:

> LINKS is a directed breed.

which is arguably correct since you can't have breeded and unbreeded links in the same model.