### PR TITLE
Indent tweaks

### DIFF
--- a/netlogo-gui/src/main/app/codetab/SmartIndenter.scala
+++ b/netlogo-gui/src/main/app/codetab/SmartIndenter.scala
@@ -11,55 +11,26 @@ extends Indenter {
 
   /// first, the four handle* methods in IndenterInterface
 
-  def handleTab() {
+  def handleTab() = {
     val line1 = code.offsetToLine(code.getSelectionStart)
     val line2 = code.offsetToLine(code.getSelectionEnd)
-    (line1 to line2).foreach(indentLine(_))
+    (line1 to line2).foreach(indentLine)
   }
-  def handleEnter() {
-    val lineStart = code.lineToStartOffset(code.offsetToLine(code.getSelectionStart))
-    val prevLineText = code.getText(lineStart, code.getSelectionStart - lineStart)
-    val tabDiff = totalValue(prevLineText)
-    if(tabDiff >= 0)
-      code.replaceSelection(
-        "\n" + spaces(countLeadingSpaces(prevLineText) + tabDiff * TAB_WIDTH))
-    else
-      code.replaceSelection(
-        "\n" + spaces(countLeadingSpaces(
-          code.getLineOfText(
-            code.offsetToLine(
-              findMatchingOpenerBackward(code.getText(0, code.getSelectionStart), 0)
-              .start)))))
+
+  def handleEnter() = {
+    code.replaceSelection("\n")
+    indentLine(code.offsetToLine(code.getSelectionEnd))
   }
-  def handleInsertion(s: String) {
+
+  def handleInsertion(s: String) = {
     if(List("e", "n", "d").contains(s.toLowerCase)) {
       val lineNum = code.offsetToLine(code.getSelectionStart)
       if(code.getLineOfText(lineNum).trim.equalsIgnoreCase("end"))
         handleCloseBracket()
     }
   }
-  def handleCloseBracket() {
-    val currentLine = code.offsetToLine(code.getSelectionStart)
-    val lineStart = code.lineToStartOffset(currentLine)
-    val lineEnd = code.lineToEndOffset(currentLine)
-    val text = code.getText(lineStart, lineEnd - lineStart)
-    val textUpToCursor = text.substring(0, code.getSelectionStart - lineStart)
-    val wordUpToCursor = textUpToCursor.trim.toLowerCase
-    if(List("]", ")", "end").contains(wordUpToCursor)) {
-      val lineSpaceCount = countLeadingSpaces(textUpToCursor)
-      val opener = findMatchingOpenerBackward(code.getText(0, code.getSelectionStart), 0)
-      val openerLineNum = code.offsetToLine(opener.start)
-      val openerLine = code.getLineOfText(openerLineNum)
-      val spaceDiff = StrictMath.min(lineSpaceCount - countLeadingSpaces(openerLine),
-                                     textUpToCursor.length)
-      if(spaceDiff > 0)
-        code.remove(code.getSelectionStart - wordUpToCursor.length - spaceDiff,
-                    spaceDiff)
-      else if(spaceDiff < 0)
-        code.insertString(code.getSelectionStart - wordUpToCursor.length,
-                          spaces(- spaceDiff))
-    }
-  }
+
+  def handleCloseBracket() = handleTab()
 
   /// private helpers
 

--- a/netlogo-gui/src/main/app/codetab/SmartIndenter.scala
+++ b/netlogo-gui/src/main/app/codetab/SmartIndenter.scala
@@ -93,33 +93,54 @@ extends Indenter {
       getComment(tokens).foreach(tok => return Some(tok.start))
     var result = countLeadingSpaces(prevLine)
     // if there is such a previous line if it's got an "opener" that has no closer bump this line in
-    if(totalValue(tokens) > 0)
-      result += TAB_WIDTH
-    else {
-      // finally, first look for the last closing bracket, then find the matching open bracket then
-      // find the previous command that is outside the brackets.
-      findCommandForLastCloser(
+    val fromUnmatched = fromUnmatchedOpener(tokens)
+    fromUnmatched match {
+      case Some(tokensInUnmatched) =>
+        // "to" and "to-report" are special because they're followed by the procedure name.
+        // We don't want to indent to the level of the procedure name.
+        // size == 2 because the last token is always EOF. This tells use there's nothing after the unmatched opener.
+        if (List("to", "to-report").contains(tokensInUnmatched.head.text.toLowerCase)
+            || tokensInUnmatched.size == 2
+            || tokensInUnmatched.tail.head.tpe == TokenType.Comment) {
+          // We drop closers at the beginning because the indenter should have
+          // already taken those into account in re-indenting that line.
+          if (totalValue(tokens.dropWhile(isCloser)) > 0) { result += TAB_WIDTH }
+        } else {
+          // There's a token after the unmatched opener on the same line. We match that tokens indentation level.
+          result = tokensInUnmatched.tail.head.start
+        }
+      case None =>
+        // finally, first look for the last closing bracket, then find the matching open bracket then
+        // find the previous command that is outside the brackets.
+        findCommandForLastCloser(
           prevLine, code.lineToStartOffset(prevLineNum),
           token != null && isOpener(token)).foreach(opener =>
-        result = countLeadingSpaces(
-          code.getLineOfText(
-            code.offsetToLine(opener.start))))
-      // look for the command on the previous line if we've got an opener (closed opener) look to
-      // see where we are in relation to the command if we're indented past the command move to 1
-      // tab stop past if we're before we move to be in line with the command
-      val cmd = findCommand(prevLine)
-      if(token != null && isOpener(token) && cmd.isDefined &&
-         countLeadingSpaces(currentLine) > result)
-           return Some(result + TAB_WIDTH)
+          result = countLeadingSpaces(
+            code.getLineOfText(
+              code.offsetToLine(opener.start))))
+        // look for the command on the previous line if we've got an opener (closed opener) look to
+        // see where we are in relation to the command if we're indented past the command move to 1
+        // tab stop past if we're before we move to be in line with the command
+        val cmd = findCommand(prevLine)
+        if (token != null && isOpener(token) && cmd.isDefined &&
+          countLeadingSpaces(currentLine) > result)
+          return Some(result + TAB_WIDTH)
     }
     Some(result)
   }
 
   private def countLeadingSpaces(s: String) = s.takeWhile(_ == ' ').size
-  private def isOnlySpaces(s: String) = s.forall(_ == ' ')
   private def spaces(n: Int) = List.fill(n)(' ').mkString
-  private def totalValue(s: String): Int = totalValue(tokenize(s))
   private def totalValue(tokens: List[Token]): Int = tokens.map(value).sum
+  private def fromUnmatchedOpener(tokens: List[Token]): Option[List[Token]] = {
+    var stack = 0
+    val result = tokens.reverse.takeWhile { t =>
+      val keepGoing = stack <= 0
+      if (keepGoing) { stack += (if (isOpener(t)) 1 else if (isCloser(t)) -1 else 0) }
+      keepGoing
+    }.reverse
+    if (stack > 0) Some(result) else None
+  }
 
   private def value(tok: Token) =
     if(isOpener(tok)) 1

--- a/test/indent.txt
+++ b/test/indent.txt
@@ -43,6 +43,15 @@ to go
 ++]
 end
 
+IfElseMultiLineCompact
+to go
+++ifelse true [
+++++show 1
+++] [
+++++show 2
+++]
+end
+
 Globals
 globals [
 ++glob1
@@ -81,7 +90,17 @@ to bar
 
 MultiLineLiteralList1
 let triangle [[75]
-  [95 64] [17 47 82]]
+++++++++++++++[95 64] [17 47 82]]
+
+WayIndentedCommands
+ask turtles [ fd 1
+++++++++++++++fd 10
+]
+
+WayIndentedComment
+ask turtles [ ;; This does crazy stuff!
+++fd 10       ;; Forward 10! Wow!
+]
 
 Hatch1
 if true
@@ -108,24 +127,10 @@ if true
 #    <-- line with only some spaces on it
 #++foo
 
-#IfElseYetAnotherStyle
-#to bar
-#++ifelse foo [
-#++++x
-#++] [
-#++++y
-#++]
-#end
-
 #MultiLineCommand
 #let digit-sum carry +
 #++read-from-string item ? n1 +
 #++read-from-string item ? n2
-
-#WayIndentedCommands
-#ask turtles [ fd 1
-#++++++++++++++fd 10
-#]
 
 #CommentLinesOneStandaloneOneNot
 #to eat-grass  ;; sheep procedure
@@ -136,10 +141,6 @@ if true
 #
 
 #MultiLineLiteralList2 -- think though, if we do this would it mess up any cases of brackets around blocks?
-#let triangle [[75]
-#              [95 64] [17 47 82]]
-
-#MultiLineLiteralList3 -- think though, if we do this would it mess up any cases of brackets around blocks?
 #let x [[1 2 [3 31 32
 #             4 5]
 #        6]

--- a/test/indent.txt
+++ b/test/indent.txt
@@ -72,6 +72,25 @@ let my-list
 ++[0 2]
 ]
 
+MultiLineVariadicCommand
+(foreach
+++list1
+++list2
+++[ [x y] ->
+++++foo x y
+++]
+)
+
+AnonymousProcedure
+let func [ [x] ->
+++x + 1
+]
+
+AnonymousProcedureComment
+let func [ [x] -> ;; this does stuff
+++x + 1
+]
+
 Comments1
 ask turtles [ fd 1 ] ;; I am a comment
 +++++++++++++++++++++;;me too
@@ -87,15 +106,6 @@ to foo
 ++ask [ [ [ [
 end
 to bar
-
-MultiLineLiteralList1
-let triangle [[75]
-++++++++++++++[95 64] [17 47 82]]
-
-WayIndentedCommands
-ask turtles [ fd 1
-++++++++++++++fd 10
-]
 
 WayIndentedComment
 ask turtles [ ;; This does crazy stuff!
@@ -127,6 +137,7 @@ if true
 #    <-- line with only some spaces on it
 #++foo
 
+
 #MultiLineCommand
 #let digit-sum carry +
 #++read-from-string item ? n1 +
@@ -138,7 +149,21 @@ if true
 
 #
 # These are even more ambitious.
-#
+# Fixing these requires lots of special casing with anonymous procedures and non-bracket openers
+
+#WayIndentedCommands
+#ask turtles [ fd 1
+#++++++++++++++fd 10
+#]
+
+#ArgIndentMatchingMultilineStatment -- is this ideal?
+#let foo (list 1
+#++++++++++++++2
+#++++++++++++++3)
+
+#MultiLineLiteralList1 -- think though, if we do this would it mess up any cases of brackets around blocks?
+#let triangle [[75]
+#              [95 64] [17 47 82]]
 
 #MultiLineLiteralList2 -- think though, if we do this would it mess up any cases of brackets around blocks?
 #let x [[1 2 [3 31 32


### PR DESCRIPTION
- Indents `] [` correctly
~~- Matches indenting in cases of custom indenting after opener, e.g.:~~ *this resulted in weird corner cases*
- Makes all indent triggers behave consistently.