### PR TITLE
bump API version number to 6

### DIFF
--- a/autogen/docs/transition.html.mustache
+++ b/autogen/docs/transition.html.mustache
@@ -78,6 +78,36 @@
       If you used it to check link directedness leaving it as-is should keep the current behavior of the model.
       Otherwise, it can simply be replaced by <code>is-&lt;breed&gt;?</code>.
     </div>
+    <h3>
+      Improved &amp; Updated Extensions API
+    </h3>
+    <p id="extensions60">
+      One of our goals in NetLogo 6.0 has been to make it easier to develop
+      extensions and easy to develop more <em>powerful</em> extensions.
+      To that end, we've bumped the extension API from 5.0 to 6.0.
+      Existing extensions will need to recompile changing the "NetLogo-Extension-API-Version"
+      in their jar's MANIFEST.MF from 5.0 to 6.0.
+    <p>
+      Some of the changes we've made to the extensions API include:
+      <ul>
+        <li><code>org.nlogo.api.Context</code> now allows access to the current world and workspace objects
+        without requiring a cast to an <code>org.nlogo.nvm.ExtensionContext</code>.</li>
+        <li><code>org.nlogo.api.Workspace</code> has been introduced as a stable API for extensions to depend on.</li>
+        <li>A NetLogo jar is now available from BinTray.</li>
+      </ul>
+      For a full list of changes between 5.0 and 6.0, please visit our
+      <a href="https://github.com/NetLogo/NetLogo/wiki/Hexy-Extension-Transition-Guide">Extension Transition Guide</a>
+      on GitHub.
+    <p>
+      In service of making it easier to build extensions, we've expanded and improved
+      the <a href="https://github.com/NetLogo/NetLogo-Extension-Plugin">NetLogo Extension Plugin</a>
+      for <a href="http://www.scala-sbt.org/"><code>sbt</code></a>, the Scala Build Tool.
+      Sbt is a powerful tool for building JVM projects and can be used in projects that
+      use Scala, Java, or a combination of the two. We're now using the Extension Plugin to build
+      all of the bundled extensions and we strongly recommend extension authors take advantage
+      of the plugin as it makes configuring a NetLogo extension build extremely straightforward.
+      The plugin handles fetching the NetLogo jar which extensions compile against as
+      well as generation of a jar for the extension containing the appropriate metadata.
     <div id="v52">
     <h2>
       <a>Changes for NetLogo 5.2</a>

--- a/autogen/docs/versions.html.mustache
+++ b/autogen/docs/versions.html.mustache
@@ -18,6 +18,11 @@
     <h2>
       Version 6.0 (Mid-2016)
     </h2>
+    <h3>Extension Changes</h3>
+      <ul>
+        <li>The Extensions API has been updated from 5.0 to 6.0. See <a href="transition.html#extensions60">the transition guide</a>
+        for more information.</li>
+      </ul>
     <h3>Internationalization Changes</h3>
       <ul>
         <li>A Japanese translation for NetLogo is now available and included with the standard download.</li>

--- a/netlogo-core/src/main/api/APIVersion.scala
+++ b/netlogo-core/src/main/api/APIVersion.scala
@@ -6,5 +6,5 @@ package org.nlogo.api
 // extensions API.
 
 object APIVersion {
-  val version = "5.0"
+  val version = "6.0"
 }

--- a/netlogo-gui/src/test/workspace/InMemoryLoaderTests.scala
+++ b/netlogo-gui/src/test/workspace/InMemoryLoaderTests.scala
@@ -14,7 +14,7 @@ class InMemoryExtensionLoaderTests extends FunSuite {
   val loader = new InMemoryExtensionLoader("foo", dummyClassManager)
   val extURL = new URL("file:/tmp/extension/foo")
   val extensionData =
-    new ExtensionData("foo", extURL, "foo", classOf[DummyClassManager].getCanonicalName, Some("5.0"), 0)
+    new ExtensionData("foo", extURL, "foo", classOf[DummyClassManager].getCanonicalName, Some("6.0"), 0)
 
   test("InMemoryExtensionLoader returns None when asked to load an extension not matching its specified prefix") {
     assert(loader.locateExtension("bar").isEmpty)

--- a/netlogo-gui/src/test/workspace/JarLoaderTests.scala
+++ b/netlogo-gui/src/test/workspace/JarLoaderTests.scala
@@ -30,12 +30,12 @@ class JarLoaderTests extends FunSuite with BeforeAndAfter {
   val emptyJarFile        = new File("tmp/empty/empty.jar")
 
   val dummyExtensionData =
-    new ExtensionData("dummy", dummyJarURL, "dummy", "org.nlogo.workspace.DummyClassManager", Some("5.0"), 0)
+    new ExtensionData("dummy", dummyJarURL, "dummy", "org.nlogo.workspace.DummyClassManager", Some("6.0"), 0)
 
   val dummyManifest = {
     val m = new JarManifest
     val attrs = m.getMainAttributes
-    attrs.putValue("NetLogo-Extension-API-Version", "5.0")
+    attrs.putValue("NetLogo-Extension-API-Version", "6.0")
     attrs.putValue("Extension-Name", dummyExtensionData.prefix)
     attrs.putValue("Class-Manager", dummyExtensionData.classManagerName)
     m
@@ -101,7 +101,7 @@ class JarLoaderTests extends FunSuite with BeforeAndAfter {
     assert(extensionData.fileURL == arrayJarURL)
     assert(extensionData.prefix == "array")
     assert(extensionData.classManagerName == "org.nlogo.extensions.array.ArrayExtension")
-    assert(extensionData.version == Some("5.0"))
+    assert(extensionData.version == Some("6.0"))
     assert(extensionData.modified == modified)
   }
 


### PR DESCRIPTION
at present on master the API version number is still 5.0, but if we can't promise that 5.0 extensions are binary compatible with the current code, the API version will need to be bumped (and everyone will need to recompile their extensions)