### PR TITLE
Open dialog reopens after wrong directory path

### DIFF
--- a/src/main/org/nlogo/swing/FileDialog.java
+++ b/src/main/org/nlogo/swing/FileDialog.java
@@ -107,6 +107,9 @@ public final strictfp class FileDialog {
       if (result != javax.swing.JFileChooser.APPROVE_OPTION) {
         throw new org.nlogo.awt.UserCancelException();
       }
+      if(mode == java.awt.FileDialog.LOAD && !new java.io.File(chooser.getSelectedFile().getAbsolutePath()).exists()){
+        return show(parentFrame, title, mode, directoriesOnly, chooser.getSelectedFile().getAbsolutePath());
+      }
       currentDirectory = selectedDirectory(chooser);
       return chooser.getSelectedFile().getAbsolutePath();
     }


### PR DESCRIPTION
Fix for #726 
This is a fix for Linux ( I only have Linux) but if this looks fine, I can do a fix for other OS.