### PR TITLE
Replace and Find honouring selection

### DIFF
--- a/src/main/org/nlogo/app/FindDialog.java
+++ b/src/main/org/nlogo/app/FindDialog.java
@@ -226,7 +226,12 @@ public strictfp class FindDialog
         notFoundLabel.setVisible(false);
       }
     } else if (e.getSource().equals(replaceAndFindButton)) {
-      replace(replaceBox.getText());
+      // Stores if the Replace and Find is selected for the first time.
+      // Also checks if the text in find field and selected text are same or not.
+      boolean firstTime = target.getSelectedText() == null || (target.getSelectedText() != null && !target.getSelectedText().equals(findBox.getText())); 
+      if (!firstTime) {
+          replace(replaceBox.getText());
+      }
       if (!next(search, ignoreCaseCheckBox.isSelected(), wrapAroundCheckBox.isSelected())) {
         java.awt.Toolkit.getDefaultToolkit().beep();
         notFoundLabel.setVisible(true);

--- a/src/main/org/nlogo/app/FindDialog.java
+++ b/src/main/org/nlogo/app/FindDialog.java
@@ -62,6 +62,12 @@ public strictfp class FindDialog
       FindDialog.getInstance().setVisible(true);
       FindDialog.getInstance().findBox.requestFocus();
       FindDialog.getInstance().findBox.selectAll();
+      // Setting find field by default to selected text
+      FindDialog findDialog = getInstance();
+      String selectedText = findDialog.target.getSelectedText();
+      if(selectedText != null){
+        FindDialog.getInstance().findBox.setText(selectedText);
+      }
       FindDialog.getInstance().setLocation
           (instance.owner.getLocation().x + instance.owner.getWidth()
               - instance.getPreferredSize().width,

--- a/src/main/org/nlogo/app/FindDialog.java
+++ b/src/main/org/nlogo/app/FindDialog.java
@@ -228,7 +228,9 @@ public strictfp class FindDialog
     } else if (e.getSource().equals(replaceAndFindButton)) {
       // Stores if the Replace and Find is selected for the first time.
       // Also checks if the text in find field and selected text are same or not.
-      boolean firstTime = target.getSelectedText() == null || (target.getSelectedText() != null && !target.getSelectedText().equals(findBox.getText())); 
+      boolean firstTime = target.getSelectedText() == null || (target.getSelectedText() != null
+                && !(ignoreCaseCheckBox.isSelected() ? target.getSelectedText().equalsIgnoreCase(findBox.getText())
+                : target.getSelectedText().equals(findBox.getText())));
       if (!firstTime) {
           replace(replaceBox.getText());
       }


### PR DESCRIPTION
Fix for #940 
This keeps the user selection as it is if nothing is found.
Now if the Replace and Find is selected for the first time it finds the text and shows it to the user. 
If Replace and Find is pressed again then the text is replaced and next occurrence is found.
This also handles the special case in which the text to be found is already selected. In this case the selected text is replaced in the first go.

The feature in which the selected text is used as initial value for find field will be done is a separate PR.