### PR TITLE
Remove `isDirectory` check on `.git` when converting a model to normal mode

### DIFF
--- a/netlogo-gui/src/main/workspace/ModelTracker.scala
+++ b/netlogo-gui/src/main/workspace/ModelTracker.scala
@@ -65,8 +65,8 @@ trait ModelTracker {
   @throws(classOf[IOException])
   def convertToNormal(): String = {
     val git = new File(ModelsLibrary.modelsRoot(), ".git")
-    if (!git.exists() || !git.isDirectory()) {
-      throw new IOException("no .git directory found")
+    if (!git.exists()) {
+      throw new IOException("The models folder is not under version control.")
     }
     _modelType = ModelType.Normal
     getModelPath


### PR DESCRIPTION
With the new project structure, `.git` is a file pointing to `../.git/modules/models` instead of being a directory.