### PR TITLE
fix for grepping javac path for openjdk or ppa:webupd8team/java packa…

### DIFF
--- a/sbt
+++ b/sbt
@@ -10,7 +10,7 @@ if [[ `uname -s` == *CYGWIN* ]] ; then
 else
   CURR_DIR=`dirname $0`
   if [ `uname -s` = Linux ] ; then
-    HIGHEST_PRIORITY_JAVA_8=`update-alternatives --display javac | grep priority | grep 1.8 | sort -k 4 | tail -1 | cut -d\  -f1`
+    HIGHEST_PRIORITY_JAVA_8=`update-alternatives --display javac | grep priority | grep -E 'java-8|1\.8' | sort -k 4 | tail -1 | cut -d\  -f1`
     if [ -e "$HIGHEST_PRIORITY_JAVA_8" ] ; then
       export JAVA_HOME="${HIGHEST_PRIORITY_JAVA_8%/bin/javac}"
     elif ! $JAVA_HOME/bin/java -version 2>&1 | head -n 1 | grep "1\.8" >> /dev/null ; then


### PR DESCRIPTION
grep arguments changed to be able to get "/usr/lib/jvm/java-8-oracle/bin/javac" path, which is default for ubuntu's openjdk or webupd8team's oracle JDK.
And surely, dot is to be escaped.