### PR TITLE
NullPointerException when editing a plot

### DIFF
--- a/src/main/org/nlogo/properties/PlotPensEditor.scala
+++ b/src/main/org/nlogo/properties/PlotPensEditor.scala
@@ -270,7 +270,12 @@ class PlotPensEditor(accessor: PropertyAccessor[List[PlotPen]], colorizer: Color
       val editor = new EditorField[TokenType](30, font, false, colorizer, I18N.gui.get _)
       def getTableCellRendererComponent(table: JTable, value: Object,
                                         isSelected: Boolean, hasFocus: Boolean, row: Int, col: Int) = {
-        editor.setText(value.asInstanceOf[String])
+        // This null check is from strange behavior in java
+        // http://stackoverflow.com/questions/3054775/jtable-strange-behavior-from-getaccessiblechild-method-resulting-in-null-point
+        // RG 2/22/16
+        if (value != null) {
+          editor.setText(value.asInstanceOf[String])
+        }
         editor
       }
     }


### PR DESCRIPTION
Nigel Gilbert writes:

>Select the right hand plot and double-click to edit it.  Delete the label, 'high', and type in another -or the same - label.  Click on the PenUpdate Commands area.  When I did this, I got the backtrace below.

```text
java.lang.NullPointerException
 at org.nlogo.editor.EditorArea.setText(EditorArea.java:201)
 at org.nlogo.properties.PlotPensEditor$PlotPensTable$CodeCellRenderer.getTableCellRendererComponent(PlotPensEditor.scala:265)
 at org.nlogo.properties.PlotPensEditor$PlotPensTable$CodeCellRenderer.getTableCellRendererComponent(PlotPensEditor.scala:260)
 at javax.swing.JTable$AccessibleJTable.getAccessibleChild(JTable.java:7023)
 at javax.swing.JTable$AccessibleJTable.getAccessibleAt(JTable.java:7410)
 at javax.swing.JTable$AccessibleJTable.valueChanged(JTable.java:6925)
 at javax.swing.DefaultListSelectionModel.fireValueChanged(DefaultListSelectionModel.java:167)
 at javax.swing.DefaultListSelectionModel.fireValueChanged(DefaultListSelectionModel.java:147)
 at javax.swing.DefaultListSelectionModel.fireValueChanged(DefaultListSelectionModel.java:194)
 at javax.swing.DefaultListSelectionModel.changeSelection(DefaultListSelectionModel.java:388)
 at javax.swing.DefaultListSelectionModel.changeSelection(DefaultListSelectionModel.java:398)
 at javax.swing.DefaultListSelectionModel.setSelectionInterval(DefaultListSelectionModel.java:442)
 at javax.swing.JTable.changeSelectionModel(JTable.java:2352)
 at javax.swing.JTable.changeSelection(JTable.java:2419)
 at ch.randelshofer.quaqua.QuaquaTableUI$Handler.mousePressed(QuaquaTableUI.java:829)
 at java.awt.AWTEventMulticaster.mousePressed(AWTEventMulticaster.java:263)
 at java.awt.Component.processMouseEvent(Component.java:6372)
 at javax.swing.JComponent.processMouseEvent(JComponent.java:3267)
 at java.awt.Component.processEvent(Component.java:6140)
 at java.awt.Container.processEvent(Container.java:2083)
 at java.awt.Component.dispatchEventImpl(Component.java:4737)
 at java.awt.Container.dispatchEventImpl(Container.java:2141)
 at java.awt.Component.dispatchEvent(Component.java:4565)
 at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4619)
 at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4277)
 at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4210)
 at java.awt.Container.dispatchEventImpl(Container.java:2127)
 at java.awt.Window.dispatchEventImpl(Window.java:2482)
 at java.awt.Component.dispatchEvent(Component.java:4565)
 at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:684)
 at java.awt.EventQueue.access$000(EventQueue.java:85)
 at java.awt.EventQueue$1.run(EventQueue.java:643)
 at java.awt.EventQueue$1.run(EventQueue.java:641)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.AccessControlContext$1.doIntersectionPrivilege(AccessControlContext.java:87)
 at java.security.AccessControlContext$1.doIntersectionPrivilege(AccessControlContext.java:98)
 at java.awt.EventQueue$2.run(EventQueue.java:657)
 at java.awt.EventQueue$2.run(EventQueue.java:655)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.AccessControlContext$1.doIntersectionPrivilege(AccessControlContext.java:87)
 at java.awt.EventQueue.dispatchEvent(EventQueue.java:654)
 at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:296)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:211)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:205)
 at java.awt.Dialog$1.run(Dialog.java:1044)
 at java.awt.Dialog$3.run(Dialog.java:1096)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.awt.Dialog.show(Dialog.java:1094)
 at java.awt.Component.show(Component.java:1584)
 at java.awt.Component.setVisible(Component.java:1536)
 at java.awt.Window.setVisible(Window.java:841)
 at java.awt.Dialog.setVisible(Dialog.java:984)
 at org.nlogo.properties.EditDialog$class.$init$(EditDialog.scala:108)
 at org.nlogo.properties.EditDialogFactory$$anon$1.<init>(EditDialogFactory.scala:15)
 at org.nlogo.properties.EditDialogFactory.canceled(EditDialogFactory.scala:15)
 at org.nlogo.app.InterfaceToolBar$$anonfun$handle$1.apply(InterfaceToolBar.scala:83)
 at org.nlogo.app.InterfaceToolBar$$anonfun$handle$1.apply(InterfaceToolBar.scala:74)
 at scala.Option.foreach(Option.scala:197)
 at org.nlogo.app.InterfaceToolBar.handle(InterfaceToolBar.scala:74)
 at org.nlogo.window.Events$EditWidgetEvent.beHandledBy(Events.java:240)
 at org.nlogo.window.Event.doRaise(Event.java:198)
 at org.nlogo.window.Event.raise(Event.java:122)
 at org.nlogo.app.WidgetWrapper.mousePressed(WidgetWrapper.java:486)
 at java.awt.Component.processMouseEvent(Component.java:6372)
 at javax.swing.JComponent.processMouseEvent(JComponent.java:3267)
 at java.awt.Component.processEvent(Component.java:6140)
 at java.awt.Container.processEvent(Container.java:2083)
 at java.awt.Component.dispatchEventImpl(Component.java:4737)
 at java.awt.Container.dispatchEventImpl(Container.java:2141)
 at java.awt.Component.dispatchEvent(Component.java:4565)
 at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4619)
 at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4277)
 at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4210)
 at java.awt.Container.dispatchEventImpl(Container.java:2127)
 at java.awt.Window.dispatchEventImpl(Window.java:2482)
 at java.awt.Component.dispatchEvent(Component.java:4565)
 at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:684)
 at java.awt.EventQueue.access$000(EventQueue.java:85)
 at java.awt.EventQueue$1.run(EventQueue.java:643)
 at java.awt.EventQueue$1.run(EventQueue.java:641)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.AccessControlContext$1.doIntersectionPrivilege(AccessControlContext.java:87)
 at java.security.AccessControlContext$1.doIntersectionPrivilege(AccessControlContext.java:98)
 at java.awt.EventQueue$2.run(EventQueue.java:657)
 at java.awt.EventQueue$2.run(EventQueue.java:655)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.AccessControlContext$1.doIntersectionPrivilege(AccessControlContext.java:87)
 at java.awt.EventQueue.dispatchEvent(EventQueue.java:654)
 at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:296)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:211)
 at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:201)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:196)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:188)
 at java.awt.EventDispatchThread.run(EventDispatchThread.java:122)

NetLogo 5.0
Java HotSpot(TM) 64-Bit Server VM 1.6.0_31 (Apple Inc.; 1.6.0_31-b04-415-10M3635)
operating system: Mac OS X 10.6.8 (x86_64 processor)
```