### PR TITLE
RNG in plots is reseeded every update

### DIFF
--- a/netlogo-gui/src/main/workspace/Evaluator.scala
+++ b/netlogo-gui/src/main/workspace/Evaluator.scala
@@ -68,12 +68,12 @@ class Evaluator(workspace: AbstractWorkspace) {
 
   private object ProcedureRunner {
     var context: Context = null
-    def run(p: Procedure): Try[Boolean] = {
+    def run(p: Procedure, ownerOption: Option[JobOwner] = None): Try[Boolean] = {
       val oldActivation = context.activation
       val newActivation = new Activation(p, context.activation, 1)
       val oldRandom = context.job.random
       context.activation = newActivation
-      context.job.random = workspace.world.mainRNG.clone
+      context.job.random = ownerOption.map(_.random).getOrElse(workspace.world.mainRNG.clone)
       val procedureResult = Try {
         context.runExclusiveJob(workspace.world.observers, 0)
         val stopped = workspace.completedActivations.get(newActivation) != true
@@ -113,7 +113,7 @@ class Evaluator(workspace: AbstractWorkspace) {
       val proc = invokeCompiler(fullSource, Some(owner.displayName), true, agent.kind)
       new MyLogoThunk(fullSource, agent, owner, true, proc) with CommandLogoThunk {
         @throws(classOf[LogoException])
-        def call(): Try[Boolean] = ProcedureRunner.run(procedure)
+        def call(): Try[Boolean] = ProcedureRunner.run(procedure, Some(owner))
       }
     }
 


### PR DESCRIPTION
Every time any update or setup code in a plot is run, its RNG is seeded with the same seed. Here's a model which demonstrates this: https://gist.githubusercontent.com/qiemem/fffd478921a720bc415bb1219ebb5e0f/raw/f60e65b7499ada996c86fb89c55ec7b7b3b16079/gross-plots.nlogo

sample output:

```
observer> reset-ticks
plot setup
0.6551991655274944
first pen setup
0.6551991655274944
second pen setup
observer: 0.6551991655274944
plot update
0.6551991655274944
first pen update
0.6551991655274944
second pen update
0.6551991655274944
observer> tick
plot update
0.6551991655274944
first pen update
0.6551991655274944
second pen update
0.6551991655274944
observer> tick
plot update
0.6551991655274944
first pen update
0.6551991655274944
second pen update
0.6551991655274944
```