### PR TITLE
use absolute path in `AbstractWorkspace.convertToNormal()`

### DIFF
--- a/netlogo-gui/src/main/workspace/AbstractWorkspace.java
+++ b/netlogo-gui/src/main/workspace/AbstractWorkspace.java
@@ -197,8 +197,8 @@ public abstract strictfp class AbstractWorkspace
    */
   public String convertToNormal()
       throws java.io.IOException {
-    java.io.File git = new java.io.File(".git");
-    if (!git.exists() || !git.isDirectory()) {
+    java.io.File git = new java.io.File(ModelsLibrary.modelsRoot() + "/.git");
+    if (!git.exists()) {
       throw new java.io.IOException("no .git directory found");
     }
     modelType = ModelTypeJ.NORMAL();


### PR DESCRIPTION
This is used by the `__edit` primitive and wasn't working anymore since the changes to the directory structure in hexy.

I have also removed the `isDirectory()` check on `.git` because we now look for the `.git` file in models instead of the NetLogo's root, and that one is a symlink to `../.git/modules/models` instead of being a proper directory.