### PR TITLE
hexy: Active jobs on the job thread should prevent app nap in OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ tmp/
 /lib/
 /netlogo-gui/lib/
 /natives/
+/mac-app/natives/
 /netlogo-gui/natives/
 /out/
 /resources/Errors_??.properties

--- a/build.sbt
+++ b/build.sbt
@@ -194,13 +194,22 @@ lazy val macApp = project.in(file("mac-app")).
   settings(jvmSettings: _*).
   settings(scalaSettings: _*).
   settings(JavaPackager.mainArtifactSettings: _*).
+  settings(NativeLibs.cocoaLibsTask).
+  settings(Running.settings).
   settings(
     fork in run                           := true,
     name                                  := "NetLogo-Mac-App",
     compile in Compile                    <<= (compile in Compile) dependsOn (packageBin in Compile in netlogo),
     unmanagedJars in Compile              += (packageBin in Compile in netlogo).value,
+    libraryDependencies                   ++= Seq(
+      "net.java.dev.jna" % "jna" % "4.2.2",
+      "ca.weblite" % "java-objc-bridge" % "1.0.0"),
     libraryDependencies                   ++= (libraryDependencies in netlogo).value,
     libraryDependencies                   ++= (libraryDependencies in parserJVM).value,
+    run in Compile                        <<= (run in Compile) dependsOn NativeLibs.cocoaLibs,
+    javaOptions in run                    += "-Djava.library.path=" + (Seq(
+      baseDirectory.value / "natives" / "macosx-universal" / "libjcocoa.dylib") ++
+      ((baseDirectory in netlogo).value / "natives" / "macosx-universal" * "*.jnilib").get).mkString(":"),
     artifactPath in Compile in packageBin := target.value / "netlogo-mac-app.jar",
     javacOptions                          ++= Seq("-bootclasspath", System.getProperty("java.home") + "/lib/rt.jar"))
 

--- a/mac-app/src/main/java/org/nlogo/app/MacApplication.java
+++ b/mac-app/src/main/java/org/nlogo/app/MacApplication.java
@@ -6,6 +6,9 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
+import ca.weblite.objc.Client;
+import ca.weblite.objc.Proxy;
+
 import com.apple.eawt.Application;
 
 // for those of you wondering why this song and dance is necessary
@@ -32,6 +35,12 @@ public class MacApplication {
     System.setProperty("apple.awt.graphics.UseQuartz", "true");
     System.setProperty("apple.awt.showGrowBox", "true");
     System.setProperty("apple.laf.useScreenMenuBar", "true");
+
+    long userInitiatedAllowingIdleSleep = 0x00FFFFFFL;
+
+    Client c = Client.getInstance();
+    Proxy processInfo = c.sendProxy("NSProcessInfo", "processInfo");
+    processInfo.sendProxy("beginActivityWithOptions:reason:", userInitiatedAllowingIdleSleep, "Running NetLogo simulation");
 
     try {
       String mainApplicationClassName = System.getProperty("org.nlogo.mac.appClassName", "org.nlogo.app.App$");

--- a/project/NativeLibs.scala
+++ b/project/NativeLibs.scala
@@ -3,6 +3,8 @@ import Keys._
 
 import java.net.URL
 
+import NetLogoBuild.cclArtifacts
+
 import scala.language.postfixOps
 
 // native libraries for JOGL
@@ -11,6 +13,9 @@ object NativeLibs {
 
   val nativeLibs = TaskKey[Seq[File]](
     "native-libs", "download native libraries for JOGL")
+
+  val cocoaLibs = TaskKey[Seq[File]](
+    "download native libraries for mac interaction")
 
   lazy val nativeLibsTask =
     nativeLibs <<= (baseDirectory, streams) map {
@@ -29,9 +34,17 @@ object NativeLibs {
         (joglNatives ***).get.foreach { f =>
           if (Seq("jocl", "mobile", "newt", "openal", "oal", "jogl_cg", "joal")
             .exists(notwanted => f.getName.contains(notwanted)))
-            IO.delete(f)
+          IO.delete(f)
         }
         (joglNatives ***).get
-      }
+    }
+
+  lazy val cocoaLibsTask =
+    cocoaLibs := {
+      val libDir = baseDirectory.value / "natives" / "macosx-universal"
+      IO.createDirectory(libDir / "natives")
+      IO.download(new java.net.URL(cclArtifacts("libjcocoa.dylib")), libDir / "libjcocoa.dylib")
+      Seq(libDir / "libjcocoa.dylib")
+    }
 
 }

--- a/project/NetLogoPackaging.scala
+++ b/project/NetLogoPackaging.scala
@@ -44,7 +44,7 @@ object NetLogoPackaging {
     case (_,                   "HubNet Client")                              => "org.nlogo.hubnet.client.App"
   }
 
-  def bundledDirs(netlogo: Project): Def.Initialize[PlatformBuild => Seq[BundledDirectory]] =
+  def bundledDirs(netlogo: Project, macApp: Project): Def.Initialize[PlatformBuild => Seq[BundledDirectory]] =
     Def.setting {
       { (platform: PlatformBuild) =>
         val nlDir = (baseDirectory in netlogo).value
@@ -55,7 +55,10 @@ object NetLogoPackaging {
         ) ++ (platform.shortName match {
           case "windows" => Seq(new NativesDir(nlDir / "natives", "windows-amd64", "windows-i586"))
           case "linux"   => Seq(new NativesDir(nlDir / "natives", "linux-amd64", "linux-i586"))
-          case "macosx"  => Seq(new NativesDir(nlDir / "natives", "macosx-universal"))
+          case "macosx"  => Seq(
+            new NativesDir(nlDir / "natives", "macosx-universal"),
+            new NativesDir((baseDirectory in macApp).value / "natives", "macosx-universal")
+          )
         })
       }
     }
@@ -185,7 +188,7 @@ object NetLogoPackaging {
     },
     packageApp            <<=
       InputTask.createDyn(packageAppParser)(PackageAction.subApplication(appMainClass,
-        mainJarAndDependencies(netlogo, macApp), bundledDirs(netlogo), jvmOptions)),
+        mainJarAndDependencies(netlogo, macApp), bundledDirs(netlogo, macApp), jvmOptions)),
     packageLinuxAggregate <<=
       InputTask.createDyn(aggregateJDKParser)(Def.task(
         PackageAction.aggregate("linux", AggregateLinuxBuild, packageApp, packageLinuxAggregate))),


### PR DESCRIPTION
Alternatively, we could disable app nap completely.

The problem is that when NetLogo is backgrounded for a little bit, it practically stops running due to OS X's "app nap". This means you must keep NetLogo foregrounded for long running simulations to complete. Anecdote: I was doing one experiment where each iteration (of 30,000 ticks) was taking about a half an hour foregrounded. I left my computer running for a while with NetLogo in the background (sleep on the computer disabled) and the next iteration took about 9 hours to complete (overnight).

App nap was disabled completely in 5.x, I assume because Java 6 just didn't support it. I would guess that Java 8 enables it by default.