### PR TITLE
HeadlessModel.open does not error on non-existent file

### DIFF
--- a/netlogo-gui/src/main/headless/HeadlessWorkspace.scala
+++ b/netlogo-gui/src/main/headless/HeadlessWorkspace.scala
@@ -498,13 +498,12 @@ with org.nlogo.api.ViewSettings {
   @throws(classOf[CompilerException])
   @throws(classOf[LogoException])
   override def open(path: String) {
-    setModelPath(path)
     try {
-      loader.readModel(Paths.get(path).toUri).foreach { m =>
-        setModelType(ModelType.Normal)
-        fileManager.handleModelChange()
-        openModel(m)
-      }
+      val m = loader.readModel(Paths.get(path).toUri).get
+      setModelPath(path)
+      setModelType(ModelType.Normal)
+      fileManager.handleModelChange()
+      openModel(m)
     }
     catch {
       case ex: CompilerException =>


### PR DESCRIPTION
This is easily verified at the scala console:

```
scala> val ws = org.nlogo.headless.HeadlessWorkspace.newInstance
ws: org.nlogo.headless.HeadlessWorkspace = org.nlogo.headless.HeadlessWorkspace@2a92b5ab

scala> ws.open("idontexist.nlogo")

scala> ws.modelFileName
res1: String = idontexist.nlogo
```