### PR TITLE
M5: `__includes`

### DIFF
--- a/netlogo-gui/project/autogen/i18n/Errors_en.txt
+++ b/netlogo-gui/project/autogen/i18n/Errors_en.txt
@@ -186,4 +186,5 @@ compiler.SetVisitor.notSettable = This isn''t something you can use "set" on.
 compiler.TaskVisitor.notDefined = This special variable isn''t defined here.
 compiler.LocalsVisitor.notDefined = Nothing named {0} has been defined.
 compiler.LetVariable.notDefined = Nothing named {0} has been defined.
+compiler.StructureParser.includeNotFound = Could not find {0}
 compiler.StructureConverter.noBreed = There is no breed "{0}"

--- a/netlogo-gui/src/main/app/CodeTab.scala
+++ b/netlogo-gui/src/main/app/CodeTab.scala
@@ -94,7 +94,7 @@ class CodeTab(val workspace: AbstractWorkspace) extends JPanel
           return None
       }
     }
-    workspace.compiler.findIncludes(path, getText)
+    workspace.compiler.findIncludes(path, getText, workspace.getCompilationEnvironment)
   }
 
   def agentClass = classOf[Observer]

--- a/netlogo-gui/src/main/app/IncludesMenu.scala
+++ b/netlogo-gui/src/main/app/IncludesMenu.scala
@@ -27,6 +27,7 @@ with org.nlogo.window.Events.CompiledEvent.Handler
     import collection.JavaConverters._
     target.getIncludesTable match {
       case Some(includesTable) =>
+        this.includesTable = includesTable
         val includes = new java.util.ArrayList[String]
         includesTable.keys.foreach(includes.add)
         java.util.Collections.sort(includes, String.CASE_INSENSITIVE_ORDER)

--- a/netlogo-gui/src/main/compiler/Compiler.scala
+++ b/netlogo-gui/src/main/compiler/Compiler.scala
@@ -126,12 +126,13 @@ class Compiler(dialect: Dialect) extends CompilerInterface {
     frontEnd.findProcedurePositions(source, Some(dialect))
 
   // used for includes menu
-  def findIncludes(sourceFileName: String, source: String): Option[Map[String, String]] = {
+  def findIncludes(sourceFileName: String, source: String,
+    compilationEnvironment: CompilationEnvironment): Option[Map[String, String]] = {
     val includes = frontEnd.findIncludes(source)
     if (includes.isEmpty)
       None
     else
-      Some((includes zip includes.map(resolvePath(sourceFileName, _))).toMap)
+      Some((includes zip includes.map(compilationEnvironment.resolvePath)).toMap)
   }
 
   // used by VariableNameEditor

--- a/netlogo-gui/src/main/compiler/CompilerMain.scala
+++ b/netlogo-gui/src/main/compiler/CompilerMain.scala
@@ -29,10 +29,13 @@ private object CompilerMain {
 
     val defs = CompilerBridge(feStructureResults, extensionManager, oldProceduresListMap, topLevelDefs)
 
+    val allSources = sources ++
+      feStructureResults.includedSources.map(i =>
+          (i -> compilationEnv.getSource(compilationEnv.resolvePath(i))))
+
     val returnedProcedures =
-      defs
-        .map(assembleProcedure(_, feStructureResults.program, sources, compilationEnv))
-        .filterNot(_.isTask) ++ oldProcedures.values
+      defs.map(assembleProcedure(_, feStructureResults.program, allSources, compilationEnv))
+      .filterNot(_.isTask) ++ oldProcedures.values
 
     // only return top level procedures.
     // task procedures can be reached via the children field on Procedure.

--- a/netlogo-gui/src/main/nvm/CompilerInterface.scala
+++ b/netlogo-gui/src/main/nvm/CompilerInterface.scala
@@ -50,7 +50,7 @@ trait CompilerInterface {
   def readFromFile(currFile: org.nlogo.core.File, world: World, extensionManager: ApiExtensionManager): AnyRef
 
   def findProcedurePositions(source: String): Map[String, ProcedureSyntax]
-  def findIncludes(sourceFileName: String, source: String): Option[Map[String, String]]
+  def findIncludes(sourceFileName: String, source: String, environment: CompilationEnvironment): Option[Map[String, String]]
   def isValidIdentifier(s: String): Boolean
   def isReporter(s: String, program: Program, procedures: java.util.Map[String, Procedure], extensionManager: ApiExtensionManager, compilationEnv: CompilationEnvironment): Boolean
   def getTokenAtPosition(source: String, position: Int): Token

--- a/netlogo-gui/src/main/workspace/AbstractWorkspaceScala.scala
+++ b/netlogo-gui/src/main/workspace/AbstractWorkspaceScala.scala
@@ -12,6 +12,7 @@ import org.nlogo.workspace.AbstractWorkspace.HubNetManagerFactory
 import java.util.WeakHashMap
 import java.net.URL
 import java.io.File
+import java.nio.file.Paths
 
 import java.io.{IOException,PrintWriter}
 
@@ -75,7 +76,7 @@ abstract class AbstractWorkspaceScala(val world: World, hubNetManagerFactory: Hu
       def profilingEnabled: Boolean = AbstractWorkspaceScala.this.profilingEnabled
       def resolvePath(path: String): String = {
         try {
-          val r = new JFile(attachModelDir(path))
+          val r = Paths.get(attachModelDir(path)).toFile
           try {
             r.getCanonicalPath
           } catch {
@@ -419,14 +420,16 @@ object AbstractWorkspaceTraits {
      */
     @throws(classOf[java.net.MalformedURLException])
     def attachModelDir(filePath: String): String = {
-      if (AbstractWorkspace.isApplet || new File(filePath).isAbsolute)
+      if (new File(filePath).isAbsolute)
         filePath
       else {
-        val path = Option(getModelPath).getOrElse(
-          System.getProperty("user.home") + File.separatorChar + "dummy.txt")
-        val urlForm = new URL(new File(path).toURI.toURL, filePath)
+        val defaultPath = Paths.get(System.getProperty("user.home"))
+        val modelParentPath =
+          Option(getModelPath).map(s => Paths.get(s)).map(_.getParent)
+            .getOrElse(defaultPath)
+        val attachedPath = modelParentPath.resolve(filePath)
 
-        new File(urlForm.getFile()).getAbsolutePath()
+        attachedPath.toAbsolutePath.toString
       }
     }
   }

--- a/parser-core/src/main/core/StructureResults.scala
+++ b/parser-core/src/main/core/StructureResults.scala
@@ -8,6 +8,7 @@ case class StructureResults(program: Program,
                         procedures: ProceduresMap = NoProcedures,
                         procedureTokens: Map[String, Iterable[Token]] = Map(),
                         includes: Seq[Token] = Seq(),
+                        includedSources: Seq[String] = Seq(),
                         extensions: Seq[Token] = Seq())
 
 object StructureResults {

--- a/parser-core/src/main/parse/StructureConverter.scala
+++ b/parser-core/src/main/parse/StructureConverter.scala
@@ -33,6 +33,7 @@ object StructureConverter {
         case (p, toks) => p.name -> toks
       },
       includes = oldResults.includes ++ is,
+      includedSources = oldResults.includedSources,
       extensions = oldResults.extensions ++
         declarations.collect {
           case e: Extensions =>

--- a/parser-core/src/main/parse/StructureParser.scala
+++ b/parser-core/src/main/parse/StructureParser.scala
@@ -29,7 +29,8 @@ object StructureParser {
   val IncludeFilesEndInNLS = "Included files must end with .nls"
 
   /// main entry point.  handles gritty extensions stuff and includes stuff.
-  def parseSources(tokenizer: core.TokenizerInterface, compilationData: CompilationOperand): StructureResults = {
+  def parseSources(tokenizer: core.TokenizerInterface, compilationData: CompilationOperand,
+    includeFile: (CompilationEnvironment, String) => Option[(String, String)] = IncludeFile.apply _): StructureResults = {
       import compilationData.{ compilationEnvironment, displayName, oldProcedures, subprogram, sources, containingProgram => program }
       parsingWithExtensions(compilationData) {
         val structureParser = new StructureParser(displayName, subprogram)
@@ -44,9 +45,11 @@ object StructureParser {
           Iterator.iterate(firstResults) { results =>
             val suppliedPath = results.includes.head.value.asInstanceOf[String]
             cAssert(suppliedPath.endsWith(".nls"), IncludeFilesEndInNLS, results.includes.head)
-            IncludeFile(compilationEnvironment, suppliedPath) match {
+            includeFile(compilationEnvironment, suppliedPath) match {
               case Some((path, fileContents)) =>
-                parseOne(tokenizer, structureParser, fileContents, path, results.copy(includes = results.includes.tail))
+                parseOne(tokenizer, structureParser, fileContents, suppliedPath,
+                  results.copy(includes = results.includes.tail,
+                    includedSources = results.includedSources :+ suppliedPath))
               case None =>
                 exception(I18N.errors.getN("compiler.StructureParser.includeNotFound", suppliedPath), results.includes.head)
             }

--- a/parser-core/src/main/parse/StructureParser.scala
+++ b/parser-core/src/main/parse/StructureParser.scala
@@ -20,8 +20,8 @@ package org.nlogo.parse
 
 import
   org.nlogo.core,
-    core.{CompilationOperand, ErrorSource, ExtensionManager, BreedIdentifierHandler, CompilationEnvironment,
-    FrontEndInterface, ProcedureSyntax, Program, Token, TokenMapperInterface, StructureDeclarations, StructureResults},
+    core.{ CompilationOperand, ErrorSource, ExtensionManager, BreedIdentifierHandler, CompilationEnvironment,
+    I18N, FrontEndInterface, ProcedureSyntax, Program, Token, TokenMapperInterface, StructureDeclarations, StructureResults},
       FrontEndInterface.ProceduresMap,
     core.Fail._
 
@@ -48,7 +48,7 @@ object StructureParser {
               case Some((path, fileContents)) =>
                 parseOne(tokenizer, structureParser, fileContents, path, results.copy(includes = results.includes.tail))
               case None =>
-                exception(s"Could not find $suppliedPath", results.includes.head)
+                exception(I18N.errors.getN("compiler.StructureParser.includeNotFound", suppliedPath), results.includes.head)
             }
           }.dropWhile(_.includes.nonEmpty).next
         }

--- a/parser-core/src/test/parse/StructureParserTests.scala
+++ b/parser-core/src/test/parse/StructureParserTests.scala
@@ -227,7 +227,9 @@ class StructureParserTests extends FunSuite {
 
   def compileAll(src: String): StructureResults = {
     StructureParser.parseSources(
-      tokenizer, CompilationOperand(Map("" -> src), new DummyExtensionManager, new DummyCompilationEnvironment, subprogram = false))
+      tokenizer,
+      CompilationOperand(Map("" -> src), new DummyExtensionManager, new DummyCompilationEnvironment, subprogram = false),
+      (_, name) => if (name == "foo.nls") Some(("foo.nls", "")) else None)
   }
 
   def expectParseAllError(src: String, error: String) = {
@@ -243,6 +245,11 @@ class StructureParserTests extends FunSuite {
 
   test("nonexistent included file") {
     expectParseAllError("""__includes [ "foobar.nls" ]""", "Could not find foobar.nls")
+  }
+
+  test("included file returns correct results") {
+    val results = compileAll("""__includes [ "foo.nls" ]""")
+    assert(results.includes.nonEmpty || results.includedSources.nonEmpty)
   }
 
   test("mutually referrent sources") {

--- a/shared/i18n/Errors_en.txt
+++ b/shared/i18n/Errors_en.txt
@@ -185,4 +185,5 @@ compiler.CarefullyVisitor.badNesting = {0} cannot be used outside of CAREFULLY.
 compiler.SetVisitor.notSettable = This isn''t something you can use "set" on.
 compiler.TaskVisitor.notDefined = This special variable isn''t defined here.
 compiler.LetVariable.notDefined = Nothing named {0} has been defined.
+compiler.StructureParser.includeNotFound = Could not find {0}
 compiler.StructureConverter.noBreed = There is no breed "{0}"


### PR DESCRIPTION
* When trying to open a file from the `__includes` dropdown, see a big NPE (Archive.zip)
* Can't find `__include` when opened from 5.2.1 model (Distributed EA.zip)
* Sometimes blows up when opening models with `__includes` (Ant Oscillator attached file)
[Archive.zip](https://github.com/NetLogo/NetLogo/files/235296/Archive.zip)
[Distributed-EA.zip](https://github.com/NetLogo/NetLogo/files/235300/Distributed-EA.zip)
[AntsOscilatorreproduction.zip](https://github.com/NetLogo/NetLogo/files/235294/AntsOscilatorreproduction.zip)
