### PR TITLE
NetLogo freezes when creating lots of links with an "empty" shape

### DIFF
--- a/netlogo-core/src/main/shape/LinkShape.scala
+++ b/netlogo-core/src/main/shape/LinkShape.scala
@@ -211,7 +211,11 @@ class LinkShape extends BaseLinkShape with Cloneable with java.io.Serializable w
     do {
       split(line, left, right)
       line = left
-    } while (!dest.contains(line.getP2))
+    } while (!dest.contains(line.getP2) &&
+      Math.abs(line.getP1.distance(line.getP2)) > 0.25) // do not split indefinitely.
+      // There are some strange conditions under which the split is on right on the
+      // edge of `dest`, but not actually contained inside it. So we bail at 0.25,
+      // which shouldn't be detectable at the whole-pixel level. RG 7/19/16
     right
   }
 


### PR DESCRIPTION
In the Link Shape Editor, create a new link shape called `"empty"`: make sure all three lines of the shape are blank and delete everything in the "direction indicator". Then run this:

```
to test
  let i 1
  loop [
    print i
    clear-all
    crt i [
      fd 8
      create-links-to other turtles [ set shape "empty" ]
    ]
    reset-ticks
    set i i + 1
  ]
end
```

At some point, NetLogo just freezes. The value of `i` when it freezes varies. I have observed up to `i = 62` but also as low as `i = 25`.

If you use the `"default"` shape instead of `"empty"`, it doesn't freeze: it gets slower and slower as the number of links increases, but it keeps on plowing.

Speculation: I'm not entirely sure that the "emptiness" of the shape is the culprit in and of itself. I'm thinking that, since the display of links is much faster with an empty shape, maybe it increases the probability of some sort of collision.

(tested in the `hexy` branch)