### PR TITLE
Fixes to Autoconverter

### DIFF
--- a/netlogo-core/src/main/fileformat/AutoConversionList.scala
+++ b/netlogo-core/src/main/fileformat/AutoConversionList.scala
@@ -4,12 +4,17 @@ package org.nlogo.fileformat
 
 import org.nlogo.core.SourceRewriter
 
-object AutoConversionList {
-  type Conversion = (Seq[SourceRewriter => String], Seq[SourceRewriter => String], Seq[String])
-  type ConversionList = Seq[(String, Conversion)]
+case class ConversionSet(
+  codeTabConversions:   Seq[SourceRewriter => String] = Seq(),
+  otherCodeConversions: Seq[SourceRewriter => String] = Seq(),
+  targets:              Seq[String] = Seq())
 
-  def changeAllCode(changes: Seq[SourceRewriter => String], targets: Seq[String]): Conversion = {
-    (changes, changes, targets)
+
+object AutoConversionList {
+  type ConversionList = Seq[(String, ConversionSet)]
+
+  def changeAllCode(changes: Seq[SourceRewriter => String], targets: Seq[String]): ConversionSet = {
+    ConversionSet(changes, changes, targets)
   }
 
   lazy val conversions: ConversionList = Seq(
@@ -44,7 +49,7 @@ object AutoConversionList {
         _.addGlobal("_recording-save-file-name"),
         _.addExtension("vid"))
 
-      (codeTabOnlyReplacements ++ sharedTransformations, sharedTransformations, targets)
+      ConversionSet(codeTabOnlyReplacements ++ sharedTransformations, sharedTransformations, targets)
     },
     "NetLogo 6.0-M9" -> {
       changeAllCode(Seq(_.remove("hubnet-set-client-interface")), Seq("hubnet-set-client-interface"))

--- a/netlogo-core/src/main/fileformat/AutoConversionList.scala
+++ b/netlogo-core/src/main/fileformat/AutoConversionList.scala
@@ -42,7 +42,7 @@ object AutoConversionList {
           Seq[SourceRewriter => String](
             _.remove("movie-set-frame-rate"),
             _.addCommand("movie-start"       -> "set _recording-save-file-name {0}"),
-            _.replaceCommand("movie-start"   -> "(vid:start-recorder)"),
+            _.replaceCommand("movie-start"   -> "vid:start-recorder"),
             _.replaceReporter("movie-status" -> "vid:recorder-status"))
 
       val codeTabOnlyReplacements = Seq[SourceRewriter => String](

--- a/netlogo-core/src/main/fileformat/NLogoThreeDFormat.scala
+++ b/netlogo-core/src/main/fileformat/NLogoThreeDFormat.scala
@@ -4,10 +4,11 @@ package org.nlogo.fileformat
 
 import java.net.URI
 
-import org.nlogo.api.ModelFormat
+import org.nlogo.api.{ AutoConvertable, ModelFormat }
+import org.nlogo.core.Model
 import org.nlogo.core.model.WidgetReader
 
-class NLogoThreeDFormat
+class NLogoThreeDFormat(modelConverter: (Model, Seq[AutoConvertable]) => Model)
   extends ModelFormat[Array[String], NLogoThreeDFormat]
   with AbstractNLogoFormat[NLogoThreeDFormat] {
     val is3DFormat = true

--- a/netlogo-gui/src/main/compiler/Backifier.scala
+++ b/netlogo-gui/src/main/compiler/Backifier.scala
@@ -188,7 +188,7 @@ class Backifier(program: Program,
       case core.prim._commandtask(argcount) =>
         new nvmprim._commandtask(argcount)  // LambdaLifter will fill in
 
-      case core.prim._reportertask(argcount) =>
+      case core.prim._reportertask(argcount, _) =>
         new nvmprim._reportertask()
 
       case core.prim._externreport(_) =>
@@ -203,7 +203,7 @@ class Backifier(program: Program,
 
       case core.prim._procedurevariable(vn, name) =>
         new nvmprim._procedurevariable(vn, name)
-      case core.prim._taskvariable(vn) =>
+      case core.prim._taskvariable(vn, _) =>
         new nvmprim._taskvariable(vn)
 
       case core.prim._observervariable(vn, _) =>

--- a/netlogo-gui/src/test/hubnet/server/HubNetManagerTests.scala
+++ b/netlogo-gui/src/test/hubnet/server/HubNetManagerTests.scala
@@ -66,7 +66,7 @@ class HubNetManagerTests extends FunSuite {
     test(name){
       val workspace = new DummyAbstractWorkspace
       val loader = new ConfigurableModelLoader()
-        .addFormat[Array[String], NLogoFormat](new NLogoFormat(Seq(), new DummyExtensionManager(), new DummyCompilationEnvironment()))
+        .addFormat[Array[String], NLogoFormat](new NLogoFormat((m, _) => m))
         .addSerializer[Array[String], NLogoFormat](new NLogoHubNetFormat(workspace))
       val manager = new HeadlessHubNetManager(workspace, loader) {
         override val connectionManager = new MockConnectionManager(this, workspace)

--- a/parser-core/src/main/core/AstNode.scala
+++ b/parser-core/src/main/core/AstNode.scala
@@ -152,7 +152,7 @@ class Statement(var command: Command, var start: Int, var end: Int, val file: St
  * jargon. Note that this is an Expression, and as such can be an argument
  * to commands and reporters, etc.
  */
-class CommandBlock(val statements: Statements, var start: Int, var end: Int, val file: String) extends Expression {
+class CommandBlock(val statements: Statements, var start: Int, var end: Int, val file: String, val synthetic: Boolean = false) extends Expression {
   def reportedType() = Syntax.CommandBlockType
   override def toString = "[" + statements.toString + "]"
 
@@ -160,7 +160,7 @@ class CommandBlock(val statements: Statements, var start: Int, var end: Int, val
            start: Int = start,
            end: Int = end,
            file: String = file): CommandBlock = {
-    new CommandBlock(statements, start, end, file)
+    new CommandBlock(statements, start, end, file, synthetic)
   }
 }
 

--- a/parser-core/src/main/core/prim/misc.scala
+++ b/parser-core/src/main/core/prim/misc.scala
@@ -351,7 +351,7 @@ case class _report() extends Command {
     Syntax.commandSyntax(
       right = List(Syntax.WildcardType))
 }
-case class _reportertask(minArgCount: Int = 0) extends Reporter {
+case class _reportertask(minArgCount: Int = 0, val synthetic: Boolean = false) extends Reporter {
   override def syntax =
     Syntax.reporterSyntax(
       ret = Syntax.ReporterTaskType)
@@ -360,6 +360,9 @@ case class _reportertask(minArgCount: Int = 0) extends Reporter {
     val rt = new _reportertask(minArgCount)
     copyInstruction(rt)
   }
+
+  override def toString =
+    s"_reportertask($minArgCount)"
 }
 case class _return() extends Command {
   override def syntax =
@@ -419,10 +422,13 @@ case class _task() extends Reporter {
       ret = anyTask)
   }
 }
-case class _taskvariable(vn: Int) extends Reporter {
+// synthetic means that it was created by the compiler while expanding a concise task
+case class _taskvariable(vn: Int, synthetic: Boolean = false) extends Reporter {
   override def syntax =
     Syntax.reporterSyntax(
       ret = Syntax.WildcardType)
+  override def toString =
+    s"_taskvariable($vn)"
 }
 case class _turtle() extends Reporter {
   override def syntax =

--- a/parser-core/src/main/parse/ExpressionParser.scala
+++ b/parser-core/src/main/parse/ExpressionParser.scala
@@ -95,7 +95,7 @@ object ExpressionParser {
         // synthesize an empty block so that later phases of compilation will be dealing with a
         // consistent number of arguments - ST 3/4/08
         val file = tokens.head.filename
-        app.addArgument(new core.CommandBlock(new core.Statements(file), app.end, app.end, file))
+        app.addArgument(new core.CommandBlock(new core.Statements(file), app.end, app.end, file, true))
       }
     // check all types
     resolveTypes(syntax, app)
@@ -420,14 +420,14 @@ object ExpressionParser {
     *  take at least one input (since otherwise a simple "map f xs" wouldn't evaluate f).
     */
   private def expandConciseReporterTask(rApp: core.ReporterApp, reporter: core.Reporter): core.ReporterApp = {
-    val task = new core.prim._reportertask
+    val task = new core.prim._reportertask(synthetic = true)
     task.token = reporter.token
     val taskApp =
       new core.ReporterApp(task,
         reporter.token.start, reporter.token.end, reporter.token.filename)
     taskApp.addArgument(rApp)
     for(argNumber <- 1 to reporter.syntax.totalDefault) {
-      val lv = new core.prim._taskvariable(argNumber)
+      val lv = new core.prim._taskvariable(argNumber, synthetic = true)
       lv.token = reporter.token
       rApp.addArgument(
         new core.ReporterApp(lv,
@@ -444,7 +444,7 @@ object ExpressionParser {
     val task = new core.prim._commandtask
     task.token = token
     for(argNumber <- 1 to coreCommand.syntax.totalDefault) {
-      val lv = new core.prim._taskvariable(argNumber)
+      val lv = new core.prim._taskvariable(argNumber, synthetic = true)
       lv.token = token
       stmt.addArgument(new core.ReporterApp(lv,
         token.start, token.end, token.filename))
@@ -455,7 +455,7 @@ object ExpressionParser {
       stmt.addArgument(
         new core.CommandBlock(
           new core.Statements(token.filename),
-          token.start, token.end, token.filename))
+          token.start, token.end, token.filename, synthetic = true))
     val stmts = new core.Statements(token.filename)
     stmts.addStatement(stmt)
     val rapp =
@@ -463,7 +463,7 @@ object ExpressionParser {
         token.start, token.end, token.filename)
     rapp.addArgument(
       new core.CommandBlock(stmts,
-        token.start, token.end, token.filename))
+        token.start, token.end, token.filename, synthetic = true))
     rapp
   }
 

--- a/parser-core/src/test/parse/AstRewriterTests.scala
+++ b/parser-core/src/test/parse/AstRewriterTests.scala
@@ -67,6 +67,7 @@ class AstRewriterTests extends FunSuite {
     assertResult("bk 1")(remove("fd 1 bk 1", "fd"))
     assertResult("create-turtles 10 [ fd 1 ]")(remove("create-turtles 10 [ fd 1 ]", "bk"))
     assertResult("create-turtles 10 [ ]")(remove("create-turtles 10 [ fd 1 ]", "fd"))
+    assertResult("create-turtles 10 fd 1")(remove("create-turtles 10", "fd"))
     assertResult("ask turtles [ ask one-of other turtles [ ] ]")(remove("ask turtles [ ask one-of other turtles [ set color blue ] ]", "set"))
     assertResult("fd 1 end to bar")(remove("fd 1 end to bar bk 2", "bk"))
     assertResult("fd 1 end to bar")(remove("fd 1 bk 1 end to bar", "bk"))
@@ -114,6 +115,7 @@ class AstRewriterTests extends FunSuite {
     assertResult("extensions [foo]\nto bar end")(addExtension("to bar end", "foo"))
     assertResult("extensions [foo baz] to bar end")(addExtension("extensions [foo] to bar end", "baz"))
     assertResult("extensions []\nglobals [x] to bar end")(addExtension("globals [x] to bar end", ""))
+    assertResult("extensions [foo baz] to bar end\n\nto baz end")(addExtension("extensions [foo] to bar end\n\nto baz end", "baz"))
   }
 
   test("add global") {


### PR DESCRIPTION
* Autoconverter converts 3D models
* Autoconverter leaves spaces between procedures intact, as per @nicolaspayette 's suggestion
* Autoconverter omits empty synthetic command blocks (eg. the final unspecified argument in `create-turtles 10`) as per @nicolaspayette 's suggestion
* Autoconverter handles synthetic command and reporter blocks properly (eg. `+` in `reduce + [1 2 3]` and `print` in `foreach [1 2 3] print`).
* Updates the vid extension to pull in the fix for [Issue 8](https://github.com/NetLogo/vid/pull/8)
