### PR TITLE
Internal error when giving invalid slider constraint

### DIFF
--- a/netlogo-gui/src/main/window/DummySliderWidget.scala
+++ b/netlogo-gui/src/main/window/DummySliderWidget.scala
@@ -22,13 +22,13 @@ class DummySliderWidget extends AbstractSliderWidget with Editable {
 
   // this sets the value in the current constraint and then ensures
   // cached values are updated -- CLB
-  def min( d: Double ){ if(setSliderConstraint(con.copy(minimum=d))) repaint() }
+  def min( d: Double ){ if(setSliderConstraint(con.copy(min=d))) repaint() }
   def min = minimum.doubleValue
 
-  def max( d: Double ){ if(setSliderConstraint(con.copy(maximum=d))) repaint() }
+  def max( d: Double ){ if(setSliderConstraint(con.copy(max=d))) repaint() }
   def max = maximum.doubleValue
 
-  def inc( d: Double ){ if(setSliderConstraint(con.copy(increment=d))) repaint() }
+  def inc( d: Double ){ if(setSliderConstraint(con.copy(inc=d))) repaint() }
   def inc = increment.doubleValue
 
   private def con = constraint.asInstanceOf[ConstantSliderConstraint]

--- a/netlogo-gui/src/main/window/GUIWorkspace.java
+++ b/netlogo-gui/src/main/window/GUIWorkspace.java
@@ -921,7 +921,7 @@ public abstract strictfp class GUIWorkspace // can't be both abstract and strict
     } catch (SliderConstraint.ConstraintExceptionHolder ex) {
       for (SliderConstraint.SliderConstraintException cce :
              scala.collection.JavaConversions.asJavaIterable(ex.getErrors())) {
-        e.slider.setConstraintError(cce.spec().fieldName(), cce);
+        e.slider.error((Object) cce.spec().fieldName(), (java.lang.Exception) cce);
       }
     }
   }

--- a/netlogo-gui/src/main/window/SliderWidget.scala
+++ b/netlogo-gui/src/main/window/SliderWidget.scala
@@ -17,7 +17,7 @@ trait AbstractSliderWidget extends MultiErrorWidget {
   protected var _name = ""
   private var _units = ""
   private var _vertical = false
-  private val sliderData = new SliderData
+  private val sliderData = new SliderData(this)
 
   // The painter is used to draw the slider and handle interactions.
   // It comes in two flavors, horizontal and vertical.
@@ -176,33 +176,27 @@ class SliderWidget(eventOnReleaseOnly: Boolean, random: MersenneTwisterFast) ext
   }
 
   override def setSliderConstraint(con: SliderConstraint): Boolean = {
-    if (!anyErrors) {
-      try if (super.setSliderConstraint(con)) {
-        revalidate()
-        repaint()
-        return true
-      }
-      catch {
-        case ex: SliderConstraint.ConstraintRuntimeException =>
-          setConstraintError(ex.spec.fieldName, ex)
-          org.nlogo.api.Exceptions.handle(ex)
-        case ex: LogoException => org.nlogo.api.Exceptions.handle(ex)
-        false
-      }
-    }
-    false
+    if (!anyErrors && super.setSliderConstraint(con)) {
+      revalidate()
+      repaint()
+      true
+    } else
+      false
   }
 
   override def updateConstraints() {
     new AddSliderConstraintEvent(this, name, minimumCode, maximumCode, incrementCode, defaultValue).raise(this)
   }
 
-  def setConstraintError(constraintField: String, ex: SliderConstraintException) {
-    super.error(constraintField, ex)
+  override def error(key: Object, e: Exception): Unit = {
+    super.error(key, e)
     setForeground(java.awt.Color.RED)
   }
 
-  override def removeAllErrors() = { super.removeAllErrors(); setForeground(java.awt.Color.BLACK) }
+  override def removeAllErrors() = {
+    super.removeAllErrors()
+    setForeground(java.awt.Color.BLACK)
+  }
 
   // EVENT HANDLING
   def handle(e: AfterLoadEvent): Unit = {

--- a/netlogo-gui/src/test/window/SliderDataTests.scala
+++ b/netlogo-gui/src/test/window/SliderDataTests.scala
@@ -6,16 +6,20 @@ import org.scalatest.PropSpec
 import org.scalatest.prop.PropertyChecks
 import org.scalacheck.{ Arbitrary, Gen }
 
-import org.nlogo.agent.ConstantSliderConstraint
+import org.nlogo.api.{ LogoException, MultiErrorHandler, ReporterLogoThunk }
+import org.nlogo.agent.{ ConstantSliderConstraint, DynamicSliderConstraint }
+
+import scala.util.{ Failure, Success, Try }
 
 class SliderDataTests extends PropSpec with PropertyChecks {
+  val dummyErrorHandler = new MultiErrorHandler {}
 
   implicit def arbSlider: Arbitrary[SliderData] = Arbitrary(genSlider)
   val genSlider: Gen[SliderData] = for {
     min <- Gen.choose(0, 100)
     max <- Gen.choose(50, 500) // make max usually bigger than min, but not always.
     inc <- Gen.oneOf(0.0, 0.1, 0.01, 1.0, 2.0)
-  } yield new SliderData(min, max, inc)
+  } yield new SliderData(dummyErrorHandler, min, max, inc)
 
   // set value tests
   property("after setting constraints, value is never higher than max(min,max)") {
@@ -35,17 +39,17 @@ class SliderDataTests extends PropSpec with PropertyChecks {
       whenever(r % 2 == 1) { // get an odd number so it doesn't end in zero.
         // use 1.r
         assertResult(r.toString.length)(
-          new SliderData(minimum = (1 + "." + r).toDouble).precision)})}
+          new SliderData(dummyErrorHandler, minimum = (1 + "." + r).toDouble).precision)})}
 
   property("precision for ints should always be zero") {
     forAll((i: Int) =>
       whenever(!i.toDouble.toString.contains("E")) {
-        assertResult(0)(new SliderData(minimum = i).precision)})}
+        assertResult(0)(new SliderData(dummyErrorHandler, minimum = i).precision)})}
 
   property("sanity precision tests") {
     def testPrecision(d: Double, expected: Int) {
       assertResult(expected)(
-        new SliderData(minimum = d).precision)
+        new SliderData(dummyErrorHandler, minimum = d).precision)
     }
     testPrecision(1.1, 1)
     testPrecision(1.0, 0)
@@ -60,7 +64,7 @@ class SliderDataTests extends PropSpec with PropertyChecks {
 
     def testPrecision2(minimum: Double, increment: Double, expected: Int) {
       assertResult(expected)(
-        new SliderData(minimum = minimum, increment = increment).precision)
+        new SliderData(dummyErrorHandler, minimum = minimum, increment = increment).precision)
     }
 
     // these tests make sure the highest precision is taken
@@ -79,33 +83,62 @@ class SliderDataTests extends PropSpec with PropertyChecks {
   //
   property("effective max sanity tests") {
     assertResult(100.0)(
-      new SliderData(minimum = 0,maximum = 100,increment = 1).effectiveMaximum)
+      new SliderData(dummyErrorHandler, minimum = 0,maximum = 100,increment = 1).effectiveMaximum)
     assertResult(50.0)(
-      new SliderData(minimum = 25,maximum = 50,increment = 1).effectiveMaximum)
+      new SliderData(dummyErrorHandler, minimum = 25,maximum = 50,increment = 1).effectiveMaximum)
     assertResult(50.0)(
-      new SliderData(minimum = 0.1,maximum = 50,increment = 0.1).effectiveMaximum)
+      new SliderData(dummyErrorHandler, minimum = 0.1,maximum = 50,increment = 0.1).effectiveMaximum)
     assertResult(49.0)(
-      new SliderData(minimum = 25,maximum = 50,increment = 2).effectiveMaximum)
+      new SliderData(dummyErrorHandler, minimum = 25,maximum = 50,increment = 2).effectiveMaximum)
     assertResult(49.0)(
-      new SliderData(minimum = 25,maximum = 50,increment = 3).effectiveMaximum)
+      new SliderData(dummyErrorHandler, minimum = 25,maximum = 50,increment = 3).effectiveMaximum)
     assertResult(46.0)(
-      new SliderData(minimum = 25,maximum = 50,increment = 7).effectiveMaximum)
+      new SliderData(dummyErrorHandler, minimum = 25,maximum = 50,increment = 7).effectiveMaximum)
   }
 
   property("when min > max, effective max is always min") {
     forAll((min: Double, max: Double) =>
       whenever(min > max) {
         assertResult(min)(
-          new SliderData(minimum = min, maximum = max).effectiveMaximum)})}
+          new SliderData(dummyErrorHandler, minimum = min, maximum = max).effectiveMaximum)})}
 
   property("when inc == 0, effective max is always min") {
     forAll((min: Double) =>
       assertResult(min)(
-        new SliderData(minimum = min, increment = 0).effectiveMaximum))}
+        new SliderData(dummyErrorHandler, minimum = min, increment = 0).effectiveMaximum))}
 
   property("effective maximum is never greater than max") {
     forAll((s: SliderData) =>
       whenever(s.minimum <= s.maximum) {
         assert(s.effectiveMaximum <= s.maximum)})}
 
+  implicit def arbDynConstraint: Arbitrary[DynamicSliderConstraint] = Arbitrary(dynConstraint)
+  val dynConstraint: Gen[DynamicSliderConstraint] = {
+    def reporterThunk(g: Gen[Double], field: String): Gen[ReporterLogoThunk] =
+      g.map(d => dummyThunk(Double.box(d))) :| s"$field reporting a double"
+
+    def errorThunks(field: String) =
+      Gen.oneOf[ReporterLogoThunk](
+        Gen.const(dummyErrorThunk(new LogoException("problem") {})) :| s"$field throws generic LogoException",
+        Gen.const(dummyThunk("abc")) :| s"$field reports a non-double")
+    for {
+      min <- Gen.oneOf[ReporterLogoThunk](reporterThunk(Gen.choose(0, 49), "min"), errorThunks("min"))
+      max <- Gen.oneOf[ReporterLogoThunk](reporterThunk(Gen.choose(50, 500), "max"), errorThunks("max"))
+      inc <- Gen.oneOf[ReporterLogoThunk](reporterThunk(Gen.oneOf(0.0, 0.1, 0.01, 1.0, 2.0), "inc"), errorThunks("inc"))
+    } yield new DynamicSliderConstraint(min, max, inc)
+  }
+
+  property("when dynamic constraint errors, set error on MultiErrorHandler") {
+    forAll { (s: SliderData, constraint: DynamicSliderConstraint) =>
+      whenever(constraint.maximum.isFailure || constraint.minimum.isFailure || constraint.increment.isFailure) {
+        s.setSliderConstraint(constraint)
+        assert(dummyErrorHandler.anyErrors)
+      }
+    }
+  }
+
+  def dummyThunk(a: AnyRef): ReporterLogoThunk =
+    new ReporterLogoThunk { override def call(): Try[AnyRef] = Success(a) }
+  def dummyErrorThunk(e: Exception): ReporterLogoThunk =
+    new ReporterLogoThunk { override def call(): Try[AnyRef] = Failure(e) }
 }


### PR DESCRIPTION
In `hexy`:

- Open a new model
- Create a slider with a dummy name
- Put `world-width / 0` in the "Maximum" constraint
- Click OK

```
org.nlogo.agent.SliderConstraint$ConstraintRuntimeException: Constraint runtime error for Maximum: Division by zero.
 at org.nlogo.agent.DynamicSliderConstraint$$anonfun$get$1.applyOrElse(SliderConstraint.scala:96)
 at org.nlogo.agent.DynamicSliderConstraint$$anonfun$get$1.applyOrElse(SliderConstraint.scala:94)
 at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:36)
 at scala.util.Failure.recoverWith(Try.scala:203)
 at org.nlogo.agent.DynamicSliderConstraint.get(SliderConstraint.scala:94)
 at org.nlogo.agent.DynamicSliderConstraint.maximum(SliderConstraint.scala:89)
 at org.nlogo.window.SliderData.setSliderConstraint(SliderData.scala:34)
 at org.nlogo.window.AbstractSliderWidget$class.setSliderConstraint(SliderWidget.scala:41)
 at org.nlogo.window.SliderWidget.setSliderConstraint(SliderWidget.scala:180)
 at org.nlogo.window.GUIWorkspace.handle(GUIWorkspace.java:915)
 at org.nlogo.window.Events$AddSliderConstraintEvent.beHandledBy(Events.java:116)
 at org.nlogo.window.Event.doRaise(Event.java:198)
 at org.nlogo.window.Event.raise(Event.java:122)
 at org.nlogo.window.SliderWidget.updateConstraints(SliderWidget.scala:197)
 at org.nlogo.window.SliderWidget.editFinished(SliderWidget.scala:174)
 at org.nlogo.properties.EditDialog$$anonfun$1.apply$mcV$sp(EditDialog.scala:52)
 at org.nlogo.swing.Implicits$$anon$5.actionPerformed(Implicits.scala:16)
 at javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:2022)
 at javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2348)
 at javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:402)
 at javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:259)
 at javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:252)
 at java.awt.Component.processMouseEvent(Component.java:6535)
 at javax.swing.JComponent.processMouseEvent(JComponent.java:3324)
 at java.awt.Component.processEvent(Component.java:6300)
 at java.awt.Container.processEvent(Container.java:2236)
 at java.awt.Component.dispatchEventImpl(Component.java:4891)
 at java.awt.Container.dispatchEventImpl(Container.java:2294)
 at java.awt.Component.dispatchEvent(Component.java:4713)
 at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4888)
 at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4525)
 at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4466)
 at java.awt.Container.dispatchEventImpl(Container.java:2280)
 at java.awt.Window.dispatchEventImpl(Window.java:2750)
 at java.awt.Component.dispatchEvent(Component.java:4713)
 at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
 at java.awt.EventQueue.access$500(EventQueue.java:97)
 at java.awt.EventQueue$3.run(EventQueue.java:709)
 at java.awt.EventQueue$3.run(EventQueue.java:703)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
 at java.awt.EventQueue$4.run(EventQueue.java:731)
 at java.awt.EventQueue$4.run(EventQueue.java:729)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
 at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
 at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:109)
 at java.awt.WaitDispatchSupport$2.run(WaitDispatchSupport.java:184)
 at java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:229)
 at java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:227)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.awt.WaitDispatchSupport.enter(WaitDispatchSupport.java:227)
 at java.awt.Dialog.show(Dialog.java:1084)
 at java.awt.Component.show(Component.java:1673)
 at java.awt.Component.setVisible(Component.java:1625)
 at java.awt.Window.setVisible(Window.java:1014)
 at java.awt.Dialog.setVisible(Dialog.java:1005)
 at org.nlogo.properties.EditDialog$class.$init$(EditDialog.scala:110)
 at org.nlogo.properties.EditDialogFactory$$anon$1.<init>(EditDialogFactory.scala:15)
 at org.nlogo.properties.EditDialogFactory.canceled(EditDialogFactory.scala:15)
 at org.nlogo.app.InterfaceToolBar$$anonfun$handle$2.apply(InterfaceToolBar.scala:85)
 at org.nlogo.app.InterfaceToolBar$$anonfun$handle$2.apply(InterfaceToolBar.scala:76)
 at scala.Option.foreach(Option.scala:257)
 at org.nlogo.app.InterfaceToolBar.handle(InterfaceToolBar.scala:76)
 at org.nlogo.window.Events$EditWidgetEvent.beHandledBy(Events.java:239)
 at org.nlogo.window.Event.doRaise(Event.java:198)
 at org.nlogo.window.Event.raise(Event.java:122)
 at org.nlogo.app.InterfacePanel$WidgetCreationMenuItem.actionPerformed(InterfacePanel.scala:124)
 at javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:2022)
 at javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2348)
 at javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:402)
 at javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:259)
 at javax.swing.AbstractButton.doClick(AbstractButton.java:376)
 at javax.swing.plaf.basic.BasicMenuItemUI.doClick(BasicMenuItemUI.java:833)
 at javax.swing.plaf.basic.BasicMenuItemUI$Handler.mouseReleased(BasicMenuItemUI.java:877)
 at java.awt.Component.processMouseEvent(Component.java:6535)
 at javax.swing.JComponent.processMouseEvent(JComponent.java:3324)
 at java.awt.Component.processEvent(Component.java:6300)
 at java.awt.Container.processEvent(Container.java:2236)
 at java.awt.Component.dispatchEventImpl(Component.java:4891)
 at java.awt.Container.dispatchEventImpl(Container.java:2294)
 at java.awt.Component.dispatchEvent(Component.java:4713)
 at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4888)
 at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4525)
 at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4466)
 at java.awt.Container.dispatchEventImpl(Container.java:2280)
 at java.awt.Window.dispatchEventImpl(Window.java:2750)
 at java.awt.Component.dispatchEvent(Component.java:4713)
 at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
 at java.awt.EventQueue.access$500(EventQueue.java:97)
 at java.awt.EventQueue$3.run(EventQueue.java:709)
 at java.awt.EventQueue$3.run(EventQueue.java:703)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
 at java.awt.EventQueue$4.run(EventQueue.java:731)
 at java.awt.EventQueue$4.run(EventQueue.java:729)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
 at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
 at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
 at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
 at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)

NetLogo 6.0-M8
main: org.nlogo.app.AppFrame
thread: AWT-EventQueue-0
Java HotSpot(TM) 64-Bit Server VM 1.8.0_91 (Oracle Corporation; 1.8.0_91-b14)
operating system: Linux 4.4.0-28-generic (amd64 processor)
Scala version 2.11.8
JOGL: 2.3.2
OpenGL graphics: Mesa DRI Intel(R) Haswell Desktop 
OpenGL version: 3.0 Mesa 11.2.0
OpenGL vendor: Intel Open Source Technology Center
model: Untitled

05:47:21.459 InterfaceGlobalEvent (org.nlogo.app.InterfacePanel$$anon$1 (org.nlogo.window.SliderWidget)) AWT-EventQueue-0
05:47:21.459 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
05:47:21.456 WidgetSelectedEvent (org.nlogo.app.WidgetWrapper) AWT-EventQueue-0
05:47:21.436 AddSliderConstraintEvent (org.nlogo.app.InterfacePanel$$anon$1 (org.nlogo.window.SliderWidget)) AWT-EventQueue-0
05:47:21.423 AddSliderConstraintEvent (org.nlogo.app.InterfacePanel$$anon$1 (org.nlogo.window.SliderWidget)) AWT-EventQueue-0
05:47:21.423 CompiledEvent (org.nlogo.window.CompilerManager) AWT-EventQueue-0
05:47:21.423 CompiledEvent (org.nlogo.window.CompilerManager) AWT-EventQueue-0
05:47:21.417 RemoveAllJobsEvent (org.nlogo.window.CompilerManager) AWT-EventQueue-0
05:47:21.417 InterfaceGlobalEvent (org.nlogo.app.InterfacePanel$$anon$1 (org.nlogo.window.SliderWidget)) AWT-EventQueue-0
05:47:21.417 DirtyEvent (org.nlogo.app.InterfacePanel) AWT-EventQueue-0
```