### PR TITLE
6.0-M9: Clash of local variable definitions

### DIFF
--- a/netlogo-gui/src/main/prim/_let.java
+++ b/netlogo-gui/src/main/prim/_let.java
@@ -16,8 +16,6 @@ public final strictfp class _let
     extends Command {
   public Let let;
 
-
-
   @Override
   public void perform(final Context context)
       throws LogoException {

--- a/netlogo-gui/src/main/prim/_setletvariable.java
+++ b/netlogo-gui/src/main/prim/_setletvariable.java
@@ -24,8 +24,6 @@ public final strictfp class _setletvariable
     context.ip = next;
   }
 
-
-
   @Override
   public String toString() {
     return super.toString() + ":" + name;

--- a/netlogo-gui/src/main/prim/_setprocedurevariable.java
+++ b/netlogo-gui/src/main/prim/_setprocedurevariable.java
@@ -16,8 +16,6 @@ public final strictfp class _setprocedurevariable
     name = original.name;
   }
 
-
-
   @Override
   public String toString() {
     return super.toString() + ":" + name;

--- a/test/commands/Let.txt
+++ b/test/commands/Let.txt
@@ -168,3 +168,7 @@ LetSameNameAsBreedVariable
   breed [mice mouse]
   mice-own [fur]
   O> let fur 5 => COMPILER ERROR There is already a MICE-OWN variable called FUR
+
+LetWithinIfNextToAsk
+  to-report test if true [ let x 1 ] let res 0 ask one-of patches [ let x 2 set res x ] report res end
+  test => 2


### PR DESCRIPTION
```
to test
  clear-all
  if true [
    let x "if block"
    print x
  ]
  ask one-of patches [
    let x "ask block"
    print x
  ]
end
```

And then:
```
observer> test
if block
if block
```

If you invert the order of the two blocks (i.e., put `ask` before `if`), you correctly get:

```
observer> test
ask block
if block
```

I came upon this while trying to isolate the cause of a `java.lang.NullPointerException` raised by a user model. I strongly suspect that both errors have the same cause, but I haven't (yet) been able to recreate the NPE in a simple model. (I can provide a private link to the user model if needed.)