### PR TITLE
Undo only if the edit can be undone

### DIFF
--- a/src/main/org/nlogo/editor/UndoManager.java
+++ b/src/main/org/nlogo/editor/UndoManager.java
@@ -136,9 +136,11 @@ public strictfp class UndoManager extends javax.swing.undo.UndoManager
     }
 
     public void actionPerformed(java.awt.event.ActionEvent e) {
-      currentManager.undo();
-      updateUndoState();
-      redoAction.updateRedoState();
+      if(currentManager.canUndo()) {
+        currentManager.undo();
+        updateUndoState();
+        redoAction.updateRedoState();
+      }
     }
 
     protected void updateUndoState() {


### PR DESCRIPTION
Fix for #450.
Prevents the original problem from occurring instead of catching the Exception. 