### PR TITLE
Median not overflowing unnecessarily

### DIFF
--- a/src/main/org/nlogo/prim/etc/_median.java
+++ b/src/main/org/nlogo/prim/etc/_median.java
@@ -43,8 +43,7 @@ public final strictfp class _median
     }
     Double middle1 = nums.get(medianPos - 1);
     Double middle2 = nums.get(medianPos);
-    return newValidDouble
-        ((middle1.doubleValue() + middle2.doubleValue()) / 2);
+    return newValidDouble(middle1.doubleValue() / 2 + middle2.doubleValue() / 2);
   }
 
   @Override


### PR DESCRIPTION
Similar to #972 
But the fix is easy in this case.
Also removed the `validDouble()` check as `Double / 2 + Double / 2` should be(?) a valid Double.