### PR TITLE
Exception when trying to open `.nls` file directly in NetLogo

### DIFF
--- a/netlogo-gui/project/autogen/i18n/GUI_Strings_en.txt
+++ b/netlogo-gui/project/autogen/i18n/GUI_Strings_en.txt
@@ -188,7 +188,8 @@ file.open.warn.intwod.openthreed = You are attempting to open a model \
   NetLogo can try to open the model, but it may or may not work.
 file.open.warn.inthreed.opentwod = You are attempting to open \
   a 2D model in {0}. You might need to make changes before it will work in 3D.
-file.open.error.invalidmodel = The file is not a valid NetLogo model file.
+file.open.error.invalidmodel = This file is not a valid NetLogo model file.
+file.open.error.invalidmodel.withPath = The file {0} is not a valid NetLogo model file.
 file.open.error.unableToOpen = NetLogo can''t open the model {0}:\n\n{1}.
 file.close.warn.movieInProgress = There is a movie in progress. Are you sure you want to exit this model? You will lose the contents of your movie.
 file.save.warn.savingInNewerVersion = This model was made with {0}. If you save it in {1} it may not work in the old version anymore.

--- a/parser-jvm/src/main/core/I18N.scala
+++ b/parser-jvm/src/main/core/I18N.scala
@@ -76,7 +76,7 @@ object I18N {
         println(s"unable to find translation for: $key in $name for locale: ${defaultBundle.getLocale}")
         getFromBundle(englishBundle)
           .getOrElse(
-            throw new IllegalArgumentException(s"coding error, bad translation key: $key for $name"))
+            throw new IllegalArgumentException(s"internal error, bad translation key: $key for $name"))
       }
       java.text.MessageFormat.format(preformattedText, args: _*)
     }


### PR DESCRIPTION
This should give a better error message:
```
java.lang.IllegalStateException: couldn't open: 'file:/media/nicolas/data/workspace/NetLogo/models/test/Really%20Long%20Code.nls'
 at org.nlogo.window.FileController.invalidModel(FileController.scala:33)
 at org.nlogo.workspace.OpenModel$.apply(OpenModel.scala:33)
 at org.nlogo.app.FileMenu.org$nlogo$app$FileMenu$$loadModel(FileMenu.scala:435)
 at org.nlogo.app.FileMenu.openFromURI(FileMenu.scala:431)
 at org.nlogo.app.FileMenu.openFromPath(FileMenu.scala:427)
 at org.nlogo.app.FileMenu$OpenAction.action(FileMenu.scala:124)
 at org.nlogo.app.FileMenu$FileMenuAction.actionPerformed(FileMenu.scala:100)
 at javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:2022)
 at javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2348)
 at javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:402)
 at javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:259)
 at javax.swing.AbstractButton.doClick(AbstractButton.java:376)
 at javax.swing.AbstractButton.doClick(AbstractButton.java:356)
 at javax.swing.plaf.basic.BasicMenuItemUI$Actions.actionPerformed(BasicMenuItemUI.java:802)
 at javax.swing.SwingUtilities.notifyAction(SwingUtilities.java:1663)
 at javax.swing.JComponent.processKeyBinding(JComponent.java:2882)
 at javax.swing.JMenuBar.processBindingForKeyStrokeRecursive(JMenuBar.java:699)
 at javax.swing.JMenuBar.processBindingForKeyStrokeRecursive(JMenuBar.java:706)
 at javax.swing.JMenuBar.processBindingForKeyStrokeRecursive(JMenuBar.java:706)
 at javax.swing.JMenuBar.processKeyBinding(JMenuBar.java:677)
 at javax.swing.KeyboardManager.fireBinding(KeyboardManager.java:307)
 at javax.swing.KeyboardManager.fireKeyboardAction(KeyboardManager.java:293)
 at javax.swing.JComponent.processKeyBindingsForAllComponents(JComponent.java:2974)
 at javax.swing.JComponent.processKeyBindings(JComponent.java:2966)
 at javax.swing.JComponent.processKeyEvent(JComponent.java:2845)
 at java.awt.Component.processEvent(Component.java:6310)
 at java.awt.Container.processEvent(Container.java:2236)
 at java.awt.Component.dispatchEventImpl(Component.java:4889)
 at java.awt.Container.dispatchEventImpl(Container.java:2294)
 at java.awt.Component.dispatchEvent(Component.java:4711)
 at java.awt.KeyboardFocusManager.redispatchEvent(KeyboardFocusManager.java:1954)
 at java.awt.DefaultKeyboardFocusManager.dispatchKeyEvent(DefaultKeyboardFocusManager.java:806)
 at java.awt.DefaultKeyboardFocusManager.preDispatchKeyEvent(DefaultKeyboardFocusManager.java:1074)
 at java.awt.DefaultKeyboardFocusManager.typeAheadAssertions(DefaultKeyboardFocusManager.java:945)
 at java.awt.DefaultKeyboardFocusManager.dispatchEvent(DefaultKeyboardFocusManager.java:771)
 at java.awt.Component.dispatchEventImpl(Component.java:4760)
 at java.awt.Container.dispatchEventImpl(Container.java:2294)
 at java.awt.Window.dispatchEventImpl(Window.java:2746)
 at java.awt.Component.dispatchEvent(Component.java:4711)
 at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
 at java.awt.EventQueue.access$500(EventQueue.java:97)
 at java.awt.EventQueue$3.run(EventQueue.java:709)
 at java.awt.EventQueue$3.run(EventQueue.java:703)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
 at java.awt.EventQueue$4.run(EventQueue.java:731)
 at java.awt.EventQueue$4.run(EventQueue.java:729)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
 at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
 at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
 at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
 at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)

NetLogo 6.0-RC1
main: org.nlogo.app.AppFrame
thread: AWT-EventQueue-0
Java HotSpot(TM) 64-Bit Server VM 1.8.0_101 (Oracle Corporation; 1.8.0_101-b13)
operating system: Linux 4.4.0-31-generic (amd64 processor)
Scala version 2.11.8
JOGL: (3D View not initialized)
OpenGL Graphics: (3D View not initialized)
model: Preferential Attachment Tester

03:59:21.113 InterfaceGlobalEvent (org.nlogo.widget.SwitchWidget) AWT-EventQueue-0
03:59:21.113 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
03:59:20.913 InterfaceGlobalEvent (org.nlogo.widget.SwitchWidget) AWT-EventQueue-0
03:59:20.912 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
03:59:20.712 InterfaceGlobalEvent (org.nlogo.widget.SwitchWidget) AWT-EventQueue-0
03:59:20.712 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
03:59:20.512 InterfaceGlobalEvent (org.nlogo.widget.SwitchWidget) AWT-EventQueue-0
03:59:20.512 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
03:59:20.312 InterfaceGlobalEvent (org.nlogo.widget.SwitchWidget) AWT-EventQueue-0
03:59:20.312 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
```