### PR TITLE
M7: Exception thrown when saving chooser that contains `nobody`

### DIFF
--- a/autogen/docs/transition.html.mustache
+++ b/autogen/docs/transition.html.mustache
@@ -39,6 +39,17 @@
       <a>Changes for NetLogo 6.0</a>
     </h2>
     <h3>
+      Nobody Not Permitted as a Chooser Value
+    </h3>
+    <p>
+    In NetLogo 6.0, <code>nobody</code> is no longer a valid chooser value.
+    Just as you can't put <code>turtle 0</code> or <code>turtles</code>,
+    <code>nobody</code> refers to a non-literal value which
+    isn't supported in choosers. As part of this transition, choosers
+    containing <code>nobody</code> (or <code>nobody</code> within a nested list)
+    will have all uses of <code>nobody</code> changed to <code>"nobody"</code> when
+    opened in NetLogo 6.0.
+    <h3>
       Improved Name Collision Detection
     </h3>
     <p>

--- a/netlogo-gui/src/main/properties/EditPanel.scala
+++ b/netlogo-gui/src/main/properties/EditPanel.scala
@@ -2,7 +2,7 @@
 
 package org.nlogo.properties
 
-import org.nlogo.core.{ CompilerException, I18N, LogoList, TokenType }
+import org.nlogo.core.{ CompilerException, I18N, LogoList, Nobody, TokenType }
 import org.nlogo.editor.Colorizer
 import org.nlogo.window.WidgetWrapperInterface
 import javax.swing.{JPanel, JLabel}
@@ -183,10 +183,18 @@ class EditPanel(val target: Editable, val compiler: CompilerServices, colorizer:
       case Property.Key =>
         new KeyEditor(accessor) with Changed
       case Property.LogoListString =>
-        new CodeEditor(accessor, colorizer, false, false) with Changed
-        { override def get = super.get.filter{x =>
+        new CodeEditor(accessor, colorizer, false, false) with Changed {
+          private def nobodyFree(a: AnyRef): Boolean = {
+            a match {
+              case Nobody       => false
+              case ll: LogoList => ll.forall(nobodyFree)
+              case _            => true
+            }
+          }
+
+          override def get = super.get.filter{x =>
             try compiler.readFromString("[ " + x + " ]") match {
-              case list: LogoList => !list.isEmpty
+              case list: LogoList => !list.isEmpty && list.forall(nobodyFree)
               case _ => false
             }
             catch { case _: CompilerException => false }

--- a/parser-core/src/main/core/model/WidgetReader.scala
+++ b/parser-core/src/main/core/model/WidgetReader.scala
@@ -409,19 +409,15 @@ object ChooserReader extends BaseWidgetReader {
     val List(_, left: Int, top: Int, right: Int, bottom: Int, display: Option[String] @unchecked, variable: Option[String] @unchecked,
     choicesStr: String, currentChoice: Int) = vals
 
-    val choices = parser.readFromString(s"[$choicesStr]").asInstanceOf[LogoList].toList
+    val choices = parser.readFromString(s"[$choicesStr]").asInstanceOf[LogoList]
 
-    def isOrContainsNobody(l: Any): Boolean = l match {
-      case Nobody       => true
-      case l: List[Any] => l.exists(isOrContainsNobody)
-      case ll: LogoList => isOrContainsNobody(ll.toList)
-      case _            => false
+    def convertAllNobodies(l: AnyRef): AnyRef = l match {
+      case Nobody       => "nobody"
+      case ll: LogoList => LogoList(ll.map(convertAllNobodies): _*)
+      case other        => other
     }
 
-    if (isOrContainsNobody(choices)) throw new CompilerException(
-      "nobody may not appear in a chooser value", Int.MaxValue, Int.MaxValue, "")
-
-    Chooser(variable, left, top, right, bottom, display, choices.map(Chooseable(_)), currentChoice)
+    Chooser(variable, left, top, right, bottom, display, choices.map(convertAllNobodies).map(Chooseable(_)).toList, currentChoice)
   }
 }
 


### PR DESCRIPTION
Highly relevant: #670

Regardless of whether or not we think `nobody` should be a valid literal, an uncaught exception should not be thrown when its put in a chooser. Either the model should save successfully, or the chooser should reject the option with the normal "Invalid option" error.

This is the stack trace currently given:

```
java.lang.RuntimeException: Invalid chooser option org.nlogo.core.Nobody$@6e6fa971
 at org.nlogo.core.Chooseable$.apply(Chooser.scala:20)
 at org.nlogo.window.ChooserWidget$$anonfun$1.apply(ChooserWidget.scala:111)
 at org.nlogo.window.ChooserWidget$$anonfun$1.apply(ChooserWidget.scala:111)
 at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
 at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
 at scala.collection.Iterator$class.foreach(Iterator.scala:893)
 at scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
 at scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
 at org.nlogo.core.LogoList.foreach(LogoList.scala:24)
 at scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
 at org.nlogo.core.LogoList.map(LogoList.scala:24)
 at org.nlogo.window.ChooserWidget.model(ChooserWidget.scala:111)
 at org.nlogo.window.ChooserWidget.model(ChooserWidget.scala:10)
 at org.nlogo.app.InterfacePanel$$anonfun$getWidgetsForSaving$1.applyOrElse(InterfacePanel.scala:244)
 at org.nlogo.app.InterfacePanel$$anonfun$getWidgetsForSaving$1.applyOrElse(InterfacePanel.scala:243)
 at scala.PartialFunction$$anonfun$runWith$1.apply(PartialFunction.scala:141)
 at scala.PartialFunction$$anonfun$runWith$1.apply(PartialFunction.scala:140)
 at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
 at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
 at scala.collection.TraversableLike$class.collect(TraversableLike.scala:271)
 at scala.collection.mutable.ArrayOps$ofRef.collect(ArrayOps.scala:186)
 at org.nlogo.app.InterfacePanel.getWidgetsForSaving(InterfacePanel.scala:243)
 at org.nlogo.app.App.widgets(App.scala:1066)
 at org.nlogo.app.ModelSaver.currentModel(ModelSaver.scala:23)
 at org.nlogo.app.FileMenu.currentModel(FileMenu.scala:461)
 at org.nlogo.app.FileMenu.save(FileMenu.scala:470)
 at org.nlogo.app.FileMenu$SaveAction.action(FileMenu.scala:146)
 at org.nlogo.app.FileMenu$FileMenuAction.actionPerformed(FileMenu.scala:98)
 at javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:2022)
 at javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2348)
 at javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:402)
 at javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:259)
 at javax.swing.AbstractButton.doClick(AbstractButton.java:376)
 at javax.swing.AbstractButton.doClick(AbstractButton.java:356)
 at javax.swing.plaf.basic.BasicMenuItemUI$Actions.actionPerformed(BasicMenuItemUI.java:802)
 at javax.swing.SwingUtilities.notifyAction(SwingUtilities.java:1663)
 at javax.swing.JComponent.processKeyBinding(JComponent.java:2882)
 at javax.swing.JMenuBar.processBindingForKeyStrokeRecursive(JMenuBar.java:699)
 at javax.swing.JMenuBar.processBindingForKeyStrokeRecursive(JMenuBar.java:706)
 at javax.swing.JMenuBar.processBindingForKeyStrokeRecursive(JMenuBar.java:706)
 at javax.swing.JMenuBar.processKeyBinding(JMenuBar.java:677)
 at javax.swing.KeyboardManager.fireBinding(KeyboardManager.java:307)
 at javax.swing.KeyboardManager.fireKeyboardAction(KeyboardManager.java:293)
 at javax.swing.JComponent.processKeyBindingsForAllComponents(JComponent.java:2974)
 at javax.swing.JComponent.processKeyBindings(JComponent.java:2966)
 at javax.swing.JComponent.processKeyEvent(JComponent.java:2845)
 at java.awt.Component.processEvent(Component.java:6312)
 at java.awt.Container.processEvent(Container.java:2236)
 at java.awt.Component.dispatchEventImpl(Component.java:4891)
 at java.awt.Container.dispatchEventImpl(Container.java:2294)
 at java.awt.Component.dispatchEvent(Component.java:4713)
 at java.awt.KeyboardFocusManager.redispatchEvent(KeyboardFocusManager.java:1954)
 at java.awt.DefaultKeyboardFocusManager.dispatchKeyEvent(DefaultKeyboardFocusManager.java:806)
 at java.awt.DefaultKeyboardFocusManager.preDispatchKeyEvent(DefaultKeyboardFocusManager.java:1074)
 at java.awt.DefaultKeyboardFocusManager.typeAheadAssertions(DefaultKeyboardFocusManager.java:945)
 at java.awt.DefaultKeyboardFocusManager.dispatchEvent(DefaultKeyboardFocusManager.java:771)
 at java.awt.Component.dispatchEventImpl(Component.java:4762)
 at java.awt.Container.dispatchEventImpl(Container.java:2294)
 at java.awt.Window.dispatchEventImpl(Window.java:2750)
 at java.awt.Component.dispatchEvent(Component.java:4713)
 at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
 at java.awt.EventQueue.access$500(EventQueue.java:97)
 at java.awt.EventQueue$3.run(EventQueue.java:709)
 at java.awt.EventQueue$3.run(EventQueue.java:703)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
 at java.awt.EventQueue$4.run(EventQueue.java:731)
 at java.awt.EventQueue$4.run(EventQueue.java:729)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
 at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
 at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
 at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
 at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
```