### PR TITLE
M5: Compiling <breeds>-own for a nonexistent breed throws an exception

### DIFF
--- a/netlogo-gui/project/autogen/i18n/Errors_en.txt
+++ b/netlogo-gui/project/autogen/i18n/Errors_en.txt
@@ -186,3 +186,4 @@ compiler.SetVisitor.notSettable = This isn''t something you can use "set" on.
 compiler.TaskVisitor.notDefined = This special variable isn''t defined here.
 compiler.LocalsVisitor.notDefined = Nothing named {0} has been defined.
 compiler.LetVariable.notDefined = Nothing named {0} has been defined.
+compiler.StructureConverter.noBreed = There is no breed "{0}"

--- a/parser-core/src/test/parse/FrontEndTests.scala
+++ b/parser-core/src/test/parse/FrontEndTests.scala
@@ -16,8 +16,8 @@ class FrontEndTests extends FunSuite {
   val POSTAMBLE = "\nend"
 
   /// helpers
-  def compile(source: String, preamble: String = PREAMBLE): Seq[core.Statements] =
-    FrontEnd.frontEnd(preamble + source + POSTAMBLE) match {
+  def compile(source: String, preamble: String = PREAMBLE, postamble: String = POSTAMBLE): Seq[core.Statements] =
+    FrontEnd.frontEnd(preamble + source + postamble) match {
       case (procs, _) =>
         procs.map(_.statements)
     }

--- a/parser-core/src/test/parse/StructureParserTests.scala
+++ b/parser-core/src/test/parse/StructureParserTests.scala
@@ -175,6 +175,9 @@ class StructureParserTests extends FunSuite {
   test("redeclaration of breed-own") {
     expectError("breed [hunters hunter] hunters-own [fear] hunters-own [loathing]",
       "Redeclaration of HUNTERS-OWN") }
+  test("breeds-own for nonexistent breed") {
+    expectError("hunters-own [fear]", "There is no breed \"HUNTERS\"")
+  }
   test("redeclaration of extensions") {
     expectError("extensions [foo] extensions [bar]",
       "Redeclaration of EXTENSIONS") }

--- a/shared/i18n/Errors_en.txt
+++ b/shared/i18n/Errors_en.txt
@@ -185,3 +185,4 @@ compiler.CarefullyVisitor.badNesting = {0} cannot be used outside of CAREFULLY.
 compiler.SetVisitor.notSettable = This isn''t something you can use "set" on.
 compiler.TaskVisitor.notDefined = This special variable isn''t defined here.
 compiler.LetVariable.notDefined = Nothing named {0} has been defined.
+compiler.StructureConverter.noBreed = There is no breed "{0}"


### PR DESCRIPTION
For instance, if a write `foobars-own [ ]` when there is no such breed:

```
NetLogo is unable to supply you with more details about this error.  Please report the problem
at https://github.com/NetLogo/NetLogo/issues, or to bugs@ccl.northwestern.edu, and paste the
contents of this window into your report.

java.util.NoSuchElementException: key not found: FOOBARS
 at scala.collection.MapLike$class.default(MapLike.scala:228)
 at scala.collection.AbstractMap.default(Map.scala:59)
 at scala.collection.MapLike$class.apply(MapLike.scala:141)
 at scala.collection.AbstractMap.apply(Map.scala:59)
 at org.nlogo.parse.StructureConverter$.updateBreedVariables(StructureConverter.scala:107)
 at org.nlogo.parse.StructureConverter$$anonfun$updateVariables$1$1.apply(StructureConverter.scala:60)
 at org.nlogo.parse.StructureConverter$$anonfun$updateVariables$1$1.apply(StructureConverter.scala:50)
 at scala.collection.LinearSeqOptimized$class.foldLeft(LinearSeqOptimized.scala:124)
 at scala.collection.immutable.List.foldLeft(List.scala:84)
 at org.nlogo.parse.StructureConverter$.updateVariables$1(StructureConverter.scala:50)
 at org.nlogo.parse.StructureConverter$.updateProgram(StructureConverter.scala:78)
 at org.nlogo.parse.StructureConverter$.convert(StructureConverter.scala:29)
 at org.nlogo.parse.StructureParser.parse(StructureParser.scala:170)
 at org.nlogo.parse.StructureParser$.org$nlogo$parse$StructureParser$$parseOne(StructureParser.scala:81)
 at org.nlogo.parse.StructureParser$$anonfun$parseSources$1$$anonfun$1.apply(StructureParser.scala:39)
 at org.nlogo.parse.StructureParser$$anonfun$parseSources$1$$anonfun$1.apply(StructureParser.scala:37)
 at scala.collection.TraversableOnce$$anonfun$foldLeft$1.apply(TraversableOnce.scala:155)
 at scala.collection.TraversableOnce$$anonfun$foldLeft$1.apply(TraversableOnce.scala:155)
 at scala.collection.immutable.Map$Map2.foreach(Map.scala:137)
 at scala.collection.TraversableOnce$class.foldLeft(TraversableOnce.scala:155)
 at scala.collection.AbstractTraversable.foldLeft(Traversable.scala:104)
 at org.nlogo.parse.StructureParser$$anonfun$parseSources$1.apply(StructureParser.scala:37)
 at org.nlogo.parse.StructureParser$$anonfun$parseSources$1.apply(StructureParser.scala:34)
 at org.nlogo.parse.StructureParser$.parsingWithExtensions(StructureParser.scala:64)
 at org.nlogo.parse.StructureParser$.parseSources(StructureParser.scala:34)
 at org.nlogo.parse.FrontEndMain$class.frontEnd(FrontEnd.scala:28)
 at org.nlogo.parse.FrontEnd.frontEnd(FrontEnd.scala:16)
 at org.nlogo.compiler.CompilerMain$.compile(CompilerMain.scala:28)
 at org.nlogo.compiler.Compiler.compileProgram(Compiler.scala:54)
 at org.nlogo.window.CompilerManager.compileProcedures(CompilerManager.java:112)
 at org.nlogo.window.CompilerManager.compileAll(CompilerManager.java:86)
 at org.nlogo.window.CompilerManager.handle(CompilerManager.java:312)
 at org.nlogo.window.Events$CompileAllEvent.beHandledBy(Events.java:174)
 at org.nlogo.window.Event.doRaise(Event.java:198)
 at org.nlogo.window.Event.raise(Event.java:122)
 at org.nlogo.app.CodeTab.recompile(CodeTab.scala:131)
 at org.nlogo.app.CodeTab.handle(CodeTab.scala:108)
 at org.nlogo.app.Events$SwitchedTabsEvent.beHandledBy(Events.java:41)
 at org.nlogo.window.Event.doRaise(Event.java:198)
 at org.nlogo.window.Event.raise(Event.java:122)
 at org.nlogo.app.Tabs.stateChanged(Tabs.scala:45)
 at javax.swing.JTabbedPane.fireStateChanged(JTabbedPane.java:416)
 at javax.swing.JTabbedPane$ModelListener.stateChanged(JTabbedPane.java:270)
 at javax.swing.DefaultSingleSelectionModel.fireStateChanged(DefaultSingleSelectionModel.java:132)
 at javax.swing.DefaultSingleSelectionModel.setSelectedIndex(DefaultSingleSelectionModel.java:67)
 at javax.swing.JTabbedPane.setSelectedIndexImpl(JTabbedPane.java:616)
 at javax.swing.JTabbedPane.setSelectedIndex(JTabbedPane.java:591)
 at org.nlogo.swing.TabsMenu$$anonfun$items$1$$anonfun$apply$1.apply$mcV$sp(TabsMenu.scala:13)
 at org.nlogo.swing.NumberedMenu$$anonfun$2$$anon$1.actionPerformed(NumberedMenu.scala:14)
 at javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:2022)
 at javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2348)
 at javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:402)
 at javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:259)
 at javax.swing.AbstractButton.doClick(AbstractButton.java:376)
 at javax.swing.AbstractButton.doClick(AbstractButton.java:356)
 at javax.swing.plaf.basic.BasicMenuItemUI$Actions.actionPerformed(BasicMenuItemUI.java:802)
 at javax.swing.SwingUtilities.notifyAction(SwingUtilities.java:1663)
 at javax.swing.JComponent.processKeyBinding(JComponent.java:2882)
 at javax.swing.JMenuBar.processBindingForKeyStrokeRecursive(JMenuBar.java:699)
 at javax.swing.JMenuBar.processBindingForKeyStrokeRecursive(JMenuBar.java:706)
 at javax.swing.JMenuBar.processBindingForKeyStrokeRecursive(JMenuBar.java:706)
 at javax.swing.JMenuBar.processKeyBinding(JMenuBar.java:677)
 at javax.swing.KeyboardManager.fireBinding(KeyboardManager.java:307)
 at javax.swing.KeyboardManager.fireKeyboardAction(KeyboardManager.java:293)
 at javax.swing.JComponent.processKeyBindingsForAllComponents(JComponent.java:2974)
 at javax.swing.JComponent.processKeyBindings(JComponent.java:2966)
 at javax.swing.JComponent.processKeyEvent(JComponent.java:2845)
 at java.awt.Component.processEvent(Component.java:6312)
 at java.awt.Container.processEvent(Container.java:2236)
 at java.awt.Component.dispatchEventImpl(Component.java:4891)
 at java.awt.Container.dispatchEventImpl(Container.java:2294)
 at java.awt.Component.dispatchEvent(Component.java:4713)
 at java.awt.KeyboardFocusManager.redispatchEvent(KeyboardFocusManager.java:1954)
 at java.awt.DefaultKeyboardFocusManager.dispatchKeyEvent(DefaultKeyboardFocusManager.java:806)
 at java.awt.DefaultKeyboardFocusManager.preDispatchKeyEvent(DefaultKeyboardFocusManager.java:1074)
 at java.awt.DefaultKeyboardFocusManager.typeAheadAssertions(DefaultKeyboardFocusManager.java:945)
 at java.awt.DefaultKeyboardFocusManager.dispatchEvent(DefaultKeyboardFocusManager.java:771)
 at java.awt.Component.dispatchEventImpl(Component.java:4762)
 at java.awt.Container.dispatchEventImpl(Container.java:2294)
 at java.awt.Window.dispatchEventImpl(Window.java:2750)
 at java.awt.Component.dispatchEvent(Component.java:4713)
 at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
 at java.awt.EventQueue.access$500(EventQueue.java:97)
 at java.awt.EventQueue$3.run(EventQueue.java:709)
 at java.awt.EventQueue$3.run(EventQueue.java:703)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
 at java.awt.EventQueue$4.run(EventQueue.java:731)
 at java.awt.EventQueue$4.run(EventQueue.java:729)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
 at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
 at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
 at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
 at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)

NetLogo 6.0-M5
main: org.nlogo.app.AppFrame
thread: AWT-EventQueue-0
Java HotSpot(TM) 64-Bit Server VM 1.8.0_77 (Oracle Corporation; 1.8.0_77-b03)
operating system: Mac OS X 10.11.4 (x86_64 processor)
Scala version 2.11.7
JOGL: (3D View not initialized)
OpenGL Graphics: (3D View not initialized)
model: Untitled

09:44:08.294 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
09:44:08.288 RemoveAllJobsEvent (org.nlogo.window.CompilerManager) AWT-EventQueue-0
09:44:08.288 CompileAllEvent (org.nlogo.app.MainCodeTab) AWT-EventQueue-0
09:44:08.287 SwitchedTabsEvent (org.nlogo.app.Tabs) AWT-EventQueue-0
09:44:08.059 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
09:44:07.885 DirtyEvent (org.nlogo.app.MainCodeTab) AWT-EventQueue-0
09:44:07.855 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
09:44:07.693 DirtyEvent (org.nlogo.app.MainCodeTab) AWT-EventQueue-0
09:44:07.651 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
09:44:07.448 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
```

In 5.3.1, it instead gave the error: "There is no breed FOOBARS"

Also, omitting the square brackets results in the error "opening bracket expected" when it was "There is no breed FOOBARS" in 5.3.1.

Discovered this when I accidentally wrote `pathes-own`...