### PR TITLE
right mouse button confuses `mouse-down?` primitive

### DIFF
--- a/src/main/org/nlogo/window/ViewMouseHandler.java
+++ b/src/main/org/nlogo/window/ViewMouseHandler.java
@@ -79,8 +79,7 @@ public strictfp class ViewMouseHandler
   }
 
   public void mouseReleased(java.awt.event.MouseEvent e) {
-    if (!e.isPopupTrigger() &&
-        org.nlogo.awt.Mouse.hasButton1(e)) {
+    if (org.nlogo.awt.Mouse.hasButton1(e)) {
       mouseDown(false);
     }
   }
@@ -93,17 +92,20 @@ public strictfp class ViewMouseHandler
   }
 
   public void mouseDragged(java.awt.event.MouseEvent e) {
-    // technically this is redundant, we should already have gotten
-    // a mousePressed, but just in case we didn't in some buggy VM,
-    // we do this for good measure... - ST 10/5/04
-    mouseDown(true);
-    // if we press the mouse button inside and then drag outside, we
-    // still get mouseDragged events even though the mouse isn't inside
-    // us anymore, so unlike in the mouseMoved case, we need this next check
-    if (parent.contains(e.getPoint())) {
-      updateMouseInside(e.getPoint());
-      translatePointToXCorYCor(e.getPoint());
-      pt = e.getPoint();
+    if (!e.isPopupTrigger() &&
+        org.nlogo.awt.Mouse.hasButton1(e)) {
+      // technically this is redundant, we should already have gotten
+      // a mousePressed, but just in case we didn't in some buggy VM,
+      // we do this for good measure... - ST 10/5/04
+      mouseDown(true);
+      // if we press the mouse button inside and then drag outside, we
+      // still get mouseDragged events even though the mouse isn't inside
+      // us anymore, so unlike in the mouseMoved case, we need this next check
+      if (parent.contains(e.getPoint())) {
+        updateMouseInside(e.getPoint());
+        translatePointToXCorYCor(e.getPoint());
+        pt = e.getPoint();
+      }
     }
   }
 


### PR DESCRIPTION
To reproduce:

1. Open Mouse Drag Multiple Example from models library
2. press setup and go
3. Click the view with right mouse button while moving cursor

Further information:

* clicking does not make the bug appear.
* mouse-down? can't become false using right mouse button
* opening a new netlogo file keeps mouse-down? true

It shouldn't be a mouse issue. I tested three of them with same results.

System:
NetLogo 5.0.2 (July 27, 2012)
Java HotSpot(TM) Server VM 1.6.0_33 (Sun Microsystems Inc.; 1.6.0_33-b03)
operating system: Windows XP 5.1 (x86 processor)