### PR TITLE
Declaring a breed with only a plural name is allowed by the compiler

### DIFF
--- a/autogen/docs/transition.html.mustache
+++ b/autogen/docs/transition.html.mustache
@@ -50,6 +50,16 @@
     will have all uses of <code>nobody</code> changed to <code>"nobody"</code> when
     opened in NetLogo 6.0.
     <h3>
+      Breeds must have singular and plural names
+    </h3>
+    <p>
+      In NetLogo 6.0, you must specify both plural and singular breed names.
+      In prior versions, declarations like <code>breed [ mice ]</code> were legal,
+      but this support has been removed in 6.0. If you have models which use only
+      plural breed names, it is recommended that you convert them to specify both
+      names before opening in 6.0 since doing so will permit the NetLogo converter
+      to work most effectively on any other code in your model which needs conversion.
+    <h3>
       Removal of "Movie" Prims
     </h3>
     <p id="movie-to-vid">

--- a/autogen/docs/versions.html.mustache
+++ b/autogen/docs/versions.html.mustache
@@ -29,6 +29,7 @@
       </ul>
     <h3>Language Changes</h3>
       <ul>
+        <li>Compiler support for plural-only breed names (e.g. <code>breed [ mice ]</code>) has been removed.</li>
         <li>The compiler detects a greater number of type errors, for instance <code>not pxcor</code> now raises a compiler error instead of erroring at runtime.</li>
         <li>The <code>hubnet-set-client-interface</code> primitive has been removed.</li>
         <li>The various prims starting with <code>movie-</code> have been removed, as has the movie encoder. <a href="transition.html#movie-to-vie">The transition guide</a> provides more details and information.</li>

--- a/netlogo-gui/src/main/workspace/SaveModel.scala
+++ b/netlogo-gui/src/main/workspace/SaveModel.scala
@@ -15,10 +15,10 @@ import SaveModel.Controller
 
 // this returns a thunk so that it can be run on a background thread, if desired
 trait SaveModel {
-  def apply(model: Model,
-    loader: ModelLoader,
-    controller: Controller,
-    modelTracker: ModelTracker,
+  def apply(model:  Model,
+    loader:         ModelLoader,
+    controller:     Controller,
+    modelTracker:   ModelTracker,
     currentVersion: Version): Option[() => Try[URI]] = {
       val savePath =
         fileFromTracker(modelTracker) orElse validFilePath(controller, loader, modelTracker.getModelType)

--- a/netlogo-gui/src/test/compiler/TestGenerator.scala
+++ b/netlogo-gui/src/test/compiler/TestGenerator.scala
@@ -146,7 +146,7 @@ class TestGenerator extends FunSuite {
         }
         compiler.compileProgram(
           """
-          |breed [agents]
+          |breed [agents an-agent]
           |
           |to-report move
           |  report all? agents-here [true] or all? agents-here [false]

--- a/netlogo-gui/src/test/headless/TestImportExport.scala
+++ b/netlogo-gui/src/test/headless/TestImportExport.scala
@@ -565,8 +565,8 @@ with BeforeAndAfterEach with OneInstancePerTest with SlowTest {
       "          empty-patch-agentset empty-turtle-agentset cats-breed all-turtles all-patches ]" +
       "turtles-own [ t-foo t-bar ]" +
       "patches-own [ p-foo p-fish-breed ]" +
-      "breed [ fish ] " +
-      "breed [ cats ]" +
+      "breed [ fish a-fish ] " +
+      "breed [ cats cat ]" +
       "fish-own [ scales? fins ]" +
       "cats-own [ fur tabby? ]" +
       "to setup [ add-breed-to-list? ]" +

--- a/parser-core/src/main/core/BreedIdentifierHandler.scala
+++ b/parser-core/src/main/core/BreedIdentifierHandler.scala
@@ -91,7 +91,7 @@ object BreedIdentifierHandler {
   private def refineName(breed: DeclBreed)(helper: BreedPrimSpec): String =
     helper.patternString.
       replaceAll("<BREEDS>", breed.plural.name).
-      replaceAll("<BREED>", breed.singular.map(_.name).getOrElse(breed.plural.name))
+      replaceAll("<BREED>", breed.singular.name)
 
   trait BreedPrimSpec {
 

--- a/parser-core/src/main/core/StructureDeclarations.scala
+++ b/parser-core/src/main/core/StructureDeclarations.scala
@@ -10,7 +10,7 @@ object StructureDeclarations {
       extends Declaration
   case class Extensions(token: Token, names: Seq[Identifier])
       extends Declaration
-  case class Breed(plural: Identifier, singular: Option[Identifier], isLinkBreed: Boolean = false, isDirected: Boolean = false)
+  case class Breed(plural: Identifier, singular: Identifier, isLinkBreed: Boolean = false, isDirected: Boolean = false)
       extends Declaration
   case class Variables(kind: Identifier, names: Seq[Identifier])
       extends Declaration

--- a/parser-core/src/main/parse/StructureChecker.scala
+++ b/parser-core/src/main/parse/StructureChecker.scala
@@ -130,15 +130,12 @@ object StructureChecker {
         occs ++ vars
       case (occs , decl@Procedure(name, _, inputs, _)) =>
         (Occurrence(decl, name, ProcedureSymbol) +: inputs.map(Occurrence(decl, _, LocalVariable, isGlobal = false))) ++ occs
-      case (occs, decl@Breed(plural, Some(singular), _, _)) =>
+      case (occs, decl@Breed(plural, singular, _, _)) =>
         val (symType, singularSymType) =
           if (decl.isLinkBreed) (LinkBreed, LinkBreedSingular)
           else (TurtleBreed, TurtleBreedSingular)
         occs ++
           Seq(Occurrence(decl, plural, symType), Occurrence(decl, singular, singularSymType))
-      case (occs, decl@Breed(plural, None, _, _)) =>
-        val symType = if (decl.isLinkBreed) LinkBreed else TurtleBreed
-        occs :+ Occurrence(decl, plural, symType)
       case (occs, _) => occs
     }
     os.sortBy(_.typeOfDeclaration)
@@ -173,7 +170,7 @@ object StructureChecker {
 
   private def breedOverridesBuiltIn(breed: Breed, duplicatedType: SymbolType, duplicatedName: String): String = {
     val typeName = SymbolType.typeName(duplicatedType)
-    s"Defining a breed [${breed.plural.name}${breed.singular.map(" " + _.name).getOrElse("")}] redefines $duplicatedName, a $typeName"
+    s"Defining a breed [${breed.plural.name} ${breed.singular.name}] redefines $duplicatedName, a $typeName"
   }
 
   private def checkNotTaskVariable(ident: Identifier) {

--- a/parser-core/src/main/parse/StructureConverter.scala
+++ b/parser-core/src/main/parse/StructureConverter.scala
@@ -66,8 +66,7 @@ object StructureConverter {
     def updateBreeds(program: Program): Program =
       declarations.foldLeft(program) {
         case (program, Breed(plural, singular, isLinkBreed, isDirected)) =>
-          val breed = core.Breed(plural.name, singular.map(_.name).getOrElse("TURTLE"),
-            isLinkBreed = isLinkBreed, isDirected = isDirected)
+          val breed = core.Breed(plural.name, singular.name, isLinkBreed = isLinkBreed, isDirected = isDirected)
           if (isLinkBreed)
             program.copy(
               linkBreeds = program.linkBreeds.updated(breed.name, breed))

--- a/parser-core/src/test/core/BreedIdentifierHandlerTests.scala
+++ b/parser-core/src/test/core/BreedIdentifierHandlerTests.scala
@@ -96,6 +96,6 @@ class BreedIdentifierHandlerTests extends FunSuite {
     def dummyToken(s: String): Token = Token(s, TokenType.Ident, "")(1, 2, "")
     def dummyIdent(s: String): Identifier = Identifier(s, dummyToken(s))
 
-    StructureDeclarations.Breed(dummyIdent(plural), Some(dummyIdent(singular)), isLink, isDirected)
+    StructureDeclarations.Breed(dummyIdent(plural), dummyIdent(singular), isLink, isDirected)
   }
 }

--- a/parser-core/src/test/parse/FrontEndTests.scala
+++ b/parser-core/src/test/parse/FrontEndTests.scala
@@ -335,6 +335,18 @@ class FrontEndTests extends FunSuite {
     duplicateName("breed [mice mouse] mice-own [fur] to foo let fur 5 end",
       "There is already a MICE-OWN variable called FUR")
   }
+  test("BreedDuplicateName") {
+    duplicateName("breed [xs xs]",
+      "There is already a breed called XS")
+  }
+  test("BreedOnlyOneName") {
+    duplicateName("breed [xs]",
+      "Breed declarations must have plural and singular. BREED [XS] has only one name.")
+  }
+  test("LinkBreedOnlyOneName") {
+    duplicateName("directed-link-breed [xs]",
+      "Breed declarations must have plural and singular. DIRECTED-LINK-BREED [XS] has only one name.")
+  }
   test("BreedPrimSameNameAsBuiltInPrim") {
     duplicateName("breed [strings string]",
       "Defining a breed [STRINGS STRING] redefines IS-STRING?, a primitive reporter")

--- a/parser-core/src/test/parse/StructureParserTests.scala
+++ b/parser-core/src/test/parse/StructureParserTests.scala
@@ -49,9 +49,9 @@ class StructureParserTests extends FunSuite {
   }
 
   test("breeds") {
-    val results = compile("breed [mice mouse] breed [frogs]")
+    val results = compile("breed [mice mouse] breed [frogs frog]")
     assertResult("breeds MICE = Breed(MICE, MOUSE, , false)" +
-           "FROGS = Breed(FROGS, TURTLE, , false)")(
+           "FROGS = Breed(FROGS, FROG, , false)")(
       results.program.dump.split("\n").drop(5).take(2).mkString)
   }
 
@@ -163,6 +163,9 @@ class StructureParserTests extends FunSuite {
   test("missing close bracket in globals") {
     expectError("globals [g turtles-own [t]",
       "closing bracket expected") }
+  test("missing breed singular") {
+    expectError("breed [xs]",
+      "Breed declarations must have plural and singular. BREED [XS] has only one name.") }
   test("attempt primitive as variable") {
     expectError("globals [turtle]",
       "There is already a primitive reporter called TURTLE") }


### PR DESCRIPTION
Example:

    breed [ xs ]

This is currently undocumented and exists for backward compatibility: NetLogo 3 (and earlier?) models had only plural breed names. When they're automatically converted to NetLogo >=4, `breed [ xs ]` is what the converter generates.

Going forward, options include:

- Documenting this possibility;
- Removing it (and dealing with the implications for automatic conversion of very old models);
- Keeping the _status quo_ (with the difference that this ticket now exists as some sort of documentation for the situation).