### PR TITLE
InterfacePanel only recompiles when its own widgets are removed

### DIFF
--- a/netlogo-gui/src/main/app/interfacetab/InterfacePanel.scala
+++ b/netlogo-gui/src/main/app/interfacetab/InterfacePanel.scala
@@ -231,7 +231,8 @@ class InterfacePanel(val viewWidget: ViewWidgetInterface, workspace: GUIWorkspac
       super.contains(w)
 
   override def handle(e: WidgetRemovedEvent): Unit = {
-    new CompileAllEvent().raise(this)
+    if (e.widget.findWidgetContainer eq this)
+      new CompileAllEvent().raise(this)
   }
 
   def interfaceImage: BufferedImage =


### PR DESCRIPTION
Fixes a problem where when an inspector is closed, forever buttons will stop.