### PR TITLE
Add a preferences dialog, including the "User Interface Language" option

### DIFF
--- a/autogen/docs/dictionary.html.mustache
+++ b/autogen/docs/dictionary.html.mustache
@@ -674,7 +674,6 @@ Go figure! - ST 12/2/04
       System
     </h3>
     <p id="systemgroup">
-      <a href="#__change-language">__change-language</a>
       <a href="#netlogo-version">netlogo-version</a>
       <a href="#netlogo-web">netlogo-web?</a>
       <!-- ======================================== -->
@@ -1477,19 +1476,6 @@ show ceiling -4.5
         See also <a href="#floor">floor</a>, <a href="#round">round</a>,
         <a href="#precision">precision</a>.
       </div>
-    </div>
-    <div class="dict_entry" id="__change-language">
-      <h3>
-        <a>__change-language<span class="since">5.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">__change-language</span>
-      </h4>
-      <p>
-       Opens a dialog which allows the user to select a language.
-       See the <a href="interface.html#i18n">"International Usage"</a> section of the manual for more information.
-       It is <i>strongly recommended</i> that models avoid using this primitive since it changes the default language for all of NetLogo.
-      </p>
     </div>
     <div class="dict_entry" id="clear-all">
       <h3>

--- a/autogen/docs/interface.html.mustache
+++ b/autogen/docs/interface.html.mustache
@@ -445,6 +445,17 @@
             &nbsp;
           <td class="nameCenter">
         <p>
+            Preferences…
+          <td class="descriptionRight">
+        <p>
+            Opens the preferences dialog, where you can customize settings
+            regarding NetLogo.
+        <tr>
+        <td class="emptyLeft">
+        <p>
+            &nbsp;
+          <td class="nameCenter">
+        <p>
             Halt
           <td class="descriptionRight">
         <p>
@@ -1504,11 +1515,9 @@ black triangle).-->
       By default, NetLogo uses the same language your operating system is
       set to, if available. (If unavailable, you get English.)
     <p>
-      You can record a preference for a different language by typing
-      <code>__change-language</code> (that's two underscore characters at
-      the start) into the Command Center. A dialog will open allowing you
-      to choose from the supported languages. Once a new language is chosen
-      you will have to restart NetLogo.
+      You can record a preference for a different language by changing the
+      "User Interface Languge" option in the preferences dialog. Once a new
+      language is chosen you will have to restart NetLogo.
     <h3>
       Support for translators
     </h3>

--- a/autogen/docs/versions.html.mustache
+++ b/autogen/docs/versions.html.mustache
@@ -22,6 +22,7 @@
       <ul>
         <li>The <code>hubnet-set-client-interface</code> primitive has been removed.</li>
         <li>The various prims starting with <code>movie-</code> have been removed, as has the movie encoder. <a href="transition.html#movie-to-vie">The transition guide</a> provides more details and information.</li>
+        <li>The <code>__change-language</code> primitive has been removed. You can now change the User Interface Language through the preferences dialog.
       </ul>
     <h3>Extension Changes</h3>
       <ul>

--- a/mac-app/src/main/java/org/nlogo/app/MacHandler.java
+++ b/mac-app/src/main/java/org/nlogo/app/MacHandler.java
@@ -14,6 +14,7 @@ import com.apple.eawt.Application;
 import com.apple.eawt.AppEvent;
 import com.apple.eawt.OpenFilesHandler;
 import com.apple.eawt.OpenURIHandler;
+import com.apple.eawt.PreferencesHandler;
 import com.apple.eawt.QuitHandler;
 import com.apple.eawt.QuitResponse;
 
@@ -28,6 +29,7 @@ public class MacHandler {
     this.application = application;
     this.application.setOpenFileHandler(new MyOpenFilesHandler());
     this.application.setOpenURIHandler(new MyOpenURIHandler());
+    this.application.setPreferencesHandler(new MyPreferencesHandler());
     this.application.setAboutHandler(new MyAboutHandler());
     this.application.setQuitHandler(new MyQuitHandler());
     log("in directory:");
@@ -64,6 +66,20 @@ public class MacHandler {
     }
   }
 
+  class MyPreferencesHandler implements PreferencesHandler {
+    @Override
+    public void handlePreferences(AppEvent.PreferencesEvent event) {
+      try {
+        Class<?> appClass = app.getClass();
+        appClass.getDeclaredMethod("handleShowPreferences").invoke(app);
+      } catch (NoSuchMethodException e) {
+      } catch (IllegalAccessException e) {
+      } catch (InvocationTargetException e) {
+        log("failed to invoke handleShowPreferences");
+      }
+    }
+  }
+
   class MyAboutHandler implements AboutHandler {
     @Override
     public void handleAbout(AppEvent.AboutEvent event) {
@@ -73,7 +89,7 @@ public class MacHandler {
       } catch (NoSuchMethodException e) {
       } catch (IllegalAccessException e) {
       } catch (InvocationTargetException e) {
-        log("failed to invoke handleOpenPath");
+        log("failed to invoke handleShowAbout");
       }
     }
   }

--- a/netlogo-gui/project/autogen/i18n/GUI_Strings_en.txt
+++ b/netlogo-gui/project/autogen/i18n/GUI_Strings_en.txt
@@ -95,6 +95,7 @@ menu.edit.uncomment = Uncomment
 menu.edit.snapToGrid = Snap to Grid
 
 menu.tools = Tools
+menu.tools.preferences = Preferences…
 menu.tools.halt = Halt
 menu.tools.globalsMonitor = Globals Monitor
 menu.tools.turtleMonitor = Turtle Monitor
@@ -367,6 +368,10 @@ edit.hubnet.view.width = Width (pixels)
 edit.hubnet.view.height = Height (pixels)
 
 # tools
+
+tools.preferences = NetLogo Preferences
+tools.preferences.restartRequired = You must restart NetLogo for the change to take effect
+tools.preferences.uiLanguage = User Interface Language:
 
 tools.colorswatch = Color Swatches
 tools.colorswatch.preview = Preview

--- a/netlogo-gui/project/autogen/i18n/GUI_Strings_en.txt
+++ b/netlogo-gui/project/autogen/i18n/GUI_Strings_en.txt
@@ -370,7 +370,7 @@ edit.hubnet.view.height = Height (pixels)
 # tools
 
 tools.preferences = NetLogo Preferences
-tools.preferences.restartRequired = You must restart NetLogo for the change to take effect
+tools.preferences.restartRequired = (restart required)
 tools.preferences.uiLanguage = User Interface Language:
 
 tools.colorswatch = Color Swatches

--- a/netlogo-gui/resources/system/tokens-legacy.txt
+++ b/netlogo-gui/resources/system/tokens-legacy.txt
@@ -1,4 +1,3 @@
-C __change-language etc._changelanguage
 C __clear-all-and-reset-ticks etc._clearallandresetticks
 C __delete-log-files gui._deletelogfiles
 C __edit etc._edit

--- a/netlogo-gui/resources/system/tokens.txt
+++ b/netlogo-gui/resources/system/tokens.txt
@@ -1,5 +1,4 @@
 C __bench gui._bench
-C __change-language etc._changelanguage
 C __change-topology etc._changetopology
 C __clear-all-and-reset-ticks etc._clearallandresetticks
 C __delete-log-files gui._deletelogfiles

--- a/netlogo-gui/src/main/app/App.scala
+++ b/netlogo-gui/src/main/app/App.scala
@@ -277,6 +277,7 @@ class App extends
   lazy val owner = new SimpleJobOwner("App", workspace.world.mainRNG, AgentKind.Observer)
   private var _tabs: Tabs = null
   def tabs = _tabs
+  lazy val preferencesDialog = new PreferencesDialog(frame, Preference.Language)
   var helpMenu:HelpMenu = null
   var fileMenu: FileMenu = null
   var monitorManager:AgentMonitorManager = null
@@ -598,7 +599,6 @@ class App extends
           org.nlogo.log.Files.deleteSessionFiles(System.getProperty("java.io.tmpdir"))
         else
           logger.deleteSessionFiles()
-      case CHANGE_LANGUAGE => changeLanguage()
       case _ =>
     }
   }
@@ -627,21 +627,6 @@ class App extends
         org.nlogo.awt.EventQueue.invokeLater(() => openFromSource(source, path, ModelType.Library))
       }
     }
-  }
-
-  def changeLanguage() {
-    val locales = I18N.availableLocales
-    val languages = locales.map{l => l.getDisplayName(l) }
-    val index = org.nlogo.swing.OptionDialog.showAsList(frame,
-      "Change Language", "Choose a new language.", languages.asInstanceOf[Array[Object]])
-    if(index > -1) {
-      val chosenLocale = locales(index)
-      val netLogoPrefs = java.util.prefs.Preferences.userRoot.node("/org/nlogo/NetLogo")
-      netLogoPrefs.put("user.language", chosenLocale.getLanguage)
-      netLogoPrefs.put("user.country", chosenLocale.getCountry)
-    }
-    val restart = "Langauge changed.\nYou must restart NetLogo for the changes to take effect."
-    org.nlogo.swing.OptionDialog.show(frame, "Change Language", restart, Array(I18N.gui.get("common.buttons.ok")))
   }
 
   ///
@@ -847,6 +832,13 @@ class App extends
     showAboutWindow()
   }
 
+  /**
+   * This is called reflectively by the mac app wrapper.
+   */
+  def handleShowPreferences(): Unit = {
+    showPreferencesDialog()
+  }
+
   @throws(classOf[java.io.IOException])
   def libraryOpen(path: String) {
     dispatchThreadOrBust(fileMenu.openFromPath(path, ModelType.Library))
@@ -1045,7 +1037,16 @@ class App extends
    * Internal use only.
    */
   // used both from HelpMenu and MacHandlers - ST 2/2/09
-  def showAboutWindow() { new AboutWindow(frame).setVisible(true) }
+  def showAboutWindow(): Unit = {
+    new AboutWindow(frame).setVisible(true)
+  }
+
+  /**
+   * Internal use only.
+   */
+  def showPreferencesDialog(): Unit = {
+    preferencesDialog.setVisible(true)
+  }
 
   /**
    * Internal use only.

--- a/netlogo-gui/src/main/app/Preference.scala
+++ b/netlogo-gui/src/main/app/Preference.scala
@@ -1,0 +1,41 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.app
+
+import java.util.Locale
+import java.util.prefs.Preferences
+import javax.swing.{ JComboBox, JComponent }
+
+import org.nlogo.core.I18N
+
+trait Preference {
+  val i18nKey: String
+  val component: JComponent
+  val restartRequired: Boolean
+  def load(prefs: Preferences): Unit
+  def save(prefs: Preferences): Unit
+}
+
+object Preference {
+  object Language extends Preference {
+    case class LocaleWrapper(val locale: Locale) {
+      override def toString = locale.getDisplayName
+    }
+
+    val languages = I18N.availableLocales map (LocaleWrapper(_)) sortBy (_.toString)
+
+    val i18nKey = "uiLanguage"
+    val component = new JComboBox(languages)
+    val restartRequired = true
+
+    def load(prefs: Preferences) = {
+      val locale = I18N.localeFromPreferences.getOrElse(I18N.gui.defaultLocale)
+      component.setSelectedItem(LocaleWrapper(locale))
+    }
+    def save(prefs: Preferences) = {
+      val chosenLocale = component.getSelectedItem.asInstanceOf[LocaleWrapper].locale
+      prefs.put("user.language", chosenLocale.getLanguage)
+      prefs.put("user.country", chosenLocale.getCountry)
+    }
+  }
+}

--- a/netlogo-gui/src/main/app/PreferencesDialog.scala
+++ b/netlogo-gui/src/main/app/PreferencesDialog.scala
@@ -13,11 +13,6 @@ import org.nlogo.core.I18N
 import org.nlogo.swing.{ OptionDialog, RichAction, TextFieldBox, Utils => SwingUtils }
 import org.nlogo.swing.Implicits._
 
-object PreferencesDialog {
-  private val restartIcon =
-    new ImageIcon(classOf[PreferencesDialog].getResource("/images/forever2.gif"))
-}
-
 class PreferencesDialog(parent: Frame, preferences: Preference*)
 extends JDialog(parent, I18N.gui.get("tools.preferences"), false) {
   private implicit val prefix = I18N.Prefix("tools.preferences")
@@ -40,14 +35,9 @@ extends JDialog(parent, I18N.gui.get("tools.preferences"), false) {
   private val preferencesPanel = new TextFieldBox(SwingConstants.TRAILING)
   preferencesPanel.setBorder(BorderFactory.createEmptyBorder(20, 10, 20, 10))
   preferences foreach { pref =>
-    val label =
-      new JLabel(
-        I18N.gui(pref.i18nKey),
-        if (pref.restartRequired) PreferencesDialog.restartIcon else null,
-        SwingConstants.TRAILING)
-    if (pref.restartRequired)
-      label.setToolTipText(I18N.gui("restartRequired"))
-    preferencesPanel.addField(label, pref.component)
+    val text = (if (pref.restartRequired) I18N.gui("restartRequired") + "  " else "") +
+      I18N.gui(pref.i18nKey)
+    preferencesPanel.addField(text, pref.component)
   }
 
   private val buttonsPanel = new Box(BoxLayout.LINE_AXIS)
@@ -73,4 +63,5 @@ extends JDialog(parent, I18N.gui.get("tools.preferences"), false) {
   addWindowListener(reset)
   Positioning.center(this, parent)
   setResizable(false)
+  parent.toFront()
 }

--- a/netlogo-gui/src/main/app/PreferencesDialog.scala
+++ b/netlogo-gui/src/main/app/PreferencesDialog.scala
@@ -1,0 +1,76 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.app
+
+import java.awt.{ BorderLayout, Frame }
+import java.awt.event.{ WindowAdapter, WindowEvent }
+import java.util.prefs.Preferences
+import javax.swing.{ BorderFactory, Box, BoxLayout, ImageIcon, JButton,
+  JComponent, JDialog, JLabel, WindowConstants, SwingConstants }
+
+import org.nlogo.awt.Positioning
+import org.nlogo.core.I18N
+import org.nlogo.swing.{ OptionDialog, RichAction, TextFieldBox, Utils => SwingUtils }
+import org.nlogo.swing.Implicits._
+
+object PreferencesDialog {
+  private val restartIcon =
+    new ImageIcon(classOf[PreferencesDialog].getResource("/images/forever2.gif"))
+}
+
+class PreferencesDialog(parent: Frame, preferences: Preference*)
+extends JDialog(parent, I18N.gui.get("tools.preferences"), false) {
+  private implicit val prefix = I18N.Prefix("tools.preferences")
+  private val netLogoPrefs = Preferences.userRoot.node("/org/nlogo/NetLogo")
+
+  private val reset = () => {
+    preferences foreach (_.load(netLogoPrefs))
+    apply()
+  }
+  private val ok = () => {
+    apply()
+    setVisible(false)
+  }
+  private val apply = () => preferences foreach (_.save(netLogoPrefs))
+  private val cancel = () => {
+    reset()
+    setVisible(false)
+  }
+
+  private val preferencesPanel = new TextFieldBox(SwingConstants.TRAILING)
+  preferencesPanel.setBorder(BorderFactory.createEmptyBorder(20, 10, 20, 10))
+  preferences foreach { pref =>
+    val label =
+      new JLabel(
+        I18N.gui(pref.i18nKey),
+        if (pref.restartRequired) PreferencesDialog.restartIcon else null,
+        SwingConstants.TRAILING)
+    if (pref.restartRequired)
+      label.setToolTipText(I18N.gui("restartRequired"))
+    preferencesPanel.addField(label, pref.component)
+  }
+
+  private val buttonsPanel = new Box(BoxLayout.LINE_AXIS)
+  buttonsPanel.setBorder(BorderFactory.createEmptyBorder(0, 20, 10, 20))
+  private val okAction = RichAction(I18N.gui.get("common.buttons.ok"))(_ => ok())
+  private val applyAction = RichAction(I18N.gui.get("common.buttons.apply"))(_ => apply())
+  private val cancelAction = RichAction(I18N.gui.get("common.buttons.cancel"))(_ => cancel())
+  buttonsPanel.add(Box.createHorizontalGlue)
+  buttonsPanel.add(new JButton(okAction))
+  buttonsPanel.add(Box.createHorizontalGlue)
+  buttonsPanel.add(new JButton(applyAction))
+  buttonsPanel.add(Box.createHorizontalGlue)
+  buttonsPanel.add(new JButton(cancelAction))
+  buttonsPanel.add(Box.createHorizontalGlue)
+
+  add(preferencesPanel, BorderLayout.CENTER)
+  add(buttonsPanel, BorderLayout.SOUTH)
+  pack()
+
+  reset()
+  setDefaultCloseOperation(WindowConstants.HIDE_ON_CLOSE)
+  SwingUtils.addEscKeyAction(this, cancel)
+  addWindowListener(reset)
+  Positioning.center(this, parent)
+  setResizable(false)
+}

--- a/netlogo-gui/src/main/app/ToolsMenu.scala
+++ b/netlogo-gui/src/main/app/ToolsMenu.scala
@@ -14,6 +14,8 @@ class ToolsMenu(app: App, modelSaver: ModelSaver) extends org.nlogo.swing.Menu(I
   implicit val i18nName = I18N.Prefix("menu.tools")
 
   setMnemonic('T')
+  addMenuItem(I18N.gui("preferences"), app.showPreferencesDialog _)
+  addSeparator()
   addMenuItem(new SimpleGUIWorkspaceAction(I18N.gui("halt"), app.workspace, _.halt))
   addSeparator()
   addMenuItem(new SimpleGUIWorkspaceAction(I18N.gui("globalsMonitor"), app.workspace, _.inspectAgent(AgentKind.Observer)))
@@ -40,7 +42,7 @@ class ToolsMenu(app: App, modelSaver: ModelSaver) extends org.nlogo.swing.Menu(I
   addMenuItem(I18N.gui("hubNetClientEditor"), openHubNetClientEditor _)
   addMenuItem('H', true, app.workspace.hubNetControlCenterAction)
 
-  def openColorDialog() {
+  def openColorDialog(): Unit = {
     if(app.colorDialog == null) {
       app.colorDialog =
         new org.nlogo.window.ColorDialog(app.frame, false)
@@ -53,7 +55,7 @@ class ToolsMenu(app: App, modelSaver: ModelSaver) extends org.nlogo.swing.Menu(I
     }
   }
 
-  def openHubNetClientEditor() {
+  def openHubNetClientEditor(): Unit = {
     app.workspace.getHubNetManager.foreach { mgr =>
       mgr.openClientEditor()
       app.frame.addLinkComponent(mgr.clientEditor)

--- a/netlogo-gui/src/main/compiler/prim/LegacyPrims.scala
+++ b/netlogo-gui/src/main/compiler/prim/LegacyPrims.scala
@@ -41,10 +41,6 @@ package etc {
     def syntax = Syntax.reporterSyntax(ret = ListType | StringType, right = List(ListType | StringType))
   }
 
-  case class _changelanguage() extends Command {
-    def syntax = Syntax.commandSyntax(agentClassString = "O---")
-  }
-
   case class _clearallandresetticks() extends Command {
     def syntax = Syntax.commandSyntax(agentClassString = "O---")
   }

--- a/netlogo-gui/src/main/headless/HeadlessWorkspace.scala
+++ b/netlogo-gui/src/main/headless/HeadlessWorkspace.scala
@@ -440,11 +440,6 @@ with org.nlogo.api.ViewSettings {
   /**
    * Internal use only.
    */
-  override def changeLanguage() = unsupported
-
-  /**
-   * Internal use only.
-   */
   def startLogging(properties: String) = unsupported
 
   /**

--- a/netlogo-gui/src/main/nvm/Workspace.scala
+++ b/netlogo-gui/src/main/nvm/Workspace.scala
@@ -62,8 +62,6 @@ trait Workspace extends org.nlogo.api.Workspace
   def updatePlots(c: Context): Unit
   def setupPlots(c: Context): Unit
 
-  def changeLanguage(): Unit
-
   def joinForeverButtons(agent: Agent): Unit
 
   def requestDisplayUpdate(force: Boolean): Unit

--- a/netlogo-gui/src/main/prim/etc/i18n.scala
+++ b/netlogo-gui/src/main/prim/etc/i18n.scala
@@ -29,12 +29,3 @@ class _english extends org.nlogo.nvm.Command {
     context.ip = next
   }
 }
-
-class _changelanguage extends org.nlogo.nvm.Command {
-
-  override def perform(context: Context) {
-    workspace.changeLanguage()
-    context.ip = next
-  }
-}
-

--- a/netlogo-gui/src/main/window/AppEventType.java
+++ b/netlogo-gui/src/main/window/AppEventType.java
@@ -4,7 +4,6 @@ package org.nlogo.window;
 
 public enum AppEventType {
   RELOAD, MAGIC_OPEN,
-  START_LOGGING, ZIP_LOG_FILES, DELETE_LOG_FILES,
-  CHANGE_LANGUAGE
+  START_LOGGING, ZIP_LOG_FILES, DELETE_LOG_FILES
 }
 

--- a/netlogo-gui/src/main/window/GUIWorkspace.java
+++ b/netlogo-gui/src/main/window/GUIWorkspace.java
@@ -442,13 +442,6 @@ public abstract strictfp class GUIWorkspace // can't be both abstract and strict
   }
 
   // called from the job thread
-  @Override
-  public void changeLanguage() {
-    new org.nlogo.window.Events.AppEvent(AppEventType.CHANGE_LANGUAGE, new Object[]{}).raiseLater(this);
-  }
-
-
-  // called from the job thread
   public void startLogging(String properties) {
     try {
       new org.nlogo.window.Events.AppEvent

--- a/netlogo-gui/src/main/workspace/AbstractWorkspace.java
+++ b/netlogo-gui/src/main/workspace/AbstractWorkspace.java
@@ -175,8 +175,6 @@ public abstract strictfp class AbstractWorkspace
 
   public abstract void magicOpen(String name);
 
-  public abstract void changeLanguage();
-
   // this is used to cache the compiled code used by the "run"
   // and "runresult" prims - ST 6/7/07
   public WeakHashMap<String, Procedure> codeBits =

--- a/netlogo-gui/src/test/compiler/TestAllSyntaxes.scala
+++ b/netlogo-gui/src/test/compiler/TestAllSyntaxes.scala
@@ -290,7 +290,6 @@ class TestAllSyntaxes extends FunSuite {
                     |_bench number/number,O---,None,0,2,2
                     |_bk number,-T--,None,0,1,1
                     |_carefully command block/command block,OTPL,None,0,2,2
-                    |_changelanguage ,O---,None,0,0,0
                     |_changetopology TRUE/FALSE/TRUE/FALSE,OTPL,None,0,2,2
                     |_clearall ,O---,None,0,0,0
                     |_clearallandresetticks ,O---,None,0,0,0

--- a/netlogo-gui/src/test/nvm/DummyWorkspace.scala
+++ b/netlogo-gui/src/test/nvm/DummyWorkspace.scala
@@ -72,7 +72,6 @@ class DummyWorkspace extends DummyCompilerServices with Workspace {
   override def patchSize = unsupported
   override def changeTopology(wrapX: Boolean, wrapY: Boolean) = unsupported
   override def magicOpen(name: String) = unsupported
-  override def changeLanguage() = unsupported
   override def startLogging(properties: String) = unsupported
   override def zipLogFiles(filename: String) = unsupported
   override def deleteLogFiles() = unsupported

--- a/netlogo-gui/src/test/workspace/DummyAbstractWorkspace.scala
+++ b/netlogo-gui/src/test/workspace/DummyAbstractWorkspace.scala
@@ -33,7 +33,6 @@ extends AbstractWorkspaceScala(
   override def open(path: String) = unsupported
   override def openString(modelContents: String) = unsupported
   override def magicOpen(name: String) = unsupported
-  override def changeLanguage() = unsupported
   override def clearOutput(): Unit = unsupported
   override def sendOutput(oo: org.nlogo.agent.OutputObject, toOutputArea: Boolean): Unit = unsupported
   override def importerErrorHandler: org.nlogo.agent.Importer.ErrorHandler = unsupported


### PR DESCRIPTION
Removed __change-language prim
Locale country in I18N is now loaded from "user.country"

I don't have a Mac, so I couldn't check that Application Menu > Preferences... shows and works correctly.
@mrerrormessage, it needs to be checked that the dialog shows correctly despite [this comment](https://github.com/NetLogo/NetLogo/blob/hexy/netlogo-gui/src/main/app/AboutWindow.scala#L88-93) (more precisely, despite the absence of that line there)
Should I remove `netlogo-gui/src/main/prim/etc/i18n.scala` entirely?