### PR TITLE
Autoconverter removes trailing comments in code

### DIFF
--- a/netlogo-gui/src/test/fileformat/ModelConverterTests.scala
+++ b/netlogo-gui/src/test/fileformat/ModelConverterTests.scala
@@ -149,6 +149,25 @@ class ModelConverterTests extends FunSuite {
     assertResult(convertedSource)(converted.code)
   }
 
+  test("handles models with trailing comments properly") {
+    val originalSource =
+      """|to abort
+         |  movie-cancel
+         |end
+         |; comment at end""".stripMargin
+    val expectedSource =
+      """|to abort
+         |  vid:reset-recorder
+         |end
+         |; comment at end""".stripMargin
+
+    val model = Model(code = originalSource)
+    val changes = Seq[SourceRewriter => String](_.replaceCommand("movie-cancel" -> "vid:reset-recorder"))
+    val targets = Seq("movie-cancel")
+    val converted = convert(model, ConversionSet(codeTabConversions = changes, targets = targets))
+    assertResult(expectedSource)(converted.code)
+  }
+
   test("handles models with includes properly") {
     val originalSource =
       """|__includes [ "foo.nls" ]


### PR DESCRIPTION
In `hexy`, open, e.g., **Movie Example** from a 5.3.1 installation: the autoconverter does its job, but the comments that should be at the end of the code tab are gone.

It's no big deal for Library models because I can just add them back (https://github.com/NetLogo/models/commit/f58122d0ce35078ccef3562d30d05d1e97557f91), but it could conceivably remove comments in user models.