### PR TITLE
Tweak appearance of "Version" float for primitives in the dictionnary

### DIFF
--- a/autogen/docs/netlogo.css
+++ b/autogen/docs/netlogo.css
@@ -81,7 +81,7 @@ h3 > a {
 }
 
 .since {
-  padding: 2px 6px;
+  padding: 0px 6px;
   background-color: rgb(210,210,210);
   border: 1px solid rgb(150,150,150);
   font-weight: normal;

--- a/autogen/docs/netlogo.css
+++ b/autogen/docs/netlogo.css
@@ -81,8 +81,10 @@ h3 > a {
 }
 
 .since {
-  padding: 2px 5px 0 5px;
-  background-color: rgba(0, 255, 0, 0.5);
+  padding: 2px 6px;
+  background-color: rgb(210,210,210);
+  border: 1px solid rgb(150,150,150);
+  font-weight: normal;
   font-style: italic;
   float: right;
 }


### PR DESCRIPTION
Showing the NetLogo version in which a primitive was introduced (#998) is a great addition to the dictionary, but having that information in a bright green box was making it by far the most eye catching element on the page, which isn't warranted. I'm proposing a more subdued appearance.