### PR TITLE
Runtime error area should not be the one to grow when resizing plot pen edit dialog

### DIFF
--- a/netlogo-gui/src/main/properties/PlotPenEditorAdvanced.scala
+++ b/netlogo-gui/src/main/properties/PlotPenEditorAdvanced.scala
@@ -2,7 +2,7 @@
 
 package org.nlogo.properties
 
-import java.awt.{ BorderLayout, Color, Dimension }
+import java.awt.{ BorderLayout, Color, Dimension, GridBagConstraints, GridBagLayout }
 
 import javax.swing.border.{EtchedBorder, TitledBorder}
 import javax.swing._
@@ -76,21 +76,21 @@ class PlotPenEditorAdvanced(inputPen: PlotPensEditor.Pen, colorizer: Colorizer, 
   }
 
   private def addWidgets() {
-    setLayout(new BorderLayout())
     val title = createTitledBorder(createEtchedBorder(EtchedBorder.LOWERED), I18N.gui("advanced"))
     title.setTitleJustification(TitledBorder.LEFT)
     setBorder(title)
     val topPanel = new JPanel(){
-      setLayout(new BoxLayout(this, BoxLayout.Y_AXIS))
-      add(new JPanel(new BorderLayout){
+      val modePanel = new JPanel(new BorderLayout){
         add(new JLabel(I18N.gui("mode")), BorderLayout.WEST)
         add(penModes, BorderLayout.CENTER)
-      })
-      add(new JPanel(new BorderLayout){
+      }
+      val intervalPanel = new JPanel(new BorderLayout){
         add(new JLabel(I18N.gui("interval")), BorderLayout.WEST)
         add(intervalField, BorderLayout.CENTER)
-      })
-      add(new JPanel(new BorderLayout){ add(showPenInLegend, BorderLayout.WEST) })
+      }
+      val showPanel = new JPanel(new BorderLayout){ add(showPenInLegend, BorderLayout.WEST) }
+      setLayout(new BoxLayout(this, BoxLayout.Y_AXIS))
+      Seq(modePanel, intervalPanel, showPanel).foreach(add)
     }
     val codePanel = new JPanel(){
       setLayout(new BoxLayout(this, BoxLayout.Y_AXIS))
@@ -98,8 +98,25 @@ class PlotPenEditorAdvanced(inputPen: PlotPensEditor.Pen, colorizer: Colorizer, 
       add(setupCode)
       add(updateCode)
     }
-    add(topPanel, BorderLayout.NORTH)
-    runtimeErrorPanel.foreach(panel => add(panel, BorderLayout.CENTER))
-    add(codePanel, BorderLayout.SOUTH)
+    val gbLayout = new GridBagLayout()
+    setLayout(gbLayout)
+    val c = new GridBagConstraints()
+    c.anchor = GridBagConstraints.NORTH
+    c.fill = GridBagConstraints.HORIZONTAL
+    c.gridheight = 3
+    c.gridx = 0
+    c.weightx = 1.0
+    c.weighty = 0
+    gbLayout.setConstraints(topPanel, c)
+    add(topPanel)
+    runtimeErrorPanel.foreach { panel =>
+      c.weighty = 0
+      gbLayout.setConstraints(panel, c)
+      add(panel)
+    }
+    c.weighty = 1.0
+    c.fill = GridBagConstraints.BOTH
+    gbLayout.setConstraints(codePanel, c)
+    add(codePanel)
   }
 }

--- a/netlogo-gui/src/main/properties/RuntimeErrorPanel.scala
+++ b/netlogo-gui/src/main/properties/RuntimeErrorPanel.scala
@@ -4,7 +4,7 @@ package org.nlogo.properties
 
 import org.nlogo.core.I18N
 
-import java.awt.{ Color, Dimension }
+import java.awt.{ Color, Dimension, GridBagConstraints }
 import java.awt.event.{ ActionEvent, ActionListener }
 
 import javax.swing.{ ImageIcon, JButton, JLabel, JPanel }
@@ -43,9 +43,10 @@ abstract class RuntimeErrorDisplay(accessor: PropertyAccessor[Option[Exception]]
 
     override def getConstraints = {
       val c = super.getConstraints
-      c.fill = java.awt.GridBagConstraints.HORIZONTAL
+      c.fill = GridBagConstraints.HORIZONTAL
       c.weightx = 1.0
-      c.weighty = if (dismissed) 0.0 else 1.0
+      c.weighty = 0
+      c.gridheight = if (dismissed) 0 else 1
       c
     }
   }


### PR DESCRIPTION
Example of the undesirable result of vertical resizing:

![screenshot from 2016-07-24 18-20-50](https://cloud.githubusercontent.com/assets/908754/17085236/5fb00068-51cb-11e6-93a0-b6456cc6745d.png)

Ideally, the height of the yellow error area would stay constant and the "Pen setup" and "Pen update" areas would grow equally.