### PR TITLE
When there's a slider that uses a reporter and an error in the code, an exception is thrown.

### DIFF
--- a/netlogo-gui/src/main/window/SliderData.scala
+++ b/netlogo-gui/src/main/window/SliderData.scala
@@ -49,6 +49,11 @@ class SliderData(errorHandler: MultiErrorHandler, var minimum:Double = 0, var ma
       e match {
         case ex: SliderConstraint.ConstraintRuntimeException =>
           errorHandler.error(ex.spec.fieldName, ex)
+        case otherEx =>
+          // If there's a non-constraint error, don't blow up.
+          // Typically, this error is generated when a slider reporter depends on the value
+          // of another slider or a compiled procedure and compilation hasn't quite caught up
+          // with where this event is.
       }
 
     (for {


### PR DESCRIPTION
The exception:

```
java.lang.reflect.InvocationTargetException
 at java.awt.EventQueue.invokeAndWait(EventQueue.java:1321)
 at java.awt.EventQueue.invokeAndWait(EventQueue.java:1296)
 at org.nlogo.awt.EventQueue$.invokeAndWait(EventQueue.scala:19)
 at org.nlogo.swing.ModalProgressTask$Boss.run(ModalProgressTask.scala:70)
Caused by: scala.MatchError: java.lang.ArrayIndexOutOfBoundsException: 1 (of class java.lang.ArrayIndexOutOfBoundsException)
 at org.nlogo.window.SliderData.org$nlogo$window$SliderData$$setError$1(SliderData.scala:49)
 at org.nlogo.window.SliderData$$anonfun$setSliderConstraint$1$$anonfun$apply$mcZ$sp$2.apply(SliderData.scala:60)
 at org.nlogo.window.SliderData$$anonfun$setSliderConstraint$1$$anonfun$apply$mcZ$sp$2.apply(SliderData.scala:60)
 at scala.util.Success.foreach(Try.scala:236)
 at org.nlogo.window.SliderData$$anonfun$setSliderConstraint$1.apply$mcZ$sp(SliderData.scala:60)
 at org.nlogo.window.SliderData$$anonfun$setSliderConstraint$1.apply(SliderData.scala:58)
 at org.nlogo.window.SliderData$$anonfun$setSliderConstraint$1.apply(SliderData.scala:58)
 at scala.util.Try.getOrElse(Try.scala:79)
 at org.nlogo.window.SliderData.setSliderConstraint(SliderData.scala:58)
 at org.nlogo.window.AbstractSliderWidget$class.setSliderConstraint(SliderWidget.scala:41)
 at org.nlogo.window.SliderWidget.setSliderConstraint(SliderWidget.scala:179)
 at org.nlogo.window.GUIWorkspace.handle(GUIWorkspace.java:915)
 at org.nlogo.window.Events$AddSliderConstraintEvent.beHandledBy(Events.java:116)
 at org.nlogo.window.Event.doRaise(Event.java:198)
 at org.nlogo.window.Event.raise(Event.java:122)
 at org.nlogo.window.SliderWidget.updateConstraints(SliderWidget.scala:188)
 at org.nlogo.window.CompilerManager$$anonfun$updateInterfaceGlobalConstraints$1.apply(CompilerManager.scala:245)
 at org.nlogo.window.CompilerManager$$anonfun$updateInterfaceGlobalConstraints$1.apply(CompilerManager.scala:245)
 at scala.collection.mutable.HashSet.foreach(HashSet.scala:78)
 at org.nlogo.window.CompilerManager.updateInterfaceGlobalConstraints(CompilerManager.scala:245)
 at org.nlogo.window.CompilerManager.compileAll(CompilerManager.scala:188)
 at org.nlogo.window.CompilerManager.handle(CompilerManager.scala:70)
 at org.nlogo.window.Events$LoadEndEvent.beHandledBy(Events.java:448)
 at org.nlogo.window.Event.doRaise(Event.java:198)
 at org.nlogo.window.Event.raise(Event.java:122)
 at org.nlogo.window.ReconfigureWorkspaceUI$Loader$$anonfun$loadHelper$1.apply(ReconfigureWorkspaceUI.scala:37)
 at org.nlogo.window.ReconfigureWorkspaceUI$Loader$$anonfun$loadHelper$1.apply(ReconfigureWorkspaceUI.scala:37)
 at scala.collection.immutable.List.foreach(List.scala:381)
 at org.nlogo.window.ReconfigureWorkspaceUI$Loader.loadHelper(ReconfigureWorkspaceUI.scala:37)
 at org.nlogo.window.ReconfigureWorkspaceUI$.apply(ReconfigureWorkspaceUI.scala:19)
 at org.nlogo.app.FileMenu.org$nlogo$app$FileMenu$$runLoad(FileMenu.scala:461)
 at org.nlogo.app.FileMenu$$anon$4.run(FileMenu.scala:450)
 at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:301)
 at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:756)
 at java.awt.EventQueue.access$500(EventQueue.java:97)
 at java.awt.EventQueue$3.run(EventQueue.java:709)
 at java.awt.EventQueue$3.run(EventQueue.java:703)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
 at java.awt.EventQueue.dispatchEvent(EventQueue.java:726)
 at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:109)
 at java.awt.WaitDispatchSupport$2.run(WaitDispatchSupport.java:184)
 at java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:229)
 at java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:227)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.awt.WaitDispatchSupport.enter(WaitDispatchSupport.java:227)
 at java.awt.Dialog.show(Dialog.java:1084)
 at java.awt.Component.show(Component.java:1671)
 at java.awt.Component.setVisible(Component.java:1623)
 at java.awt.Window.setVisible(Window.java:1014)
 at java.awt.Dialog.setVisible(Dialog.java:1005)
 at org.nlogo.swing.ModalProgressTask$.apply(ModalProgressTask.scala:43)
 at org.nlogo.app.FileMenu.org$nlogo$app$FileMenu$$openFromModel(FileMenu.scala:453)
 at org.nlogo.app.FileMenu$$anonfun$openFromURI$1.apply(FileMenu.scala:436)
 at org.nlogo.app.FileMenu$$anonfun$openFromURI$1.apply(FileMenu.scala:436)
 at scala.Option.foreach(Option.scala:257)
 at org.nlogo.app.FileMenu.openFromURI(FileMenu.scala:436)
 at org.nlogo.app.FileMenu.openFromPath(FileMenu.scala:432)
 at org.nlogo.app.App$$anonfun$open$1.apply$mcV$sp(App.scala:787)
 at org.nlogo.app.App$$anonfun$open$1.apply(App.scala:787)
 at org.nlogo.app.App$$anonfun$open$1.apply(App.scala:787)
 at org.nlogo.app.App.dispatchThreadOrBust(App.scala:1059)
 at org.nlogo.app.App.open(App.scala:787)
 at org.nlogo.app.App.loadDefaultModel(App.scala:515)
 at org.nlogo.app.App.org$nlogo$app$App$$finishStartup(App.scala:452)
 at org.nlogo.app.App$$anonfun$mainWithAppHandler$1.apply$mcV$sp(App.scala:188)
 at org.nlogo.swing.Implicits$$anon$17.run(Implicits.scala:13)
 at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:301)
 at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:756)
 at java.awt.EventQueue.access$500(EventQueue.java:97)
 at java.awt.EventQueue$3.run(EventQueue.java:709)
 at java.awt.EventQueue$3.run(EventQueue.java:703)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
 at java.awt.EventQueue.dispatchEvent(EventQueue.java:726)
 at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
 at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
 at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
```

A simple model that demonstrates this behavior: https://gist.github.com/qiemem/3bb87ef0af5cca0c8081896e78406520
