### PR TITLE
Regression: Mismatched braces cause error in 6.0

### DIFF
--- a/parser-core/src/main/parse/LetScoper.scala
+++ b/parser-core/src/main/parse/LetScoper.scala
@@ -108,7 +108,10 @@ class LetScoper(usedNames: Map[String, String]) {
     def get(name: String): Option[Let] =
       lets.flatten.find(_.name == name)
     def pop(): Unit =
-      lets = lets.tail
+      lets = lets match {
+        case Nil => Nil
+        case hd::tail => tail
+      }
     def used: Map[String, String] =
       lets.flatten
         .map(_.name -> "local variable here")

--- a/parser-core/src/test/parse/FrontEndTests.scala
+++ b/parser-core/src/test/parse/FrontEndTests.scala
@@ -69,8 +69,8 @@ class FrontEndTests extends FunSuite {
   def doFailure(input: String, message: String, start: Int, end: Int) {
     val e = intercept[CompilerException] { compile(input) }
     assertResult(message)(e.getMessage)
-    assertResult(start + PREAMBLE.length)(e.start)
-    assertResult(end + PREAMBLE.length)(e.end)
+    assertResult(start)(e.start - PREAMBLE.length)
+    assertResult(end)(e.end - PREAMBLE.length)
   }
 
   /// now, the actual tests
@@ -96,6 +96,9 @@ class FrontEndTests extends FunSuite {
   }
   test("WrongArgumentType") {
     runFailure("__ignore count 0", "COUNT expected this input to be an agentset, but got a number instead", 15, 16)
+  }
+  test("tooManyCloseBrackets") {
+    runFailure("ask turtles [ fd 1 ] ] ]", "Expected command.", 21, 22)
   }
   test("missingCloseBracket") {
     // You could argue that it ought to point to the second bracket and not the first, but this is


### PR DESCRIPTION
Sample code:
```NetLogo
to go
  ask patches []]]
end
```