### PR TITLE
Weird behavior with `carefully` inside task inside plot

### DIFF
--- a/netlogo-gui/src/main/nvm/Task.scala
+++ b/netlogo-gui/src/main/nvm/Task.scala
@@ -82,10 +82,12 @@ extends Task with org.nlogo.api.ReporterTask {
     context.activation.args = locals
     context.letBindings = lets
     bindArgs(context, args)
-    val result = body.report(context)
-    context.letBindings = oldLets
-    context.activation.args = oldLocals
-    result
+    try {
+      body.report(context)
+    } finally {
+      context.letBindings = oldLets
+      context.activation.args = oldLocals
+    }
   }
 }
 

--- a/test/commands/Ask.txt
+++ b/test/commands/Ask.txt
@@ -66,3 +66,8 @@ AskAllPatches
   O> crt 1
   O> ask one-of patches [ ask patches [ sprout 1 ] ] => ERROR Only the observer can ASK the set of all patches.
   O> ask one-of turtles [ ask patches [ sprout 1 ] ] => ERROR Only the observer can ASK the set of all patches.
+
+AskWithCarefullyWithRunresult
+  globals [ zero ]
+  to careful-run [t] ask turtles [ carefully [ show runresult t ] [] ] end
+  O> crt 2 careful-run task [1 / zero]


### PR DESCRIPTION
A couple of opening remarks:

- This is an issue that is fairly unlikely to be encountered by users. I'm reporting it in case it is indicative of a deeper problem.

- I stumbled upon this while working on a fairly complex model. I spent a long time trying to narrow it down to a simpler example, but there might still be superfluous elements in there.

Here we go. In a new model, paste the following code:

```
to setup
  clear-all
  crt 2
  reset-ticks
end

to update-plot [ t ]
  ask turtles [
    carefully [
      set-current-plot-pen (word self)
      plotxy ticks runresult t
    ] []
  ]
end
```

Now create a plot like this:

![screenshot from 2016-07-22 20-12-43](https://cloud.githubusercontent.com/assets/908754/17068403/af1941d4-5048-11e6-8da7-2e135be4eac7.png)

After running `setup`, you get:

![screenshot from 2016-07-22 20-14-48](https://cloud.githubusercontent.com/assets/908754/17068455/fa669ea2-5048-11e6-99cc-b4136415493b.png)

Two weird things:

- That's a weird error! It should probably say "Division by 0", not just "0".
- Shouldn't the `carefully` be honored? If you just do `carefully [ plot 1 / ticks ] []` instead of crazy task stuff, you don't get a runtime error.

But it gets weirder.

Keep things as they were, but replace `crt 2` in `setup` by `crt 1`. When you run `setup`: no error! With just one pen, everything is fine and dandy.

Now put back `crt 2` in `setup` so we're liable to get the error again, but in the plot's update commands, replace:

    update-plot task [ 1 / ticks ]

with

    let t task [ 1 / ticks ]
    update-plot t

When you run `setup`: no error! _Storing the task in a local variable instead of passing it as an argument makes the error disappear!_

Nice head-scratcher, innit?

(That's in `hexy`: I haven't tried in 5.x.)