### PR TITLE
Merged the comment uncomment into one.

### DIFF
--- a/src/main/org/nlogo/app/EditMenu.scala
+++ b/src/main/org/nlogo/app/EditMenu.scala
@@ -40,8 +40,7 @@ with org.nlogo.window.Events.LoadSectionEvent.Handler
   addMenuItem(I18N.gui("shiftRight"), ']', org.nlogo.editor.Actions.shiftRightAction)
   addMenuItem(I18N.gui("format"), (java.awt.event.KeyEvent.VK_TAB).toChar, org.nlogo.editor.Actions.tabKeyAction, false)
   addSeparator()
-  addMenuItem(I18N.gui("comment"), ';', org.nlogo.editor.Actions.commentAction)
-  addMenuItem(I18N.gui("uncomment"), ';', true, org.nlogo.editor.Actions.uncommentAction)
+  addMenuItem(I18N.gui("comment") + " / " + I18N.gui("uncomment"), ';', org.nlogo.editor.Actions.commentToggleAction)
   addSeparator()
   snapper = addCheckBoxMenuItem(I18N.gui("snapToGrid"), app.workspace.snapOn(), snapAction)
 

--- a/src/main/org/nlogo/editor/Actions.scala
+++ b/src/main/org/nlogo/editor/Actions.scala
@@ -9,8 +9,7 @@ import javax.swing.text.DefaultEditorKit.{CutAction, CopyAction, PasteAction, In
 
 object Actions {
 
-  val commentAction = new CommentAction()
-  val uncommentAction = new UncommentAction()
+  val commentToggleAction = new CommentToggleAction()
   val shiftLeftAction = new ShiftLeftAction()
   val shiftRightAction = new ShiftRightAction()
   val tabKeyAction = new TabKeyAction()
@@ -26,13 +25,12 @@ object Actions {
   val SELECT_ALL_ACTION = getDefaultEditorKitAction(DefaultEditorKit.selectAllAction)
 
   def setEnabled(enabled:Boolean){
-    List(commentAction,uncommentAction,shiftLeftAction,shiftRightAction).foreach(_.setEnabled(enabled))
+    List(commentToggleAction,shiftLeftAction,shiftRightAction).foreach(_.setEnabled(enabled))
   }
 
   class TabKeyAction extends MyTextAction("tab-key", _.indentSelection() )
   class ShiftTabKeyAction extends MyTextAction("shift-tab-key", e => { e.shiftLeft(); e.shiftLeft() })
-  class CommentAction extends MyTextAction("comment-line", _.insertBeforeEachSelectedLine(";"))
-  class UncommentAction extends MyTextAction("uncomment-line", _.uncomment())
+  class CommentToggleAction extends MyTextAction("toggle-comment", _.toggleComment())
   class ShiftLeftAction extends MyTextAction("shift-line-left", _.shiftLeft() )
   class ShiftRightAction extends MyTextAction("shift-line-right", _.insertBeforeEachSelectedLine(" ") )
   def quickHelpAction(colorizer: Colorizer[_], i18n: String => String) =


### PR DESCRIPTION
In most of the editors there are no separate shortcuts for comment uncomment.
There is a single shortcut that toggles the line. This is implemented in the PR.
If multiple lines are selected then all are commented(one more `;`) if even a single one is not already commented(this is the behavior that i found in eclipse, intelliJ, etc.).
I have changed the language files but would need someone to contribute to them(or should i just google the translation and put it?).