### PR TITLE
6.0 regression: __includes with empty argument should enable Includes button

### DIFF
--- a/netlogo-gui/src/main/compile/Compiler.scala
+++ b/netlogo-gui/src/main/compile/Compiler.scala
@@ -124,9 +124,11 @@ class Compiler(dialect: Dialect) extends CompilerInterface {
   def findIncludes(sourceFileName: String, source: String,
     compilationEnvironment: CompilationEnvironment): Option[Map[String, String]] = {
     val includes = frontEnd.findIncludes(source)
-    if (includes.isEmpty)
-      None
-    else
+    if (includes.isEmpty) { // this allows the includes menu to be displayed for __includes []
+      parserTokenizer.tokenizeString(source)
+        .find(t => t.text.equalsIgnoreCase("__includes"))
+        .map(_ => Map.empty[String, String])
+    } else
       Some((includes zip includes.map(compilationEnvironment.resolvePath)).toMap)
   }
 


### PR DESCRIPTION
This was previously fixed in the 5.x branch (https://github.com/NetLogo/NetLogo/issues/717) but appears to have regressed in the `hexy` branch. Typing just `__includes []` in the code tab doesn't raise a compilation error, but it doesn't enable the "Includes" drop-down like it should.