### PR TITLE
symlink are resolved once

### DIFF
--- a/dist/hubnet.sh
+++ b/dist/hubnet.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
-cd "`dirname "$0"`"             # the copious quoting is for handling paths with spaces
-# -Xmx1024m                     use up to 1GB RAM (edit to increase)
-# -classpath NetLogo.jar        specify main jar (HubNet.jar is only for the client applet)
-# -Dfile.encoding=UTF-8         ensure Unicode characters in model files are compatible cross-platform
-# org.nlogo.hubnet.client.App   specify the client
-# "$@"                          pass along any command line arguments
+DIR="$(dirname "$(readlink $0)")" # the copious quoting is for handling paths with spaces
+cd $DIR
+# -Xmx1024m                       use up to 1GB RAM (edit to increase)
+# -classpath NetLogo.jar          specify main jar (HubNet.jar is only for the client applet)
+# -Dfile.encoding=UTF-8           ensure Unicode characters in model files are compatible cross-platform
+# org.nlogo.hubnet.client.App     specify the client
+# "$@"                            pass along any command line arguments
 java -Xmx1024m -classpath NetLogo.jar -Dfile.encoding=UTF-8 org.nlogo.hubnet.client.App "$@"

--- a/dist/netlogo-3D.sh
+++ b/dist/netlogo-3D.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
-cd "`dirname "$0"`"             # the copious quoting is for handling paths with spaces
-# -Djava.library.path=./lib     ensure JOGL can find native libraries
-# -Djava.ext.dir=               ignore any existing JOGL installation
-# -XX:MaxPermSize=128m          avoid OutOfMemory errors for large models
-# -Xmx1024m                     use up to 1GB RAM (edit to increase)
-# -Dfile.encoding=UTF-8         ensure Unicode characters in model files are compatible cross-platform
-# -Dorg.nlogo.is3d=true         run 3D NetLogo
-# -jar NetLogo.jar              specify main jar
-# "$@"                          pass along any command line arguments
+DIR="$(dirname "$(readlink $0)")" # the copious quoting is for handling paths with spaces
+cd $DIR
+# -Djava.library.path=./lib       ensure JOGL can find native libraries
+# -Djava.ext.dir=                 ignore any existing JOGL installation
+# -XX:MaxPermSize=128m            avoid OutOfMemory errors for large models
+# -Xmx1024m                       use up to 1GB RAM (edit to increase)
+# -Dfile.encoding=UTF-8           ensure Unicode characters in model files are compatible cross-platform
+# -Dorg.nlogo.is3d=true           run 3D NetLogo
+# -jar NetLogo.jar                specify main jar
+# "$@"                            pass along any command line arguments
 java -Djava.library.path=./lib -Djava.ext.dir= -XX:MaxPermSize=128m -Xmx1024m -Dfile.encoding=UTF-8 -Dorg.nlogo.is3d=true -jar NetLogo.jar "$@"

--- a/dist/netlogo-headless.sh
+++ b/dist/netlogo-headless.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
-cd "`dirname "$0"`"             # the copious quoting is for handling paths with spaces
-# -Xmx1024m                     use up to 1GB RAM (edit to increase)
-# -Dfile.encoding=UTF-8         ensure Unicode characters in model files are compatible cross-platform
-# -classpath NetLogo.jar        specify main jar
-# org.nlogo.headless.Main       specify we want headless, not GUI
-# "$@"                          pass along any command line arguments
+DIR="$(dirname "$(readlink $0)")" # the copious quoting is for handling paths with spaces
+cd $DIR
+# -Xmx1024m                       use up to 1GB RAM (edit to increase)
+# -Dfile.encoding=UTF-8           ensure Unicode characters in model files are compatible cross-platform
+# -classpath NetLogo.jar          specify main jar
+# org.nlogo.headless.Main         specify we want headless, not GUI
+# "$@"                            pass along any command line arguments
 java -Xmx1024m -Dfile.encoding=UTF-8 -classpath NetLogo.jar org.nlogo.headless.Main "$@"

--- a/dist/netlogo.sh
+++ b/dist/netlogo.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
-cd "`dirname "$0"`"             # the copious quoting is for handling paths with spaces
-# -Djava.library.path=./lib     ensure JOGL can find native libraries
-# -Djava.ext.dirs=              ignore any existing JOGL installation
-# -XX:MaxPermSize=128m          avoid OutOfMemory errors for large models
-# -Xmx1024m                     use up to 1GB RAM (edit to increase)
-# -Dfile.encoding=UTF-8         ensure Unicode characters in model files are compatible cross-platform
-# -jar NetLogo.jar              specify main jar
-# "$@"                          pass along any command line arguments
+DIR="$(dirname "$(readlink $0)")" # the copious quoting is for handling paths with spaces
+cd $DIR
+# -Djava.library.path=./lib       ensure JOGL can find native libraries
+# -Djava.ext.dirs=                ignore any existing JOGL installation
+# -XX:MaxPermSize=128m            avoid OutOfMemory errors for large models
+# -Xmx1024m                       use up to 1GB RAM (edit to increase)
+# -Dfile.encoding=UTF-8           ensure Unicode characters in model files are compatible cross-platform
+# -jar NetLogo.jar                specify main jar
+# "$@"                            pass along any command line arguments
 java -Djava.library.path=./lib -Djava.ext.dirs= -XX:MaxPermSize=128m -Xmx1024m -Dfile.encoding=UTF-8 -jar NetLogo.jar "$@"


### PR DESCRIPTION
Fix for #43
The symlink to the script is resolve once.
Can't use `readlink -f` as `-f` is not available on OS X. But still `readlink` will resolve the symlink once.  