### PR TITLE
Removed control strip and added ticks to ViewUpdatePanel

### DIFF
--- a/src/main/org/nlogo/app/InterfacePanel.java
+++ b/src/main/org/nlogo/app/InterfacePanel.java
@@ -258,8 +258,7 @@ strictfp class InterfacePanel
     if (viewWidget instanceof org.nlogo.window.ViewWidget &&
         !type.equals("GRAPHICS-WINDOW") &&
         VersionHistory.olderThan13pre1(modelVersion)) {
-      y += ((org.nlogo.window.ViewWidget) viewWidget).getExtraHeight() +
-          ((org.nlogo.window.ViewWidget) viewWidget).controlStrip.getHeight();
+      y += ((org.nlogo.window.ViewWidget) viewWidget).getExtraHeight();
     }
     if (type.equals("GRAPHICS-WINDOW")) {
       // the graphics widget (and the command center) are special cases because

--- a/src/main/org/nlogo/window/SpeedSliderPanel.java
+++ b/src/main/org/nlogo/window/SpeedSliderPanel.java
@@ -85,7 +85,7 @@ public strictfp class SpeedSliderPanel
   void enableLabels(int value) {
     if (value == 0) {
       if (labelsBelow) {
-        normal.setText("      " + I18N.guiJ().get("tabs.run.speedslider.normalspeed"));
+        normal.setText("        " + I18N.guiJ().get("tabs.run.speedslider.normalspeed"));
       } else {
         normal.setText(I18N.guiJ().get("tabs.run.speedslider.normalspeed"));
       }

--- a/src/main/org/nlogo/window/ViewUpdatePanel.java
+++ b/src/main/org/nlogo/window/ViewUpdatePanel.java
@@ -38,7 +38,14 @@ public strictfp class ViewUpdatePanel
         });
     org.nlogo.awt.Fonts.adjustDefaultFont(displaySwitch);
     settings = workspace.viewWidget.settings();
-    add(speedSlider);
+
+    javax.swing.JPanel speedPanel = new javax.swing.JPanel();
+    speedPanel.setLayout(new javax.swing.BoxLayout(speedPanel, javax.swing.BoxLayout.PAGE_AXIS));
+    workspace.viewWidget.tickCounter.setAlignmentX(java.awt.Component.CENTER_ALIGNMENT);
+    speedPanel.add(speedSlider);
+    speedPanel.add(workspace.viewWidget.tickCounter);
+
+    add(speedPanel);
     SettingsButton settingsButton = new SettingsButton();
     viewUpdates.addItem(I18N.guiJ().get("tabs.run.viewUpdates.dropdown.onticks"));
     viewUpdates.addItem(I18N.guiJ().get("tabs.run.viewUpdates.dropdown.continuous"));


### PR DESCRIPTION
Fix for #930 
* Basically deleted every line that contained the word  `controlStrip`.
* Added the ticks counter below the speed slider.
* Deleted the spaces before "ticks"
* Added spaces before normal-speed to center(though this should be done in a better way but that would be a different PR)

The interface looks like this now:
![screenshot from 2016-03-09 00 42 10](https://cloud.githubusercontent.com/assets/7762605/13613511/68f69b14-e592-11e5-9b3b-e9170b681029.png)
