### PR TITLE
Autoconverter doesn't convert use of `task` without brackets

### DIFF
--- a/parser-core/src/main/core/prim/Lambda.scala
+++ b/parser-core/src/main/core/prim/Lambda.scala
@@ -1,0 +1,15 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.core
+package prim
+
+trait Lambda {
+  def argumentNames: Seq[String]
+  def synthetic: Boolean
+  def closedVariables: Set[ClosedVariable]
+}
+
+object Lambda {
+  def unapply(l: Lambda): Option[(Seq[String], Boolean, Set[ClosedVariable])] =
+    Some((l.argumentNames, l.synthetic, l.closedVariables))
+}

--- a/parser-core/src/main/core/prim/misc.scala
+++ b/parser-core/src/main/core/prim/misc.scala
@@ -72,7 +72,7 @@ case class _carefully() extends Command {
       right = List(Syntax.CommandBlockType, Syntax.CommandBlockType),
       introducesContext = true)
 }
-case class _commandlambda(argumentNames: Seq[String], synthetic: Boolean, closedVariables: Set[ClosedVariable]) extends Reporter {
+case class _commandlambda(argumentNames: Seq[String], synthetic: Boolean, closedVariables: Set[ClosedVariable]) extends Lambda with Reporter {
   def this() = this(Seq(), false, Set())
   def this(arguments: Seq[String]) = this(arguments, false, Set())
   def this(arguments: Seq[String], synthetic: Boolean) = this(arguments, synthetic, Set())
@@ -381,7 +381,7 @@ case class _report() extends Command {
     Syntax.commandSyntax(
       right = List(Syntax.WildcardType))
 }
-case class _reporterlambda(argumentNames: Seq[String], synthetic: Boolean, closedVariables: Set[ClosedVariable]) extends Reporter {
+case class _reporterlambda(argumentNames: Seq[String], synthetic: Boolean, closedVariables: Set[ClosedVariable]) extends Lambda with Reporter {
   def this() = this(Seq(), false, Set())
   def this(arguments: Seq[String]) = this(arguments, false, Set())
   def this(arguments: Seq[String], synthetic: Boolean) = this(arguments, synthetic, Set())

--- a/parser-jvm/src/test/parse/AstRewriterTests.scala
+++ b/parser-jvm/src/test/parse/AstRewriterTests.scala
@@ -119,6 +119,8 @@ class AstRewriterTests extends FunSuite {
     "__ignore (map [list (?1 + 1) (?2 - 1)] (list 2 1))")
   testLambda("let a-task [ [] -> tick ]", "let a-task task tick")
   testLambda("let a-task [ [] -> tick ]", "let a-task task [tick]")
+  testLambda("foreach [1 2 3] [ [?1] -> crt ?1 ]", "foreach [1 2 3] task crt")
+  testLambda("show (map ([ [?1 ?2] -> ?1 + ?2 ]) [1 2 3] [1 2 3])", "show (map (task +) [1 2 3] [1 2 3])")
   testLambda("show is-list? [ [] -> tick ]", "show is-list? task [tick]")
   testLambda("let a-value 1 let a-task [ [] -> a-value ]", "let a-value 1 let a-task task [a-value]")
   testLambda("baz ([ [] ->  fd 1 ]) ([ [?1 ?2] -> bk ?2 ])", "baz (task [ fd 1 ]) (task [ bk ?2 ])", preamble = "TO baz [a b] END TO FOO ")
@@ -219,7 +221,7 @@ class AstRewriterTests extends FunSuite {
 
     test("lambda-izes " + body + " to " + changedBody) {
       val lambdaized = lambdaize(preamble + body + postamble)
-      assertResult(preamble + changedBody + postamble, s"""expected: "$changedBody", got: "$lambdaized"""")(lambdaized)
+      assertResult(preamble + changedBody + postamble, s"""expected: "$preamble$changedBody$postamble", got: "$lambdaized"""")(lambdaized)
     }
   }
 }


### PR DESCRIPTION
For example:

```netlogo
to test
  foreach [1 2 3] task crt
end
```