### PR TITLE
M7 LevelSpace Improvements

### DIFF
--- a/netlogo-gui/src/main/headless/HeadlessWorkspace.scala
+++ b/netlogo-gui/src/main/headless/HeadlessWorkspace.scala
@@ -10,7 +10,7 @@ import java.nio.file.Paths
 
 import org.nlogo.agent.{ Agent, Observer }
 import org.nlogo.api.{ ComponentSerialization, Version, ModelLoader, RendererInterface,
-  WorldDimensions3D, AggregateManagerInterface, FileIO, LogoException, ModelReader, SimpleJobOwner,
+  WorldDimensions3D, AggregateManagerInterface, FileIO, LogoException, ModelReader, ModelType, SimpleJobOwner,
   HubNetInterface, CommandRunnable, ReporterRunnable }, ModelReader.modelSuffix
 import org.nlogo.core.{ AgentKind, CompilerException, Femto, Model, UpdateMode, WorldDimensions }
 import org.nlogo.agent.{ World, World3D }
@@ -503,6 +503,7 @@ with org.nlogo.api.ViewSettings {
     setModelPath(path)
     try {
       loader.readModel(Paths.get(path).toUri).foreach { m =>
+        setModelType(ModelType.Normal)
         fileManager.handleModelChange()
         openModel(m)
       }

--- a/netlogo-gui/src/main/window/InterfacePanelLite.scala
+++ b/netlogo-gui/src/main/window/InterfacePanelLite.scala
@@ -39,7 +39,6 @@ class InterfacePanelLite(val viewWidget: ViewWidgetInterface, compiler: Compiler
   addFocusListener(this)
   addMouseListener(iPMouseListener)
   addKeyListener(getKeyAdapter)
-  addWidget(viewWidget.asInstanceOf[Widget], 0, 0)
 
   // made protected so that hubnet could override it to implement message throttling. -JC 8/19/10
   protected def getKeyAdapter: KeyAdapter =
@@ -229,15 +228,14 @@ class InterfacePanelLite(val viewWidget: ViewWidgetInterface, compiler: Compiler
         case v: CoreView =>
           // the graphics widget (and the command center) are special cases because
           // they are not recreated at load time, but reused
-          val widget = viewWidget.asWidget.asInstanceOf[ViewWidgetInterface]
           try {
-            widget.load(v)
+            viewWidget.load(v)
           } catch {
             case ex: RuntimeException => Exceptions.handle(ex)
           }
-          widget.setSize(widget.getSize)
-          widget.setLocation(x, y)
-          widget
+          viewWidget.setSize(viewWidget.getSize())
+          addWidget(viewWidget, x, y)
+          viewWidget
         case _ =>
           val newGuy = widgetBuilderMap.get(coreWidget.getClass.getSimpleName).flatMap(createWidget =>
             try Some(createWidget())


### PR DESCRIPTION
Meta-issue for NetLogo improvements that would be useful to LevelSpace post-M7

- [x] Make `InterfacePanelLite` add the viewWidget in `loadWidget` (so the view actually shows up)
- [x] Make HeadlessWorkspace have modelType Normal once a model with a path has actually been opened