### PR TITLE
Allow `run` and `runresult` to run `api.Task`s

### DIFF
--- a/netlogo-core/src/main/api/Task.scala
+++ b/netlogo-core/src/main/api/Task.scala
@@ -2,10 +2,24 @@
 
 package org.nlogo.api
 
-sealed trait Task
+import org.nlogo.core.Syntax
+
+sealed trait Task {
+  /**
+   * Used to specify the number of arguments required to run a task.
+   * Note that a task may be supplied with more arguments depending
+   * on the number of arguments supplied to run/runresult.
+   * While this is only used to calculate argument count at the moment,
+   * future versions may check whether the task is variadic and may
+   * make use of the type information to provide error messages.
+   */
+  def syntax: Syntax
+}
+
 trait ReporterTask extends Task {
   def report(c: Context, args: Array[AnyRef]): AnyRef
 }
+
 trait CommandTask extends Task {
   def perform(c: Context, args: Array[AnyRef])
 }

--- a/netlogo-core/src/main/api/Task.scala
+++ b/netlogo-core/src/main/api/Task.scala
@@ -5,21 +5,55 @@ package org.nlogo.api
 import org.nlogo.core.Syntax
 
 sealed trait Task {
-  /**
-   * Used to specify the number of arguments required to run a task.
-   * Note that a task may be supplied with more arguments depending
-   * on the number of arguments supplied to run/runresult.
-   * While this is only used to calculate argument count at the moment,
-   * future versions may check whether the task is variadic and may
-   * make use of the type information to provide error messages.
-   */
+  /** Used to specify the number of arguments required to run a task.
+    *
+    * Note that a task may be supplied with more arguments depending
+    * on the number of arguments supplied to run/runresult.
+    * This only used to calculate argument count at the moment.
+    * Note that tasks as created by `task` are variadic in the number of arguments
+    * they accept. For instance, the task returned by `task [?1 + ?2]`
+    * can be run with 10 arguments and the last 8 will be ignored.
+    * The current versions only makes assertions that the number of arguments is
+    * greater than the syntax minimum.
+    *
+    * Future versions ''may'' make greater use of the information provided by
+    * `syntax`. Primitives returning tasks will want to ensure the task's syntax is
+    * not more restrictive than the expected argument(s).
+    */
   def syntax: Syntax
 }
 
 trait ReporterTask extends Task {
+  /** Computes and reports a value
+    *
+    * When run by the `runresult` primitive or other primitives which take
+    * reporter tasks as arguments, this is run on the Job Thread.
+    * Before invoking this, the NetLogo primitives which use tasks
+    * will check that the number of arguments contained in `args` is
+    * at least as long as the number of arguments specified by
+    * the tasks [[org.nlogo.api.Task#syntax syntax method]].
+    * It is a user error to run `report` with fewer `args` than specified.
+    *
+    * @param c The [[org.nlogo.api.Context]] in which the task is being run.
+    * @param args The arguments to the task
+    * @return The value returned by the task
+    */
   def report(c: Context, args: Array[AnyRef]): AnyRef
 }
 
 trait CommandTask extends Task {
+  /** Performs an action
+    *
+    * When run by the `run` primitive, or other primitives which take command
+    * tasks as arguments, this is run on the Job Thread.
+    * Before invoking this, the NetLogo primitives which use tasks
+    * will check that the number of arguments contained in `args` is
+    * at least as long as the number of arguments specified by
+    * the tasks [[org.nlogo.api.Task#syntax syntax method]].
+    * It is a user error to run `perform` with fewer `args` than specified.
+    *
+    * @param c The [[org.nlogo.api.Context]] in which the task is being run.
+    * @param args The arguments to the task
+    */
   def perform(c: Context, args: Array[AnyRef])
 }

--- a/netlogo-core/src/main/job/JobManager.scala
+++ b/netlogo-core/src/main/job/JobManager.scala
@@ -2,7 +2,7 @@
 
 package org.nlogo.job
 
-import org.nlogo.nvm.{ExclusiveJob, ConcurrentJob, Procedure, Job, JobManagerOwner}
+import org.nlogo.nvm.{ExclusiveJob, ConcurrentJob, Procedure, Job, JobManagerOwner, Workspace}
 import org.nlogo.core.AgentKind
 import org.nlogo.api.{JobOwner, LogoException}
 import org.nlogo.agent.{Agent, Turtle, Link, AgentSet, World}
@@ -31,33 +31,33 @@ class JobManager(jobManagerOwner: JobManagerOwner,
     else add(job, thread.primaryJobs)
   }
 
-  def makeConcurrentJob(owner: JobOwner, agentSet: AgentSet, procedure: Procedure): Job =
-    new ConcurrentJob(owner, agentSet, procedure, 0, null, owner.random)
+  def makeConcurrentJob(owner: JobOwner, agentSet: AgentSet, workspace: Workspace, procedure: Procedure): Job =
+    new ConcurrentJob(owner, agentSet, procedure, 0, null, workspace, owner.random)
 
   @throws(classOf[LogoException])
-  def callReporterProcedure(owner: JobOwner, agentSet: AgentSet, procedure: Procedure): Object =
-    new ExclusiveJob(owner, agentSet, procedure, 0, null, owner.random).callReporterProcedure()
+  def callReporterProcedure(owner: JobOwner, agentSet: AgentSet, workspace: Workspace, procedure: Procedure): Object =
+    new ExclusiveJob(owner, agentSet, procedure, 0, null, workspace, owner.random).callReporterProcedure()
 
-  def addReporterJobAndWait(owner: JobOwner, agentSet: AgentSet, procedure: Procedure): Object = {
-    val job = new ConcurrentJob(owner, agentSet, procedure, 0, null, owner.random)
+  def addReporterJobAndWait(owner: JobOwner, agentSet: AgentSet, workspace: Workspace, procedure: Procedure): Object = {
+    val job = new ConcurrentJob(owner, agentSet, procedure, 0, null, workspace, owner.random)
     add(job, thread.primaryJobs)
     waitFor(job, false)
     job.result
   }
 
   def addJobFromJobThread(job: Job) {thread.primaryJobs.add(job)}
-  def addJob(owner: JobOwner, agents: AgentSet, procedure: Procedure) {
-    add(new ConcurrentJob(owner, agents, procedure, 0, null, owner.random),
+  def addJob(owner: JobOwner, agents: AgentSet, workspace: Workspace, procedure: Procedure) {
+    add(new ConcurrentJob(owner, agents, procedure, 0, null, workspace, owner.random),
         thread.primaryJobs)
   }
-  def addSecondaryJob(owner: JobOwner, agents: AgentSet, procedure: Procedure) {
+  def addSecondaryJob(owner: JobOwner, agents: AgentSet, workspace: Workspace, procedure: Procedure) {
     // we only allow one secondary job per owner -- this is so MonitorWidgets
     // don't wind up with multiple jobs -- it's a bit of a kludge - ST 9/19/01
     val found = thread.secondaryJobs.synchronized {
       thread.secondaryJobs.asScala.exists{ s => s != null && s.owner == owner && s.state == Job.RUNNING }
     }
     if(!found)
-      add(new ConcurrentJob(owner, agents, procedure, 0, null, owner.random),
+      add(new ConcurrentJob(owner, agents, procedure, 0, null, workspace, owner.random),
           thread.secondaryJobs)
   }
 

--- a/netlogo-gui/project/autogen/i18n/Errors_en.txt
+++ b/netlogo-gui/project/autogen/i18n/Errors_en.txt
@@ -176,6 +176,8 @@ org.nlogo.workspace.DefaultFileManager.noOpenFile = No file has been opened.
 
 org.nlogo.prim.etc._foreach.listsMustBeSameLength = All the list arguments to FOREACH must be the same length.
 org.nlogo.prim.$common.noSumOfListWithNonNumbers =  Can''t find the sum of a list that contains non-numbers {0} is a {1}.
+org.nlogo.prim.task.missingInput = task expected 1 input, but only got 0
+org.nlogo.prim.task.missingInputs = task expected {0} inputs, but only got {1}
 org.nlogo.prim._returnreport.reportNotCalledInReportProcedure = Reached end of reporter procedure without REPORT being called.
 org.nlogo.prim.etc.$common.expectedLastInputToBeLinkBreed = Expected the last input to be a link breed.
 

--- a/netlogo-gui/src/main/nvm/ConcurrentJob.java
+++ b/netlogo-gui/src/main/nvm/ConcurrentJob.java
@@ -15,8 +15,9 @@ public strictfp class ConcurrentJob
                        Procedure topLevelProcedure,
                        int address,
                        Context parentContext,
+                       Workspace workspace,
                        org.nlogo.api.MersenneTwisterFast random) {
-    super(owner, agentset, topLevelProcedure, address, parentContext, random);
+    super(owner, agentset, topLevelProcedure, address, parentContext, workspace, random);
   }
 
   private Context[] contexts;
@@ -42,7 +43,7 @@ public strictfp class ConcurrentJob
             address,
             parentContext == null
                 ? new Activation(topLevelProcedure, null, 0)
-                : parentContext.activation);
+                : parentContext.activation, workspace);
     if (count == -1) // this whole -1 as a special value business is a bit kludgey - ST
     {
       if (contexts == null) {

--- a/netlogo-gui/src/main/nvm/ExclusiveJob.java
+++ b/netlogo-gui/src/main/nvm/ExclusiveJob.java
@@ -14,8 +14,9 @@ public strictfp class ExclusiveJob
                       Procedure topLevelProcedure,
                       int address,
                       Context parentContext,
+                      Workspace workspace,
                       org.nlogo.api.MersenneTwisterFast random) {
-    super(owner, agentset, topLevelProcedure, address, parentContext, random);
+    super(owner, agentset, topLevelProcedure, address, parentContext, workspace, random);
   }
 
   @Override
@@ -39,7 +40,7 @@ public strictfp class ExclusiveJob
     // turtle must not be returned by the shufflerator.
     // - ST 12/5/05, 3/15/06
     AgentSet.Iterator it = agentset.shufflerator(random);
-    Context context = new Context(this, null, 0, null);
+    Context context = new Context(this, null, 0, null, workspace);
     context.agentBit = agentset.getAgentBit();
     while (it.hasNext()) {
       context.agent = it.next();
@@ -62,7 +63,7 @@ public strictfp class ExclusiveJob
   // used by Evaluator.MyThunk
   public Object callReporterProcedure()
       throws LogoException {
-    return new Context(this, agentset.iterator().next(), 0, null)
+    return new Context(this, agentset.iterator().next(), 0, null, workspace)
         .callReporterProcedure(new Activation(topLevelProcedure, null, 0));
   }
 

--- a/netlogo-gui/src/main/nvm/Instruction.java
+++ b/netlogo-gui/src/main/nvm/Instruction.java
@@ -451,19 +451,19 @@ public abstract strictfp class Instruction
     }
   }
 
-  public ReporterTask argEvalReporterTask(Context context, int argIndex) throws LogoException {
+  public org.nlogo.api.ReporterTask argEvalReporterTask(Context context, int argIndex) throws LogoException {
     Object obj = args[argIndex].report(context);
     try {
-      return (ReporterTask) obj;
+      return (org.nlogo.api.ReporterTask) obj;
     } catch (ClassCastException ex) {
       throw new ArgumentTypeException(context, this, argIndex, Syntax.ReporterTaskType(), obj);
     }
   }
 
-  public CommandTask argEvalCommandTask(Context context, int argIndex) throws LogoException {
+  public org.nlogo.api.CommandTask argEvalCommandTask(Context context, int argIndex) throws LogoException {
     Object obj = args[argIndex].report(context);
     try {
-      return (CommandTask) obj;
+      return (org.nlogo.api.CommandTask) obj;
     } catch (ClassCastException ex) {
       throw new ArgumentTypeException(context, this, argIndex, Syntax.CommandTaskType(), obj);
     }

--- a/netlogo-gui/src/main/nvm/Job.java
+++ b/netlogo-gui/src/main/nvm/Job.java
@@ -23,6 +23,7 @@ public abstract strictfp class Job {
   public final AgentSet agentset;
   public final Context parentContext;
   public final Procedure topLevelProcedure;
+  protected final Workspace workspace;
 
   public org.nlogo.api.MersenneTwisterFast random;
 
@@ -31,12 +32,14 @@ public abstract strictfp class Job {
       Procedure topLevelProcedure,
       int address,
       Context parentContext,
+      Workspace workspace,
       org.nlogo.api.MersenneTwisterFast random) {
     this.owner = owner;
     this.agentset = agentset;
     this.topLevelProcedure = topLevelProcedure;
     this.address = address;
     this.parentContext = parentContext;
+    this.workspace = workspace;
     this.random = random;
   }
 

--- a/netlogo-gui/src/main/nvm/JobManagerInterface.scala
+++ b/netlogo-gui/src/main/nvm/JobManagerInterface.scala
@@ -14,13 +14,13 @@ trait JobManagerInterface {
   def maybeRunSecondaryJobs()
   def anyPrimaryJobs(): Boolean
   def addJob(job: Job, waitForCompletion: Boolean)
-  def makeConcurrentJob(owner: JobOwner, agentset: AgentSet, procedure: Procedure): Job
+  def makeConcurrentJob(owner: JobOwner, agentset: AgentSet, workspace: Workspace, procedure: Procedure): Job
   @throws(classOf[LogoException])
-  def callReporterProcedure(owner: JobOwner, agentset: AgentSet, procedure: Procedure): AnyRef
-  def addReporterJobAndWait(owner: JobOwner, agentset: AgentSet, procedure: Procedure): AnyRef
+  def callReporterProcedure(owner: JobOwner, agentset: AgentSet, workspace: Workspace, procedure: Procedure): AnyRef
+  def addReporterJobAndWait(owner: JobOwner, agentset: AgentSet, workspace: Workspace, procedure: Procedure): AnyRef
   def addJobFromJobThread(job: Job)
-  def addJob(owner: JobOwner, agents: AgentSet, procedure: Procedure)
-  def addSecondaryJob(owner: JobOwner, agents: AgentSet, procedure: Procedure)
+  def addJob(owner: JobOwner, agents: AgentSet, workspace: Workspace, procedure: Procedure)
+  def addSecondaryJob(owner: JobOwner, agents: AgentSet, workspace: Workspace, procedure: Procedure)
   def joinForeverButtons(agent: Agent)
   def haltPrimary()
   def haltNonObserverJobs()

--- a/netlogo-gui/src/main/nvm/Task.scala
+++ b/netlogo-gui/src/main/nvm/Task.scala
@@ -2,8 +2,8 @@
 
 package org.nlogo.nvm
 
-import org.nlogo.api
-import org.nlogo.core.Let
+import org.nlogo.api, api.{ Task => ApiTask }
+import org.nlogo.core.{ Let, I18N, Syntax }
 
 // tasks are created by the _task prim, which may appear in user code, or may be inserted by
 // ExpressionParser during parsing, when a task is known to be expected.
@@ -29,12 +29,14 @@ sealed trait Task {
       i += 1
     }
   }
-  def missingInputs(n: Int) = {
-    val plural =
-      if(formals.size == 1) ""
-      else "s"
-    "task expected " + formals.size + " input" + plural + ", but only got " + n
-  }
+}
+
+object Task {
+  def missingInputs(task: ApiTask, argCount: Int): String =
+    if (task.syntax.minimum == 1)
+      I18N.errors.get("org.nlogo.prim.task.missingInput")
+    else
+      I18N.errors.getN("org.nlogo.prim.task.missingInputs", task.syntax.minimum.toString, argCount.toString)
 }
 
 // Reporter tasks are pretty simple.  The body is simply a Reporter.  To run it, we swap closed-over
@@ -42,9 +44,17 @@ sealed trait Task {
 
 case class ReporterTask(body: Reporter, formals: Array[Let], lets: List[LetBinding], locals: Array[AnyRef])
 extends Task with org.nlogo.api.ReporterTask {
+  // tasks are allowed to take more than the number of arguments (hence repeatable-type)
+  def syntax =
+    Syntax.reporterSyntax(
+      ret = Syntax.WildcardType,
+      right = formals.map(_ => Syntax.WildcardType | Syntax.RepeatableType).toList)
   override def toString = "(reporter task: [ " + body.fullSource + " ])"
   def report(context: api.Context, args: Array[AnyRef]): AnyRef =
-    report(context.asInstanceOf[ExtensionContext].nvmContext, args)
+    context match {
+      case e: ExtensionContext => report(e.nvmContext, args)
+      case c: Context          => report(c, args)
+    }
   def report(context: Context, args: Array[AnyRef]): AnyRef = {
     val oldLets = context.letBindings
     val oldLocals = context.activation.args
@@ -65,9 +75,15 @@ extends Task with org.nlogo.api.ReporterTask {
 
 case class CommandTask(procedure: Procedure, formals: Array[Let], lets: List[LetBinding], locals: Array[AnyRef])
 extends Task with org.nlogo.api.CommandTask {
+  def syntax =
+    Syntax.commandSyntax(right = formals.map(_ => Syntax.WildcardType | Syntax.RepeatableType).toList)
   override def toString = procedure.displayName
+  // tasks are allowed to take more than the number of arguments (hence repeatable-type)
   def perform(context: api.Context, args: Array[AnyRef]) {
-    perform(context.asInstanceOf[ExtensionContext].nvmContext, args)
+    context match {
+      case e: ExtensionContext => perform(e.nvmContext, args)
+      case c: Context          => perform(c, args)
+    }
   }
   def perform(context: Context, args: Array[AnyRef]) {
     val oldLets = context.letBindings

--- a/netlogo-gui/src/main/prim/etc/_filter.scala
+++ b/netlogo-gui/src/main/prim/etc/_filter.scala
@@ -5,18 +5,15 @@ package org.nlogo.prim.etc
 import org.nlogo.api.{ LogoListBuilder}
 import org.nlogo.core.Syntax
 import org.nlogo.core.LogoList
-import org.nlogo.nvm.{ ArgumentTypeException, Context, EngineException, Reporter }
+import org.nlogo.nvm.{ ArgumentTypeException, Context, EngineException, Reporter, Task }
 
 class _filter extends Reporter {
-
-
 
   def report(context: Context): LogoList = {
     val task = argEvalReporterTask(context, 0)
     val list = argEvalList(context, 1)
-    if(task.formals.size > 1)
-      throw new EngineException(
-        context, this, task.missingInputs(1))
+    if (task.syntax.minimum > 1)
+      throw new EngineException(context, this, Task.missingInputs(task, 1))
     val builder = new LogoListBuilder
     for (item <- list)
       task.report(context, Array(item)) match {

--- a/netlogo-gui/src/main/prim/etc/_foreach.scala
+++ b/netlogo-gui/src/main/prim/etc/_foreach.scala
@@ -4,7 +4,7 @@ package org.nlogo.prim.etc
 
 import org.nlogo.core.Syntax
 import org.nlogo.core.I18N
-import org.nlogo.nvm.{ Command, Context, EngineException, NonLocalExit, Procedure }
+import org.nlogo.nvm.{ Command, Context, EngineException, NonLocalExit, Procedure, Task }
 
 class _foreach extends Command {
 
@@ -20,9 +20,8 @@ class _foreach extends Command {
       list.iterator
     }
     val task = argEvalCommandTask(context, n)
-    if(n < task.formals.size)
-      throw new EngineException(
-        context, this, task.missingInputs(n))
+    if (n < task.syntax.minimum)
+      throw new EngineException(context, this, Task.missingInputs(task, n))
     var i = 0
     val actuals = new Array[AnyRef](n)
     try {

--- a/netlogo-gui/src/main/prim/etc/_map.scala
+++ b/netlogo-gui/src/main/prim/etc/_map.scala
@@ -5,7 +5,7 @@ package org.nlogo.prim.etc
 import org.nlogo.api.{ LogoListBuilder}
 import org.nlogo.core.Syntax
 import org.nlogo.core.LogoList
-import org.nlogo.nvm.{ EngineException, Context, Reporter }
+import org.nlogo.nvm.{ EngineException, Context, Reporter, Task }
 
 class _map extends Reporter {
 
@@ -18,9 +18,8 @@ class _map extends Reporter {
 
     val task = argEvalReporterTask(context, 0)
     val n = args.length - 1
-    if(n < task.formals.size)
-      throw new EngineException(
-        context, this, task.missingInputs(n))
+    if (n < task.syntax.minimum)
+      throw new EngineException(context, this, Task.missingInputs(task, n))
 
     // get all of the list args, if any.
     var size = 0

--- a/netlogo-gui/src/main/prim/etc/_nvalues.scala
+++ b/netlogo-gui/src/main/prim/etc/_nvalues.scala
@@ -5,11 +5,9 @@ package org.nlogo.prim.etc
 import org.nlogo.core.{ I18N, LogoList }
 import org.nlogo.api.{ LogoListBuilder}
 import org.nlogo.core.Syntax
-import org.nlogo.nvm.{ Context, EngineException, Reporter }
+import org.nlogo.nvm.{ Context, EngineException, Reporter, Task }
 
 class _nvalues extends Reporter {
-
-
 
   override def report(context: Context) = {
     // get the first argument...
@@ -20,9 +18,8 @@ class _nvalues extends Reporter {
     // make the result list.
     val result = new LogoListBuilder
     val task = argEvalReporterTask(context, 1)
-    if(task.formals.size > 1)
-      throw new EngineException(
-        context, this, task.missingInputs(1))
+    if (task.syntax.minimum > 1)
+      throw new EngineException(context, this, Task.missingInputs(task, 1))
     for (i <- 0 until n)
       result.add(task.report(context, Array[AnyRef](Double.box(i))))
     result.toLogoList

--- a/netlogo-gui/src/main/prim/etc/_reduce.scala
+++ b/netlogo-gui/src/main/prim/etc/_reduce.scala
@@ -4,20 +4,17 @@ package org.nlogo.prim.etc
 
 import org.nlogo.core.Syntax
 import org.nlogo.core.I18N
-import org.nlogo.nvm.{ EngineException, Context, Reporter }
+import org.nlogo.nvm.{ EngineException, Context, Reporter, Task }
 
 class _reduce extends Reporter {
 
-
-
   override def report(context: Context) = {
     val task = argEvalReporterTask(context, 0)
-    if(task.formals.size > 2)
-      throw new EngineException(
-        context, this, task.missingInputs(2))
+    if (task.syntax.minimum > 2)
+      throw new EngineException(context, this, Task.missingInputs(task, 2))
     val list = argEvalList(context, 1)
     if (list.size < 1)
-      throw new EngineException( context , this , I18N.errors.get("org.nlogo.prim._reduce.emptyListInvalidInput"))
+      throw new EngineException(context , this , I18N.errors.get("org.nlogo.prim._reduce.emptyListInvalidInput"))
     val it = list.iterator
     var result = it.next()
     while (it.hasNext)

--- a/netlogo-gui/src/main/prim/etc/_run.scala
+++ b/netlogo-gui/src/main/prim/etc/_run.scala
@@ -2,10 +2,10 @@
 
 package org.nlogo.prim.etc
 
-import org.nlogo.core.Syntax
-import org.nlogo.core.CompilerException
-import org.nlogo.nvm.{ Activation, ArgumentTypeException, Command, CommandTask, Context,
-                       EngineException, NonLocalExit, Procedure }
+import org.nlogo.core.{ CompilerException, I18N, Syntax }
+import org.nlogo.api.CommandTask
+import org.nlogo.nvm.{ Activation, ArgumentTypeException, Command, Context,
+                       EngineException, NonLocalExit, Procedure, Task }
 
 class _run extends Command {
 
@@ -33,9 +33,8 @@ class _run extends Command {
         }
       case task: CommandTask =>
         val n = args.size - 1
-        if(n < task.formals.size)
-          throw new EngineException(
-            context, this, task.missingInputs(n))
+        if (n < task.syntax.minimum)
+          throw new EngineException(context, this, Task.missingInputs(task, n))
         val actuals = new Array[AnyRef](n)
         var i = 0
         while(i < n) {

--- a/netlogo-gui/src/main/prim/etc/_runresult.scala
+++ b/netlogo-gui/src/main/prim/etc/_runresult.scala
@@ -2,14 +2,12 @@
 
 package org.nlogo.prim.etc
 
-import org.nlogo.api.{ LogoException}
-import org.nlogo.core.Syntax
+import org.nlogo.api.{ LogoException, ReporterTask }
+import org.nlogo.core.{ I18N, Syntax }
 import org.nlogo.core.CompilerException
-import org.nlogo.nvm.{ Activation, ArgumentTypeException, Context, EngineException, Reporter, ReporterTask }
+import org.nlogo.nvm.{ Activation, ArgumentTypeException, Context, EngineException, Reporter, Task }
 
 class _runresult extends Reporter {
-
-
 
   override def report(context: Context) =
     args(0).report(context) match {
@@ -36,9 +34,8 @@ class _runresult extends Reporter {
         }
       case task: ReporterTask =>
         val n = args.size - 1
-        if(n < task.formals.size)
-          throw new EngineException(
-            context, this, task.missingInputs(n))
+        if (n < task.syntax.minimum)
+          throw new EngineException(context, this, Task.missingInputs(task, n))
         val actuals = new Array[AnyRef](n)
         var i = 0
         while(i < n) {

--- a/netlogo-gui/src/main/prim/etc/_sortby.scala
+++ b/netlogo-gui/src/main/prim/etc/_sortby.scala
@@ -3,24 +3,20 @@
 package org.nlogo.prim.etc
 
 import org.nlogo.agent.AgentSet
-import org.nlogo.api.{ LogoException}
+import org.nlogo.api.{ LogoException, ReporterTask }
 import org.nlogo.core.Syntax
 import org.nlogo.core.LogoList
-import org.nlogo.nvm.{ ArgumentTypeException, Context, EngineException, Reporter, ReporterTask  }
+import org.nlogo.nvm.{ ArgumentTypeException, Context, EngineException, Reporter, Task }
 
 class _sortby extends Reporter {
-
   // see issue #172
   private val Java7SoPicky =
     "Comparison method violates its general contract!"
 
-
-
   override def report(context: Context) = {
     val task = argEvalReporterTask(context, 0)
-    if(task.formals.size > 2)
-      throw new EngineException(
-        context, this, task.missingInputs(2))
+    if (task.syntax.minimum > 2)
+      throw new EngineException(context, this, Task.missingInputs(task, 2))
     val obj = args(1).report(context)
     val input = obj match {
       case list: LogoList =>

--- a/netlogo-gui/src/main/window/GUIWorkspace.java
+++ b/netlogo-gui/src/main/window/GUIWorkspace.java
@@ -858,12 +858,12 @@ public abstract strictfp class GUIWorkspace // can't be both abstract and strict
     }
     if (owner.ownsPrimaryJobs()) {
       if (e.procedure != null) {
-        jobManager.addJob(owner, agents, e.procedure);
+        jobManager.addJob(owner, agents, this, e.procedure);
       } else {
         new org.nlogo.window.Events.JobRemovedEvent(owner).raiseLater(this);
       }
     } else {
-      jobManager.addSecondaryJob(owner, agents, e.procedure);
+      jobManager.addSecondaryJob(owner, agents, this, e.procedure);
     }
   }
 

--- a/netlogo-gui/src/main/workspace/Evaluator.scala
+++ b/netlogo-gui/src/main/workspace/Evaluator.scala
@@ -19,14 +19,14 @@ class Evaluator(workspace: AbstractWorkspace) {
                        waitForCompletion: Boolean = true) = {
     val procedure = invokeCompiler(source, None, true, agentSet.kind)
     workspace.jobManager.addJob(
-      workspace.jobManager.makeConcurrentJob(owner, agentSet, procedure),
+      workspace.jobManager.makeConcurrentJob(owner, agentSet, workspace, procedure),
       waitForCompletion)
   }
 
   @throws(classOf[CompilerException])
   def evaluateReporter(owner: JobOwner, source: String, agents: AgentSet = workspace.world.observers): Object = {
     val procedure = invokeCompiler(source, None, false, agents.kind)
-    workspace.jobManager.addReporterJobAndWait(owner, agents, procedure)
+    workspace.jobManager.addReporterJobAndWait(owner, agents, workspace, procedure)
   }
 
   @throws(classOf[CompilerException])
@@ -41,13 +41,13 @@ class Evaluator(workspace: AbstractWorkspace) {
    * @return whether the code did a "stop" at the top level
    */
   def runCompiledCommands(owner: JobOwner, procedure: Procedure) = {
-    val job = workspace.jobManager.makeConcurrentJob(owner, workspace.world.observers, procedure)
+    val job = workspace.jobManager.makeConcurrentJob(owner, workspace.world.observers, workspace, procedure)
     workspace.jobManager.addJob(job, true)
     job.stopping
   }
 
   def runCompiledReporter(owner: JobOwner, procedure: Procedure) =
-    workspace.jobManager.addReporterJobAndWait(owner, workspace.world.observers, procedure)
+    workspace.jobManager.addReporterJobAndWait(owner, workspace.world.observers, workspace, procedure)
 
   ///
 
@@ -105,8 +105,8 @@ class Evaluator(workspace: AbstractWorkspace) {
           // calling the procedure directly.  This is temporary code that never got cleaned up.
           // Submitting jobs through the job manager is supposed to be the only way that NetLogo code
           // is ever run. - ST 1/8/10
-          val job = new ExclusiveJob(owner, agentset, procedure, 0, null, owner.random)
-          val context = new Context(job, agent, 0, null)
+          val job = new ExclusiveJob(owner, agentset, procedure, 0, null, workspace, owner.random)
+          val context = new Context(job, agent, 0, null, workspace)
           try context.callReporterProcedure(new Activation(procedure, null, 0))
           catch {
             case ex @ (_: LogoException | _: RuntimeException) =>

--- a/netlogo-gui/src/test/nvm/ContextTests.scala
+++ b/netlogo-gui/src/test/nvm/ContextTests.scala
@@ -7,7 +7,7 @@ import org.nlogo.core.Let
 
 class ContextTests extends FunSuite {
   test("let 1") {
-    val c = new Context(null, null, 0, null)
+    val c = new Context(null, null, 0, null, null)
     val let = new Let
     c.let(let, "foo")
     assert(c.getLet(let) === "foo")
@@ -15,7 +15,7 @@ class ContextTests extends FunSuite {
     assert(c.getLet(let) === "bar")
   }
   test("let 2") {
-    val c = new Context(null, null, 0, null)
+    val c = new Context(null, null, 0, null, null)
     val (let1, let2) = (new Let, new Let)
     c.let(let1, "foo")
     assert(c.getLet(let1) === "foo")

--- a/netlogo-headless/src/main/nvm/ConcurrentJob.scala
+++ b/netlogo-headless/src/main/nvm/ConcurrentJob.scala
@@ -7,8 +7,8 @@ import org.nlogo.api.{ JobOwner, LogoException }
 import org.nlogo.api.MersenneTwisterFast
 
 class ConcurrentJob(owner: JobOwner, agentset: AgentSet, topLevelProcedure: Procedure,
-                    address: Int, parentContext: Context, random: MersenneTwisterFast)
-extends Job(owner, agentset, topLevelProcedure, address, parentContext, random) {
+                    address: Int, parentContext: Context, workspace: Workspace, random: MersenneTwisterFast)
+extends Job(owner, agentset, topLevelProcedure, address, parentContext, workspace, random) {
 
   override def exclusive = false
 

--- a/netlogo-headless/src/main/nvm/ExclusiveJob.scala
+++ b/netlogo-headless/src/main/nvm/ExclusiveJob.scala
@@ -7,8 +7,8 @@ import org.nlogo.api.JobOwner
 import org.nlogo.api.MersenneTwisterFast
 
 class ExclusiveJob(owner: JobOwner, agentset: AgentSet, topLevelProcedure: Procedure,
-                   address: Int, parentContext: Context, random: MersenneTwisterFast)
-extends Job(owner, agentset, topLevelProcedure, address, parentContext, random) {
+                   address: Int, parentContext: Context, workspace: Workspace, random: MersenneTwisterFast)
+extends Job(owner, agentset, topLevelProcedure, address, parentContext, workspace, random) {
 
   override def exclusive = true
 

--- a/netlogo-headless/src/main/nvm/Instruction.scala
+++ b/netlogo-headless/src/main/nvm/Instruction.scala
@@ -2,9 +2,8 @@
 
 package org.nlogo.nvm
 
-import org.nlogo.core.{ AgentKind, Syntax, Token, TokenHolder }
-import org.nlogo.core.I18N
-import org.nlogo.core.LogoList
+import org.nlogo.api.{ CommandTask => ApiCommandTask, ReporterTask => ApiReporterTask }
+import org.nlogo.core.{ AgentKind, I18N, LogoList, Syntax, Token, TokenHolder }
 import org.nlogo.agent.{ Agent, AgentSet, AgentBit, Turtle, Patch, Link, World }
 
 object Instruction {
@@ -180,18 +179,18 @@ abstract class Instruction extends InstructionJ with TokenHolder {
           context, this, index, Syntax.AgentsetType, x)
     }
 
-  def argEvalReporterTask(context: Context, index: Int): ReporterTask =
+  def argEvalReporterTask(context: Context, index: Int): ApiReporterTask =
     args(index).report(context) match {
-      case t: ReporterTask =>
+      case t: ApiReporterTask =>
         t
       case x =>
         throw new ArgumentTypeException(
           context, this, index, Syntax.ReporterTaskType, x)
     }
 
-  def argEvalCommandTask(context: Context, index: Int): CommandTask =
+  def argEvalCommandTask(context: Context, index: Int): ApiCommandTask =
     args(index).report(context) match {
-      case t: CommandTask =>
+      case t: ApiCommandTask =>
         t
       case x =>
         throw new ArgumentTypeException(

--- a/netlogo-headless/src/main/nvm/Job.java
+++ b/netlogo-headless/src/main/nvm/Job.java
@@ -22,6 +22,7 @@ public abstract strictfp class Job {
   public final AgentSet agentset;
   public final Context parentContext;
   public final Procedure topLevelProcedure;
+  protected final Workspace workspace;
 
   public org.nlogo.api.MersenneTwisterFast random;
 
@@ -30,12 +31,14 @@ public abstract strictfp class Job {
       Procedure topLevelProcedure,
       int address,
       Context parentContext,
+      Workspace workspace,
       org.nlogo.api.MersenneTwisterFast random) {
     this.owner = owner;
     this.agentset = agentset;
     this.topLevelProcedure = topLevelProcedure;
     this.address = address;
     this.parentContext = parentContext;
+    this.workspace = workspace;
     this.random = random;
   }
 

--- a/netlogo-headless/src/main/nvm/JobManagerInterface.scala
+++ b/netlogo-headless/src/main/nvm/JobManagerInterface.scala
@@ -14,12 +14,12 @@ trait JobManagerInterface {
   def maybeRunSecondaryJobs()
   def anyPrimaryJobs(): Boolean
   def addJob(job: Job, waitForCompletion: Boolean)
-  def makeConcurrentJob(owner: JobOwner, agentset: AgentSet, procedure: Procedure): Job
-  def callReporterProcedure(owner: JobOwner, agentset: AgentSet, procedure: Procedure): AnyRef
-  def addReporterJobAndWait(owner: JobOwner, agentset: AgentSet, procedure: Procedure): AnyRef
+  def makeConcurrentJob(owner: JobOwner, agentset: AgentSet, workspace: Workspace, procedure: Procedure): Job
+  def callReporterProcedure(owner: JobOwner, agentset: AgentSet, workspace: Workspace, procedure: Procedure): AnyRef
+  def addReporterJobAndWait(owner: JobOwner, agentset: AgentSet, workspace: Workspace, procedure: Procedure): AnyRef
   def addJobFromJobThread(job: Job)
-  def addJob(owner: JobOwner, agents: AgentSet, procedure: Procedure)
-  def addSecondaryJob(owner: JobOwner, agents: AgentSet, procedure: Procedure)
+  def addJob(owner: JobOwner, agents: AgentSet, workspace: Workspace, procedure: Procedure)
+  def addSecondaryJob(owner: JobOwner, agents: AgentSet, workspace: Workspace, procedure: Procedure)
   def joinForeverButtons(agent: Agent)
   def haltPrimary()
   def haltNonObserverJobs()

--- a/netlogo-headless/src/main/nvm/Workspace.scala
+++ b/netlogo-headless/src/main/nvm/Workspace.scala
@@ -8,6 +8,7 @@ import org.nlogo.agent.{ Agent, AgentSet }
 import collection.mutable.WeakHashMap
 
 trait Workspace extends api.Workspace with JobManagerOwner with api.ViewSettings {
+  def world: org.nlogo.agent.World
   def breathe(context: Context) // called when engine comes up for air
   def requestDisplayUpdate(context: Context, force: Boolean)
   def updateUI(context: Context) { }

--- a/netlogo-headless/src/main/prim/_run.scala
+++ b/netlogo-headless/src/main/prim/_run.scala
@@ -2,9 +2,10 @@
 
 package org.nlogo.prim
 
+import org.nlogo.api.CommandTask
 import org.nlogo.core.{ CompilerException, Syntax }
 import org.nlogo.nvm.{ Activation, ArgumentTypeException, Command,
-                       CommandTask, Context, EngineException, NonLocalExit }
+                       Context, EngineException, NonLocalExit, Task }
 
 class _run extends Command {
 
@@ -30,9 +31,8 @@ class _run extends Command {
         }
       case task: CommandTask =>
         val n = args.size - 1
-        if(n < task.formals.size)
-          throw new EngineException(
-            context, this, task.missingInputs(n))
+        if (n < task.syntax.minimum)
+          throw new EngineException(context, this, Task.missingInputs(task, n))
         val actuals = new Array[AnyRef](n)
         var i = 0
         while(i < n) {

--- a/netlogo-headless/src/main/prim/etc/_filter.scala
+++ b/netlogo-headless/src/main/prim/etc/_filter.scala
@@ -4,16 +4,16 @@ package org.nlogo.prim.etc
 
 import org.nlogo.api.LogoListBuilder
 import org.nlogo.core.{ LogoList, Syntax }
-import org.nlogo.nvm.{ ArgumentTypeException, Context, EngineException, Reporter }
+import org.nlogo.nvm.{ ArgumentTypeException, Context, EngineException, Reporter, Task }
 
 class _filter extends Reporter {
 
   def report(context: Context): LogoList = {
     val task = argEvalReporterTask(context, 0)
     val list = argEvalList(context, 1)
-    if(task.formals.size > 1)
+    if (task.syntax.minimum > 1)
       throw new EngineException(
-        context, this, task.missingInputs(1))
+        context, this, Task.missingInputs(task, 1))
     val builder = new LogoListBuilder
     for (item <- list)
       task.report(context, Array(item)) match {

--- a/netlogo-headless/src/main/prim/etc/_foreach.scala
+++ b/netlogo-headless/src/main/prim/etc/_foreach.scala
@@ -3,7 +3,7 @@
 package org.nlogo.prim.etc
 
 import org.nlogo.core.I18N
-import org.nlogo.nvm.{ Command, Context, EngineException, NonLocalExit }
+import org.nlogo.nvm.{ Command, Context, EngineException, NonLocalExit, Task }
 
 class _foreach extends Command {
   override def perform(context: Context) {
@@ -18,9 +18,9 @@ class _foreach extends Command {
       list.javaIterator
     }
     val task = argEvalCommandTask(context, n)
-    if(n < task.formals.size)
+    if (n < task.syntax.minimum)
       throw new EngineException(
-        context, this, task.missingInputs(n))
+        context, this, Task.missingInputs(task, n))
     var i = 0
     val actuals = new Array[AnyRef](n)
     try {

--- a/netlogo-headless/src/main/prim/etc/_map.scala
+++ b/netlogo-headless/src/main/prim/etc/_map.scala
@@ -4,7 +4,7 @@ package org.nlogo.prim.etc
 
 import org.nlogo.api.LogoListBuilder
 import org.nlogo.core.LogoList
-import org.nlogo.nvm.{ Context, EngineException, Reporter }
+import org.nlogo.nvm.{ Context, EngineException, Reporter, Task }
 
 class _map extends Reporter {
 
@@ -17,9 +17,8 @@ class _map extends Reporter {
 
     val task = argEvalReporterTask(context, 0)
     val n = args.length - 1
-    if(n < task.formals.size)
-      throw new EngineException(
-        context, this, task.missingInputs(n))
+    if(n < task.syntax.minimum)
+      throw new EngineException(context, this, Task.missingInputs(task, n))
 
     // get all of the list args, if any.
     var size = 0

--- a/netlogo-headless/src/main/prim/etc/_nvalues.scala
+++ b/netlogo-headless/src/main/prim/etc/_nvalues.scala
@@ -4,7 +4,7 @@ package org.nlogo.prim.etc
 
 import org.nlogo.api.LogoListBuilder
 import org.nlogo.core.{ I18N, LogoList }
-import org.nlogo.nvm.{ Context, EngineException, Reporter }
+import org.nlogo.nvm.{ Context, EngineException, Reporter, Task }
 
 class _nvalues extends Reporter {
 
@@ -17,9 +17,8 @@ class _nvalues extends Reporter {
     // make the result list.
     val result = new LogoListBuilder
     val task = argEvalReporterTask(context, 1)
-    if(task.formals.size > 1)
-      throw new EngineException(
-        context, this, task.missingInputs(1))
+    if (task.syntax.minimum > 1)
+      throw new EngineException(context, this, Task.missingInputs(task, 1))
     for (i <- 0 until n)
       result.add(task.report(context, Array[AnyRef](Double.box(i))))
     result.toLogoList

--- a/netlogo-headless/src/main/prim/etc/_reduce.scala
+++ b/netlogo-headless/src/main/prim/etc/_reduce.scala
@@ -3,15 +3,14 @@
 package org.nlogo.prim.etc
 
 import org.nlogo.core.I18N
-import org.nlogo.nvm.{ Context, EngineException, Reporter }
+import org.nlogo.nvm.{ Context, EngineException, Reporter, Task }
 
 class _reduce extends Reporter {
 
   override def report(context: Context): AnyRef = {
     val task = argEvalReporterTask(context, 0)
-    if(task.formals.size > 2)
-      throw new EngineException(
-        context, this, task.missingInputs(2))
+    if (task.syntax.minimum > 2)
+      throw new EngineException(context, this, Task.missingInputs(task, 2))
     val list = argEvalList(context, 1)
     if (list.size < 1)
       throw new EngineException( context , this , I18N.errors.get("org.nlogo.prim._reduce.emptyListInvalidInput"))

--- a/netlogo-headless/src/main/prim/etc/_runresult.scala
+++ b/netlogo-headless/src/main/prim/etc/_runresult.scala
@@ -2,9 +2,9 @@
 
 package org.nlogo.prim.etc
 
-import org.nlogo.api.LogoException
+import org.nlogo.api.{ LogoException, ReporterTask }
 import org.nlogo.core.{ CompilerException, Syntax }
-import org.nlogo.nvm.{ Activation, ArgumentTypeException, Context, EngineException, Reporter, ReporterTask }
+import org.nlogo.nvm.{ Activation, ArgumentTypeException, Context, EngineException, Reporter, Task }
 
 class _runresult extends Reporter {
 
@@ -35,9 +35,8 @@ class _runresult extends Reporter {
         }
       case task: ReporterTask =>
         val n = args.size - 1
-        if(n < task.formals.size)
-          throw new EngineException(
-            context, this, task.missingInputs(n))
+        if (n < task.syntax.minimum)
+          throw new EngineException(context, this, Task.missingInputs(task, n))
         val actuals = new Array[AnyRef](n)
         var i = 0
         while(i < n) {

--- a/netlogo-headless/src/main/prim/etc/_sortby.scala
+++ b/netlogo-headless/src/main/prim/etc/_sortby.scala
@@ -5,9 +5,9 @@ package org.nlogo.prim.etc
 import scala.collection.mutable
 import scala.math.Ordering
 import org.nlogo.agent.AgentSet
-import org.nlogo.api.LogoException
+import org.nlogo.api.{ LogoException, ReporterTask }
 import org.nlogo.core.{ LogoList, Syntax }
-import org.nlogo.nvm.{ ArgumentTypeException, Context, EngineException, Reporter, ReporterTask }
+import org.nlogo.nvm.{ ArgumentTypeException, Context, EngineException, Reporter, Task }
 
 class _sortby extends Reporter {
 
@@ -17,9 +17,9 @@ class _sortby extends Reporter {
 
   override def report(context: Context): LogoList = {
     val task = argEvalReporterTask(context, 0)
-    if(task.formals.size > 2)
+    if (task.syntax.minimum > 2)
       throw new EngineException(
-        context, this, task.missingInputs(2))
+        context, this, Task.missingInputs(task, 2))
     val obj = args(1).report(context)
     val input = obj match {
       case list: LogoList => list

--- a/shared/i18n/Errors_en.txt
+++ b/shared/i18n/Errors_en.txt
@@ -176,6 +176,8 @@ org.nlogo.workspace.DefaultFileManager.noOpenFile = No file has been opened.
 
 org.nlogo.prim.etc._foreach.listsMustBeSameLength = All the list arguments to FOREACH must be the same length.
 org.nlogo.prim.$common.noSumOfListWithNonNumbers =  Can''t find the sum of a list that contains non-numbers {0} is a {1}.
+org.nlogo.prim.task.missingInput = task expected 1 input, but only got 0
+org.nlogo.prim.task.missingInputs = task expected {0} inputs, but only got {1}
 org.nlogo.prim._returnreport.reportNotCalledInReportProcedure = Reached end of reporter procedure without REPORT being called.
 org.nlogo.prim.etc.$common.expectedLastInputToBeLinkBreed = Expected the last input to be a link breed.
 

--- a/test/commands/CommandTasks.txt
+++ b/test/commands/CommandTasks.txt
@@ -132,7 +132,7 @@ command-and-reporter-tasks-close-over-same-procedure-input
   O> run task [run task [print __boom]] => STACKTRACE boom!\
   error while observer running __BOOM\
     called by (command task from: procedure __EVALUATOR: [print __boom])\
-    called by (command task from: procedure __EVALUATOR: [(run task [print __boom])])\
+    called by (command task from: procedure __EVALUATOR: [run task [print __boom]])\
     called by procedure __EVALUATOR
 
 turtle-executing-command-task


### PR DESCRIPTION
The purpose of this is to allow extensions to easily generate tasks that wrap JVM code that can be used by the rest of NetLogo. Currently, you have to instantiate `nvm.*Task`  with bogus data. It's not a lot of code, but it gross. The CF extension currently does it here: https://github.com/qiemem/ControlFlowExtension/blob/0e703c8c47a406cd8364d6749f9ae417b8bf8e2a/src/main/CFExtension.scala#L24

It would be nice if extensions just had to override `api.ReporterTask.report`/`api.CommandTask.perform`.