### PR TITLE
Added checks for validDouble

### DIFF
--- a/src/main/org/nlogo/prim/_minus.java
+++ b/src/main/org/nlogo/prim/_minus.java
@@ -25,7 +25,7 @@ public final strictfp class _minus extends Reporter implements Pure {
         argEvalDoubleValue(context, 1));
   }
 
-  public double report_1(Context context, double arg0, double arg1) {
-    return arg0 - arg1;
+  public double report_1(Context context, double arg0, double arg1) throws LogoException {
+    return validDouble(arg0 - arg1);
   }
 }

--- a/src/main/org/nlogo/prim/_plus.java
+++ b/src/main/org/nlogo/prim/_plus.java
@@ -24,7 +24,7 @@ public final strictfp class _plus extends Reporter implements Pure {
             argEvalDoubleValue(context, 1));
   }
 
-  public double report_1(Context context, double d1, double d2) {
-    return d1 + d2;
+  public double report_1(Context context, double d1, double d2) throws LogoException {
+    return validDouble(d1 + d2);
   }
 }

--- a/src/main/org/nlogo/prim/etc/_approximatehsb.scala
+++ b/src/main/org/nlogo/prim/etc/_approximatehsb.scala
@@ -16,7 +16,7 @@ class _approximatehsb extends Reporter with Pure {
         argEvalDoubleValue(context, 2));
 
   def report_1(context: Context, h: Double, s: Double, b: Double): java.lang.Double =
-    api.Color.getClosestColorNumberByHSB(h.toFloat, s.toFloat, b.toFloat, 360.0f, 100.0f, 100.0f);
+    validDouble(api.Color.getClosestColorNumberByHSB(h.toFloat, s.toFloat, b.toFloat, 360.0f, 100.0f, 100.0f))
 }
 
 class _approximatehsbold extends Reporter with Pure {
@@ -30,5 +30,5 @@ class _approximatehsbold extends Reporter with Pure {
         argEvalDoubleValue(context, 2));
 
   def report_1(context: Context, h: Double, s: Double, b: Double): java.lang.Double =
-    api.Color.getClosestColorNumberByHSB(h.toFloat, s.toFloat, b.toFloat, 255.0f, 255.0f, 255.0f);
+    validDouble(api.Color.getClosestColorNumberByHSB(h.toFloat, s.toFloat, b.toFloat, 255.0f, 255.0f, 255.0f))
 }

--- a/src/main/org/nlogo/prim/etc/_atan.java
+++ b/src/main/org/nlogo/prim/etc/_atan.java
@@ -34,7 +34,7 @@ public final strictfp class _atan extends Reporter implements Pure {
     if (d2 == 0) {
       return d1 > 0 ? 90 : 270;
     }
-    return (StrictMath.toDegrees(StrictMath.atan2(d1, d2))
+    return validDouble(StrictMath.toDegrees(StrictMath.atan2(d1, d2))
         + 360)
         % 360;
   }

--- a/src/main/org/nlogo/prim/etc/_ceil.java
+++ b/src/main/org/nlogo/prim/etc/_ceil.java
@@ -21,7 +21,7 @@ public final strictfp class _ceil extends Reporter implements Pure {
     return report_1(context, argEvalDoubleValue(context, 0));
   }
 
-  public double report_1(Context context, double d0) {
-    return StrictMath.ceil(d0);
+  public double report_1(Context context, double d0) throws LogoException {
+    return validDouble(StrictMath.ceil(d0));
   }
 }

--- a/src/main/org/nlogo/prim/etc/_distancexy.java
+++ b/src/main/org/nlogo/prim/etc/_distancexy.java
@@ -21,8 +21,8 @@ public final strictfp class _distancexy extends Reporter {
         argEvalDoubleValue(context, 1));
   }
 
-  public double report_1(Context context, double arg0, double arg1) {
-    return world.protractor().distance
-        (context.agent, arg0, arg1, true); // true = wrap
+  public double report_1(Context context, double arg0, double arg1) throws LogoException {
+    return validDouble(world.protractor().distance
+        (context.agent, arg0, arg1, true)); // true = wrap
   }
 }

--- a/src/main/org/nlogo/prim/etc/_distancexynowrap.java
+++ b/src/main/org/nlogo/prim/etc/_distancexynowrap.java
@@ -21,8 +21,8 @@ public final strictfp class _distancexynowrap extends Reporter {
         argEvalDoubleValue(context, 1));
   }
 
-  public double report_1(Context context, double arg0, double arg1) {
-    return world.protractor().distance
-        (context.agent, arg0, arg1, false); // false = don't wrap
+  public double report_1(Context context, double arg0, double arg1) throws LogoException {
+    return validDouble(world.protractor().distance
+        (context.agent, arg0, arg1, false)); // false = don't wrap
   }
 }

--- a/src/main/org/nlogo/prim/etc/_div.java
+++ b/src/main/org/nlogo/prim/etc/_div.java
@@ -31,6 +31,6 @@ public final strictfp class _div extends Reporter implements Pure {
     if (arg1 == 0) {
       throw new EngineException(context, this, I18N.errorsJ().get("org.nlogo.prim.etc.$common.divByZero"));
     }
-    return arg0 / arg1;
+    return validDouble(arg0 / arg1);
   }
 }

--- a/src/main/org/nlogo/prim/etc/_exp.java
+++ b/src/main/org/nlogo/prim/etc/_exp.java
@@ -20,7 +20,7 @@ public final strictfp class _exp extends Reporter implements Pure {
     return report_1(context, argEvalDoubleValue(context, 0));
   }
 
-  public double report_1(Context context, double d0) {
-    return StrictMath.exp(d0);
+  public double report_1(Context context, double d0) throws LogoException {
+    return validDouble(StrictMath.exp(d0));
   }
 }

--- a/src/main/org/nlogo/prim/etc/_mult.java
+++ b/src/main/org/nlogo/prim/etc/_mult.java
@@ -24,7 +24,7 @@ public final strictfp class _mult extends Reporter implements Pure {
         argEvalDoubleValue(context, 1));
   }
 
-  public double report_1(Context context, double arg0, double arg1) {
-    return arg0 * arg1;
+  public double report_1(Context context, double arg0, double arg1) throws LogoException {
+    return validDouble(arg0 * arg1);
   }
 }

--- a/src/main/org/nlogo/prim/etc/_randomfloat.java
+++ b/src/main/org/nlogo/prim/etc/_randomfloat.java
@@ -20,7 +20,7 @@ public final strictfp class _randomfloat extends Reporter {
     return report_1(context, argEvalDoubleValue(context, 0));
   }
 
-  public double report_1(Context context, double d) {
-    return d * context.job.random.nextDouble();
+  public double report_1(Context context, double d) throws LogoException {
+    return validDouble(d * context.job.random.nextDouble());
   }
 }

--- a/src/main/org/nlogo/prim/etc/_round.java
+++ b/src/main/org/nlogo/prim/etc/_round.java
@@ -21,7 +21,7 @@ public final strictfp class _round extends Reporter implements Pure {
     return report_1(context, argEvalDoubleValue(context, 0));
   }
 
-  public double report_1(Context context, double d0) {
-    return org.nlogo.api.Approximate.approximate(d0, 0);
+  public double report_1(Context context, double d0) throws LogoException {
+    return validDouble(org.nlogo.api.Approximate.approximate(d0, 0));
   }
 }

--- a/src/main/org/nlogo/prim/threed/_linkpitch.scala
+++ b/src/main/org/nlogo/prim/threed/_linkpitch.scala
@@ -12,7 +12,7 @@ class _linkpitch extends Reporter {
       Syntax.NumberType, "---L")
   override def report(context: Context) = {
     val link = context.agent.asInstanceOf[Link]
-    try Double.box(world.protractor.towardsPitch(link.end1, link.end2, true))
+    try newValidDouble(world.protractor.towardsPitch(link.end1, link.end2, true))
     catch {
       case e: org.nlogo.api.AgentException =>
         throw new org.nlogo.nvm.EngineException(

--- a/test/benchdumps/Ants.txt
+++ b/test/benchdumps/Ants.txt
@@ -132,9 +132,11 @@ procedure GO:[]{O---}:
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L6
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_div_3.validDouble (D)D
            L7
             DSTORE 2
             NEW java/lang/Double
@@ -933,9 +935,11 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurelookforfood_setpatchvariable_2.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -3113,15 +3117,19 @@ procedure GO-PATCHES:[]{-TP-}:
          L14
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregopatches_setpatchvariable_0.validDouble (D)D
          L15
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregopatches_setpatchvariable_0.validDouble (D)D
          L16
           LDC 100.0
          L17
@@ -3141,9 +3149,11 @@ procedure GO-PATCHES:[]{-TP-}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L18
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregopatches_setpatchvariable_0.validDouble (D)D
          L19
           DSTORE 2
           NEW java/lang/Double
@@ -3809,9 +3819,11 @@ procedure RETURN-TO-NEST:[]{-T--}:
          L15
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereturntonest_setpatchvariable_5.validDouble (D)D
          L16
           DSTORE 2
           NEW java/lang/Double
@@ -3890,9 +3902,11 @@ procedure RETURN-TO-NEST:[]{-T--}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereturntonest_setturtlevariable_6.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -4782,12 +4796,14 @@ procedure SETUP-TURTLES:[]{O---}:
           LDC 360.0
          L1
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupturtles_right_4.validDouble (D)D
          L2
           DSTORE 2
           ALOAD 1
@@ -4903,9 +4919,11 @@ procedure WIGGLE:[]{-T--}:
          L2
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurewiggle_right_0.validDouble (D)D
          L3
           DSTORE 2
           ALOAD 1
@@ -5568,6 +5586,7 @@ procedure SETUP-NEST:[]{-TP-}:
           DSTORE 4
           DSTORE 2
           ALOAD 0
+          ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupnest_setpatchvariable_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.protractor ()Lorg/nlogo/agent/Protractor;
           ALOAD 1
@@ -5576,6 +5595,7 @@ procedure SETUP-NEST:[]{-TP-}:
           DLOAD 4
           ICONST_1
           INVOKEVIRTUAL org/nlogo/agent/Protractor.distance (Lorg/nlogo/api/Agent;DDZ)D
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnest_setpatchvariable_0.validDouble (D)D
          L6
           LDC 5.0
          L7
@@ -5638,6 +5658,7 @@ procedure SETUP-NEST:[]{-TP-}:
           DSTORE 4
           DSTORE 2
           ALOAD 0
+          ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupnest_setpatchvariable_1.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.protractor ()Lorg/nlogo/agent/Protractor;
           ALOAD 1
@@ -5646,12 +5667,15 @@ procedure SETUP-NEST:[]{-TP-}:
           DLOAD 4
           ICONST_1
           INVOKEVIRTUAL org/nlogo/agent/Protractor.distance (Lorg/nlogo/api/Agent;DDZ)D
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnest_setpatchvariable_1.validDouble (D)D
          L7
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnest_setpatchvariable_1.validDouble (D)D
          L8
           DSTORE 2
           NEW java/lang/Double
@@ -5712,14 +5736,17 @@ procedure SETUP-FOOD:[]{-TP-}:
          L2
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_0.validDouble (D)D
          L3
           DCONST_0
          L4
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupfood_if_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.protractor ()Lorg/nlogo/agent/Protractor;
@@ -5729,6 +5756,7 @@ procedure SETUP-FOOD:[]{-TP-}:
           DLOAD 4
           ICONST_1
           INVOKEVIRTUAL org/nlogo/agent/Protractor.distance (Lorg/nlogo/api/Agent;DDZ)D
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_0.validDouble (D)D
          L5
           LDC 5.0
          L6
@@ -5807,9 +5835,11 @@ procedure SETUP-FOOD:[]{-TP-}:
          L2
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_2.validDouble (D)D
          L3
           LDC -0.6
          L4
@@ -5820,12 +5850,15 @@ procedure SETUP-FOOD:[]{-TP-}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_2.validDouble (D)D
          L6
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupfood_if_2.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.protractor ()Lorg/nlogo/agent/Protractor;
@@ -5835,6 +5868,7 @@ procedure SETUP-FOOD:[]{-TP-}:
           DLOAD 4
           ICONST_1
           INVOKEVIRTUAL org/nlogo/agent/Protractor.distance (Lorg/nlogo/api/Agent;DDZ)D
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_2.validDouble (D)D
          L7
           LDC 5.0
          L8
@@ -5913,9 +5947,11 @@ procedure SETUP-FOOD:[]{-TP-}:
          L2
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_4.validDouble (D)D
          L3
           LDC 0.8
          L4
@@ -5926,12 +5962,15 @@ procedure SETUP-FOOD:[]{-TP-}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_4.validDouble (D)D
          L6
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupfood_if_4.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.protractor ()Lorg/nlogo/agent/Protractor;
@@ -5941,6 +5980,7 @@ procedure SETUP-FOOD:[]{-TP-}:
           DLOAD 4
           ICONST_1
           INVOKEVIRTUAL org/nlogo/agent/Protractor.distance (Lorg/nlogo/api/Agent;DDZ)D
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_4.validDouble (D)D
          L7
           LDC 5.0
          L8
@@ -6094,9 +6134,11 @@ procedure SETUP-FOOD:[]{-TP-}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_setpatchvariable_7.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double

--- a/test/benchdumps/BZ.txt
+++ b/test/benchdumps/BZ.txt
@@ -283,9 +283,11 @@ procedure SETUP:[]{O---}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_1.validDouble (D)D
          L9
           DSTORE 2
           ALOAD 0
@@ -1653,9 +1655,11 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L16
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8.validDouble (D)D
          L17
           DSTORE 2
           ALOAD 0
@@ -1726,9 +1730,11 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L23
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8.validDouble (D)D
          L24
           DSTORE 2
           ALOAD 0
@@ -1738,9 +1744,11 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
          L25
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8.validDouble (D)D
          L26
           DSTORE 2
           NEW java/lang/Double
@@ -1893,9 +1901,11 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
          L12
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10.validDouble (D)D
          L13
           DSTORE 2
           NEW java/lang/Double
@@ -2005,17 +2015,21 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
          L17
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_11.validDouble (D)D
          L18
           DCONST_1
          L19
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_11.validDouble (D)D
          L20
           DSTORE 4
           DSTORE 2
@@ -2033,9 +2047,11 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L21
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_11.validDouble (D)D
          L22
           DSTORE 2
           ALOAD 0
@@ -2068,9 +2084,11 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
          L25
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_11.validDouble (D)D
          L26
           DSTORE 2
           NEW java/lang/Double

--- a/test/benchdumps/Bureaucrats.txt
+++ b/test/benchdumps/Bureaucrats.txt
@@ -324,9 +324,11 @@ procedure SETUP:[]{O---}:
          L6
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_4.validDouble (D)D
          L7
           DSTORE 2
           NEW java/lang/Double
@@ -576,9 +578,11 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_3.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -644,9 +648,11 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_4.validDouble (D)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -1070,9 +1076,11 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_11.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -1138,9 +1146,11 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_12.validDouble (D)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -1300,9 +1310,11 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_15.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -1368,9 +1380,11 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_16.validDouble (D)D
          L9
           DSTORE 2
           NEW java/lang/Double

--- a/test/benchdumps/CA1D.txt
+++ b/test/benchdumps/CA1D.txt
@@ -551,9 +551,11 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
              L4
               DSTORE 4
               DSTORE 2
+              ALOAD 0
               DLOAD 2
               DLOAD 4
               DADD
+              INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupcontinue_plus_11.validDouble (D)D
              L5
               DSTORE 2
               NEW java/lang/Double
@@ -1300,9 +1302,11 @@ procedure GO:[]{O---}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_11.validDouble (D)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -1603,9 +1607,11 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L2
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validDouble (D)D
          L3
           DSTORE 2
           ALOAD 1
@@ -3704,9 +3710,11 @@ procedure CALCULATE-RULE:[RRESULT]{OTPL}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_2.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -3798,9 +3806,11 @@ procedure CALCULATE-RULE:[RRESULT]{OTPL}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_4.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -3892,9 +3902,11 @@ procedure CALCULATE-RULE:[RRESULT]{OTPL}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_6.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -3986,9 +3998,11 @@ procedure CALCULATE-RULE:[RRESULT]{OTPL}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_8.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -4080,9 +4094,11 @@ procedure CALCULATE-RULE:[RRESULT]{OTPL}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_10.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -4174,9 +4190,11 @@ procedure CALCULATE-RULE:[RRESULT]{OTPL}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_12.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -4268,9 +4286,11 @@ procedure CALCULATE-RULE:[RRESULT]{OTPL}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_14.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -4362,9 +4382,11 @@ procedure CALCULATE-RULE:[RRESULT]{OTPL}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_16.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -4825,9 +4847,11 @@ procedure SHOW-RULES:[RULES]{O---}:
              L5
               DSTORE 4
               DSTORE 2
+              ALOAD 0
               DLOAD 2
               DLOAD 4
               DSUB
+              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureshowrules_greaterthan_3.validDouble (D)D
              L6
               DSTORE 4
               DSTORE 2
@@ -5102,9 +5126,11 @@ procedure SHOW-RULES:[RULES]{O---}:
              L12
               DSTORE 4
               DSTORE 2
+              ALOAD 0
               DLOAD 2
               DLOAD 4
               DADD
+              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureshowrules_and_7.validDouble (D)D
              L13
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedureshowrules_and_7.world : Lorg/nlogo/agent/World;
@@ -5129,9 +5155,11 @@ procedure SHOW-RULES:[RULES]{O---}:
               INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
               ATHROW
              L16
+              ALOAD 0
               DLOAD 2
               DLOAD 4
               DDIV
+              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureshowrules_and_7.validDouble (D)D
              L17
               DSTORE 2
               DLOAD 2
@@ -8707,9 +8735,11 @@ procedure BINDIGIT:[NUMBER POWER-OF-TWO]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L10
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebindigit_report_3.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -8749,9 +8779,11 @@ procedure BINDIGIT:[NUMBER POWER-OF-TWO]{OTPL}:
          L15
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebindigit_report_3.validDouble (D)D
          L16
           DSTORE 2
           NEW java/lang/Double

--- a/test/benchdumps/Erosion.txt
+++ b/test/benchdumps/Erosion.txt
@@ -131,12 +131,14 @@ procedure GO:[]{O---}:
           DCONST_1
          L1
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_if_1.validDouble (D)D
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -243,9 +245,11 @@ procedure GO:[]{O---}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_2.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -1651,9 +1655,11 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
              L12
               DSTORE 4
               DSTORE 2
+              ALOAD 0
               DLOAD 2
               DLOAD 4
               DADD
+              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_plus_2.validDouble (D)D
              L13
               DSTORE 2
               NEW java/lang/Double
@@ -1804,9 +1810,11 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
          L34
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3.validDouble (D)D
          L35
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -1940,9 +1948,11 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
          L42
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3.validDouble (D)D
          L43
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -2076,15 +2086,19 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
          L50
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3.validDouble (D)D
          L51
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3.validDouble (D)D
          L52
           DSTORE 2
           NEW java/lang/Double
@@ -2297,15 +2311,19 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
          L9
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_5.validDouble (D)D
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_5.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -2394,9 +2412,11 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
          L13
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setpatchvariable_6.validDouble (D)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -2554,9 +2574,11 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
          L34
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7.validDouble (D)D
          L35
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -2690,9 +2712,11 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
          L42
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7.validDouble (D)D
          L43
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -2826,15 +2850,19 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
          L50
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7.validDouble (D)D
          L51
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7.validDouble (D)D
          L52
           DSTORE 2
           NEW java/lang/Double
@@ -2991,9 +3019,11 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
          L13
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setpatchvariable_8.validDouble (D)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -3209,9 +3239,11 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
          L13
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setpatchvariable_10.validDouble (D)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -3447,6 +3479,7 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           DSTORE 4
           DSTORE 2
           ALOAD 0
+          ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.protractor ()Lorg/nlogo/agent/Protractor;
           ALOAD 1
@@ -3455,6 +3488,7 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           DLOAD 4
           ICONST_1
           INVOKEVIRTUAL org/nlogo/agent/Protractor.distance (Lorg/nlogo/api/Agent;DDZ)D
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.validDouble (D)D
          L7
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.world : Lorg/nlogo/agent/World;
@@ -3477,23 +3511,29 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L9
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.validDouble (D)D
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.validDouble (D)D
          L11
           LDC 100.0
          L12
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.validDouble (D)D
          L13
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -3504,9 +3544,11 @@ procedure SETUP:[_repeatlocal:0]{O---}:
          L14
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.validDouble (D)D
          L15
           DSTORE 2
           NEW java/lang/Double

--- a/test/benchdumps/Fire.txt
+++ b/test/benchdumps/Fire.txt
@@ -671,9 +671,11 @@ procedure GO:[]{O---}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_12.validDouble (D)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -814,9 +816,11 @@ procedure GO:[]{O---}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_15.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -1408,17 +1412,21 @@ procedure PERCENT-BURNED:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L9
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepercentburned_report_1.validDouble (D)D
          L10
           LDC 100.0
          L11
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepercentburned_report_1.validDouble (D)D
          L12
           DSTORE 2
           NEW java/lang/Double
@@ -1695,9 +1703,11 @@ procedure SETUP:[]{O---}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_if_2.validDouble (D)D
          L6
           DSTORE 4
           DSTORE 2
@@ -1859,9 +1869,11 @@ procedure SETUP:[]{O---}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_if_5.validDouble (D)D
          L6
           DSTORE 4
           DSTORE 2

--- a/test/benchdumps/FireBig.txt
+++ b/test/benchdumps/FireBig.txt
@@ -671,9 +671,11 @@ procedure GO:[]{O---}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_12.validDouble (D)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -814,9 +816,11 @@ procedure GO:[]{O---}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_15.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -1408,17 +1412,21 @@ procedure PERCENT-BURNED:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L9
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepercentburned_report_1.validDouble (D)D
          L10
           LDC 100.0
          L11
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepercentburned_report_1.validDouble (D)D
          L12
           DSTORE 2
           NEW java/lang/Double
@@ -1695,9 +1703,11 @@ procedure SETUP:[]{O---}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_if_2.validDouble (D)D
          L6
           DSTORE 4
           DSTORE 2
@@ -1859,9 +1869,11 @@ procedure SETUP:[]{O---}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_if_5.validDouble (D)D
          L6
           DSTORE 4
           DSTORE 2

--- a/test/benchdumps/Flocking.txt
+++ b/test/benchdumps/Flocking.txt
@@ -69,9 +69,11 @@ procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_ifelse_0.validDouble (D)D
          L9
           DSTORE 2
           DLOAD 2
@@ -166,9 +168,11 @@ procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_report_1.validDouble (D)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -423,17 +427,21 @@ procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_report_4.validDouble (D)D
          L9
           LDC 360.0
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_report_4.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -567,17 +575,21 @@ procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_report_6.validDouble (D)D
          L9
           LDC 360.0
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_report_6.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -809,9 +821,11 @@ procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
                  L4
                   DSTORE 4
                   DSTORE 2
+                  ALOAD 0
                   DLOAD 2
                   DLOAD 4
                   DADD
+                  INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_sin_1.validDouble (D)D
                  L5
                   DSTORE 2
                   DLOAD 2
@@ -903,9 +917,11 @@ procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
                  L4
                   DSTORE 4
                   DSTORE 2
+                  ALOAD 0
                   DLOAD 2
                   DLOAD 4
                   DADD
+                  INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_cos_4.validDouble (D)D
                  L5
                   DSTORE 2
                   DLOAD 2
@@ -1169,12 +1185,14 @@ procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
          L25
           GOTO L22
          L23
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_report_0.validDouble (D)D
           LDC 360.0
           DREM
          L22
@@ -1785,9 +1803,11 @@ procedure SETUP:[]{O---}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtleorlinkvariable_1.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -1833,12 +1853,14 @@ procedure SETUP:[]{O---}:
           I2D
          L4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_2.validDouble (D)D
          L5
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_setxy_2.world : Lorg/nlogo/agent/World;
@@ -1846,12 +1868,14 @@ procedure SETUP:[]{O---}:
           I2D
          L6
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_2.validDouble (D)D
          L7
           DSTORE 4
           DSTORE 2
@@ -1906,12 +1930,14 @@ procedure SETUP:[]{O---}:
           LDC 360.0
          L1
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_right_3.validDouble (D)D
          L2
           DSTORE 2
           ALOAD 1
@@ -2807,12 +2833,14 @@ procedure AVERAGE-FLOCKMATE-HEADING:[]{-T--}:
          L25
           GOTO L22
          L23
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageflockmateheading_report_0.validDouble (D)D
           LDC 360.0
           DREM
          L22

--- a/test/benchdumps/GasLabCirc.txt
+++ b/test/benchdumps/GasLabCirc.txt
@@ -1188,9 +1188,11 @@ procedure GO:[]{O---}:
          L13
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_jump_37.validDouble (D)D
          L14
           DSTORE 2
          L7
@@ -1335,9 +1337,11 @@ procedure GO:[]{O---}:
          L6
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_if_42.validDouble (D)D
          L7
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -2487,9 +2491,11 @@ procedure SORT-COLLISIONS:[WINNER DT]{OTPL}:
          L6
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresortcollisions_ifelse_18.validDouble (D)D
          L7
           DCONST_1
          L8
@@ -2569,9 +2575,11 @@ procedure SORT-COLLISIONS:[WINNER DT]{OTPL}:
          L9
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresortcollisions_setobservervariable_19.validDouble (D)D
          L10
           DSTORE 2
           NEW java/lang/Double
@@ -3414,9 +3422,11 @@ procedure OVERLAPPING?:[]{-T--}:
              L17
               DSTORE 4
               DSTORE 2
+              ALOAD 0
               DLOAD 2
               DLOAD 4
               DADD
+              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureoverlapping_lessthan_1.validDouble (D)D
              L18
               LDC 2.0
              L19
@@ -3436,9 +3446,11 @@ procedure OVERLAPPING?:[]{-T--}:
               INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
               ATHROW
              L20
+              ALOAD 0
               DLOAD 2
               DLOAD 4
               DDIV
+              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureoverlapping_lessthan_1.validDouble (D)D
              L21
               DSTORE 4
               DSTORE 2
@@ -3496,9 +3508,11 @@ procedure OVERLAPPING?:[]{-T--}:
          L6
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureoverlapping_report_0.validDouble (D)D
          L7
           LDC 2.0
          L8
@@ -3518,9 +3532,11 @@ procedure OVERLAPPING?:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L9
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureoverlapping_report_0.validDouble (D)D
          L10
           DSTORE 3
           ASTORE 2
@@ -3847,9 +3863,11 @@ procedure RANDOM-POSITION:[]{-T--}:
          L18
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L19
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -3875,29 +3893,37 @@ procedure RANDOM-POSITION:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L22
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L23
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L24
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L25
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L26
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerandomposition_setxy_0.kept15_value : Lorg/nlogo/api/LogoList;
@@ -3977,9 +4003,11 @@ procedure RANDOM-POSITION:[]{-T--}:
          L33
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L34
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -4005,29 +4033,37 @@ procedure RANDOM-POSITION:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L37
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L38
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L39
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L40
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L41
           DSTORE 4
           DSTORE 2
@@ -4311,9 +4347,11 @@ procedure ASSIGN-COLLIDING-WALL:[TIME-TO-COLLISION WALL COLLIDING-PAIR]{-TPL}:
          L7
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureassigncollidingwall_setprocedurevariable_0.validDouble (D)D
          L8
           DSTORE 2
           NEW java/lang/Double
@@ -4715,9 +4753,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L11
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_7.validDouble (D)D
          L12
           DSTORE 2
           DLOAD 2
@@ -4726,9 +4766,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L13
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_7.validDouble (D)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -4825,9 +4867,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L11
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_8.validDouble (D)D
          L12
           DSTORE 2
           DLOAD 2
@@ -4836,9 +4880,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L13
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_8.validDouble (D)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -4942,9 +4988,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L12
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_9.validDouble (D)D
          L13
           DSTORE 2
           DLOAD 2
@@ -4953,9 +5001,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L14
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_9.validDouble (D)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -5059,9 +5109,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L12
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (D)D
          L13
           DSTORE 2
           DLOAD 2
@@ -5070,9 +5122,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L14
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (D)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -5173,9 +5227,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L21
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (D)D
          L22
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5227,15 +5283,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L26
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (D)D
          L27
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (D)D
          L11
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -5298,9 +5358,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L31
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (D)D
          L32
           DSTORE 4
           DSTORE 2
@@ -5318,9 +5380,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L33
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (D)D
          L34
           DSTORE 2
           NEW java/lang/Double
@@ -5376,9 +5440,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L7
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_12.validDouble (D)D
          L8
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5406,9 +5472,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_12.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -5464,9 +5532,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L7
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_13.validDouble (D)D
          L8
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5494,9 +5564,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_13.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -5579,9 +5651,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
            L12
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_14.validDouble (D)D
            L13
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5633,15 +5707,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
            L17
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_14.validDouble (D)D
            L18
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DADD
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_14.validDouble (D)D
            L19
             DSTORE 2
             DLOAD 2
@@ -5884,20 +5962,24 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L23
           GOTO L20
          L21
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_16.validDouble (D)D
           LDC 360.0
           DREM
          L20
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_16.validDouble (D)D
          L24
           DSTORE 2
           NEW java/lang/Double
@@ -6107,9 +6189,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
            L12
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (D)D
            L13
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -6161,15 +6245,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
            L17
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (D)D
            L18
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DADD
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (D)D
            L19
             DSTORE 2
             DLOAD 2
@@ -6533,20 +6621,24 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L23
           GOTO L20
          L21
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_22.validDouble (D)D
           LDC 360.0
           DREM
          L20
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_22.validDouble (D)D
          L24
           DSTORE 2
           NEW java/lang/Double
@@ -6852,23 +6944,29 @@ procedure MAKE-PARTICLES:[]{O---}:
          L15
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeparticles_setturtlevariable_2.validDouble (D)D
          L16
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeparticles_setturtlevariable_2.validDouble (D)D
          L17
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeparticles_setturtlevariable_2.validDouble (D)D
          L18
           DSTORE 2
           NEW java/lang/Double
@@ -6919,9 +7017,11 @@ procedure MAKE-PARTICLES:[]{O---}:
            L2
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeparticles_mult_3.validDouble (D)D
            L3
             DSTORE 2
             NEW java/lang/Double
@@ -6955,12 +7055,14 @@ procedure MAKE-PARTICLES:[]{O---}:
           LDC 360.0
          L4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeparticles_setturtlevariable_5.validDouble (D)D
          L5
           DSTORE 2
           NEW java/lang/Double
@@ -7111,9 +7213,11 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorshaded_ifelse_1.validDouble (D)D
          L9
           DSTORE 3
           ASTORE 2
@@ -7224,9 +7328,11 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
          L13
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorshaded_setturtleorlinkvariable_2.validDouble (D)D
          L14
           LDC 3.0
          L15
@@ -7256,9 +7362,11 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
          L17
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorshaded_setturtleorlinkvariable_2.validDouble (D)D
          L18
           DSTORE 4
           DSTORE 2
@@ -7276,15 +7384,19 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L19
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorshaded_setturtleorlinkvariable_2.validDouble (D)D
          L20
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorshaded_setturtleorlinkvariable_2.validDouble (D)D
          L21
           DSTORE 2
           NEW java/lang/Double
@@ -7461,9 +7573,11 @@ procedure SETUP:[]{O---}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_4.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -7574,8 +7688,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L8
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           INVOKESTATIC java/lang/StrictMath.ceil (D)D
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_7.validDouble (D)D
          L9
           DSTORE 4
           DSTORE 2
@@ -7593,9 +7709,11 @@ procedure SETUP:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L10
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_7.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -8351,9 +8469,11 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
          L14
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_0.validDouble (D)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -8481,9 +8601,11 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
          L14
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_1.validDouble (D)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -8535,9 +8657,11 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_2.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -8594,9 +8718,11 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
          L6
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_3.validDouble (D)D
          L7
           DSTORE 2
           NEW java/lang/Double
@@ -8648,9 +8774,11 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_4.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -8707,9 +8835,11 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
          L6
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_5.validDouble (D)D
          L7
           DSTORE 2
           NEW java/lang/Double
@@ -8765,15 +8895,19 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_6.validDouble (D)D
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_6.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -8829,15 +8963,19 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_7.validDouble (D)D
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_7.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -8893,15 +9031,19 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_8.validDouble (D)D
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_8.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -8957,15 +9099,19 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_9.validDouble (D)D
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_9.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -9041,9 +9187,11 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_10.validDouble (D)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -9119,9 +9267,11 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_11.validDouble (D)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -9197,9 +9347,11 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_12.validDouble (D)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -9275,9 +9427,11 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_13.validDouble (D)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -9427,9 +9581,11 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L9
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_16.validDouble (D)D
          L10
           DSTORE 2
           NEW java/lang/Double
@@ -9708,9 +9864,11 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L9
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_23.validDouble (D)D
          L10
           DSTORE 2
           NEW java/lang/Double
@@ -9989,9 +10147,11 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L9
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_30.validDouble (D)D
          L10
           DSTORE 2
           NEW java/lang/Double
@@ -10270,9 +10430,11 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L9
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_37.validDouble (D)D
          L10
           DSTORE 2
           NEW java/lang/Double
@@ -11074,9 +11236,11 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewinners_setturtlevariable_9.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -11396,9 +11560,11 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorbanded_ifelse_1.validDouble (D)D
          L9
           DSTORE 3
           ASTORE 2
@@ -11546,9 +11712,11 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorbanded_ifelse_4.validDouble (D)D
          L9
           DSTORE 3
           ASTORE 2
@@ -12313,9 +12481,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
          L14
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_setprocedurevariable_3.validDouble (D)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -12443,9 +12613,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
          L14
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_setprocedurevariable_4.validDouble (D)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -12597,9 +12769,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L5
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DSUB
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_minus_7.validDouble (D)D
            L6
             DSTORE 2
             NEW java/lang/Double
@@ -12653,9 +12827,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L5
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DSUB
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_minus_9.validDouble (D)D
            L6
             DSTORE 2
             NEW java/lang/Double
@@ -12780,9 +12956,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L14
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_mult_11.validDouble (D)D
            L15
             DSTORE 2
             NEW java/lang/Double
@@ -12907,9 +13085,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L14
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_mult_13.validDouble (D)D
            L15
             DSTORE 2
             NEW java/lang/Double
@@ -12981,9 +13161,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L8
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DSUB
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_minus_15.validDouble (D)D
            L9
             DSTORE 2
             NEW java/lang/Double
@@ -13055,9 +13237,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L8
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DSUB
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_minus_17.validDouble (D)D
            L9
             DSTORE 2
             NEW java/lang/Double
@@ -13128,9 +13312,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L11
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_plus_19.validDouble (D)D
            L12
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -13210,15 +13396,19 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L17
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_plus_19.validDouble (D)D
            L18
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DADD
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_plus_19.validDouble (D)D
            L19
             DSTORE 2
             NEW java/lang/Double
@@ -13300,9 +13490,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L14
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_minus_21.validDouble (D)D
            L15
             ALOAD 1
             ALOAD 0
@@ -13352,15 +13544,19 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L19
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_minus_21.validDouble (D)D
            L20
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DADD
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_minus_21.validDouble (D)D
            L21
             ALOAD 1
             ALOAD 0
@@ -13397,9 +13593,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L25
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DSUB
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_minus_21.validDouble (D)D
            L26
             DSTORE 2
             NEW java/lang/Double
@@ -13480,9 +13678,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L13
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_mult_23.validDouble (D)D
            L14
             ALOAD 1
             ALOAD 0
@@ -13532,21 +13732,27 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L18
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_mult_23.validDouble (D)D
            L19
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DADD
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_mult_23.validDouble (D)D
            L20
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_mult_23.validDouble (D)D
            L21
             DSTORE 2
             NEW java/lang/Double
@@ -13623,9 +13829,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L12
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_plus_25.validDouble (D)D
            L13
             ALOAD 1
             ALOAD 0
@@ -13675,15 +13883,19 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L17
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_plus_25.validDouble (D)D
            L18
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DADD
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_plus_25.validDouble (D)D
            L19
             DSTORE 2
             NEW java/lang/Double
@@ -13773,9 +13985,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L13
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_minus_27.validDouble (D)D
            L14
             ALOAD 1
             ALOAD 0
@@ -13802,15 +14016,19 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L16
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_minus_27.validDouble (D)D
            L17
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DSUB
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_minus_27.validDouble (D)D
            L18
             DSTORE 2
             NEW java/lang/Double
@@ -13989,9 +14207,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L13
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DSUB
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_div_31.validDouble (D)D
            L14
             LDC 2.0
            L15
@@ -14020,9 +14240,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L17
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_div_31.validDouble (D)D
            L18
             DSTORE 4
             DSTORE 2
@@ -14040,9 +14262,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L19
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_div_31.validDouble (D)D
            L20
             DSTORE 2
             NEW java/lang/Double
@@ -14182,9 +14406,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
            L7
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DADD
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_list_34.validDouble (D)D
            L8
             DSTORE 2
             NEW java/lang/Double
@@ -14634,9 +14860,11 @@ procedure TEST-TIME-REVERSAL:[N OLD-CLOCK]{O---}:
          L7
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduretesttimereversal_while_10.validDouble (D)D
          L8
           DSTORE 4
           DSTORE 2

--- a/test/benchdumps/GasLabNew.txt
+++ b/test/benchdumps/GasLabNew.txt
@@ -93,9 +93,11 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
          L12
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatepressure_setobservervariable_0.validDouble (D)D
          L13
           DSTORE 2
           NEW java/lang/Double
@@ -1051,9 +1053,11 @@ procedure GO:[OLD-CLOCK]{O---}:
          L9
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_if_17.validDouble (D)D
          L10
           DSTORE 2
           DLOAD 2
@@ -1560,9 +1564,11 @@ procedure GO:[OLD-CLOCK]{O---}:
          L6
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setturtlevariable_33.validDouble (D)D
          L7
           DSTORE 2
           NEW java/lang/Double
@@ -1669,9 +1675,11 @@ procedure GO:[OLD-CLOCK]{O---}:
              L8
               DSTORE 4
               DSTORE 2
+              ALOAD 0
               DLOAD 2
               DLOAD 4
               DSUB
+              INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_greaterthan_36.validDouble (D)D
              L9
               LDC 0.4
              L10
@@ -2821,9 +2829,11 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
            L5
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_2.validDouble (D)D
            L6
             DSTORE 2
             NEW java/lang/Double
@@ -2885,13 +2895,17 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L6
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_ceil_4.validDouble (D)D
            L7
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             INVOKESTATIC java/lang/StrictMath.ceil (D)D
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_ceil_4.validDouble (D)D
            L8
             DSTORE 2
             NEW java/lang/Double
@@ -3030,15 +3044,19 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
            L10
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_15.validDouble (D)D
            L11
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_15.validDouble (D)D
            L12
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -3067,15 +3085,19 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
            L15
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_15.validDouble (D)D
            L16
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_15.validDouble (D)D
            L17
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -3102,9 +3124,11 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
            L19
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_15.validDouble (D)D
            L20
             DSTORE 2
             NEW java/lang/Double
@@ -3166,13 +3190,17 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L6
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_ceil_17.validDouble (D)D
            L7
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             INVOKESTATIC java/lang/StrictMath.ceil (D)D
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_ceil_17.validDouble (D)D
            L8
             DSTORE 2
             NEW java/lang/Double
@@ -4538,9 +4566,11 @@ procedure RANDOM-POSITION:[]{-T--}:
          L14
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L15
           LDC 2.0
          L16
@@ -4569,31 +4599,39 @@ procedure RANDOM-POSITION:[]{-T--}:
          L18
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L19
           LDC 2.0
          L20
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L21
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L22
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L23
           DCONST_1
          L24
@@ -4622,9 +4660,11 @@ procedure RANDOM-POSITION:[]{-T--}:
          L26
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L27
           LDC 2.0
          L28
@@ -4653,31 +4693,39 @@ procedure RANDOM-POSITION:[]{-T--}:
          L30
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L31
           LDC 2.0
          L32
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L33
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L34
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L35
           DSTORE 4
           DSTORE 2
@@ -4733,12 +4781,14 @@ procedure RANDOM-POSITION:[]{-T--}:
           LDC 360.0
          L4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setturtlevariable_1.validDouble (D)D
          L5
           DSTORE 2
           NEW java/lang/Double
@@ -6509,9 +6559,11 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
            L7
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DADD
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_16.validDouble (D)D
            L8
             DSTORE 2
             NEW java/lang/Double
@@ -6591,9 +6643,11 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
            L21
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_17.validDouble (D)D
            L5
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -6632,9 +6686,11 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
            L23
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_17.validDouble (D)D
            L10
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -6673,9 +6729,11 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
            L25
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_17.validDouble (D)D
            L26
             DSTORE 2
             DLOAD 2
@@ -6727,15 +6785,19 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L31
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_17.validDouble (D)D
            L32
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DADD
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_17.validDouble (D)D
            L33
             DSTORE 2
             NEW java/lang/Double
@@ -6834,9 +6896,11 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_setturtlevariable_19.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -6914,9 +6978,11 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
            L7
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DADD
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_20.validDouble (D)D
            L8
             DSTORE 2
             NEW java/lang/Double
@@ -6996,9 +7062,11 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
            L21
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_21.validDouble (D)D
            L5
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -7037,9 +7105,11 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
            L23
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_21.validDouble (D)D
            L10
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -7078,9 +7148,11 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
            L25
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_21.validDouble (D)D
            L26
             DSTORE 2
             DLOAD 2
@@ -7132,15 +7204,19 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L31
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_21.validDouble (D)D
            L32
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DADD
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_21.validDouble (D)D
            L33
             DSTORE 2
             NEW java/lang/Double
@@ -7561,12 +7637,14 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           LDC 360.0
          L1
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_5.validDouble (D)D
          L2
           DSTORE 2
           NEW java/lang/Double
@@ -7663,9 +7741,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L11
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_6.validDouble (D)D
          L12
           DSTORE 2
           DLOAD 2
@@ -7674,9 +7754,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L13
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_6.validDouble (D)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -7773,9 +7855,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L11
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_7.validDouble (D)D
          L12
           DSTORE 2
           DLOAD 2
@@ -7784,9 +7868,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L13
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_7.validDouble (D)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -7890,9 +7976,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L12
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_8.validDouble (D)D
          L13
           DSTORE 2
           DLOAD 2
@@ -7901,9 +7989,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L14
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_8.validDouble (D)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -8007,9 +8097,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L12
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_9.validDouble (D)D
          L13
           DSTORE 2
           DLOAD 2
@@ -8018,9 +8110,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L14
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_9.validDouble (D)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -8121,9 +8215,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L21
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (D)D
          L22
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -8175,15 +8271,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L26
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (D)D
          L27
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (D)D
          L11
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -8246,9 +8346,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L31
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (D)D
          L32
           DSTORE 4
           DSTORE 2
@@ -8266,9 +8368,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L33
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (D)D
          L34
           DSTORE 2
           NEW java/lang/Double
@@ -8324,9 +8428,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L7
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (D)D
          L8
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -8354,9 +8460,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -8412,9 +8520,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L7
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_12.validDouble (D)D
          L8
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -8442,9 +8552,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_12.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -8527,9 +8639,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
            L12
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_13.validDouble (D)D
            L13
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -8581,15 +8695,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
            L17
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_13.validDouble (D)D
            L18
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DADD
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_13.validDouble (D)D
            L19
             DSTORE 2
             DLOAD 2
@@ -8676,9 +8794,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
            L17
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_14.validDouble (D)D
            L5
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -8717,9 +8837,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
            L19
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_14.validDouble (D)D
            L10
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -8758,9 +8880,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
            L21
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_14.validDouble (D)D
            L22
             DSTORE 2
             NEW java/lang/Double
@@ -8978,20 +9102,24 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L23
           GOTO L20
          L21
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_16.validDouble (D)D
           LDC 360.0
           DREM
          L20
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_16.validDouble (D)D
          L24
           DSTORE 2
           NEW java/lang/Double
@@ -9201,9 +9329,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
            L12
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (D)D
            L13
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9255,15 +9385,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
            L17
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (D)D
            L18
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DADD
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (D)D
            L19
             DSTORE 2
             DLOAD 2
@@ -9471,9 +9605,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
            L17
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_21.validDouble (D)D
            L5
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -9512,9 +9648,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
            L19
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_21.validDouble (D)D
            L10
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -9553,9 +9691,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
            L21
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_21.validDouble (D)D
            L22
             DSTORE 2
             NEW java/lang/Double
@@ -9894,20 +10034,24 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L23
           GOTO L20
          L21
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_25.validDouble (D)D
           LDC 360.0
           DREM
          L20
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_25.validDouble (D)D
          L24
           DSTORE 2
           NEW java/lang/Double
@@ -10276,9 +10420,11 @@ procedure SETUP:[]{O---}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_3.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -10350,23 +10496,29 @@ procedure SETUP:[]{O---}:
          L9
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_4.validDouble (D)D
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_4.validDouble (D)D
          L11
           DCONST_1
          L12
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_4.validDouble (D)D
          L13
           DSTORE 2
           NEW java/lang/Double
@@ -10438,23 +10590,29 @@ procedure SETUP:[]{O---}:
          L9
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_5.validDouble (D)D
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_5.validDouble (D)D
          L11
           DCONST_1
          L12
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_5.validDouble (D)D
          L13
           DSTORE 2
           NEW java/lang/Double
@@ -11167,9 +11325,11 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefadepatches_setpatchvariable_4.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -11282,9 +11442,11 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           ATHROW
          L14
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ICONST_0
           INVOKESTATIC org/nlogo/api/Approximate.approximate (DI)D
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefadepatches_if_5.validDouble (D)D
          L15
           DCONST_0
          L16
@@ -11966,9 +12128,11 @@ procedure SETUP-PARTICLE:[]{-T--}:
            L17
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupparticle_mult_2.validDouble (D)D
            L5
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -12007,9 +12171,11 @@ procedure SETUP-PARTICLE:[]{-T--}:
            L19
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupparticle_mult_2.validDouble (D)D
            L10
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -12048,9 +12214,11 @@ procedure SETUP-PARTICLE:[]{-T--}:
            L21
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupparticle_mult_2.validDouble (D)D
            L22
             DSTORE 2
             NEW java/lang/Double
@@ -13179,9 +13347,11 @@ procedure MOVE:[OLD-PATCH]{-T--}:
          L13
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremove_jump_1.validDouble (D)D
          L14
           DSTORE 2
          L7
@@ -13315,9 +13485,11 @@ procedure MAKE-CLOCKER:[]{O---}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeclocker_setxy_3.validDouble (D)D
          L11
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -13346,9 +13518,11 @@ procedure MAKE-CLOCKER:[]{O---}:
          L14
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeclocker_setxy_3.validDouble (D)D
          L15
           DSTORE 4
           DSTORE 2
@@ -13605,13 +13779,17 @@ procedure SETUP-PLOTZ:[]{OTPL}:
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L6
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupplotz_ceil_2.validDouble (D)D
            L7
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             INVOKESTATIC java/lang/StrictMath.ceil (D)D
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupplotz_ceil_2.validDouble (D)D
            L8
             DSTORE 2
             NEW java/lang/Double
@@ -13831,8 +14009,10 @@ procedure CALCULATE-TICK-LENGTH:[]{OTPL}:
           ATHROW
          L8
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           INVOKESTATIC java/lang/StrictMath.ceil (D)D
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculateticklength_setobservervariable_2.validDouble (D)D
          L9
           DSTORE 4
           DSTORE 2
@@ -13850,9 +14030,11 @@ procedure CALCULATE-TICK-LENGTH:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L10
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculateticklength_setobservervariable_2.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double

--- a/test/benchdumps/GasLabOld.txt
+++ b/test/benchdumps/GasLabOld.txt
@@ -195,9 +195,11 @@ procedure GO:[]{O---}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_6.validDouble (D)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -729,9 +731,11 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
            L5
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_2.validDouble (D)D
            L6
             DSTORE 2
             NEW java/lang/Double
@@ -793,14 +797,18 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L6
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_round_4.validDouble (D)D
            L7
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             ICONST_0
             INVOKESTATIC org/nlogo/api/Approximate.approximate (DI)D
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_round_4.validDouble (D)D
            L8
             DSTORE 2
             NEW java/lang/Double
@@ -904,15 +912,19 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
            L10
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_13.validDouble (D)D
            L11
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_13.validDouble (D)D
            L12
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -941,15 +953,19 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
            L15
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_13.validDouble (D)D
            L16
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_13.validDouble (D)D
            L17
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -976,9 +992,11 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
            L19
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_13.validDouble (D)D
            L20
             DSTORE 2
             NEW java/lang/Double
@@ -1040,14 +1058,18 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L6
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_round_15.validDouble (D)D
            L7
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             ICONST_0
             INVOKESTATIC org/nlogo/api/Approximate.approximate (DI)D
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_round_15.validDouble (D)D
            L8
             DSTORE 2
             NEW java/lang/Double
@@ -1819,9 +1841,11 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
          L17
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0.validDouble (D)D
          L18
           DSTORE 3
           ASTORE 2
@@ -2182,9 +2206,11 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
          L17
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5.validDouble (D)D
          L18
           DSTORE 3
           ASTORE 2
@@ -2618,9 +2644,11 @@ procedure RANDOM-POSITION:[]{-T--}:
          L14
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L15
           LDC 2.0
          L16
@@ -2649,17 +2677,21 @@ procedure RANDOM-POSITION:[]{-T--}:
          L18
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L19
           LDC 2.0
          L20
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L21
           DSTORE 2
           ALOAD 0
@@ -2714,9 +2746,11 @@ procedure RANDOM-POSITION:[]{-T--}:
          L26
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L28
           DCONST_1
          L29
@@ -2745,9 +2779,11 @@ procedure RANDOM-POSITION:[]{-T--}:
          L31
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L32
           LDC 2.0
          L33
@@ -2776,17 +2812,21 @@ procedure RANDOM-POSITION:[]{-T--}:
          L35
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L36
           LDC 2.0
          L37
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L38
           DSTORE 2
           ALOAD 0
@@ -2841,9 +2881,11 @@ procedure RANDOM-POSITION:[]{-T--}:
          L43
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
          L45
           DSTORE 4
           DSTORE 2
@@ -3057,9 +3099,11 @@ procedure FADE:[]{-TP-}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefade_setpatchvariable_1.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -3135,9 +3179,11 @@ procedure FADE:[]{-TP-}:
           ATHROW
          L6
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ICONST_0
           INVOKESTATIC org/nlogo/api/Approximate.approximate (DI)D
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefade_if_2.validDouble (D)D
          L7
           LDC 40.0
          L8
@@ -3360,9 +3406,11 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
          L20
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setturtlevariable_2.validDouble (D)D
          L5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -3401,9 +3449,11 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
          L22
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setturtlevariable_2.validDouble (D)D
          L10
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -3442,9 +3492,11 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
          L24
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setturtlevariable_2.validDouble (D)D
          L25
           DSTORE 2
           NEW java/lang/Double
@@ -4394,14 +4446,18 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
          L7
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_12.validDouble (D)D
          L8
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ICONST_0
           INVOKESTATIC org/nlogo/api/Approximate.approximate (DI)D
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_12.validDouble (D)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -4611,9 +4667,11 @@ procedure BOUNCE:[]{-T--}:
          L30
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_if_0.validDouble (D)D
          L31
           DSTORE 4
           DSTORE 2
@@ -4708,9 +4766,11 @@ procedure BOUNCE:[]{-T--}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_setturtlevariable_1.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -4905,9 +4965,11 @@ procedure BOUNCE:[]{-T--}:
          L30
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_if_2.validDouble (D)D
          L31
           DSTORE 4
           DSTORE 2
@@ -4977,9 +5039,11 @@ procedure BOUNCE:[]{-T--}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_setturtlevariable_3.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -5064,9 +5128,11 @@ procedure SETUP:[]{O---}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_0.validDouble (D)D
          L9
           LDC 100.0
          L10
@@ -5086,14 +5152,18 @@ procedure SETUP:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_0.validDouble (D)D
          L12
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ICONST_0
           INVOKESTATIC org/nlogo/api/Approximate.approximate (DI)D
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_0.validDouble (D)D
          L13
           DSTORE 2
           NEW java/lang/Double
@@ -7954,9 +8024,11 @@ procedure MOVE:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L14
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremove_jump_0.validDouble (D)D
          L15
           DSTORE 2
          L7
@@ -8804,9 +8876,11 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
          L16
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_1.validDouble (D)D
          L17
           DSTORE 2
           DLOAD 2
@@ -8815,9 +8889,11 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
          L18
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_1.validDouble (D)D
          L19
           DSTORE 2
           NEW java/lang/Double
@@ -8940,9 +9016,11 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
          L16
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_2.validDouble (D)D
          L17
           DSTORE 2
           DLOAD 2
@@ -8951,9 +9029,11 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
          L18
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_2.validDouble (D)D
          L19
           DSTORE 2
           NEW java/lang/Double
@@ -9107,9 +9187,11 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
          L21
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_3.validDouble (D)D
          L22
           DSTORE 2
           DLOAD 2
@@ -9118,9 +9200,11 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
          L23
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_3.validDouble (D)D
          L24
           DSTORE 2
           NEW java/lang/Double
@@ -9274,9 +9358,11 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
          L21
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_4.validDouble (D)D
          L22
           DSTORE 2
           DLOAD 2
@@ -9285,9 +9371,11 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
          L23
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_4.validDouble (D)D
          L24
           DSTORE 2
           NEW java/lang/Double
@@ -9416,9 +9504,11 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
          L32
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setprocedurevariable_5.validDouble (D)D
          L10
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -9492,15 +9582,19 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
          L35
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setprocedurevariable_5.validDouble (D)D
          L36
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setprocedurevariable_5.validDouble (D)D
          L20
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -9574,9 +9668,11 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
          L39
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setprocedurevariable_5.validDouble (D)D
          L40
           DSTORE 4
           DSTORE 2
@@ -9594,9 +9690,11 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L41
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setprocedurevariable_5.validDouble (D)D
          L42
           DSTORE 2
           NEW java/lang/Double
@@ -9677,9 +9775,11 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
          L16
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_6.validDouble (D)D
          L4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -9718,9 +9818,11 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
          L18
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_6.validDouble (D)D
          L19
           DSTORE 2
           NEW java/lang/Double
@@ -9814,9 +9916,11 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
          L16
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_7.validDouble (D)D
          L4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -9855,9 +9959,11 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
          L18
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_7.validDouble (D)D
          L19
           DSTORE 2
           NEW java/lang/Double
@@ -9991,9 +10097,11 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L25
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_0.validDouble (D)D
          L10
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -10067,15 +10175,19 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L28
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_0.validDouble (D)D
          L29
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_0.validDouble (D)D
          L30
           DSTORE 2
           DLOAD 2
@@ -10450,20 +10562,24 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L29
           GOTO L26
          L27
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_2.validDouble (D)D
           LDC 360.0
           DREM
          L26
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_2.validDouble (D)D
          L30
           DSTORE 2
           NEW java/lang/Double
@@ -10706,9 +10822,11 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L20
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_5.validDouble (D)D
          L5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -10830,20 +10948,24 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L31
           GOTO L28
          L29
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_5.validDouble (D)D
           LDC 360.0
           DREM
          L28
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_5.validDouble (D)D
          L32
           DSTORE 2
           NEW java/lang/Double
@@ -11086,9 +11208,11 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L20
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_8.validDouble (D)D
          L5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -11210,20 +11334,24 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L31
           GOTO L28
          L29
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_8.validDouble (D)D
           LDC 360.0
           DREM
          L28
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_8.validDouble (D)D
          L32
           DSTORE 2
           NEW java/lang/Double
@@ -11580,20 +11708,24 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L29
           GOTO L26
          L27
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_11.validDouble (D)D
           LDC 360.0
           DREM
          L26
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_11.validDouble (D)D
          L30
           DSTORE 2
           NEW java/lang/Double
@@ -11715,9 +11847,11 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L22
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setprocedurevariable_12.validDouble (D)D
          L10
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -11791,15 +11925,19 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L25
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setprocedurevariable_12.validDouble (D)D
          L26
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setprocedurevariable_12.validDouble (D)D
          L27
           DSTORE 2
           DLOAD 2
@@ -12329,20 +12467,24 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L29
           GOTO L26
          L27
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_17.validDouble (D)D
           LDC 360.0
           DREM
          L26
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_17.validDouble (D)D
          L30
           DSTORE 2
           NEW java/lang/Double
@@ -12585,9 +12727,11 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L20
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_20.validDouble (D)D
          L5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -12709,20 +12853,24 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L31
           GOTO L28
          L29
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_20.validDouble (D)D
           LDC 360.0
           DREM
          L28
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_20.validDouble (D)D
          L32
           DSTORE 2
           NEW java/lang/Double
@@ -12965,9 +13113,11 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L20
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_23.validDouble (D)D
          L5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -13089,20 +13239,24 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L31
           GOTO L28
          L29
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_23.validDouble (D)D
           LDC 360.0
           DREM
          L28
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_23.validDouble (D)D
          L32
           DSTORE 2
           NEW java/lang/Double
@@ -13459,20 +13613,24 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L29
           GOTO L26
          L27
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_26.validDouble (D)D
           LDC 360.0
           DREM
          L26
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_26.validDouble (D)D
          L30
           DSTORE 2
           NEW java/lang/Double

--- a/test/benchdumps/Heatbugs.txt
+++ b/test/benchdumps/Heatbugs.txt
@@ -335,15 +335,19 @@ procedure RECOLOR-PATCHES:[]{OTPL}:
          L14
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorpatches_setpatchvariable_1.validDouble (D)D
          L15
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorpatches_setpatchvariable_1.validDouble (D)D
          L16
           DSTORE 2
           NEW java/lang/Double
@@ -842,9 +846,11 @@ procedure STEP:[TARGET]{-T--}:
          L15
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurestep_setturtlevariable_0.validDouble (D)D
          L16
           DSTORE 2
           DLOAD 2
@@ -1022,9 +1028,11 @@ procedure STEP:[TARGET]{-T--}:
          L15
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurestep_setpatchvariable_2.validDouble (D)D
          L16
           DSTORE 2
           NEW java/lang/Double
@@ -1313,9 +1321,11 @@ procedure STEP:[TARGET]{-T--}:
          L15
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurestep_setpatchvariable_7.validDouble (D)D
          L16
           DSTORE 2
           NEW java/lang/Double
@@ -1541,9 +1551,11 @@ procedure BUG-MOVE:[TARGET TRIES]{-T--}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebugmove_setprocedurevariable_6.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -2097,9 +2109,11 @@ procedure SETUP:[]{O---}:
          L15
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_6.validDouble (D)D
          L16
           DSTORE 2
           DLOAD 2
@@ -2165,9 +2179,11 @@ procedure SETUP:[]{O---}:
          L23
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_6.validDouble (D)D
          L25
           DSTORE 2
           NEW java/lang/Double
@@ -2283,9 +2299,11 @@ procedure SETUP:[]{O---}:
          L15
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_7.validDouble (D)D
          L16
           DSTORE 2
           DLOAD 2
@@ -2351,9 +2369,11 @@ procedure SETUP:[]{O---}:
          L23
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_7.validDouble (D)D
          L25
           DSTORE 2
           NEW java/lang/Double
@@ -2468,9 +2488,11 @@ procedure SETUP:[]{O---}:
          L15
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_8.validDouble (D)D
          L16
           DSTORE 2
           DLOAD 2

--- a/test/benchdumps/Ising.txt
+++ b/test/benchdumps/Ising.txt
@@ -624,9 +624,11 @@ procedure UPDATE:[EDIFF]{-TP-}:
          L7
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0.validDouble (D)D
          L8
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -700,9 +702,11 @@ procedure UPDATE:[EDIFF]{-TP-}:
          L14
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0.validDouble (D)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -846,12 +850,14 @@ procedure UPDATE:[EDIFF]{-TP-}:
           DCONST_1
          L21
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_if_1.validDouble (D)D
          L22
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -920,13 +926,17 @@ procedure UPDATE:[EDIFF]{-TP-}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L28
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_if_1.validDouble (D)D
          L29
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           INVOKESTATIC java/lang/StrictMath.exp (D)D
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_if_1.validDouble (D)D
          L30
           DSTORE 4
           DSTORE 2
@@ -1517,9 +1527,11 @@ procedure MAGNETIZATION:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L7
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremagnetization_report_0.validDouble (D)D
          L8
           DSTORE 2
           NEW java/lang/Double
@@ -1751,15 +1763,19 @@ procedure FLIP:[]{-TP-}:
          L14
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflip_setobservervariable_1.validDouble (D)D
          L15
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflip_setobservervariable_1.validDouble (D)D
          L16
           DSTORE 2
           NEW java/lang/Double

--- a/test/benchdumps/Life.txt
+++ b/test/benchdumps/Life.txt
@@ -678,12 +678,14 @@ procedure SETUP-RANDOM:[]{O---}:
           DCONST_1
          L1
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuprandom_ifelse_1.validDouble (D)D
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;

--- a/test/benchdumps/PrefAttach.txt
+++ b/test/benchdumps/PrefAttach.txt
@@ -931,12 +931,14 @@ procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
           INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindpartner_setprocedurevariable_0.validDouble (D)D
          L7
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindpartner_setprocedurevariable_0.validDouble (D)D
          L8
           DSTORE 2
           NEW java/lang/Double
@@ -1306,9 +1308,11 @@ procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindpartner_setprocedurevariable_11.validDouble (D)D
          L9
           DSTORE 2
           NEW java/lang/Double

--- a/test/benchdumps/Team.txt
+++ b/test/benchdumps/Team.txt
@@ -591,9 +591,11 @@ procedure GO:[]{O---}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setturtlevariable_15.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -1922,12 +1924,14 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           LDC 100.0
          L1
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepickteammembers_ifelse_2.validDouble (D)D
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -2247,12 +2251,14 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           LDC 100.0
          L1
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6.validDouble (D)D
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -3742,9 +3748,11 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L9
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_12.validDouble (D)D
          L10
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -3754,9 +3762,11 @@ procedure SETUP:[_repeatlocal:0]{O---}:
          L11
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_12.validDouble (D)D
          L12
           DSTORE 2
           NEW java/lang/Double
@@ -4102,9 +4112,11 @@ procedure EXPLORE:[]{-T--}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureexplore_setobservervariable_3.validDouble (D)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -4469,9 +4481,11 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_5.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -4729,9 +4743,11 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_12.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -4989,9 +5005,11 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_19.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -5249,9 +5267,11 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_26.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -5416,9 +5436,11 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L7
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_div_33.validDouble (D)D
            L8
             DSTORE 2
             NEW java/lang/Double

--- a/test/benchdumps/Termites.txt
+++ b/test/benchdumps/Termites.txt
@@ -1315,9 +1315,11 @@ procedure WIGGLE:[]{-T--}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurewiggle_setturtlevariable_1.validDouble (D)D
          L6
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -1328,9 +1330,11 @@ procedure WIGGLE:[]{-T--}:
          L7
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurewiggle_setturtlevariable_1.validDouble (D)D
          L8
           DSTORE 2
           NEW java/lang/Double

--- a/test/benchdumps/VirusNet.txt
+++ b/test/benchdumps/VirusNet.txt
@@ -300,9 +300,11 @@ procedure GO:[]{O---}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setturtlevariable_4.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -735,9 +737,11 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_setprocedurevariable_0.validDouble (D)D
          L9
           LDC 2.0
          L10
@@ -757,9 +761,11 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_setprocedurevariable_0.validDouble (D)D
          L12
           DSTORE 2
           NEW java/lang/Double
@@ -1455,9 +1461,11 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L8
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_div_16.validDouble (D)D
            L9
             DSTORE 2
             NEW java/lang/Double
@@ -2927,17 +2935,21 @@ procedure UPDATE-PLOT:[]{OTPL}:
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L9
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_2.validDouble (D)D
            L10
             LDC 100.0
            L11
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_2.validDouble (D)D
            L12
             DSTORE 2
             NEW java/lang/Double
@@ -3081,17 +3093,21 @@ procedure UPDATE-PLOT:[]{OTPL}:
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L9
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_5.validDouble (D)D
            L10
             LDC 100.0
            L11
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_5.validDouble (D)D
            L12
             DSTORE 2
             NEW java/lang/Double
@@ -3235,17 +3251,21 @@ procedure UPDATE-PLOT:[]{OTPL}:
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L9
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_8.validDouble (D)D
            L10
             LDC 100.0
            L11
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_8.validDouble (D)D
            L12
             DSTORE 2
             NEW java/lang/Double
@@ -3651,12 +3671,14 @@ procedure SPREAD-VIRUS:[]{OTPL}:
           LDC 100.0
          L1
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurespreadvirus_if_4.validDouble (D)D
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -3819,9 +3841,11 @@ procedure SETUP-NODES:[]{O---}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnodes_setxy_3.validDouble (D)D
          L6
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupnodes_setxy_3.world : Lorg/nlogo/agent/World;
@@ -3852,9 +3876,11 @@ procedure SETUP-NODES:[]{O---}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnodes_setxy_3.validDouble (D)D
          L9
           DSTORE 4
           DSTORE 2

--- a/test/benchdumps/Wealth.txt
+++ b/test/benchdumps/Wealth.txt
@@ -276,9 +276,11 @@ procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
          L19
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3.validDouble (D)D
          L20
           DSTORE 2
           NEW java/lang/Double
@@ -331,9 +333,11 @@ procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_5.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -1387,12 +1391,14 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           LDC 100.0
          L1
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuppatches_if_2.validDouble (D)D
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -3437,15 +3443,19 @@ procedure AREA-OF-EQUALITY-TRIANGLE:[]{OTPL}:
          L11
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureareaofequalitytriangle_report_0.validDouble (D)D
          L12
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureareaofequalitytriangle_report_0.validDouble (D)D
          L13
           LDC 2.0
          L14
@@ -3465,9 +3475,11 @@ procedure AREA-OF-EQUALITY-TRIANGLE:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L15
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureareaofequalitytriangle_report_0.validDouble (D)D
          L16
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -3518,9 +3530,11 @@ procedure AREA-OF-EQUALITY-TRIANGLE:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L21
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureareaofequalitytriangle_report_0.validDouble (D)D
          L22
           DSTORE 2
           NEW java/lang/Double
@@ -3970,9 +3984,11 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L9
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorturtles_ifelse_3.validDouble (D)D
          L10
           DSTORE 3
           ASTORE 2
@@ -4122,9 +4138,11 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorturtles_ifelse_6.validDouble (D)D
          L9
           LDC 3.0
          L10
@@ -4144,9 +4162,11 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorturtles_ifelse_6.validDouble (D)D
          L12
           DSTORE 3
           ASTORE 2
@@ -4390,9 +4410,11 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
          L15
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremoveeatagedie_setturtlevariable_1.validDouble (D)D
          L16
           DSTORE 2
           NEW java/lang/Double
@@ -4471,9 +4493,11 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremoveeatagedie_setturtlevariable_2.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -5399,9 +5423,11 @@ procedure GROW-GRAIN:[]{-TP-}:
          L13
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregrowgrain_setpatchvariable_1.validDouble (D)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -6027,9 +6053,11 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_1.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -6147,17 +6175,21 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
          L15
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_2.validDouble (D)D
          L16
           DCONST_1
          L17
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_2.validDouble (D)D
          L18
           DSTORE 2
           ALOAD 0
@@ -6212,9 +6244,11 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
          L23
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_2.validDouble (D)D
          L25
           DSTORE 2
           NEW java/lang/Double
@@ -6332,9 +6366,11 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
          L13
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_3.validDouble (D)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -6418,9 +6454,11 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_4.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -6538,9 +6576,11 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
          L13
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_5.validDouble (D)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -6663,9 +6703,11 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L6
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_div_5.validDouble (D)D
            L7
             DSTORE 2
             NEW java/lang/Double
@@ -7154,9 +7196,11 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
          L7
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_13.validDouble (D)D
          L8
           DSTORE 2
           NEW java/lang/Double
@@ -7248,17 +7292,21 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L9
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_mult_16.validDouble (D)D
            L10
             LDC 100.0
            L11
             DSTORE 4
             DSTORE 2
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DMUL
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_mult_16.validDouble (D)D
            L12
             DSTORE 2
             NEW java/lang/Double
@@ -7300,9 +7348,11 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
          L5
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_17.validDouble (D)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -7427,15 +7477,19 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L17
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_18.validDouble (D)D
          L18
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_18.validDouble (D)D
          L19
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7501,15 +7555,19 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L24
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_18.validDouble (D)D
          L25
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_18.validDouble (D)D
          L26
           DSTORE 2
           NEW java/lang/Double
@@ -7637,9 +7695,11 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L11
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_div_21.validDouble (D)D
            L12
             NEW org/nlogo/nvm/Activation
             DUP
@@ -7696,9 +7756,11 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L15
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_div_21.validDouble (D)D
            L16
             DSTORE 2
             NEW java/lang/Double
@@ -7945,15 +8007,19 @@ procedure HARVEST:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L20
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureharvest_setturtlevariable_1.validDouble (D)D
          L21
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureharvest_setturtlevariable_1.validDouble (D)D
          L22
           DSTORE 2
           DLOAD 2

--- a/test/benchdumps/Wolf.txt
+++ b/test/benchdumps/Wolf.txt
@@ -173,9 +173,11 @@ procedure GO:[]{O---}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setturtlevariable_3.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -385,9 +387,11 @@ procedure GO:[]{O---}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setturtlevariable_10.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -948,12 +952,14 @@ procedure REPRODUCE-WOLVES:[]{-T--}:
           LDC 100.0
          L1
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducewolves_if_0.validDouble (D)D
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -1075,14 +1081,18 @@ procedure REPRODUCE-WOLVES:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducewolves_setturtlevariable_1.validDouble (D)D
          L12
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ICONST_0
           INVOKESTATIC org/nlogo/api/Approximate.approximate (DI)D
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducewolves_setturtlevariable_1.validDouble (D)D
          L13
           DSTORE 2
           NEW java/lang/Double
@@ -1187,12 +1197,14 @@ procedure REPRODUCE-SHEEP:[]{-T--}:
           LDC 100.0
          L1
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducesheep_if_0.validDouble (D)D
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -1314,14 +1326,18 @@ procedure REPRODUCE-SHEEP:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DDIV
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducesheep_setturtlevariable_1.validDouble (D)D
          L12
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ICONST_0
           INVOKESTATIC org/nlogo/api/Approximate.approximate (DI)D
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducesheep_setturtlevariable_1.validDouble (D)D
          L13
           DSTORE 2
           NEW java/lang/Double
@@ -1771,9 +1787,11 @@ procedure GRAPH:[]{OTPL}:
             INVOKESPECIAL org/nlogo/nvm/EngineException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
            L8
+            ALOAD 0
             DLOAD 2
             DLOAD 4
             DDIV
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregraph_div_6.validDouble (D)D
            L9
             DSTORE 2
             NEW java/lang/Double
@@ -2043,9 +2061,11 @@ procedure GROW-GRASS:[]{-TP-}:
          L10
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregrowgrass_setpatchvariable_5.validDouble (D)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -2584,17 +2604,21 @@ procedure SETUP:[]{O---}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_12.validDouble (D)D
          L9
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_12.validDouble (D)D
          L10
           DSTORE 2
           NEW java/lang/Double
@@ -2957,17 +2981,21 @@ procedure SETUP:[]{O---}:
          L8
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_19.validDouble (D)D
          L9
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/util/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/util/MersenneTwisterFast.nextDouble ()D
           DMUL
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_19.validDouble (D)D
          L10
           DSTORE 2
           NEW java/lang/Double
@@ -3291,9 +3319,11 @@ procedure MOVE:[]{-T--}:
          L2
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DSUB
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremove_right_0.validDouble (D)D
          L3
           DSTORE 2
           ALOAD 1
@@ -3720,9 +3750,11 @@ procedure CATCH-SHEEP:[]{-T--}:
          L13
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecatchsheep_setturtlevariable_5.validDouble (D)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -3919,9 +3951,11 @@ procedure EAT-GRASS:[]{-T--}:
          L13
           DSTORE 4
           DSTORE 2
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           DADD
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureeatgrass_setturtlevariable_2.validDouble (D)D
          L14
           DSTORE 2
           NEW java/lang/Double


### PR DESCRIPTION
Fix for #895 
There is a validDouble check in `dz` but not in `dy` and `dx`. Any specific reason?
The list is as follows now: (crossed out items have validDouble checks)
* count
* `countother`
* `countotherwith`
* `countwith`
* ~~`minus`~~
* ~~`nsum`~~ (already had the check)
* ~~`nsum4`~~ (already had the check)
* `patchvariabledouble`
* ~~`plus`~~
* `random`
* `randomconst`
* ~~`sum`~~ (already had the check)
* `turtlevariabledouble`
* `unaryminus`
* `randomorrandomfloat`
* `abs`
* ~~`acos`~~ (already had the check)
* ~~`approximatehsb`~~
* ~~`approximatehsbold`~~
* ~~`approximatergb`~~ (already had the check)
* ~~`asin`~~  (already had the check)
* ~~`atan`~~ Review this
* `behaviorspacerunnumber`
* ~~`ceil`~~
* ~~`cos`~~
* `distance`
* `distancenowrap`
* ~~`distancexy`~~
* ~~`distancexynowrap`~~
* ~~`div`~~
* `dx`
* `dy`
* ~~`exp`~~
* `floor`
* `int`
* `length`
* `linkheading`
* `linklength`
* ~~`ln`~~  (already had the check)
* ~~`log`~~  (already had the check)
* `max`
* `maxpxcor`
* `maxpycor`
* ~~`mean`~~  (already had the check)
* ~~`median`~~  (already had the check)
* `min`
* `minpxcor`
* `minpycor`
* `mod`
* `monitorprecision`
* ~~`mult`~~
* `nanotime`
* `newseed`
* `patchsize`
* `position`
* ~~`pow`~~  (already had the check)
* `precision`
* `processors`
* ~~`randomexponential`~~  (already had the check)
* ~~`randomfloat`~~
* ~~`randomgamma`~~  (already had the check)
* ~~`randomnormal`~~  (already had the check)
* `randompoisson`
* `randompxcor`
* `randompycor`
* `readfromstring`
* ~~`remainder`~~  (already had the check)
* ~~`round`~~
* ~~`scalecolor`~~  (already had the check)
* `sin`
* `sqrt`
* ~~`standarddeviation`~~  (already had the check)
* `subtractheadings`
* ~~`tan`~~  (already had the check)
* `ticks`
* `timer`
* ~~`towards`~~  (already had the check)
* ~~`towardsnowrap`~~  (already had the check)
* ~~`towardsxy`~~  (already had the check)
* ~~`towardsxynowrap`~~  (already had the check)
* ~~`variance`~~  (already had the check)
* `worldheight`
* `worldwidth`
* `wrapcolor`
* `fileread`
* `mousexcor`
* `mouseycor`
* `hubnetinqsize`
* `hubnetoutqsize`
* `plotxmax`
* `plotxmin`
* `plotymax`
* `plotymin`
* ~~`distancexyz`~~  (already had the check)
* ~~`distancexyznowrap`~~  (already had the check)
* `dz`
* ~~`linkpitch`~~
* `maxpzcor`
* `minpzcor`
* `oheading`
* `opitch`
* `oroll`
* `oxcor`
* `oycor`
* `ozcor`
* `randompzcor`
* `randomzcor`
* ~~`towardspitch`~~  (already had the check)
* ~~`towardspitchnowrap`~~  (already had the check)
* ~~`towardspitchxyz`~~  (already had the check)
* ~~`towardspitchxyznowrap`~~  (already had the check)
* `worlddepth`
