### PR TITLE
M5: Blank axis labels become NIL on model reload

### DIFF
--- a/netlogo-gui/src/main/window/AbstractPlotWidget.scala
+++ b/netlogo-gui/src/main/window/AbstractPlotWidget.scala
@@ -264,11 +264,11 @@ abstract class AbstractPlotWidget(val plot:Plot, val plotManager: PlotManagerInt
     WidgetReader.read(strings.toList, literalParser) match {
       case corePlot: org.nlogo.core.Plot =>
         setSize(corePlot.right - corePlot.left, corePlot.bottom - corePlot.top)
-        xLabel(corePlot.xAxis)
-        yLabel(corePlot.yAxis)
+        xLabel(if (corePlot.xAxis == "NIL") "" else corePlot.xAxis)
+        yLabel(if (corePlot.yAxis == "NIL") "" else corePlot.yAxis)
         legend.open = corePlot.legendOn
         PlotLoader.loadPlot(corePlot, plot, helper.convert(_, false))
-        plotName(plot.name)
+        plotName(if (corePlot.display == "NIL") "" else corePlot.display)
         clear()
         this
       case _ =>


### PR DESCRIPTION
To reproduce: Create a model with a plot that has blank plot axis labels. Save. Reload. The axis labels now read `NIL`.