### PR TITLE
Set layout for buttons and added margins

### DIFF
--- a/src/main/org/nlogo/properties/PlotPensEditor.scala
+++ b/src/main/org/nlogo/properties/PlotPensEditor.scala
@@ -136,12 +136,13 @@ class PlotPensEditor(accessor: PropertyAccessor[List[PlotPen]], colorizer: Color
     val model = new PenTableModel()
     locally{
       setModel(model)
-
-      setRowHeight(getRowHeight + 10)
+      setRowHeight(getRowHeight + 14)
+      setRowMargin(1)
       setGridColor(Color.BLACK)
       setShowGrid(true)
       setRowSelectionAllowed(false)
       getTableHeader.setReorderingAllowed(false)
+      getColumnModel().setColumnMargin(1)
 
       getSelectionModel.addListSelectionListener(new RowListener())
       getColumnModel.getSelectionModel.addListSelectionListener(new ColumnListener())

--- a/src/main/org/nlogo/properties/PlotPensEditor.scala
+++ b/src/main/org/nlogo/properties/PlotPensEditor.scala
@@ -256,7 +256,15 @@ class PlotPensEditor(accessor: PropertyAccessor[List[PlotPen]], colorizer: Color
       }
       editButton.putClientProperty("JComponent.sizeVariant", "small")
       deleteButton.putClientProperty("JComponent.sizeVariant", "small")
-      val buttonPanel = new JPanel {add(editButton); add(deleteButton)}
+      val buttonPanel = new JPanel()
+      val layout = new GroupLayout(buttonPanel)
+      layout.setAutoCreateGaps(true)
+      layout.setVerticalGroup(layout.createParallelGroup().addComponent(editButton).addComponent(deleteButton))
+      layout.setHorizontalGroup(layout.createSequentialGroup()
+        .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED, GroupLayout.DEFAULT_SIZE, Short.MaxValue)
+        .addComponent(editButton).addComponent(deleteButton)
+        .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED, GroupLayout.DEFAULT_SIZE, Short.MaxValue))
+      buttonPanel.setLayout(layout)
       def getTableCellRendererComponent(table: JTable, value: Object,
                                         isSelected: Boolean, hasFocus: Boolean,
                                         row: Int, col: Int) = buttonPanel


### PR DESCRIPTION
Fix for #961 
I have used Group Layout so i think this should be fixed for all platforms and resolutions.
The buttons now look like below.

![screenshot from 2016-03-08 21 46 10](https://cloud.githubusercontent.com/assets/7762605/13607865/3ea480ca-e578-11e5-8cb2-c48724441a4d.png)
In the second commit a different issue is addressed. When editing the `Pen Update Command` column the right and bottom grid used to disappear like below

![screenshot from 2016-03-08 21 53 32](https://cloud.githubusercontent.com/assets/7762605/13608007/d1ac933a-e578-11e5-90f4-c17d729187b4.png)

To prevent this a margin of 1 pixel is added and the row height is increased to make the buttons appear in center(vertically).
