### PR TITLE
CrossReferencer updates for new Code Examples organization

### DIFF
--- a/project/ModelCrossReference.scala
+++ b/project/ModelCrossReference.scala
@@ -15,7 +15,9 @@ object ModelCrossReference {
     }
   }
 
-  val directoriesToCreate = Seq("Curricular Models/EACH/Unverified")
+  val directoriesToCreate = Seq(
+    "Curricular Models/EACH/Unverified",
+    "Code Examples/Extensions Examples/bitmap")
 
   val foldersToCopy = Seq(
     "Sample Models/Chemistry & Physics/GasLab"      -> "Curricular Models/GasLab",

--- a/project/ModelCrossReference.scala
+++ b/project/ModelCrossReference.scala
@@ -17,7 +17,8 @@ object ModelCrossReference {
 
   val directoriesToCreate = Seq(
     "Curricular Models/EACH/Unverified",
-    "Code Examples/Extensions Examples/bitmap")
+    "Code Examples/Extensions Examples/bitmap",
+    "Code Examples/Extensions Examples/arduino")
 
   val foldersToCopy = Seq(
     "Sample Models/Chemistry & Physics/GasLab"      -> "Curricular Models/GasLab",
@@ -37,10 +38,10 @@ object ModelCrossReference {
   ( "Sample Models/Mathematics/Probability/ProbLab", new SimpleFileFilter(_.isFile), "Curricular Models/ProbLab"), // copy the files, but not the Unverified folder
   ( "Sample Models/Mathematics/Probability/ProbLab/Unverified", "*",                 "Curricular Models/ProbLab"), // copy all of the files from the Unverified folder
 
-  ( "Sample Models/Biology/Evolution",            "Altruism*",    "Curricular Models/EACH"),
-  ( "Sample Models/Biology/Evolution",            "Cooperation*", "Curricular Models/EACH"),
-  ( "Sample Models/Biology/Evolution/Unverified", "Divide*",      "Curricular Models/EACH/Unverified"),
-  ( "Code Examples/Extensions Examples/vid", "Video Camera Example*", "Code Examples/Extensions Examples/bitmap"),
+  ( "Sample Models/Biology/Evolution",            "Altruism*",             "Curricular Models/EACH"),
+  ( "Sample Models/Biology/Evolution",            "Cooperation*",          "Curricular Models/EACH"),
+  ( "Sample Models/Biology/Evolution/Unverified", "Divide*",               "Curricular Models/EACH/Unverified"),
+  ( "Code Examples/Extensions Examples/vid",      "Video Camera Example*", "Code Examples/Extensions Examples/bitmap"),
 
   // BEAGLE curricular models
   ("Sample Models/Biology", "Wolf Sheep Predation*",                        "Curricular Models/BEAGLE Evolution"),
@@ -67,9 +68,10 @@ object ModelCrossReference {
   // Copy Oil Cartel HubNet to HubNet Activities
   ("Sample Models/Social Science",                         "Oil Cartel HubNet*",              "HubNet Activities"),
 
-  // IABM Textbook models duplicated in Sample Models
+  // IABM Textbook models duplicated in Sample Models and Code Examples
   ("IABM Textbook/chapter 3/El Farol Extensions", "El Farol.nlogo",   "Sample Models/Social Science"),
-  ("IABM Textbook/chapter 3/DLA extensions",      "DLA Simple.nlogo", "Sample Models/Chemistry & Physics/Diffusion Limited Aggregation")
+  ("IABM Textbook/chapter 3/DLA extensions",      "DLA Simple.nlogo", "Sample Models/Chemistry & Physics/Diffusion Limited Aggregation"),
+  ("IABM Textbook/chapter 8",                     "Arduino*",         "Code Examples/Extensions Examples/arduino")
 )
 
 }

--- a/project/ModelCrossReference.scala
+++ b/project/ModelCrossReference.scala
@@ -21,8 +21,9 @@ object ModelCrossReference {
     "Code Examples/Extensions Examples/arduino")
 
   val foldersToCopy = Seq(
-    "Sample Models/Chemistry & Physics/GasLab"      -> "Curricular Models/GasLab",
-    "Sample Models/Chemistry & Physics/MaterialSim" -> "Curricular Models/MaterialSim")
+    "Sample Models/Chemistry & Physics/GasLab"       -> "Curricular Models/GasLab",
+    "Sample Models/Chemistry & Physics/MaterialSim"  -> "Curricular Models/MaterialSim",
+    "IABM Textbook/chapter 8/arduino-example-sketch" -> "Code Examples/Extensions Examples/arduino/arduino-example-sketch")
 
   val modelDuplications = Seq[(String, FileFilter, String)](
   // these need to fuzzy-find, since we may have pngs
@@ -71,7 +72,7 @@ object ModelCrossReference {
   // IABM Textbook models duplicated in Sample Models and Code Examples
   ("IABM Textbook/chapter 3/El Farol Extensions", "El Farol.nlogo",   "Sample Models/Social Science"),
   ("IABM Textbook/chapter 3/DLA extensions",      "DLA Simple.nlogo", "Sample Models/Chemistry & Physics/Diffusion Limited Aggregation"),
-  ("IABM Textbook/chapter 8",                     "Arduino*",         "Code Examples/Extensions Examples/arduino")
+  ("IABM Textbook/chapter 8",                     "Arduino*",       , "Code Examples/Extensions Examples/arduino"),
 )
 
 }

--- a/project/ModelCrossReference.scala
+++ b/project/ModelCrossReference.scala
@@ -38,6 +38,7 @@ object ModelCrossReference {
   ( "Sample Models/Biology/Evolution",            "Altruism*",    "Curricular Models/EACH"),
   ( "Sample Models/Biology/Evolution",            "Cooperation*", "Curricular Models/EACH"),
   ( "Sample Models/Biology/Evolution/Unverified", "Divide*",      "Curricular Models/EACH/Unverified"),
+  ( "Code Examples/vid", "Video Camera Example*", "Code Examples/bitmap"),
 
   // BEAGLE curricular models
   ("Sample Models/Biology", "Wolf Sheep Predation*",                        "Curricular Models/BEAGLE Evolution"),

--- a/project/ModelCrossReference.scala
+++ b/project/ModelCrossReference.scala
@@ -38,7 +38,7 @@ object ModelCrossReference {
   ( "Sample Models/Biology/Evolution",            "Altruism*",    "Curricular Models/EACH"),
   ( "Sample Models/Biology/Evolution",            "Cooperation*", "Curricular Models/EACH"),
   ( "Sample Models/Biology/Evolution/Unverified", "Divide*",      "Curricular Models/EACH/Unverified"),
-  ( "Code Examples/vid", "Video Camera Example*", "Code Examples/bitmap"),
+  ( "Code Examples/Extensions Examples/vid", "Video Camera Example*", "Code Examples/Extensions Examples/bitmap"),
 
   // BEAGLE curricular models
   ("Sample Models/Biology", "Wolf Sheep Predation*",                        "Curricular Models/BEAGLE Evolution"),


### PR DESCRIPTION
Updates the model cross referencer in order to adhere to the new organization (see NetLogo/models#273) of the `Code Examples` folder in the models library.

+ Adds Video Camera Example to` bitmap` folder of `Code Examples/Extensions Examples`
+ Copies Arduino Example from `IAMB Textbook/chapter 8/` to the `arduino` folder of `Code Examples/Extensions Examples` (this is includes the model and the Arduino sketch)

This needs to happen in concert with NetLogo/models#274, so this shouldn't be merged until after the official models repo is merged with the new organizational scheme. 
