### PR TITLE
Number-too-large stacktrace computation raises NullPointerException

### DIFF
--- a/netlogo-gui/src/main/nvm/Instruction.java
+++ b/netlogo-gui/src/main/nvm/Instruction.java
@@ -184,12 +184,12 @@ public abstract strictfp class Instruction
 
   // checking of numeric types
 
-  public long validLong(double d) throws LogoException {
+  public long validLong(double d, Context context) throws LogoException {
     // 9007199254740992 is the largest/smallest integer
     // exactly representable in a double - ST 1/29/08
     if (d > 9007199254740992L || d < -9007199254740992L) {
       throw new RuntimePrimitiveException
-          (null, this,
+          (context, this,
               d + " is too large to be represented exactly as an integer in NetLogo");
     }
     return (long) d;
@@ -201,19 +201,19 @@ public abstract strictfp class Instruction
     return d <= 9007199254740992L && d >= -9007199254740992L;
   }
 
-  public Double newValidDouble(double d) throws LogoException {
+  public Double newValidDouble(double d, Context context) throws LogoException {
     if (Double.isInfinite(d) || Double.isNaN(d)) {
-      invalidDouble(d);
+      invalidDouble(d, context);
     }
     return Double.valueOf(d);
   }
 
-  public double validDouble(double d) throws LogoException {
+  public double validDouble(double d, Context context) throws LogoException {
     // yeah, this line is repeated from the previous method,
     // but factoring it out would cost us a method call, and this
     // is extremely efficiency-critical code, so... - ST 11/1/04
     if (Double.isInfinite(d) || Double.isNaN(d)) {
-      invalidDouble(d);
+      invalidDouble(d, context);
     }
     // Returning d makes it easier to insert validDouble() calls into
     // expressions without having to break those expressions up into
@@ -222,11 +222,9 @@ public abstract strictfp class Instruction
     return d;
   }
 
-  private void invalidDouble(double d) throws LogoException {
-    // it's hard to get a context here in some situations because
-    // of optimizations. the context will get set later.
+  private void invalidDouble(double d, Context context) throws LogoException {
     throw new RuntimePrimitiveException
-        (null, this,
+        (context, this,
             "math operation produced "
                 + (Double.isInfinite(d)
                 ? "a number too large for NetLogo"

--- a/netlogo-gui/src/main/prim/_breedsingular.scala
+++ b/netlogo-gui/src/main/prim/_breedsingular.scala
@@ -16,7 +16,7 @@ class _breedsingular(breedName: String) extends Reporter {
   override def report(context: Context) = report_1(context, argEvalDoubleValue(context, 0))
 
   def report_1(context: Context, idDouble: Double): AnyRef = {
-    val id = validLong(idDouble)
+    val id = validLong(idDouble, context)
     if (id != idDouble)
       throw new RuntimePrimitiveException(context, this, s"$idDouble is not an integer")
     val turtle = world.getTurtle(id)

--- a/netlogo-gui/src/main/prim/_minus.java
+++ b/netlogo-gui/src/main/prim/_minus.java
@@ -19,6 +19,6 @@ public final strictfp class _minus extends Reporter implements Pure {
   }
 
   public double report_1(Context context, double arg0, double arg1) throws LogoException {
-    return validDouble(arg0 - arg1);
+    return validDouble(arg0 - arg1, context);
   }
 }

--- a/netlogo-gui/src/main/prim/_nsum.java
+++ b/netlogo-gui/src/main/prim/_nsum.java
@@ -54,6 +54,6 @@ public final strictfp class _nsum extends Reporter {
 
       sum += ((Double) value).doubleValue();
     }
-    return validDouble(sum);
+    return validDouble(sum, context);
   }
 }

--- a/netlogo-gui/src/main/prim/_nsum4.java
+++ b/netlogo-gui/src/main/prim/_nsum4.java
@@ -54,6 +54,6 @@ public final strictfp class _nsum4 extends Reporter {
 
       sum += ((Double) value).doubleValue();
     }
-    return validDouble(sum);
+    return validDouble(sum, context);
   }
 }

--- a/netlogo-gui/src/main/prim/_plus.java
+++ b/netlogo-gui/src/main/prim/_plus.java
@@ -15,10 +15,10 @@ public final strictfp class _plus extends Reporter implements Pure {
   public Object report(Context context) throws LogoException {
     return validDouble
         (argEvalDoubleValue(context, 0) +
-            argEvalDoubleValue(context, 1));
+            argEvalDoubleValue(context, 1), context);
   }
 
   public double report_1(Context context, double d1, double d2) throws LogoException {
-    return validDouble(d1 + d2);
+    return validDouble(d1 + d2, context);
   }
 }

--- a/netlogo-gui/src/main/prim/_random.java
+++ b/netlogo-gui/src/main/prim/_random.java
@@ -16,7 +16,7 @@ public final strictfp class _random extends Reporter {
   }
 
   public double report_1(final Context context, double maxdouble) throws LogoException {
-    long maxlong = validLong(maxdouble);
+    long maxlong = validLong(maxdouble, context);
     if (maxdouble != maxlong) {
       maxlong += (maxdouble >= 0) ? 1 : -1;
     }

--- a/netlogo-gui/src/main/prim/_repeat.scala
+++ b/netlogo-gui/src/main/prim/_repeat.scala
@@ -17,7 +17,7 @@ class _repeat extends Command with CustomAssembled {
 
   @throws(classOf[LogoException])
   def perform_1(context: Context, d0: Double): Unit = {
-    context.let(_let, new MutableLong(validLong(d0)))
+    context.let(_let, new MutableLong(validLong(d0, context)))
     context.ip = offset
   }
 

--- a/netlogo-gui/src/main/prim/_repeatlocal.scala
+++ b/netlogo-gui/src/main/prim/_repeatlocal.scala
@@ -16,7 +16,7 @@ class _repeatlocal(private[this] val vn: Int) extends Command with CustomAssembl
 
   @throws(classOf[LogoException])
   def perform_1(context: Context, arg0: Double): Unit = {
-    context.activation.args(vn) = new MutableLong(validLong(arg0))
+    context.activation.args(vn) = new MutableLong(validLong(arg0, context))
     context.ip = offset
   }
 

--- a/netlogo-gui/src/main/prim/_sum.java
+++ b/netlogo-gui/src/main/prim/_sum.java
@@ -27,6 +27,6 @@ public final strictfp class _sum extends Reporter implements Pure {
         sum += ((Double) elt).doubleValue();
       }
     }
-    return validDouble(sum);
+    return validDouble(sum, context);
   }
 }

--- a/netlogo-gui/src/main/prim/_turtle.java
+++ b/netlogo-gui/src/main/prim/_turtle.java
@@ -20,7 +20,7 @@ public final strictfp class _turtle extends Reporter {
 
   public Object report_1(Context context, double idDouble)
       throws LogoException {
-    long id = validLong(idDouble);
+    long id = validLong(idDouble, context);
     if (id != idDouble) {
       throw new RuntimePrimitiveException
           (context, this, idDouble + " is not an integer");

--- a/netlogo-gui/src/main/prim/etc/_acos.java
+++ b/netlogo-gui/src/main/prim/etc/_acos.java
@@ -17,6 +17,6 @@ public final strictfp class _acos extends Reporter implements Pure {
   }
 
   public double report_1(Context context, double arg0) throws LogoException {
-    return validDouble(StrictMath.toDegrees(StrictMath.acos(arg0)));
+    return validDouble(StrictMath.toDegrees(StrictMath.acos(arg0)), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_approximatehsb.scala
+++ b/netlogo-gui/src/main/prim/etc/_approximatehsb.scala
@@ -15,7 +15,7 @@ class _approximatehsb extends Reporter with Pure {
         argEvalDoubleValue(context, 2));
 
   def report_1(context: Context, h: Double, s: Double, b: Double): java.lang.Double =
-    validDouble(api.Color.getClosestColorNumberByHSB(h.toFloat, s.toFloat, b.toFloat))
+    validDouble(api.Color.getClosestColorNumberByHSB(h.toFloat, s.toFloat, b.toFloat), context)
 }
 
 class _approximatehsbold extends Reporter with Pure {
@@ -27,5 +27,5 @@ class _approximatehsbold extends Reporter with Pure {
         argEvalDoubleValue(context, 2));
 
   def report_1(context: Context, h: Double, s: Double, b: Double): java.lang.Double =
-    validDouble(api.Color.getClosestColorNumberByHSB(h.toFloat * (360.0f / 255.0f), s.toFloat * (100.0f / 255.0f), b.toFloat * (100.0f / 255.0f)))
+    validDouble(api.Color.getClosestColorNumberByHSB(h.toFloat * (360.0f / 255.0f), s.toFloat * (100.0f / 255.0f), b.toFloat * (100.0f / 255.0f)), context)
 }

--- a/netlogo-gui/src/main/prim/etc/_approximatergb.java
+++ b/netlogo-gui/src/main/prim/etc/_approximatergb.java
@@ -33,6 +33,6 @@ public final strictfp class _approximatergb extends Reporter implements Pure {
             ((0xff << 24) +
                 (StrictMath.round(r) << 16) +
                 (StrictMath.round(g) << 8) +
-                (StrictMath.round(b))));
+                (StrictMath.round(b))), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_asin.java
+++ b/netlogo-gui/src/main/prim/etc/_asin.java
@@ -17,6 +17,6 @@ public final strictfp class _asin extends Reporter implements Pure {
   }
 
   public double report_1(Context context, double arg0) throws LogoException {
-    return validDouble(StrictMath.toDegrees(StrictMath.asin(arg0)));
+    return validDouble(StrictMath.toDegrees(StrictMath.asin(arg0)), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_atan.java
+++ b/netlogo-gui/src/main/prim/etc/_atan.java
@@ -31,7 +31,7 @@ public final strictfp class _atan extends Reporter implements Pure {
       return d1 > 0 ? 90 : 270;
     }
     return validDouble(StrictMath.toDegrees(StrictMath.atan2(d1, d2))
-        + 360)
+        + 360, context)
         % 360;
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_ceil.java
+++ b/netlogo-gui/src/main/prim/etc/_ceil.java
@@ -17,6 +17,6 @@ public final strictfp class _ceil extends Reporter implements Pure {
   }
 
   public double report_1(Context context, double d0) throws LogoException {
-    return validDouble(StrictMath.ceil(d0));
+    return validDouble(StrictMath.ceil(d0), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_distancexy.java
+++ b/netlogo-gui/src/main/prim/etc/_distancexy.java
@@ -18,7 +18,7 @@ public final strictfp class _distancexy extends Reporter {
   }
 
   public double report_1(Context context, double arg0, double arg1) throws LogoException {
-    return validDouble(world.protractor().distance
-        (context.agent, arg0, arg1, true)); // true = wrap
+    return validDouble(world.protractor().distance(context.agent, arg0, arg1, true), // true = wrap
+        context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_distancexynowrap.java
+++ b/netlogo-gui/src/main/prim/etc/_distancexynowrap.java
@@ -18,7 +18,7 @@ public final strictfp class _distancexynowrap extends Reporter {
   }
 
   public double report_1(Context context, double arg0, double arg1) throws LogoException {
-    return validDouble(world.protractor().distance
-        (context.agent, arg0, arg1, false)); // false = don't wrap
+    return validDouble(world.protractor().distance(context.agent, arg0, arg1, false), // false = don't wrap
+        context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_div.java
+++ b/netlogo-gui/src/main/prim/etc/_div.java
@@ -25,6 +25,6 @@ public final strictfp class _div extends Reporter implements Pure {
     if (arg1 == 0) {
       throw new RuntimePrimitiveException(context, this, I18N.errorsJ().get("org.nlogo.prim.etc.$common.divByZero"));
     }
-    return validDouble(arg0 / arg1);
+    return validDouble(arg0 / arg1, context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_exp.java
+++ b/netlogo-gui/src/main/prim/etc/_exp.java
@@ -17,6 +17,6 @@ public final strictfp class _exp extends Reporter implements Pure {
   }
 
   public double report_1(Context context, double d0) throws LogoException {
-    return validDouble(StrictMath.exp(d0));
+    return validDouble(StrictMath.exp(d0), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_int.java
+++ b/netlogo-gui/src/main/prim/etc/_int.java
@@ -17,6 +17,6 @@ public final strictfp class _int extends Reporter implements Pure {
   }
 
   public double report_1(Context context, double d0) throws LogoException {
-    return validLong(d0);
+    return validLong(d0, context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_ln.java
+++ b/netlogo-gui/src/main/prim/etc/_ln.java
@@ -23,6 +23,6 @@ public final strictfp class _ln extends Reporter implements Pure {
       throw new RuntimePrimitiveException(context, this,
           I18N.errorsJ().getN("org.nlogo.prim.etc.$common.cantTakeLogarithmOf", d));
     }
-    return validDouble(StrictMath.log(d));
+    return validDouble(StrictMath.log(d), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_log.java
+++ b/netlogo-gui/src/main/prim/etc/_log.java
@@ -30,6 +30,6 @@ public final strictfp class _log extends Reporter implements Pure {
       throw new RuntimePrimitiveException(context, this,
           I18N.errorsJ().getN("org.nlogo.prim.etc._log.notAValidBase", base));
     }
-    return validDouble(StrictMath.log(n) / StrictMath.log(base));
+    return validDouble(StrictMath.log(n) / StrictMath.log(base), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_mean.java
+++ b/netlogo-gui/src/main/prim/etc/_mean.java
@@ -38,6 +38,6 @@ public final strictfp class _mean extends Reporter implements Pure {
       }
       sum += ((Double) elt).doubleValue();
     }
-    return validDouble(sum / list.size());
+    return validDouble(sum / list.size(), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_median.java
+++ b/netlogo-gui/src/main/prim/etc/_median.java
@@ -43,7 +43,7 @@ public final strictfp class _median
     }
     Double middle1 = nums.get(medianPos - 1);
     Double middle2 = nums.get(medianPos);
-    return newValidDouble(middle1.doubleValue() / 2 + middle2.doubleValue() / 2);
+    return newValidDouble(middle1.doubleValue() / 2 + middle2.doubleValue() / 2, context);
   }
 
 

--- a/netlogo-gui/src/main/prim/etc/_mod.java
+++ b/netlogo-gui/src/main/prim/etc/_mod.java
@@ -24,6 +24,6 @@ public final strictfp class _mod extends Reporter implements Pure {
     if (d1 == 0) {
       throw new RuntimePrimitiveException(context, this, I18N.errorsJ().get("org.nlogo.prim.etc.$common.divByZero"));
     }
-    return validDouble(d0 - (StrictMath.floor(d0 / d1) * d1));
+    return validDouble(d0 - (StrictMath.floor(d0 / d1) * d1), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_monitorprecision.java
+++ b/netlogo-gui/src/main/prim/etc/_monitorprecision.java
@@ -20,6 +20,6 @@ public final strictfp class _monitorprecision
     }
     return newValidDouble
         (org.nlogo.api.Approximate.approximate
-            (((Double) value).doubleValue(), numberOfPlaces));
+            (((Double) value).doubleValue(), numberOfPlaces), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_mult.java
+++ b/netlogo-gui/src/main/prim/etc/_mult.java
@@ -19,6 +19,6 @@ public final strictfp class _mult extends Reporter implements Pure {
   }
 
   public double report_1(Context context, double arg0, double arg1) throws LogoException {
-    return validDouble(arg0 * arg1);
+    return validDouble(arg0 * arg1, context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_pow.java
+++ b/netlogo-gui/src/main/prim/etc/_pow.java
@@ -20,6 +20,6 @@ public final strictfp class _pow extends Reporter implements Pure {
 
   public double report_1(Context context, double d0, double d1)
       throws LogoException {
-    return validDouble(StrictMath.pow(d0, d1));
+    return validDouble(StrictMath.pow(d0, d1), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_precision.java
+++ b/netlogo-gui/src/main/prim/etc/_precision.java
@@ -16,6 +16,6 @@ public final strictfp class _precision extends Reporter implements Pure {
     double d = argEvalDoubleValue(context, 0);
     int numberOfPlaces = argEvalIntValue(context, 1);
     return validDouble(org.nlogo.api.Approximate.approximate
-        (d, numberOfPlaces));
+        (d, numberOfPlaces), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_randomexponential.java
+++ b/netlogo-gui/src/main/prim/etc/_randomexponential.java
@@ -17,6 +17,6 @@ public final strictfp class _randomexponential extends Reporter {
 
   public double report_1(Context context, double d) throws LogoException {
     return validDouble
-        (-d * StrictMath.log(context.job.random.nextDouble()));
+        (-d * StrictMath.log(context.job.random.nextDouble()), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_randomfloat.java
+++ b/netlogo-gui/src/main/prim/etc/_randomfloat.java
@@ -16,6 +16,6 @@ public final strictfp class _randomfloat extends Reporter {
   }
 
   public double report_1(Context context, double d) throws LogoException {
-    return validDouble(d * context.job.random.nextDouble());
+    return validDouble(d * context.job.random.nextDouble(), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_randomgamma.java
+++ b/netlogo-gui/src/main/prim/etc/_randomgamma.java
@@ -24,6 +24,6 @@ public final strictfp class _randomgamma extends Reporter {
       throw new RuntimePrimitiveException(context, this,
           I18N.errorsJ().getN("org.nlogo.prim.etc._randomgamma.noNegativeInputs", displayName()));
     }
-    return validDouble(org.nlogo.agent.Gamma.nextDouble(context.job.random, alpha, lambda));
+    return validDouble(org.nlogo.agent.Gamma.nextDouble(context.job.random, alpha, lambda), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_randomnormal.java
+++ b/netlogo-gui/src/main/prim/etc/_randomnormal.java
@@ -25,6 +25,6 @@ public final strictfp class _randomnormal extends Reporter {
           context, this, I18N.errorsJ().get("org.nlogo.prim.etc._randomNormal.secondInputNotNegative"));
 
     }
-    return validDouble(mean + sdev * context.job.random.nextGaussian());
+    return validDouble(mean + sdev * context.job.random.nextGaussian(), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_remainder.java
+++ b/netlogo-gui/src/main/prim/etc/_remainder.java
@@ -25,6 +25,6 @@ public final strictfp class _remainder extends Reporter implements Pure {
     if (d2 == 0) {
       throw new RuntimePrimitiveException(context, this, I18N.errorsJ().get("org.nlogo.prim.etc.$common.divByZero"));
     }
-    return validDouble(d1 % d2);
+    return validDouble(d1 % d2, context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_round.java
+++ b/netlogo-gui/src/main/prim/etc/_round.java
@@ -17,6 +17,6 @@ public final strictfp class _round extends Reporter implements Pure {
   }
 
   public double report_1(Context context, double d0) throws LogoException {
-    return validDouble(org.nlogo.api.Approximate.approximate(d0, 0));
+    return validDouble(org.nlogo.api.Approximate.approximate(d0, 0), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_scalecolor.java
+++ b/netlogo-gui/src/main/prim/etc/_scalecolor.java
@@ -53,6 +53,6 @@ public final strictfp class _scalecolor extends Reporter implements Pure {
     } else if (perc < 0) {
       perc = 0;
     }
-    return validDouble(color + perc);
+    return validDouble(color + perc, context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_standarddeviation.java
+++ b/netlogo-gui/src/main/prim/etc/_standarddeviation.java
@@ -48,6 +48,6 @@ public final strictfp class _standarddeviation extends Reporter implements Pure 
     }
     return validDouble
         (StrictMath.sqrt
-            (squareOfDifference / (listSize - badElts - 1)));
+            (squareOfDifference / (listSize - badElts - 1)), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_tan.java
+++ b/netlogo-gui/src/main/prim/etc/_tan.java
@@ -17,6 +17,6 @@ public final strictfp class _tan extends Reporter implements Pure {
   }
 
   public double report_1(Context context, double angle) throws LogoException {
-    return validDouble(StrictMath.tan(StrictMath.toRadians(angle)));
+    return validDouble(StrictMath.tan(StrictMath.toRadians(angle)), context);
   }
 }

--- a/netlogo-gui/src/main/prim/etc/_towards.java
+++ b/netlogo-gui/src/main/prim/etc/_towards.java
@@ -27,7 +27,7 @@ public final strictfp class _towards extends Reporter {
     try {
       return validDouble
           (world.protractor().towards
-              (context.agent, agent, true)); // true = wrap
+              (context.agent, agent, true), context); // true = wrap
     } catch (org.nlogo.api.AgentException ex) {
       throw new RuntimePrimitiveException
           (context, this, ex.getMessage());

--- a/netlogo-gui/src/main/prim/etc/_towardsnowrap.java
+++ b/netlogo-gui/src/main/prim/etc/_towardsnowrap.java
@@ -24,7 +24,7 @@ public final strictfp class _towardsnowrap extends Reporter {
           I18N.errorsJ().getN("org.nlogo.$common.thatAgentIsDead", agent.classDisplayName()));
     }
     try {
-      return validDouble(world.protractor().towards(context.agent, agent, false)); // false = don't wrap
+      return validDouble(world.protractor().towards(context.agent, agent, false), context); // false = don't wrap
     } catch (org.nlogo.api.AgentException ex) {
       throw new RuntimePrimitiveException(context, this, ex.getMessage());
     }

--- a/netlogo-gui/src/main/prim/etc/_towardsxy.java
+++ b/netlogo-gui/src/main/prim/etc/_towardsxy.java
@@ -19,7 +19,7 @@ public final strictfp class _towardsxy extends Reporter {
               (context.agent,
                   argEvalDoubleValue(context, 0),
                   argEvalDoubleValue(context, 1),
-                  true)); // true = wrap
+                  true), context); // true = wrap
     } catch (org.nlogo.api.AgentException ex) {
       throw new RuntimePrimitiveException
           (context, this, ex.getMessage());

--- a/netlogo-gui/src/main/prim/etc/_towardsxynowrap.java
+++ b/netlogo-gui/src/main/prim/etc/_towardsxynowrap.java
@@ -19,7 +19,7 @@ public final strictfp class _towardsxynowrap extends Reporter {
               (context.agent,
                   argEvalDoubleValue(context, 0),
                   argEvalDoubleValue(context, 1),
-                  false)); // true = don't wrap
+                  false), context); // true = don't wrap
     } catch (org.nlogo.api.AgentException ex) {
       throw new RuntimePrimitiveException
           (context, this, ex.getMessage());

--- a/netlogo-gui/src/main/prim/etc/_variance.java
+++ b/netlogo-gui/src/main/prim/etc/_variance.java
@@ -46,6 +46,6 @@ public final strictfp class _variance extends Reporter implements Pure {
             StrictMath.pow(((Number) elt).doubleValue() - mean, 2);
       }
     }
-    return validDouble(squareOfDifference / (listSize - badElts - 1));
+    return validDouble(squareOfDifference / (listSize - badElts - 1), context);
   }
 }

--- a/netlogo-gui/src/main/prim/threed/_distancexyz.scala
+++ b/netlogo-gui/src/main/prim/threed/_distancexyz.scala
@@ -15,5 +15,5 @@ class _distancexyz extends Reporter {
         argEvalDoubleValue(context, 0),
         argEvalDoubleValue(context, 1),
         argEvalDoubleValue(context, 2),
-        true)) // wrap = true
+        true), context) // wrap = true
 }

--- a/netlogo-gui/src/main/prim/threed/_distancexyznowrap.scala
+++ b/netlogo-gui/src/main/prim/threed/_distancexyznowrap.scala
@@ -15,5 +15,5 @@ class _distancexyznowrap extends Reporter {
         argEvalDoubleValue(context, 0),
         argEvalDoubleValue(context, 1),
         argEvalDoubleValue(context, 2),
-        false))  // wrap = false
+        false), context)  // wrap = false
 }

--- a/netlogo-gui/src/main/prim/threed/_dz.scala
+++ b/netlogo-gui/src/main/prim/threed/_dz.scala
@@ -11,7 +11,7 @@ class _dz extends Reporter {
   override def report(context: Context) = {
     val turtle = context.agent.asInstanceOf[Turtle3D]
     val value = turtle.dz
-    validDouble(value)
+    validDouble(value, context)
     Double.box(
       if (StrictMath.abs(value) < 3.2e-15)
         0

--- a/netlogo-gui/src/main/prim/threed/_linkpitch.scala
+++ b/netlogo-gui/src/main/prim/threed/_linkpitch.scala
@@ -10,7 +10,7 @@ class _linkpitch extends Reporter {
 
   override def report(context: Context) = {
     val link = context.agent.asInstanceOf[Link]
-    try newValidDouble(world.protractor.towardsPitch(link.end1, link.end2, true))
+    try newValidDouble(world.protractor.towardsPitch(link.end1, link.end2, true), context)
     catch {
       case e: org.nlogo.api.AgentException =>
         throw new org.nlogo.nvm.RuntimePrimitiveException(

--- a/netlogo-gui/src/main/prim/threed/_towardspitch.scala
+++ b/netlogo-gui/src/main/prim/threed/_towardspitch.scala
@@ -16,7 +16,7 @@ class _towardspitch extends Reporter {
       throw new RuntimePrimitiveException(
         context, this, I18N.errors.getN("org.nlogo.$common.thatAgentIsDead",
           agent.classDisplayName))
-    try newValidDouble(world.protractor.towardsPitch(context.agent, agent, true)) // true = wrap
+    try newValidDouble(world.protractor.towardsPitch(context.agent, agent, true), context) // true = wrap
     catch {
       case ex: AgentException =>
         throw new RuntimePrimitiveException(context, this, ex.getMessage)

--- a/netlogo-gui/src/main/prim/threed/_towardspitchnowrap.scala
+++ b/netlogo-gui/src/main/prim/threed/_towardspitchnowrap.scala
@@ -17,7 +17,7 @@ class _towardspitchnowrap extends Reporter {
         context, this, I18N.errors.getN("org.nlogo.$common.thatAgentIsDead",
           agent.classDisplayName))
     try newValidDouble(world.protractor.towardsPitch(
-      context.agent, agent, false)) // false = nowrap
+      context.agent, agent, false), context) // false = nowrap
     catch {
       case ex: AgentException =>
         throw new RuntimePrimitiveException(context, this, ex.getMessage)

--- a/netlogo-gui/src/main/prim/threed/_towardspitchxyz.scala
+++ b/netlogo-gui/src/main/prim/threed/_towardspitchxyz.scala
@@ -16,7 +16,7 @@ class _towardspitchxyz extends Reporter {
         argEvalDoubleValue(context, 0),
         argEvalDoubleValue(context, 1),
         argEvalDoubleValue(context, 2),
-        true)) // true = wrap
+        true), context) // true = wrap
     catch {
       case ex: AgentException =>
         throw new RuntimePrimitiveException(context, this, ex.getMessage)

--- a/netlogo-gui/src/main/prim/threed/_towardspitchxyznowrap.scala
+++ b/netlogo-gui/src/main/prim/threed/_towardspitchxyznowrap.scala
@@ -15,7 +15,7 @@ class _towardspitchxyznowrap extends Reporter {
       argEvalDoubleValue(context, 0),
       argEvalDoubleValue(context, 1),
       argEvalDoubleValue(context, 2),
-      false)) // true = don't wrap
+      false), context) // true = don't wrap
     catch {
       case ex: AgentException =>
         throw new RuntimePrimitiveException(context, this, ex.getMessage)

--- a/netlogo-headless/src/main/nvm/Instruction.scala
+++ b/netlogo-headless/src/main/nvm/Instruction.scala
@@ -337,27 +337,27 @@ abstract class Instruction extends InstructionJ with TokenHolder {
 
   /// checking of numeric types
 
-  def validLong(d: Double): Long = {
+  def validLong(d: Double, context: Context): Long = {
     // 9007199254740992 is the largest/smallest integer
     // exactly representable in a double - ST 1/29/08
     if (d > 9007199254740992L || d < -9007199254740992L)
-      throw new RuntimePrimitiveException(null, this,
+      throw new RuntimePrimitiveException(context, this,
         s"$d is too large to be represented exactly as an integer in NetLogo")
     d.toLong
   }
 
-  def newValidDouble(d: Double): java.lang.Double = {
+  def newValidDouble(d: Double, context: Context): java.lang.Double = {
     if (java.lang.Double.isInfinite(d) || java.lang.Double.isNaN(d))
-      invalidDouble(d)
+      invalidDouble(d, context)
     Double.box(d)
   }
 
-  def validDouble(d: Double): Double = {
+  def validDouble(d: Double, context: Context): Double = {
     // yeah, this line is repeated from the previous method,
     // but factoring it out would cost us a method call, and this
     // is extremely efficiency-critical code, so... - ST 11/1/04
     if (java.lang.Double.isInfinite(d) || java.lang.Double.isNaN(d))
-      invalidDouble(d)
+      invalidDouble(d, context)
     // Returning d makes it easier to insert validDouble() calls into
     // expressions without having to break those expressions up into
     // multiple statements.  The caller is free to ignore the return
@@ -365,10 +365,8 @@ abstract class Instruction extends InstructionJ with TokenHolder {
     d
   }
 
-  private def invalidDouble(d: Double): Nothing =
-    // it's hard to get a context here in some situations because
-    // of optimizations. the context will get set later.
-    throw new RuntimePrimitiveException(null, this,
+  private def invalidDouble(d: Double, context: Context): Nothing =
+    throw new RuntimePrimitiveException(context, this,
       "math operation produced "
         + (if (java.lang.Double.isInfinite(d))
              "a number too large for NetLogo"

--- a/netlogo-headless/src/main/prim/_nsum.scala
+++ b/netlogo-headless/src/main/prim/_nsum.scala
@@ -33,7 +33,7 @@ class _nsum(vn: Int) extends Reporter {
               "org.nlogo.prim.$common.noSumOfListWithNonNumbers",
               Dump.logoObject(x).toString, TypeNames.name(x)))
       }
-    validDouble(sum)
+    validDouble(sum, context)
   }
 
 }

--- a/netlogo-headless/src/main/prim/_nsum4.scala
+++ b/netlogo-headless/src/main/prim/_nsum4.scala
@@ -34,7 +34,7 @@ class _nsum4(vn: Int) extends Reporter {
               "org.nlogo.prim.$common.noSumOfListWithNonNumbers",
               Dump.logoObject(x).toString, TypeNames.name(x)))
       }
-    validDouble(sum)
+    validDouble(sum, context)
   }
 
 }

--- a/netlogo-headless/src/main/prim/_random.scala
+++ b/netlogo-headless/src/main/prim/_random.scala
@@ -10,7 +10,7 @@ class _random extends Reporter {
     Double.box(report_1(context, argEvalDoubleValue(context, 0)))
 
   def report_1(context: Context, maxDouble: Double): Double = {
-    var maxLong = validLong(maxDouble)
+    var maxLong = validLong(maxDouble, context)
     if (maxDouble != maxLong)
       maxLong += (if (maxDouble >= 0) 1 else -1)
     if (maxLong > 0)

--- a/netlogo-headless/src/main/prim/_repeat.scala
+++ b/netlogo-headless/src/main/prim/_repeat.scala
@@ -16,7 +16,7 @@ class _repeat extends Command with CustomAssembled {
   }
 
   def perform_1(context: Context, d0: Double) {
-    context.let(_let, new MutableLong(validLong(d0)))
+    context.let(_let, new MutableLong(validLong(d0, context)))
     context.ip = offset
   }
 

--- a/netlogo-headless/src/main/prim/_repeatlocal.scala
+++ b/netlogo-headless/src/main/prim/_repeatlocal.scala
@@ -14,7 +14,7 @@ class _repeatlocal(vn: Int) extends Command with CustomAssembled {
   }
 
   def perform_1(context: Context, arg0: Double) {
-    context.activation.args(vn) = new MutableLong(validLong(arg0))
+    context.activation.args(vn) = new MutableLong(validLong(arg0, context))
     context.ip = offset
   }
 

--- a/netlogo-headless/src/main/prim/_sum.scala
+++ b/netlogo-headless/src/main/prim/_sum.scala
@@ -19,7 +19,7 @@ class _sum extends Reporter with Pure {
           sum += d.doubleValue
         case _ => // ignore
       }
-    validDouble(sum)
+    validDouble(sum, context)
   }
 
 }

--- a/netlogo-headless/src/main/prim/_turtle.scala
+++ b/netlogo-headless/src/main/prim/_turtle.scala
@@ -12,7 +12,7 @@ class _turtle extends Reporter {
     report_1(context, argEvalDoubleValue(context, 0))
 
   def report_1(context: Context, idDouble: Double): AnyRef = {
-    val id = validLong(idDouble)
+    val id = validLong(idDouble, context)
     if (id != idDouble)
       throw new RuntimePrimitiveException(
         context, this, idDouble + " is not an integer")

--- a/netlogo-headless/src/main/prim/etc/_acos.scala
+++ b/netlogo-headless/src/main/prim/etc/_acos.scala
@@ -9,5 +9,5 @@ class _acos extends Reporter with Pure {
   override def report(context: Context): java.lang.Double =
     Double.box(report_1(context, argEvalDoubleValue(context, 0)))
   def report_1(context: Context, arg0: Double): Double =
-    validDouble(StrictMath.toDegrees(StrictMath.acos(arg0)))
+    validDouble(StrictMath.toDegrees(StrictMath.acos(arg0)), context)
 }

--- a/netlogo-headless/src/main/prim/etc/_approximatehsb.java
+++ b/netlogo-headless/src/main/prim/etc/_approximatehsb.java
@@ -12,7 +12,7 @@ public final strictfp class _approximatehsb extends Reporter implements Pure {
     return validDouble(report_1(context,
         argEvalDoubleValue(context, 0),
         argEvalDoubleValue(context, 1),
-        argEvalDoubleValue(context, 2)));
+        argEvalDoubleValue(context, 2)), context);
   }
 
   public double report_1(Context context, double h, double s, double b) {

--- a/netlogo-headless/src/main/prim/etc/_approximatergb.java
+++ b/netlogo-headless/src/main/prim/etc/_approximatergb.java
@@ -28,6 +28,6 @@ public final strictfp class _approximatergb extends Reporter implements Pure {
             ((0xff << 24) +
                 (StrictMath.round(r) << 16) +
                 (StrictMath.round(g) << 8) +
-                (StrictMath.round(b))));
+                (StrictMath.round(b))), context);
   }
 }

--- a/netlogo-headless/src/main/prim/etc/_asin.scala
+++ b/netlogo-headless/src/main/prim/etc/_asin.scala
@@ -9,5 +9,5 @@ class _asin extends Reporter with Pure {
   override def report(context: Context): java.lang.Double =
     Double.box(report_1(context, argEvalDoubleValue(context, 0)))
   def report_1(context: Context, arg0: Double): Double =
-    validDouble(StrictMath.toDegrees(StrictMath.asin(arg0)))
+    validDouble(StrictMath.toDegrees(StrictMath.asin(arg0)), context)
 }

--- a/netlogo-headless/src/main/prim/etc/_atan.scala
+++ b/netlogo-headless/src/main/prim/etc/_atan.scala
@@ -20,5 +20,5 @@ class _atan extends Reporter with Pure {
       if (d2 > 0) 0 else 180
     else if (d2 == 0)
       if (d1 > 0) 90 else 270
-    else (StrictMath.toDegrees(StrictMath.atan2(d1, d2)) + 360) % 360
+    else validDouble(StrictMath.toDegrees(StrictMath.atan2(d1, d2)) + 360, context) % 360
 }

--- a/netlogo-headless/src/main/prim/etc/_breedsingular.scala
+++ b/netlogo-headless/src/main/prim/etc/_breedsingular.scala
@@ -15,7 +15,7 @@ class _breedsingular(_breedName: String) extends Reporter {
     report_1(context, argEvalDoubleValue(context, 0))
 
   def report_1(context: Context, idDouble: Double): AnyRef = {
-    val id = validLong(idDouble)
+    val id = validLong(idDouble, context)
     if (id != idDouble)
       throw new RuntimePrimitiveException(
         context, this, idDouble + " is not an integer")

--- a/netlogo-headless/src/main/prim/etc/_int.scala
+++ b/netlogo-headless/src/main/prim/etc/_int.scala
@@ -9,5 +9,5 @@ class _int extends Reporter with Pure {
   override def report(context: Context): java.lang.Double =
     Double.box(report_1(context, argEvalDoubleValue(context, 0)))
   def report_1(context: Context, d0: Double): Double =
-    validLong(d0).toDouble
+    validLong(d0, context).toDouble
 }

--- a/netlogo-headless/src/main/prim/etc/_ln.java
+++ b/netlogo-headless/src/main/prim/etc/_ln.java
@@ -20,6 +20,6 @@ public final strictfp class _ln extends Reporter implements Pure {
       throw new RuntimePrimitiveException(context, this,
           I18N.errorsJ().getN("org.nlogo.prim.etc.$common.cantTakeLogarithmOf", d));
     }
-    return validDouble(StrictMath.log(d));
+    return validDouble(StrictMath.log(d), context);
   }
 }

--- a/netlogo-headless/src/main/prim/etc/_log.java
+++ b/netlogo-headless/src/main/prim/etc/_log.java
@@ -26,6 +26,6 @@ public final strictfp class _log extends Reporter implements Pure {
       throw new RuntimePrimitiveException(context, this,
           I18N.errorsJ().getN("org.nlogo.prim.etc._log.notAValidBase", base));
     }
-    return validDouble(StrictMath.log(n) / StrictMath.log(base));
+    return validDouble(StrictMath.log(n) / StrictMath.log(base), context);
   }
 }

--- a/netlogo-headless/src/main/prim/etc/_mean.java
+++ b/netlogo-headless/src/main/prim/etc/_mean.java
@@ -32,6 +32,6 @@ public final strictfp class _mean extends Reporter implements Pure {
       }
       sum += ((Double) elt).doubleValue();
     }
-    return validDouble(sum / list.size());
+    return validDouble(sum / list.size(), context);
   }
 }

--- a/netlogo-headless/src/main/prim/etc/_median.java
+++ b/netlogo-headless/src/main/prim/etc/_median.java
@@ -42,8 +42,7 @@ public final strictfp class _median
     }
     Double middle1 = nums.get(medianPos - 1);
     Double middle2 = nums.get(medianPos);
-    return newValidDouble
-        ((middle1.doubleValue() + middle2.doubleValue()) / 2);
+    return newValidDouble((middle1.doubleValue() + middle2.doubleValue()) / 2, context);
   }
 
 }

--- a/netlogo-headless/src/main/prim/etc/_mod.java
+++ b/netlogo-headless/src/main/prim/etc/_mod.java
@@ -21,6 +21,6 @@ public final strictfp class _mod extends Reporter implements Pure {
     if (d1 == 0) {
       throw new RuntimePrimitiveException(context, this, I18N.errorsJ().get("org.nlogo.prim.etc.$common.divByZero"));
     }
-    return validDouble(d0 - (StrictMath.floor(d0 / d1) * d1));
+    return validDouble(d0 - (StrictMath.floor(d0 / d1) * d1), context);
   }
 }

--- a/netlogo-headless/src/main/prim/etc/_pow.scala
+++ b/netlogo-headless/src/main/prim/etc/_pow.scala
@@ -15,6 +15,6 @@ class _pow extends Reporter with Pure {
         argEvalDoubleValue(context, 1)))
 
   def report_1(context: Context, d0: Double, d1: Double): Double =
-    validDouble(StrictMath.pow(d0, d1))
+    validDouble(StrictMath.pow(d0, d1), context)
 
 }

--- a/netlogo-headless/src/main/prim/etc/_precision.scala
+++ b/netlogo-headless/src/main/prim/etc/_precision.scala
@@ -10,5 +10,5 @@ class _precision extends Reporter with Pure {
     newValidDouble(
       org.nlogo.api.Approximate.approximate(
         argEvalDoubleValue(context, 0),
-        argEvalIntValue(context, 1)))
+        argEvalIntValue(context, 1)), context)
 }

--- a/netlogo-headless/src/main/prim/etc/_randomexponential.scala
+++ b/netlogo-headless/src/main/prim/etc/_randomexponential.scala
@@ -8,5 +8,5 @@ class _randomexponential extends Reporter {
   override def report(context: Context): java.lang.Double =
     Double.box(report_1(context, argEvalDoubleValue(context, 0)))
   def report_1(context: Context, d: Double): Double =
-    validDouble(-d * StrictMath.log(context.job.random.nextDouble))
+    validDouble(-d * StrictMath.log(context.job.random.nextDouble), context)
 }

--- a/netlogo-headless/src/main/prim/etc/_randomgamma.java
+++ b/netlogo-headless/src/main/prim/etc/_randomgamma.java
@@ -21,6 +21,6 @@ public final strictfp class _randomgamma extends Reporter {
       throw new RuntimePrimitiveException(context, this,
           I18N.errorsJ().getN("org.nlogo.prim.etc._randomgamma.noNegativeInputs", displayName()));
     }
-    return validDouble(org.nlogo.agent.Gamma.nextDouble(context.job.random, alpha, lambda));
+    return validDouble(org.nlogo.agent.Gamma.nextDouble(context.job.random, alpha, lambda), context);
   }
 }

--- a/netlogo-headless/src/main/prim/etc/_randomnormal.scala
+++ b/netlogo-headless/src/main/prim/etc/_randomnormal.scala
@@ -17,6 +17,6 @@ class _randomnormal extends Reporter {
       throw new RuntimePrimitiveException(
           context, this, I18N.errors.get(
             "org.nlogo.prim.etc._randomNormal.secondInputNotNegative"))
-    validDouble(mean + sdev * context.job.random.nextGaussian)
+    validDouble(mean + sdev * context.job.random.nextGaussian, context)
   }
 }

--- a/netlogo-headless/src/main/prim/etc/_remainder.java
+++ b/netlogo-headless/src/main/prim/etc/_remainder.java
@@ -21,6 +21,6 @@ public final strictfp class _remainder extends Reporter implements Pure {
     if (d2 == 0) {
       throw new RuntimePrimitiveException(context, this, I18N.errorsJ().get("org.nlogo.prim.etc.$common.divByZero"));
     }
-    return validDouble(d1 % d2);
+    return validDouble(d1 % d2, context);
   }
 }

--- a/netlogo-headless/src/main/prim/etc/_scalecolor.java
+++ b/netlogo-headless/src/main/prim/etc/_scalecolor.java
@@ -49,6 +49,6 @@ public final strictfp class _scalecolor extends Reporter implements Pure {
     } else if (perc < 0) {
       perc = 0;
     }
-    return validDouble(color + perc);
+    return validDouble(color + perc, context);
   }
 }

--- a/netlogo-headless/src/main/prim/etc/_standarddeviation.java
+++ b/netlogo-headless/src/main/prim/etc/_standarddeviation.java
@@ -41,6 +41,6 @@ public final strictfp class _standarddeviation extends Reporter implements Pure 
     }
     return validDouble
         (StrictMath.sqrt
-            (squareOfDifference / (listSize - badElts - 1)));
+            (squareOfDifference / (listSize - badElts - 1)), context);
   }
 }

--- a/netlogo-headless/src/main/prim/etc/_tan.scala
+++ b/netlogo-headless/src/main/prim/etc/_tan.scala
@@ -9,5 +9,5 @@ class _tan extends Reporter with Pure {
   override def report(context: Context): java.lang.Double =
     Double.box(report_1(context, argEvalDoubleValue(context, 0)))
   def report_1(context: Context, angle: Double): Double =
-    validDouble(StrictMath.tan(StrictMath.toRadians(angle)))
+    validDouble(StrictMath.tan(StrictMath.toRadians(angle)), context)
 }

--- a/netlogo-headless/src/main/prim/etc/_towards.java
+++ b/netlogo-headless/src/main/prim/etc/_towards.java
@@ -24,7 +24,7 @@ public final strictfp class _towards extends Reporter {
     try {
       return validDouble
           (world.protractor().towards
-              (context.agent, agent, true)); // true = wrap
+              (context.agent, agent, true), context); // true = wrap
     } catch (org.nlogo.api.AgentException ex) {
       throw new RuntimePrimitiveException
           (context, this, ex.getMessage());

--- a/netlogo-headless/src/main/prim/etc/_towardsxy.java
+++ b/netlogo-headless/src/main/prim/etc/_towardsxy.java
@@ -16,7 +16,7 @@ public final strictfp class _towardsxy extends Reporter {
               (context.agent,
                   argEvalDoubleValue(context, 0),
                   argEvalDoubleValue(context, 1),
-                  true)); // true = wrap
+                  true), context); // true = wrap
     } catch (org.nlogo.api.AgentException ex) {
       throw new RuntimePrimitiveException
           (context, this, ex.getMessage());

--- a/netlogo-headless/src/main/prim/etc/_variance.java
+++ b/netlogo-headless/src/main/prim/etc/_variance.java
@@ -39,6 +39,6 @@ public final strictfp class _variance extends Reporter implements Pure {
             StrictMath.pow(((Number) elt).doubleValue() - mean, 2);
       }
     }
-    return validDouble(squareOfDifference / (listSize - badElts - 1));
+    return validDouble(squareOfDifference / (listSize - badElts - 1), context);
   }
 }

--- a/netlogo-headless/test/benchdumps/Ants.txt
+++ b/netlogo-headless/test/benchdumps/Ants.txt
@@ -64,6 +64,7 @@ procedure SETUP:[]{O---}:
          L1
           RETURN
 [5]_asm_proceduresetup_return_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -76,6 +77,9 @@ procedure SETUP:[]{O---}:
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:337.0 "337" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 337.0
          L1
@@ -97,16 +101,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -144,6 +148,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:800.0 "800" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 800.0
          L1
@@ -156,7 +163,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -183,6 +191,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -216,6 +225,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -237,9 +249,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -254,8 +263,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -268,6 +282,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
 procedure SETUP-TURTLES:[]{O---}:
 [0]_setdefaultshape "set-default-shape"
       _asm_proceduresetupturtles_turtles_0 "turtles" => AgentSet
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupturtles_turtles_0.world : Lorg/nlogo/agent/World;
@@ -275,12 +290,14 @@ procedure SETUP-TURTLES:[]{O---}:
            L1
             ARETURN
       _asm_proceduresetupturtles_conststring_1 ""bug"" => String
+            // parameter final  context
            L0
             LDC "bug"
            L1
             ARETURN
 [1]_createorderedturtles:,+7 "cro"
       _asm_proceduresetupturtles_observervariable_2 "ants" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupturtles_observervariable_2.world : Lorg/nlogo/agent/World;
@@ -291,6 +308,9 @@ procedure SETUP-TURTLES:[]{O---}:
             ARETURN
 [2]_asm_proceduresetupturtles_setturtlevariable_3 "set" Object => void
       _constdouble:2.0 "2" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -304,9 +324,6 @@ procedure SETUP-TURTLES:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupturtles_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -321,10 +338,19 @@ procedure SETUP-TURTLES:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_proceduresetupturtles_right_4 "rt" double => void
       _randomfloat "random-float" double => double
         _constdouble:360.0 "360" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  delta
          L0
           LDC 360.0
          L1
@@ -349,6 +375,9 @@ procedure SETUP-TURTLES:[]{O---}:
           RETURN
 [4]_asm_proceduresetupturtles_setturtleorlinkvariable_5 "set" Object => void
       _constdouble:15.0 "red" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -362,9 +391,6 @@ procedure SETUP-TURTLES:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupturtles_setturtleorlinkvariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -379,9 +405,16 @@ procedure SETUP-TURTLES:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [5]_asm_proceduresetupturtles_setturtlevariable_6 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -395,9 +428,6 @@ procedure SETUP-TURTLES:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupturtles_setturtlevariable_6 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -412,8 +442,13 @@ procedure SETUP-TURTLES:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [6]_asm_proceduresetupturtles_done_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -421,6 +456,7 @@ procedure SETUP-TURTLES:[]{O---}:
          L1
           RETURN
 [7]_asm_proceduresetupturtles_return_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -433,6 +469,9 @@ procedure SETUP-TURTLES:[]{O---}:
 procedure SETUP-PATCHES:[]{OTPL}:
 [0]_asm_proceduresetuppatches_ask_0 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetuppatches_ask_0.world : Lorg/nlogo/agent/World;
@@ -488,6 +527,9 @@ procedure SETUP-PATCHES:[]{OTPL}:
           RETURN
 [1]_asm_proceduresetuppatches_setpatchvariable_1 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -501,9 +543,6 @@ procedure SETUP-PATCHES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetuppatches_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -518,9 +557,16 @@ procedure SETUP-PATCHES:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_proceduresetuppatches_setpatchvariable_2 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -534,9 +580,6 @@ procedure SETUP-PATCHES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetuppatches_setpatchvariable_2 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -551,9 +594,16 @@ procedure SETUP-PATCHES:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_proceduresetuppatches_setpatchvariable_3 "set" Object => void
       _constdouble:-1.0 "-1" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -567,9 +617,6 @@ procedure SETUP-PATCHES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetuppatches_setpatchvariable_3 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -584,6 +631,10 @@ procedure SETUP-PATCHES:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduresetuppatches_call_4 "setup-nest"
          L0
@@ -640,6 +691,7 @@ procedure SETUP-PATCHES:[]{OTPL}:
          L1
           RETURN
 [7]_asm_proceduresetuppatches_done_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -647,6 +699,7 @@ procedure SETUP-PATCHES:[]{OTPL}:
          L1
           RETURN
 [8]_asm_proceduresetuppatches_return_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -663,6 +716,17 @@ procedure SETUP-NEST:[]{-TP-}:
           _constdouble:0.0 "0" => double
           _constdouble:0.0 "0" => double
         _constdouble:5.0 "5" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           DCONST_0
@@ -712,9 +776,6 @@ procedure SETUP-NEST:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupnest_setpatchvariable_0 org/nlogo/nvm/Context java/lang/Boolean T D] [org/nlogo/api/AgentException]
@@ -729,6 +790,10 @@ procedure SETUP-NEST:[]{-TP-}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [1]_asm_proceduresetupnest_setpatchvariable_1 "set" Object => void
       _minus "-" double,double => double
@@ -736,6 +801,17 @@ procedure SETUP-NEST:[]{-TP-}:
         _distancexy "distancexy" double,double => double
           _constdouble:0.0 "0" => double
           _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           LDC 200.0
@@ -775,9 +851,6 @@ procedure SETUP-NEST:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L9
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupnest_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -792,8 +865,13 @@ procedure SETUP-NEST:[]{-TP-}:
           ATHROW
          L9
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [2]_asm_proceduresetupnest_return_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -812,6 +890,21 @@ procedure SETUP-FOOD:[]{-TP-}:
             _maxpxcor "max-pxcor" => double
           _constdouble:0.0 "0" => double
         _constdouble:5.0 "5" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 0.6
          L1
@@ -871,6 +964,9 @@ procedure SETUP-FOOD:[]{-TP-}:
           RETURN
 [1]_asm_proceduresetupfood_setpatchvariable_1 "set" Object => void
       _constdouble:1.0 "1" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -884,9 +980,6 @@ procedure SETUP-FOOD:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupfood_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -901,6 +994,10 @@ procedure SETUP-FOOD:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_proceduresetupfood_if_2 "if" boolean => void
       _lessthan "<" double,double => boolean
@@ -912,6 +1009,25 @@ procedure SETUP-FOOD:[]{-TP-}:
             _constdouble:-0.6 "-0.6" => double
             _maxpycor "max-pycor" => double
         _constdouble:5.0 "5" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC -0.6
          L1
@@ -982,6 +1098,9 @@ procedure SETUP-FOOD:[]{-TP-}:
           RETURN
 [3]_asm_proceduresetupfood_setpatchvariable_3 "set" Object => void
       _constdouble:2.0 "2" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -995,9 +1114,6 @@ procedure SETUP-FOOD:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupfood_setpatchvariable_3 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1012,6 +1128,10 @@ procedure SETUP-FOOD:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduresetupfood_if_4 "if" boolean => void
       _lessthan "<" double,double => boolean
@@ -1023,6 +1143,25 @@ procedure SETUP-FOOD:[]{-TP-}:
             _constdouble:0.8 "0.8" => double
             _maxpycor "max-pycor" => double
         _constdouble:5.0 "5" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC -0.8
          L1
@@ -1093,6 +1232,9 @@ procedure SETUP-FOOD:[]{-TP-}:
           RETURN
 [5]_asm_proceduresetupfood_setpatchvariable_5 "set" Object => void
       _constdouble:3.0 "3" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1106,9 +1248,6 @@ procedure SETUP-FOOD:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupfood_setpatchvariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1123,11 +1262,22 @@ procedure SETUP-FOOD:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [6]_asm_proceduresetupfood_if_6 "if" boolean => void
       _greaterthan ">" Object,double => boolean
         _patchvariable:FOOD-SOURCE-NUMBER "food-source-number" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1154,14 +1304,10 @@ procedure SETUP-FOOD:[]{-TP-}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -1169,15 +1315,14 @@ procedure SETUP-FOOD:[]{-TP-}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetupfood_if_6 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1206,25 +1351,34 @@ procedure SETUP-FOOD:[]{-TP-}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L8
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetupfood_if_6 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L9
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L9
+          IFEQ L10
           BIPUSH 7
-          GOTO L10
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetupfood_if_6 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 8
+          GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetupfood_if_6 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetupfood_if_6 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 8
          L11
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetupfood_if_6 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [7]_asm_proceduresetupfood_setpatchvariable_7 "set" Object => void
       _plus "+" double,double => double
         _constdouble:1.0 "1" => double
         _randomconst:2 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           DCONST_1
@@ -1255,9 +1409,6 @@ procedure SETUP-FOOD:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupfood_setpatchvariable_7 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1272,8 +1423,13 @@ procedure SETUP-FOOD:[]{-TP-}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [8]_asm_proceduresetupfood_return_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1286,6 +1442,9 @@ procedure SETUP-FOOD:[]{-TP-}:
 procedure UPDATE-DISPLAY:[]{-TP-}:
 [0]_asm_procedureupdatedisplay_ifelse_0 "ifelse" boolean => void
       _patchvariable:NEST? "nest?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -1344,6 +1503,9 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           RETURN
 [1]_asm_procedureupdatedisplay_setpatchvariable_1 "set" Object => void
       _constdouble:115.0 "violet" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1357,9 +1519,6 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1374,8 +1533,13 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedureupdatedisplay_goto_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 12
@@ -1386,6 +1550,13 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
       _greaterthan ">" Object,double => boolean
         _patchvariable:FOOD "food" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1412,14 +1583,10 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -1427,15 +1594,14 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_ifelse_3 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1464,25 +1630,34 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_ifelse_3 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L9
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L9
+          IFEQ L10
           ICONST_4
-          GOTO L10
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_ifelse_3 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 11
+          GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_ifelse_3 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_ifelse_3 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 11
          L11
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_ifelse_3 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [4]_asm_procedureupdatedisplay_if_4 "if" boolean => void
       _equal "=" Object,double => boolean
         _patchvariable:FOOD-SOURCE-NUMBER "food-source-number" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1509,11 +1684,9 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -1524,19 +1697,19 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_4 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_4 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -1545,15 +1718,18 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           ICONST_5
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_4 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_4 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 6
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_4 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_4 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
 [5]_asm_procedureupdatedisplay_setpatchvariable_5 "set" Object => void
       _constdouble:85.0 "cyan" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1567,9 +1743,6 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_setpatchvariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1584,11 +1757,22 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [6]_asm_procedureupdatedisplay_if_6 "if" boolean => void
       _equal "=" Object,double => boolean
         _patchvariable:FOOD-SOURCE-NUMBER "food-source-number" => Object
         _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1615,11 +1799,9 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -1630,19 +1812,19 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_6 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_6 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -1651,15 +1833,18 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           BIPUSH 7
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_6 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_6 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 8
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_6 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_6 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
 [7]_asm_procedureupdatedisplay_setpatchvariable_7 "set" Object => void
       _constdouble:95.0 "sky" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1673,9 +1858,6 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_setpatchvariable_7 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1690,11 +1872,22 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [8]_asm_procedureupdatedisplay_if_8 "if" boolean => void
       _equal "=" Object,double => boolean
         _patchvariable:FOOD-SOURCE-NUMBER "food-source-number" => Object
         _constdouble:3.0 "3" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1721,11 +1914,9 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -1736,19 +1927,19 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_8 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_8 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -1757,15 +1948,18 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           BIPUSH 9
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_8 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_8 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 10
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_8 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_if_8 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
 [9]_asm_procedureupdatedisplay_setpatchvariable_9 "set" Object => void
       _constdouble:105.0 "blue" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1779,9 +1973,6 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_setpatchvariable_9 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1796,8 +1987,13 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [10]_asm_procedureupdatedisplay_goto_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 12
@@ -1810,6 +2006,12 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
         _patchvariable:CHEMICAL "chemical" => Object
         _constdouble:0.1 "0.1" => double
         _constdouble:5.0 "5" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -1964,7 +2166,8 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           DLOAD 2
           DLOAD 10
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatedisplay_setpatchvariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatedisplay_setpatchvariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L21
           DSTORE 2
           NEW java/lang/Double
@@ -1979,9 +2182,6 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          BIPUSH 12
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L22
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatedisplay_setpatchvariable_11 org/nlogo/nvm/Context java/lang/Double T D D D D] [org/nlogo/api/AgentException]
@@ -1996,8 +2196,13 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           ATHROW
          L22
          FRAME SAME
+          ALOAD 1
+          BIPUSH 12
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L23
           RETURN
 [12]_asm_procedureupdatedisplay_return_12 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2010,6 +2215,9 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
 procedure GO:[]{O---}:
 [0]_asm_procedurego_ask_0 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_0.world : Lorg/nlogo/agent/World;
@@ -2082,6 +2290,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [2]_asm_procedurego_done_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2092,6 +2301,8 @@ procedure GO:[]{O---}:
       _asm_procedurego_div_3 "/" double,double => double
         _observervariable:DIFFUSION-RATE "diffusion-rate" => Object
         _constdouble:100.0 "100" => double
+            // parameter final  context
+            // parameter final  context
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
            L2
             ALOAD 0
@@ -2151,6 +2362,9 @@ procedure GO:[]{O---}:
             ARETURN
 [4]_asm_procedurego_ask_4 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_4.world : Lorg/nlogo/agent/World;
@@ -2223,6 +2437,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [6]_asm_procedurego_done_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2249,6 +2464,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [9]_asm_procedurego_return_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2263,6 +2479,12 @@ procedure GO-TURTLES:[]{-T--}:
       _lessthan "<" double,double => boolean
         _turtlevariabledouble:WHO "who" => double
         _ticks "ticks" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -2320,6 +2542,9 @@ procedure GO-TURTLES:[]{-T--}:
           RETURN
 [1]_asm_proceduregoturtles_ifelse_1 "ifelse" boolean => void
       _turtlevariable:CARRYING-FOOD? "carrying-food?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -2378,6 +2603,9 @@ procedure GO-TURTLES:[]{-T--}:
           RETURN
 [2]_asm_proceduregoturtles_setturtleorlinkvariable_2 "set" Object => void
       _constdouble:26.0 "+" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2391,9 +2619,6 @@ procedure GO-TURTLES:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduregoturtles_setturtleorlinkvariable_2 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -2408,6 +2633,10 @@ procedure GO-TURTLES:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_proceduregoturtles_call_3 "return-to-nest"
          L0
@@ -2428,6 +2657,7 @@ procedure GO-TURTLES:[]{-T--}:
          L1
           RETURN
 [4]_asm_proceduregoturtles_goto_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 7
@@ -2436,6 +2666,9 @@ procedure GO-TURTLES:[]{-T--}:
           RETURN
 [5]_asm_proceduregoturtles_setturtleorlinkvariable_5 "set" Object => void
       _constdouble:15.0 "red" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2449,9 +2682,6 @@ procedure GO-TURTLES:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduregoturtles_setturtleorlinkvariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -2466,6 +2696,10 @@ procedure GO-TURTLES:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [6]_asm_proceduregoturtles_call_6 "look-for-food"
          L0
@@ -2486,6 +2720,7 @@ procedure GO-TURTLES:[]{-T--}:
          L1
           RETURN
 [7]_asm_proceduregoturtles_return_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2504,6 +2739,18 @@ procedure GO-PATCHES:[]{-TP-}:
             _constdouble:100.0 "100" => double
             _observervariable:EVAPORATION-RATE "evaporation-rate" => Object
         _constdouble:100.0 "100" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -2624,9 +2871,6 @@ procedure GO-PATCHES:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L8
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L20
          L9
          FRAME FULL [org/nlogo/prim/_asm_proceduregopatches_setpatchvariable_0 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -2641,6 +2885,10 @@ procedure GO-PATCHES:[]{-TP-}:
           ATHROW
          L20
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L21
           RETURN
 [1]_asm_proceduregopatches_call_1 "update-display"
          L0
@@ -2661,6 +2909,7 @@ procedure GO-PATCHES:[]{-TP-}:
          L1
           RETURN
 [2]_asm_proceduregopatches_return_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2673,6 +2922,9 @@ procedure GO-PATCHES:[]{-TP-}:
 procedure RETURN-TO-NEST:[]{-T--}:
 [0]_asm_procedurereturntonest_ifelse_0 "ifelse" boolean => void
       _patchvariable:NEST? "nest?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -2731,6 +2983,9 @@ procedure RETURN-TO-NEST:[]{-T--}:
           RETURN
 [1]_asm_procedurereturntonest_setturtlevariable_1 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2744,9 +2999,6 @@ procedure RETURN-TO-NEST:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurereturntonest_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -2761,9 +3013,16 @@ procedure RETURN-TO-NEST:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedurereturntonest_right_2 "rt" double => void
       _constdouble:180.0 "180" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  delta
          L0
           LDC 180.0
          L1
@@ -2779,25 +3038,28 @@ procedure RETURN-TO-NEST:[]{-T--}:
          L2
           RETURN
 [3]_asm_procedurereturntonest_fd1_3 "fd" => void
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
+          // parameter final  context
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
           DCONST_1
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L2
          L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          ASTORE 2
+          GOTO L3
          L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L3
          FRAME SAME
           ALOAD 1
           ICONST_4
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L3
+         L4
           RETURN
 [4]_asm_procedurereturntonest_goto_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 12
@@ -2808,6 +3070,13 @@ procedure RETURN-TO-NEST:[]{-T--}:
       _plus "+" double,double => double
         _patchvariable:CHEMICAL "chemical" => Object
         _turtlevariable:DROP-SIZE "drop-size" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -2911,9 +3180,6 @@ procedure RETURN-TO-NEST:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L11
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L17
          L12
          FRAME FULL [org/nlogo/prim/_asm_procedurereturntonest_setpatchvariable_5 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -2928,11 +3194,22 @@ procedure RETURN-TO-NEST:[]{-T--}:
           ATHROW
          L17
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [6]_asm_procedurereturntonest_setturtlevariable_6 "set" Object => void
       _minus "-" double,double => double
         _turtlevariable:DROP-SIZE "drop-size" => Object
         _constdouble:1.5 "1.5" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -2997,9 +3274,6 @@ procedure RETURN-TO-NEST:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurereturntonest_setturtlevariable_6 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -3014,11 +3288,22 @@ procedure RETURN-TO-NEST:[]{-T--}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [7]_asm_procedurereturntonest_if_7 "if" boolean => void
       _lessthan "<" Object,double => boolean
         _turtlevariable:DROP-SIZE "drop-size" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -3045,14 +3330,10 @@ procedure RETURN-TO-NEST:[]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
@@ -3060,15 +3341,14 @@ procedure RETURN-TO-NEST:[]{-T--}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurereturntonest_if_7 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3097,23 +3377,28 @@ procedure RETURN-TO-NEST:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurereturntonest_if_7 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L9
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L9
+          IFEQ L10
           BIPUSH 8
-          GOTO L10
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurereturntonest_if_7 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 9
+          GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurereturntonest_if_7 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurereturntonest_if_7 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 9
          L11
+         FRAME FULL [org/nlogo/prim/_asm_procedurereturntonest_if_7 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [8]_asm_procedurereturntonest_setturtlevariable_8 "set" Object => void
       _constdouble:1.0 "1" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3127,9 +3412,6 @@ procedure RETURN-TO-NEST:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurereturntonest_setturtlevariable_8 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -3144,6 +3426,10 @@ procedure RETURN-TO-NEST:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [9]_asm_procedurereturntonest_call_9 "uphill-nest-scent"
          L0
@@ -3182,25 +3468,28 @@ procedure RETURN-TO-NEST:[]{-T--}:
          L1
           RETURN
 [11]_asm_procedurereturntonest_fd1_11 "fd" => void
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
+          // parameter final  context
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
           DCONST_1
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L2
          L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          ASTORE 2
+          GOTO L3
          L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L3
          FRAME SAME
           ALOAD 1
           BIPUSH 12
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L3
+         L4
           RETURN
 [12]_asm_procedurereturntonest_return_12 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -3215,6 +3504,13 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
       _greaterthan ">" Object,double => boolean
         _patchvariable:FOOD "food" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -3241,14 +3537,10 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -3256,15 +3548,14 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_if_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3293,23 +3584,28 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_if_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L9
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L9
+          IFEQ L10
           ICONST_1
-          GOTO L10
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_if_0 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 6
+          GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_if_0 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_if_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 6
          L11
+         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_if_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [1]_asm_procedurelookforfood_setturtlevariable_1 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3323,9 +3619,6 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -3340,11 +3633,22 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedurelookforfood_setpatchvariable_2 "set" Object => void
       _minus "-" double,double => double
         _patchvariable:FOOD "food" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -3409,9 +3713,6 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_setpatchvariable_2 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -3426,9 +3727,16 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [3]_asm_procedurelookforfood_setturtlevariable_3 "set" Object => void
       _constdouble:60.0 "60" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3442,9 +3750,6 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -3459,9 +3764,16 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_procedurelookforfood_right_4 "rt" double => void
       _constdouble:180.0 "180" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  delta
          L0
           LDC 180.0
          L1
@@ -3518,6 +3830,13 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
       _greaterthan ">" Object,double => boolean
         _patchvariable:CHEMICAL "chemical" => Object
         _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -3544,14 +3863,10 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -3559,15 +3874,14 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_ifelse_6 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3596,41 +3910,46 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_ifelse_6 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L9
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L9
+          IFEQ L10
           BIPUSH 7
-          GOTO L10
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_ifelse_6 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 9
+          GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_ifelse_6 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_ifelse_6 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 9
          L11
+         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_ifelse_6 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [7]_asm_procedurelookforfood_fd1_7 "fd" => void
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
+          // parameter final  context
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
           DCONST_1
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L2
          L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          ASTORE 2
+          GOTO L3
          L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L3
          FRAME SAME
           ALOAD 1
           BIPUSH 8
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L3
+         L4
           RETURN
 [8]_asm_procedurelookforfood_goto_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 15
@@ -3641,6 +3960,13 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
       _lessthan "<" Object,double => boolean
         _patchvariable:CHEMICAL "chemical" => Object
         _constdouble:0.05 "0.05" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -3667,14 +3993,10 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
@@ -3682,15 +4004,14 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_ifelse_9 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3719,20 +4040,22 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_ifelse_9 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L9
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L9
+          IFEQ L10
           BIPUSH 10
-          GOTO L10
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_ifelse_9 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 13
+          GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_ifelse_9 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_ifelse_9 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 13
          L11
+         FRAME FULL [org/nlogo/prim/_asm_procedurelookforfood_ifelse_9 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [10]_asm_procedurelookforfood_call_10 "wiggle"
          L0
@@ -3753,25 +4076,28 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
          L1
           RETURN
 [11]_asm_procedurelookforfood_fd1_11 "fd" => void
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
+          // parameter final  context
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
           DCONST_1
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L2
          L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          ASTORE 2
+          GOTO L3
          L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L3
          FRAME SAME
           ALOAD 1
           BIPUSH 12
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L3
+         L4
           RETURN
 [12]_asm_procedurelookforfood_goto_12 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 15
@@ -3797,25 +4123,28 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
          L1
           RETURN
 [14]_asm_procedurelookforfood_fd1_14 "fd" => void
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
+          // parameter final  context
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
           DCONST_1
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L2
          L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          ASTORE 2
+          GOTO L3
          L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L3
          FRAME SAME
           ALOAD 1
           BIPUSH 15
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L3
+         L4
           RETURN
 [15]_asm_procedurelookforfood_return_15 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -3848,33 +4177,35 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
       _patchvariableof:CHEMICAL "of" Object => Object
         _patchahead "patch-ahead"
           _asm_procedureuphillchemical_constdouble_2 "1" => Double
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedureuphillchemical_constdouble_2.kept1_value : Ljava/lang/Double;
                L1
                 ARETURN
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureuphillchemical_setprocedurevariable_1.keptinstr3 : Lorg/nlogo/prim/etc/_patchahead;
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/prim/etc/_patchahead.report (Lorg/nlogo/nvm/Context;)Ljava/lang/Object;
-         L4
+         L3
           ASTORE 2
-         L2
+         L0
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L4
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L5
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L6
+          IFNE L5
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3887,45 +4218,45 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L6
-         FRAME FULL [org/nlogo/prim/_asm_procedureuphillchemical_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-          ALOAD 5
+         L5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+          ALOAD 4
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L7
-         L5
-         FRAME CHOP 1
-          ALOAD 4
+          ASTORE 3
+          GOTO L6
+         L4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L0
-          ALOAD 4
+          IFEQ L7
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedureuphillchemical_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedureuphillchemical_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L9
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
@@ -3933,16 +4264,12 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           GOTO L8
          L9
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedureuphillchemical_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
           ALOAD 6
-         L3
-          GOTO L10
-         L0
-         FRAME CHOP 2
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L6
+         L7
+         FRAME FULL [org/nlogo/prim/_asm_procedureuphillchemical_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -3959,22 +4286,27 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           GETSTATIC org/nlogo/core/Syntax$.MODULE$ : Lorg/nlogo/core/Syntax$;
           INVOKEVIRTUAL org/nlogo/core/Syntax$.PatchsetType ()I
           IOR
-          ALOAD 4
+          ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L6
+         FRAME APPEND [java/lang/Object]
+          ALOAD 3
          L1
+          GOTO L10
+         L2
          FRAME FULL [org/nlogo/prim/_asm_procedureuphillchemical_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedureuphillchemical_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_procedureuphillchemical_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -3990,6 +4322,9 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
 [2]_asm_procedureuphillchemical_setprocedurevariable_3 "let" Object => void
       _callreport:CHEMICAL-SCENT "chemical-scent"
         _constdouble:45.0 "45" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -4036,6 +4371,9 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
 [3]_asm_procedureuphillchemical_setprocedurevariable_4 "let" Object => void
       _callreport:CHEMICAL-SCENT "chemical-scent"
         _constdouble:-45.0 "-45" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -4087,6 +4425,18 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
         _greaterthan ">" Object,Object => boolean
           _procedurevariable:SCENT-LEFT "scent-left" => Object
           _procedurevariable:SCENT-AHEAD "scent-ahead" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  o1
+          // parameter final  o2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  o1
+          // parameter final  o2
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -4121,40 +4471,36 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
          L4
          FRAME APPEND [java/lang/Object java/lang/Object]
           ICONST_0
-         L5
-         FRAME SAME1 I
-          GOTO L6
+          GOTO L5
          L3
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
           ICONST_0
-          IF_ICMPLE L8
+          IF_ICMPLE L7
           ICONST_1
-          GOTO L9
-         L8
+          GOTO L5
+         L7
          FRAME SAME
           ICONST_0
-         L9
-         FRAME SAME1 I
-          GOTO L6
-         L7
+          GOTO L5
+         L6
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -4165,21 +4511,19 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L10
+          IF_ICMPNE L8
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
           ICONST_0
-          IF_ICMPLE L11
+          IF_ICMPLE L9
           ICONST_1
-          GOTO L12
-         L11
+          GOTO L5
+         L9
          FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
           ICONST_0
-         L12
-         FRAME SAME1 I
-          GOTO L6
-         L10
+          GOTO L5
+         L8
          FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -4207,30 +4551,30 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L6
+         L5
          FRAME SAME1 I
-          IFNE L13
-         L14
+          IFNE L10
+         L11
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_2
           AALOAD
-         L15
+         L12
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_0
           AALOAD
-         L16
+         L13
           ASTORE 3
           ASTORE 2
           ALOAD 2
           INSTANCEOF java/lang/Double
-          IFEQ L17
+          IFEQ L14
           ALOAD 3
           INSTANCEOF java/lang/Double
-          IFEQ L17
+          IFEQ L14
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
@@ -4238,46 +4582,42 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DCMPL
-          IFLE L18
+          IFLE L15
           ICONST_1
-          GOTO L19
-         L18
+          GOTO L16
+         L15
          FRAME SAME
           ICONST_0
-         L19
-         FRAME SAME1 I
-          GOTO L20
-         L17
+          GOTO L16
+         L14
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L21
+          IFEQ L17
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L21
+          IFEQ L17
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
           ICONST_0
-          IF_ICMPLE L22
+          IF_ICMPLE L18
           ICONST_1
-          GOTO L23
-         L22
+          GOTO L16
+         L18
          FRAME SAME
           ICONST_0
-         L23
-         FRAME SAME1 I
-          GOTO L20
-         L21
+          GOTO L16
+         L17
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L24
+          IFEQ L19
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L24
+          IFEQ L19
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -4288,21 +4628,19 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L24
+          IF_ICMPNE L19
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
           ICONST_0
-          IF_ICMPLE L25
+          IF_ICMPLE L20
           ICONST_1
-          GOTO L26
-         L25
+          GOTO L16
+         L20
          FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
           ICONST_0
-         L26
-         FRAME SAME1 I
-          GOTO L20
-         L24
+          GOTO L16
+         L19
          FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -4330,32 +4668,39 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L20
+         L16
          FRAME SAME1 I
-          GOTO L27
-         L13
+          GOTO L21
+         L10
          FRAME SAME
           ICONST_1
-         L27
+         L21
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L28
+          IFEQ L22
           ICONST_5
-          GOTO L29
-         L28
+          GOTO L23
+         L22
          FRAME FULL [org/nlogo/prim/_asm_procedureuphillchemical_if_5 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
           BIPUSH 9
-         L29
+         L23
          FRAME FULL [org/nlogo/prim/_asm_procedureuphillchemical_if_5 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L30
+         L24
           RETURN
 [5]_asm_procedureuphillchemical_ifelse_6 "ifelse" boolean => void
       _greaterthan ">" Object,Object => boolean
         _procedurevariable:SCENT-RIGHT "scent-right" => Object
         _procedurevariable:SCENT-LEFT "scent-left" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  o1
+          // parameter final  o2
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -4390,40 +4735,36 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
          L4
          FRAME APPEND [java/lang/Object java/lang/Object]
           ICONST_0
-         L5
-         FRAME SAME1 I
-          GOTO L6
+          GOTO L5
          L3
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
           ICONST_0
-          IF_ICMPLE L8
+          IF_ICMPLE L7
           ICONST_1
-          GOTO L9
-         L8
+          GOTO L5
+         L7
          FRAME SAME
           ICONST_0
-         L9
-         FRAME SAME1 I
-          GOTO L6
-         L7
+          GOTO L5
+         L6
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -4434,21 +4775,19 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L10
+          IF_ICMPNE L8
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
           ICONST_0
-          IF_ICMPLE L11
+          IF_ICMPLE L9
           ICONST_1
-          GOTO L12
-         L11
+          GOTO L5
+         L9
          FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
           ICONST_0
-         L12
-         FRAME SAME1 I
-          GOTO L6
-         L10
+          GOTO L5
+         L8
          FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -4476,24 +4815,27 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L6
+         L5
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L13
+          IFEQ L10
           BIPUSH 6
-          GOTO L14
-         L13
+          GOTO L11
+         L10
          FRAME FULL [org/nlogo/prim/_asm_procedureuphillchemical_ifelse_6 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
           BIPUSH 8
-         L14
+         L11
          FRAME FULL [org/nlogo/prim/_asm_procedureuphillchemical_ifelse_6 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L15
+         L12
           RETURN
 [6]_asm_procedureuphillchemical_right_7 "rt" double => void
       _constdouble:45.0 "45" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  delta
          L0
           LDC 45.0
          L1
@@ -4509,6 +4851,7 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
          L2
           RETURN
 [7]_asm_procedureuphillchemical_goto_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 9
@@ -4517,6 +4860,9 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           RETURN
 [8]_asm_procedureuphillchemical_left_9 "lt" double => void
       _constdouble:45.0 "45" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  delta
          L0
           LDC 45.0
          L1
@@ -4533,6 +4879,7 @@ procedure UPHILL-CHEMICAL:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
          L2
           RETURN
 [9]_asm_procedureuphillchemical_return_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -4565,33 +4912,35 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
       _patchvariableof:NEST-SCENT "of" Object => Object
         _patchahead "patch-ahead"
           _asm_procedureuphillnestscent_constdouble_2 "1" => Double
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedureuphillnestscent_constdouble_2.kept1_value : Ljava/lang/Double;
                L1
                 ARETURN
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureuphillnestscent_setprocedurevariable_1.keptinstr3 : Lorg/nlogo/prim/etc/_patchahead;
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/prim/etc/_patchahead.report (Lorg/nlogo/nvm/Context;)Ljava/lang/Object;
-         L4
+         L3
           ASTORE 2
-         L2
+         L0
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L4
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L5
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L6
+          IFNE L5
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4604,45 +4953,45 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L6
-         FRAME FULL [org/nlogo/prim/_asm_procedureuphillnestscent_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-          ALOAD 5
+         L5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+          ALOAD 4
           BIPUSH 8
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L7
-         L5
-         FRAME CHOP 1
-          ALOAD 4
+          ASTORE 3
+          GOTO L6
+         L4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L0
-          ALOAD 4
+          IFEQ L7
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedureuphillnestscent_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedureuphillnestscent_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L9
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           BIPUSH 8
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
@@ -4650,16 +4999,12 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           GOTO L8
          L9
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedureuphillnestscent_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
           ALOAD 6
-         L3
-          GOTO L10
-         L0
-         FRAME CHOP 2
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L6
+         L7
+         FRAME FULL [org/nlogo/prim/_asm_procedureuphillnestscent_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -4676,22 +5021,27 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           GETSTATIC org/nlogo/core/Syntax$.MODULE$ : Lorg/nlogo/core/Syntax$;
           INVOKEVIRTUAL org/nlogo/core/Syntax$.PatchsetType ()I
           IOR
-          ALOAD 4
+          ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L6
+         FRAME APPEND [java/lang/Object]
+          ALOAD 3
          L1
+          GOTO L10
+         L2
          FRAME FULL [org/nlogo/prim/_asm_procedureuphillnestscent_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedureuphillnestscent_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_procedureuphillnestscent_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -4707,6 +5057,9 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
 [2]_asm_procedureuphillnestscent_setprocedurevariable_3 "let" Object => void
       _callreport:GET-NEST-SCENT "get-nest-scent"
         _constdouble:45.0 "45" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -4753,6 +5106,9 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
 [3]_asm_procedureuphillnestscent_setprocedurevariable_4 "let" Object => void
       _callreport:GET-NEST-SCENT "get-nest-scent"
         _constdouble:-45.0 "-45" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -4804,6 +5160,18 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
         _greaterthan ">" Object,Object => boolean
           _procedurevariable:SCENT-LEFT "scent-left" => Object
           _procedurevariable:SCENT-AHEAD "scent-ahead" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  o1
+          // parameter final  o2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  o1
+          // parameter final  o2
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -4838,40 +5206,36 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
          L4
          FRAME APPEND [java/lang/Object java/lang/Object]
           ICONST_0
-         L5
-         FRAME SAME1 I
-          GOTO L6
+          GOTO L5
          L3
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
           ICONST_0
-          IF_ICMPLE L8
+          IF_ICMPLE L7
           ICONST_1
-          GOTO L9
-         L8
+          GOTO L5
+         L7
          FRAME SAME
           ICONST_0
-         L9
-         FRAME SAME1 I
-          GOTO L6
-         L7
+          GOTO L5
+         L6
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -4882,21 +5246,19 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L10
+          IF_ICMPNE L8
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
           ICONST_0
-          IF_ICMPLE L11
+          IF_ICMPLE L9
           ICONST_1
-          GOTO L12
-         L11
+          GOTO L5
+         L9
          FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
           ICONST_0
-         L12
-         FRAME SAME1 I
-          GOTO L6
-         L10
+          GOTO L5
+         L8
          FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -4924,30 +5286,30 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L6
+         L5
          FRAME SAME1 I
-          IFNE L13
-         L14
+          IFNE L10
+         L11
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_2
           AALOAD
-         L15
+         L12
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_0
           AALOAD
-         L16
+         L13
           ASTORE 3
           ASTORE 2
           ALOAD 2
           INSTANCEOF java/lang/Double
-          IFEQ L17
+          IFEQ L14
           ALOAD 3
           INSTANCEOF java/lang/Double
-          IFEQ L17
+          IFEQ L14
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
@@ -4955,46 +5317,42 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DCMPL
-          IFLE L18
+          IFLE L15
           ICONST_1
-          GOTO L19
-         L18
+          GOTO L16
+         L15
          FRAME SAME
           ICONST_0
-         L19
-         FRAME SAME1 I
-          GOTO L20
-         L17
+          GOTO L16
+         L14
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L21
+          IFEQ L17
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L21
+          IFEQ L17
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
           ICONST_0
-          IF_ICMPLE L22
+          IF_ICMPLE L18
           ICONST_1
-          GOTO L23
-         L22
+          GOTO L16
+         L18
          FRAME SAME
           ICONST_0
-         L23
-         FRAME SAME1 I
-          GOTO L20
-         L21
+          GOTO L16
+         L17
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L24
+          IFEQ L19
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L24
+          IFEQ L19
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -5005,21 +5363,19 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L24
+          IF_ICMPNE L19
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
           ICONST_0
-          IF_ICMPLE L25
+          IF_ICMPLE L20
           ICONST_1
-          GOTO L26
-         L25
+          GOTO L16
+         L20
          FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
           ICONST_0
-         L26
-         FRAME SAME1 I
-          GOTO L20
-         L24
+          GOTO L16
+         L19
          FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -5047,32 +5403,39 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L20
+         L16
          FRAME SAME1 I
-          GOTO L27
-         L13
+          GOTO L21
+         L10
          FRAME SAME
           ICONST_1
-         L27
+         L21
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L28
+          IFEQ L22
           ICONST_5
-          GOTO L29
-         L28
+          GOTO L23
+         L22
          FRAME FULL [org/nlogo/prim/_asm_procedureuphillnestscent_if_5 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
           BIPUSH 9
-         L29
+         L23
          FRAME FULL [org/nlogo/prim/_asm_procedureuphillnestscent_if_5 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L30
+         L24
           RETURN
 [5]_asm_procedureuphillnestscent_ifelse_6 "ifelse" boolean => void
       _greaterthan ">" Object,Object => boolean
         _procedurevariable:SCENT-RIGHT "scent-right" => Object
         _procedurevariable:SCENT-LEFT "scent-left" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  o1
+          // parameter final  o2
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5107,40 +5470,36 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
          L4
          FRAME APPEND [java/lang/Object java/lang/Object]
           ICONST_0
-         L5
-         FRAME SAME1 I
-          GOTO L6
+          GOTO L5
          L3
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
           ICONST_0
-          IF_ICMPLE L8
+          IF_ICMPLE L7
           ICONST_1
-          GOTO L9
-         L8
+          GOTO L5
+         L7
          FRAME SAME
           ICONST_0
-         L9
-         FRAME SAME1 I
-          GOTO L6
-         L7
+          GOTO L5
+         L6
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -5151,21 +5510,19 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L10
+          IF_ICMPNE L8
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
           ICONST_0
-          IF_ICMPLE L11
+          IF_ICMPLE L9
           ICONST_1
-          GOTO L12
-         L11
+          GOTO L5
+         L9
          FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
           ICONST_0
-         L12
-         FRAME SAME1 I
-          GOTO L6
-         L10
+          GOTO L5
+         L8
          FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -5193,24 +5550,27 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L6
+         L5
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L13
+          IFEQ L10
           BIPUSH 6
-          GOTO L14
-         L13
+          GOTO L11
+         L10
          FRAME FULL [org/nlogo/prim/_asm_procedureuphillnestscent_ifelse_6 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
           BIPUSH 8
-         L14
+         L11
          FRAME FULL [org/nlogo/prim/_asm_procedureuphillnestscent_ifelse_6 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L15
+         L12
           RETURN
 [6]_asm_procedureuphillnestscent_right_7 "rt" double => void
       _constdouble:45.0 "45" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  delta
          L0
           LDC 45.0
          L1
@@ -5226,6 +5586,7 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
          L2
           RETURN
 [7]_asm_procedureuphillnestscent_goto_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 9
@@ -5234,6 +5595,9 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
           RETURN
 [8]_asm_procedureuphillnestscent_left_9 "lt" double => void
       _constdouble:45.0 "45" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  delta
          L0
           LDC 45.0
          L1
@@ -5250,6 +5614,7 @@ procedure UPHILL-NEST-SCENT:[SCENT-AHEAD SCENT-RIGHT SCENT-LEFT]{-T--}:
          L2
           RETURN
 [9]_asm_procedureuphillnestscent_return_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -5264,6 +5629,13 @@ procedure WIGGLE:[]{-T--}:
       _minus "-" double,double => double
         _randomconst:40 "random" => double
         _randomconst:40 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  delta
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -5300,11 +5672,16 @@ procedure WIGGLE:[]{-T--}:
       _not "not" boolean => boolean
         _canmove "can-move?"
           _asm_procedurewiggle_constdouble_2 "1" => Double
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurewiggle_constdouble_2.kept1_value : Ljava/lang/Double;
                L1
                 ARETURN
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurewiggle_if_1.keptinstr3 : Lorg/nlogo/prim/etc/_canmove;
@@ -5333,12 +5710,12 @@ procedure WIGGLE:[]{-T--}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L4
-          ICONST_0
+          IFNE L4
+          ICONST_1
           GOTO L5
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurewiggle_if_1 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L5
          FRAME SAME1 I
           ISTORE 2
@@ -5357,6 +5734,9 @@ procedure WIGGLE:[]{-T--}:
           RETURN
 [2]_asm_procedurewiggle_right_3 "rt" double => void
       _constdouble:180.0 "180" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  delta
          L0
           LDC 180.0
          L1
@@ -5372,6 +5752,7 @@ procedure WIGGLE:[]{-T--}:
          L2
           RETURN
 [3]_asm_procedurewiggle_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -5385,6 +5766,7 @@ reporter procedure GET-NEST-SCENT:[ANGLE P]{-T--}:
 [0]_asm_proceduregetnestscent_setprocedurevariable_0 "let" Object => void
       _patchrightandahead "patch-right-and-ahead"
         _asm_proceduregetnestscent_procedurevariable_1 "angle" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5394,11 +5776,14 @@ reporter procedure GET-NEST-SCENT:[ANGLE P]{-T--}:
              L1
               ARETURN
         _asm_proceduregetnestscent_constdouble_2 "1" => Double
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_proceduregetnestscent_constdouble_2.kept1_value : Ljava/lang/Double;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduregetnestscent_setprocedurevariable_0.keptinstr2 : Lorg/nlogo/prim/etc/_patchrightandahead;
           ALOAD 1
@@ -5420,6 +5805,13 @@ reporter procedure GET-NEST-SCENT:[ANGLE P]{-T--}:
       _notequal "!=" Object,Object => boolean
         _procedurevariable:P "p" => Object
         _nobody "nobody" => Nobody$
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5435,12 +5827,12 @@ reporter procedure GET-NEST-SCENT:[ANGLE P]{-T--}:
           ALOAD 2
           ALOAD 3
           INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-          IFEQ L3
-          ICONST_0
+          IFNE L3
+          ICONST_1
           GOTO L4
          L3
          FRAME APPEND [java/lang/Object org/nlogo/core/Nobody$]
-          ICONST_1
+          ICONST_0
          L4
          FRAME SAME1 I
           ISTORE 2
@@ -5460,30 +5852,30 @@ reporter procedure GET-NEST-SCENT:[ANGLE P]{-T--}:
 [2]_asm_proceduregetnestscent_report_4 "report" Object => void
       _patchvariableof:NEST-SCENT "of" Object => Object
         _procedurevariable:P "p" => Object
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-         L4
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+         L3
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_1
           AALOAD
-         L5
+         L4
           ASTORE 2
-         L2
+         L0
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L5
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L6
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L7
+          IFNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -5496,45 +5888,45 @@ reporter procedure GET-NEST-SCENT:[ANGLE P]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetnestscent_report_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-          ALOAD 5
+         L6
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+          ALOAD 4
           BIPUSH 8
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L8
-         L6
-         FRAME CHOP 1
-          ALOAD 4
+          ASTORE 3
+          GOTO L7
+         L5
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L0
-          ALOAD 4
+          IFEQ L8
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetnestscent_report_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_proceduregetnestscent_report_4 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L10
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           BIPUSH 8
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
@@ -5542,16 +5934,12 @@ reporter procedure GET-NEST-SCENT:[ANGLE P]{-T--}:
           GOTO L9
          L10
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetnestscent_report_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
           ALOAD 6
-         L3
-          GOTO L11
-         L0
-         FRAME CHOP 2
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L7
+         L8
+         FRAME FULL [org/nlogo/prim/_asm_proceduregetnestscent_report_4 org/nlogo/nvm/Context java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -5568,22 +5956,27 @@ reporter procedure GET-NEST-SCENT:[ANGLE P]{-T--}:
           GETSTATIC org/nlogo/core/Syntax$.MODULE$ : Lorg/nlogo/core/Syntax$;
           INVOKEVIRTUAL org/nlogo/core/Syntax$.PatchsetType ()I
           IOR
-          ALOAD 4
+          ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L7
+         FRAME APPEND [java/lang/Object]
+          ALOAD 3
          L1
+          GOTO L11
+         L2
          FRAME FULL [org/nlogo/prim/_asm_proceduregetnestscent_report_4 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetnestscent_report_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_proceduregetnestscent_report_4 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -5652,6 +6045,7 @@ reporter procedure GET-NEST-SCENT:[ANGLE P]{-T--}:
           RETURN
 [3]_asm_proceduregetnestscent_report_5 "report" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduregetnestscent_report_5.kept2_value : Ljava/lang/Double;
@@ -5723,6 +6117,7 @@ reporter procedure GET-NEST-SCENT:[ANGLE P]{-T--}:
          FRAME SAME
           RETURN
 [4]_asm_proceduregetnestscent_returnreport_6 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -5742,6 +6137,7 @@ reporter procedure CHEMICAL-SCENT:[ANGLE P]{-T--}:
 [0]_asm_procedurechemicalscent_setprocedurevariable_0 "let" Object => void
       _patchrightandahead "patch-right-and-ahead"
         _asm_procedurechemicalscent_procedurevariable_1 "angle" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5751,11 +6147,14 @@ reporter procedure CHEMICAL-SCENT:[ANGLE P]{-T--}:
              L1
               ARETURN
         _asm_procedurechemicalscent_constdouble_2 "1" => Double
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurechemicalscent_constdouble_2.kept1_value : Ljava/lang/Double;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurechemicalscent_setprocedurevariable_0.keptinstr2 : Lorg/nlogo/prim/etc/_patchrightandahead;
           ALOAD 1
@@ -5777,6 +6176,13 @@ reporter procedure CHEMICAL-SCENT:[ANGLE P]{-T--}:
       _notequal "!=" Object,Object => boolean
         _procedurevariable:P "p" => Object
         _nobody "nobody" => Nobody$
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5792,12 +6198,12 @@ reporter procedure CHEMICAL-SCENT:[ANGLE P]{-T--}:
           ALOAD 2
           ALOAD 3
           INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-          IFEQ L3
-          ICONST_0
+          IFNE L3
+          ICONST_1
           GOTO L4
          L3
          FRAME APPEND [java/lang/Object org/nlogo/core/Nobody$]
-          ICONST_1
+          ICONST_0
          L4
          FRAME SAME1 I
           ISTORE 2
@@ -5817,30 +6223,30 @@ reporter procedure CHEMICAL-SCENT:[ANGLE P]{-T--}:
 [2]_asm_procedurechemicalscent_report_4 "report" Object => void
       _patchvariableof:CHEMICAL "of" Object => Object
         _procedurevariable:P "p" => Object
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-         L4
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+         L3
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_1
           AALOAD
-         L5
+         L4
           ASTORE 2
-         L2
+         L0
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L5
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L6
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L7
+          IFNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -5853,45 +6259,45 @@ reporter procedure CHEMICAL-SCENT:[ANGLE P]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurechemicalscent_report_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-          ALOAD 5
+         L6
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+          ALOAD 4
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L8
-         L6
-         FRAME CHOP 1
-          ALOAD 4
+          ASTORE 3
+          GOTO L7
+         L5
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L0
-          ALOAD 4
+          IFEQ L8
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurechemicalscent_report_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedurechemicalscent_report_4 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L10
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
@@ -5899,16 +6305,12 @@ reporter procedure CHEMICAL-SCENT:[ANGLE P]{-T--}:
           GOTO L9
          L10
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurechemicalscent_report_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
           ALOAD 6
-         L3
-          GOTO L11
-         L0
-         FRAME CHOP 2
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L7
+         L8
+         FRAME FULL [org/nlogo/prim/_asm_procedurechemicalscent_report_4 org/nlogo/nvm/Context java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -5925,22 +6327,27 @@ reporter procedure CHEMICAL-SCENT:[ANGLE P]{-T--}:
           GETSTATIC org/nlogo/core/Syntax$.MODULE$ : Lorg/nlogo/core/Syntax$;
           INVOKEVIRTUAL org/nlogo/core/Syntax$.PatchsetType ()I
           IOR
-          ALOAD 4
+          ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L7
+         FRAME APPEND [java/lang/Object]
+          ALOAD 3
          L1
+          GOTO L11
+         L2
          FRAME FULL [org/nlogo/prim/_asm_procedurechemicalscent_report_4 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurechemicalscent_report_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_procedurechemicalscent_report_4 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -6009,6 +6416,7 @@ reporter procedure CHEMICAL-SCENT:[ANGLE P]{-T--}:
           RETURN
 [3]_asm_procedurechemicalscent_report_5 "report" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurechemicalscent_report_5.kept2_value : Ljava/lang/Double;
@@ -6080,6 +6488,7 @@ reporter procedure CHEMICAL-SCENT:[ANGLE P]{-T--}:
          FRAME SAME
           RETURN
 [4]_asm_procedurechemicalscent_returnreport_6 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -6099,6 +6508,11 @@ procedure DO-PLOTTING:[]{OTPL}:
 [0]_asm_proceduredoplotting_if_0 "if" boolean => void
       _not "not" boolean => boolean
         _observervariable:PLOT? "plot?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -6129,12 +6543,12 @@ procedure DO-PLOTTING:[]{OTPL}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L5
-          ICONST_0
+          IFNE L5
+          ICONST_1
           GOTO L6
          L5
          FRAME FULL [org/nlogo/prim/_asm_proceduredoplotting_if_0 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L6
          FRAME SAME1 I
           ISTORE 2
@@ -6191,12 +6605,14 @@ procedure DO-PLOTTING:[]{OTPL}:
           RETURN
 [2]_setcurrentplot "set-current-plot"
       _asm_proceduredoplotting_conststring_2 ""Food in each pile"" => String
+            // parameter final  context
            L0
             LDC "Food in each pile"
            L1
             ARETURN
 [3]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredoplotting_conststring_3 ""food-in-pile1"" => String
+            // parameter final  context
            L0
             LDC "food-in-pile1"
            L1
@@ -6207,6 +6623,11 @@ procedure DO-PLOTTING:[]{OTPL}:
         _asm_proceduredoplotting_equal_5 "=" Object,double => boolean
           _patchvariable:PCOLOR "pcolor" => Object
           _constdouble:85.0 "cyan" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -6233,11 +6654,9 @@ procedure DO-PLOTTING:[]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -6248,19 +6667,19 @@ procedure DO-PLOTTING:[]{OTPL}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_proceduredoplotting_equal_5 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduredoplotting_equal_5 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -6271,6 +6690,10 @@ procedure DO-PLOTTING:[]{OTPL}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  block
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredoplotting_countwith_4.world : Lorg/nlogo/agent/World;
@@ -6313,25 +6736,15 @@ procedure DO-PLOTTING:[]{OTPL}:
             IFEQ L4
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L5
+            IFEQ L2
             ILOAD 5
             ICONST_1
             IADD
             ISTORE 5
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-            GOTO L6
-           L5
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L6
-           FRAME SAME1 scala/runtime/BoxedUnit
-            ASTORE 10
             GOTO L2
            L4
-           FRAME CHOP 1
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -6366,7 +6779,7 @@ procedure DO-PLOTTING:[]{OTPL}:
            FRAME CHOP 2
             ILOAD 5
             I2D
-           L7
+           L5
             DSTORE 2
             NEW java/lang/Double
             DUP
@@ -6375,6 +6788,7 @@ procedure DO-PLOTTING:[]{OTPL}:
             ARETURN
 [5]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredoplotting_conststring_6 ""food-in-pile2"" => String
+            // parameter final  context
            L0
             LDC "food-in-pile2"
            L1
@@ -6385,6 +6799,11 @@ procedure DO-PLOTTING:[]{OTPL}:
         _asm_proceduredoplotting_equal_8 "=" Object,double => boolean
           _patchvariable:PCOLOR "pcolor" => Object
           _constdouble:95.0 "sky" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -6411,11 +6830,9 @@ procedure DO-PLOTTING:[]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -6426,19 +6843,19 @@ procedure DO-PLOTTING:[]{OTPL}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_proceduredoplotting_equal_8 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduredoplotting_equal_8 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -6449,6 +6866,10 @@ procedure DO-PLOTTING:[]{OTPL}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  block
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredoplotting_countwith_7.world : Lorg/nlogo/agent/World;
@@ -6491,25 +6912,15 @@ procedure DO-PLOTTING:[]{OTPL}:
             IFEQ L4
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L5
+            IFEQ L2
             ILOAD 5
             ICONST_1
             IADD
             ISTORE 5
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-            GOTO L6
-           L5
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L6
-           FRAME SAME1 scala/runtime/BoxedUnit
-            ASTORE 10
             GOTO L2
            L4
-           FRAME CHOP 1
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -6544,7 +6955,7 @@ procedure DO-PLOTTING:[]{OTPL}:
            FRAME CHOP 2
             ILOAD 5
             I2D
-           L7
+           L5
             DSTORE 2
             NEW java/lang/Double
             DUP
@@ -6553,6 +6964,7 @@ procedure DO-PLOTTING:[]{OTPL}:
             ARETURN
 [7]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredoplotting_conststring_9 ""food-in-pile3"" => String
+            // parameter final  context
            L0
             LDC "food-in-pile3"
            L1
@@ -6563,6 +6975,11 @@ procedure DO-PLOTTING:[]{OTPL}:
         _asm_proceduredoplotting_equal_11 "=" Object,double => boolean
           _patchvariable:PCOLOR "pcolor" => Object
           _constdouble:105.0 "blue" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -6589,11 +7006,9 @@ procedure DO-PLOTTING:[]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -6604,19 +7019,19 @@ procedure DO-PLOTTING:[]{OTPL}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_proceduredoplotting_equal_11 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduredoplotting_equal_11 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -6627,6 +7042,10 @@ procedure DO-PLOTTING:[]{OTPL}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  block
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredoplotting_countwith_10.world : Lorg/nlogo/agent/World;
@@ -6669,25 +7088,15 @@ procedure DO-PLOTTING:[]{OTPL}:
             IFEQ L4
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L5
+            IFEQ L2
             ILOAD 5
             ICONST_1
             IADD
             ISTORE 5
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-            GOTO L6
-           L5
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L6
-           FRAME SAME1 scala/runtime/BoxedUnit
-            ASTORE 10
             GOTO L2
            L4
-           FRAME CHOP 1
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -6722,7 +7131,7 @@ procedure DO-PLOTTING:[]{OTPL}:
            FRAME CHOP 2
             ILOAD 5
             I2D
-           L7
+           L5
             DSTORE 2
             NEW java/lang/Double
             DUP
@@ -6730,6 +7139,7 @@ procedure DO-PLOTTING:[]{OTPL}:
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
 [9]_asm_proceduredoplotting_return_12 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V

--- a/netlogo-headless/test/benchdumps/BZ.txt
+++ b/netlogo-headless/test/benchdumps/BZ.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:5454.0 "5454" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 5454.0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -77,6 +80,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:20.0 "20" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 20.0
          L1
@@ -89,7 +95,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -116,6 +123,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -149,6 +157,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -170,9 +181,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -187,8 +195,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -203,6 +216,9 @@ procedure SETUP:[]{O---}:
 [1]_resetticks "reset-ticks"
 [2]_asm_proceduresetup_ask_0 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_0.world : Lorg/nlogo/agent/World;
@@ -261,6 +277,15 @@ procedure SETUP:[]{O---}:
         _plus "+" double,double => double
           _observervariable:N "n" => Object
           _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  maxDouble
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -301,7 +326,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_1.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_1.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -370,9 +396,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L16
          L4
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double T J] [org/nlogo/api/AgentException]
@@ -387,6 +410,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L16
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L17
           RETURN
 [4]_asm_proceduresetup_setpatchvariable_2 "set" Object => void
       _scalecolor "scale-color" double,double,double,double => double
@@ -394,6 +421,12 @@ procedure SETUP:[]{O---}:
         _patchvariable:STATE "state" => Object
         _constdouble:0.0 "0" => double
         _observervariable:N "n" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -573,7 +606,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 10
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L24
           DSTORE 2
           NEW java/lang/Double
@@ -588,9 +622,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L8
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L25
          L9
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_2 org/nlogo/nvm/Context java/lang/Double T D D D D] [org/nlogo/api/AgentException]
@@ -605,8 +636,13 @@ procedure SETUP:[]{O---}:
           ATHROW
          L25
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L26
           RETURN
 [5]_asm_proceduresetup_done_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -614,6 +650,7 @@ procedure SETUP:[]{O---}:
          L1
           RETURN
 [6]_asm_proceduresetup_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -626,6 +663,9 @@ procedure SETUP:[]{O---}:
 procedure GO:[]{O---}:
 [0]_asm_procedurego_ask_0 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_0.world : Lorg/nlogo/agent/World;
@@ -698,6 +738,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [2]_asm_procedurego_done_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -706,6 +747,9 @@ procedure GO:[]{O---}:
           RETURN
 [3]_asm_procedurego_ask_3 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_3.world : Lorg/nlogo/agent/World;
@@ -761,6 +805,9 @@ procedure GO:[]{O---}:
           RETURN
 [4]_asm_procedurego_setpatchvariable_4 "set" Object => void
       _patchvariable:NEW-STATE "new-state" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -791,9 +838,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L4
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L5
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_4 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -808,6 +852,10 @@ procedure GO:[]{O---}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [5]_asm_procedurego_setpatchvariable_5 "set" Object => void
       _scalecolor "scale-color" double,double,double,double => double
@@ -815,6 +863,12 @@ procedure GO:[]{O---}:
         _patchvariable:STATE "state" => Object
         _constdouble:0.0 "0" => double
         _observervariable:N "n" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -994,7 +1048,8 @@ procedure GO:[]{O---}:
           DLOAD 2
           DLOAD 10
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L24
           DSTORE 2
           NEW java/lang/Double
@@ -1009,9 +1064,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L8
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L25
          L9
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_5 org/nlogo/nvm/Context java/lang/Double T D D D D] [org/nlogo/api/AgentException]
@@ -1026,8 +1078,13 @@ procedure GO:[]{O---}:
           ATHROW
          L25
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L26
           RETURN
 [6]_asm_procedurego_done_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1036,6 +1093,7 @@ procedure GO:[]{O---}:
           RETURN
 [7]_tick "tick"
 [8]_asm_procedurego_return_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1050,6 +1108,13 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
       _equal "=" Object,Object => boolean
         _patchvariable:STATE "state" => Object
         _observervariable:N "n" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1100,6 +1165,9 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           RETURN
 [1]_asm_procedurefindnewstate_setpatchvariable_1 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1113,9 +1181,6 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1130,8 +1195,13 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedurefindnewstate_goto_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 12
@@ -1148,6 +1218,16 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           _lessthan "<" Object,Object => boolean
             _patchvariable:STATE "state" => Object
             _observervariable:N "n" => Object
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  arg1
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  o1
+              // parameter final  o2
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
               TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
              L0
@@ -1175,14 +1255,10 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L8
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
-              ASTORE 6
-              ALOAD 6
               INVOKEVIRTUAL java/lang/Double.doubleValue ()D
               DLOAD 3
               DCMPL
@@ -1190,15 +1266,14 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
               ICONST_1
               GOTO L10
              L9
-             FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_and_4 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME APPEND [java/lang/Object D]
               ICONST_0
              L10
              FRAME SAME1 I
-              ISTORE 7
-              ILOAD 7
+              ISTORE 5
               GOTO L11
              L8
-             FRAME CHOP 1
+             FRAME SAME
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
@@ -1227,15 +1302,17 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
               INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
               ATHROW
              L11
-             FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_and_4 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
-              IFEQ L12
+             FRAME APPEND [I]
+              ILOAD 5
+             L12
+              IFEQ L13
              L3
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
               ICONST_5
               INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
              L4
-              GOTO L13
+              GOTO L14
              L5
              FRAME SAME1 org/nlogo/api/AgentException
               ASTORE 2
@@ -1247,22 +1324,22 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
               INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
               INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
               ATHROW
-             L13
+             L14
              FRAME SAME1 java/lang/Object
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurefindnewstate_and_4.world : Lorg/nlogo/agent/World;
               INVOKEVIRTUAL org/nlogo/agent/World.observer ()Lorg/nlogo/agent/Observer;
               ICONST_0
               INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
-             L14
+             L15
               ASTORE 3
               ASTORE 2
               ALOAD 2
               INSTANCEOF java/lang/Double
-              IFEQ L15
+              IFEQ L16
               ALOAD 3
               INSTANCEOF java/lang/Double
-              IFEQ L15
+              IFEQ L16
               ALOAD 2
               CHECKCAST java/lang/Double
               INVOKEVIRTUAL java/lang/Double.doubleValue ()D
@@ -1270,16 +1347,14 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
               CHECKCAST java/lang/Double
               INVOKEVIRTUAL java/lang/Double.doubleValue ()D
               DCMPG
-              IFGE L16
+              IFGE L17
               ICONST_1
-              GOTO L17
-             L16
-             FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_and_4 org/nlogo/nvm/Context java/lang/Object java/lang/Object T java/lang/Object java/lang/Double I] []
-              ICONST_0
-             L17
-             FRAME SAME1 I
               GOTO L18
-             L15
+             L17
+             FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_and_4 org/nlogo/nvm/Context java/lang/Object java/lang/Object T I] []
+              ICONST_0
+              GOTO L18
+             L16
              FRAME SAME
               ALOAD 2
               INSTANCEOF java/lang/String
@@ -1295,21 +1370,19 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
               ICONST_0
               IF_ICMPGE L20
               ICONST_1
-              GOTO L21
+              GOTO L18
              L20
              FRAME SAME
               ICONST_0
-             L21
-             FRAME SAME1 I
               GOTO L18
              L19
              FRAME SAME
               ALOAD 2
               INSTANCEOF org/nlogo/agent/Agent
-              IFEQ L22
+              IFEQ L21
               ALOAD 3
               INSTANCEOF org/nlogo/agent/Agent
-              IFEQ L22
+              IFEQ L21
               ALOAD 2
               CHECKCAST org/nlogo/agent/Agent
               ASTORE 4
@@ -1320,22 +1393,20 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
               INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
               ALOAD 5
               INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-              IF_ICMPNE L22
+              IF_ICMPNE L21
               ALOAD 4
               ALOAD 5
               INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
               ICONST_0
-              IF_ICMPGE L23
+              IF_ICMPGE L22
               ICONST_1
-              GOTO L24
-             L23
-             FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_and_4 org/nlogo/nvm/Context java/lang/Object java/lang/Object org/nlogo/agent/Agent org/nlogo/agent/Agent java/lang/Double I] []
-              ICONST_0
-             L24
-             FRAME SAME1 I
               GOTO L18
              L22
-             FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_and_4 org/nlogo/nvm/Context java/lang/Object java/lang/Object T java/lang/Object java/lang/Double I] []
+             FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_and_4 org/nlogo/nvm/Context java/lang/Object java/lang/Object org/nlogo/agent/Agent org/nlogo/agent/Agent] []
+              ICONST_0
+              GOTO L18
+             L21
+             FRAME CHOP 2
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
@@ -1364,59 +1435,60 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
               ATHROW
              L18
              FRAME SAME1 I
-              GOTO L25
-             L12
-             FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_and_4 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] []
+              GOTO L23
+             L13
+             FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_and_4 org/nlogo/nvm/Context java/lang/Object D I] []
               ICONST_0
-             L25
-             FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_and_4 org/nlogo/nvm/Context java/lang/Object T T java/lang/Object java/lang/Double I] [I]
-              IFEQ L26
+             L23
+             FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_and_4 org/nlogo/nvm/Context java/lang/Object] [I]
+              IFEQ L24
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
-              GOTO L27
-             L26
+              GOTO L25
+             L24
              FRAME SAME
               GETSTATIC java/lang/Boolean.FALSE : Ljava/lang/Boolean;
-             L27
+             L25
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  block
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-          ASTORE 2
-          ALOAD 2
-          INSTANCEOF org/nlogo/agent/Turtle
-          IFEQ L1
-          ALOAD 2
-          CHECKCAST org/nlogo/agent/Turtle
           ASTORE 3
           ALOAD 3
+          INSTANCEOF org/nlogo/agent/Turtle
+          IFEQ L1
+          ALOAD 3
+          CHECKCAST org/nlogo/agent/Turtle
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 4
+          ASTORE 2
           GOTO L2
          L1
-         FRAME APPEND [org/nlogo/agent/Agent]
-          ALOAD 2
+         FRAME APPEND [T org/nlogo/agent/Agent]
+          ALOAD 3
           INSTANCEOF org/nlogo/agent/Patch
           IFEQ L3
-          ALOAD 2
+          ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 5
-          ALOAD 5
-          ASTORE 4
-         L2
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 4
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/AgentSet;
-          GOTO L4
+          ASTORE 2
+          GOTO L2
          L3
-         FRAME CHOP 2
+         FRAME SAME
           NEW scala/MatchError
           DUP
-          ALOAD 2
+          ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L2
+         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_3 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 2
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/AgentSet;
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_3 org/nlogo/nvm/Context org/nlogo/agent/Agent T org/nlogo/agent/Patch] [org/nlogo/agent/AgentSet]
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_3.keptinstr4 : Lorg/nlogo/nvm/Reporter;
           ASTORE 3
@@ -1454,25 +1526,15 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           IFEQ L7
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L8
+          IFEQ L5
           ILOAD 5
           ICONST_1
           IADD
           ISTORE 5
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          GOTO L9
-         L8
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L9
-         FRAME SAME1 scala/runtime/BoxedUnit
-          ASTORE 10
           GOTO L5
          L7
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1507,7 +1569,7 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
          FRAME CHOP 2
           ILOAD 5
           I2D
-         L10
+         L8
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -1523,7 +1585,7 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           ALOAD 1
           ICONST_4
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L11
+         L9
           RETURN
 [4]_asm_procedurefindnewstate_setprocedurevariable_5 "let" Object => void
       _countwith "count" AgentSet,Reporter => double
@@ -1531,6 +1593,11 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
         _asm_procedurefindnewstate_equal_6 "=" Object,Object => boolean
           _patchvariable:STATE "state" => Object
           _observervariable:N "n" => Object
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  arg1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -1574,44 +1641,45 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
              L7
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  block
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-          ASTORE 2
-          ALOAD 2
-          INSTANCEOF org/nlogo/agent/Turtle
-          IFEQ L1
-          ALOAD 2
-          CHECKCAST org/nlogo/agent/Turtle
           ASTORE 3
           ALOAD 3
+          INSTANCEOF org/nlogo/agent/Turtle
+          IFEQ L1
+          ALOAD 3
+          CHECKCAST org/nlogo/agent/Turtle
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 4
+          ASTORE 2
           GOTO L2
          L1
-         FRAME APPEND [org/nlogo/agent/Agent]
-          ALOAD 2
+         FRAME APPEND [T org/nlogo/agent/Agent]
+          ALOAD 3
           INSTANCEOF org/nlogo/agent/Patch
           IFEQ L3
-          ALOAD 2
+          ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 5
-          ALOAD 5
-          ASTORE 4
-         L2
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 4
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/AgentSet;
-          GOTO L4
+          ASTORE 2
+          GOTO L2
          L3
-         FRAME CHOP 2
+         FRAME SAME
           NEW scala/MatchError
           DUP
-          ALOAD 2
+          ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L2
+         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_5 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 2
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/AgentSet;
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_5 org/nlogo/nvm/Context org/nlogo/agent/Agent T org/nlogo/agent/Patch] [org/nlogo/agent/AgentSet]
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_5.keptinstr4 : Lorg/nlogo/nvm/Reporter;
           ASTORE 3
@@ -1649,25 +1717,15 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           IFEQ L7
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L8
+          IFEQ L5
           ILOAD 5
           ICONST_1
           IADD
           ISTORE 5
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          GOTO L9
-         L8
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L9
-         FRAME SAME1 scala/runtime/BoxedUnit
-          ASTORE 10
           GOTO L5
          L7
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1702,7 +1760,7 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
          FRAME CHOP 2
           ILOAD 5
           I2D
-         L10
+         L8
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -1718,12 +1776,19 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           ALOAD 1
           ICONST_5
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L11
+         L9
           RETURN
 [5]_asm_procedurefindnewstate_ifelse_7 "ifelse" boolean => void
       _equal "=" Object,double => boolean
         _patchvariable:STATE "state" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1750,11 +1815,9 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -1765,19 +1828,19 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_ifelse_7 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_ifelse_7 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -1786,10 +1849,10 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           BIPUSH 6
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_ifelse_7 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_ifelse_7 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 8
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_ifelse_7 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_ifelse_7 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
@@ -1803,6 +1866,19 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           _div "/" double,double => double
             _procedurevariable:B "b" => Object
             _observervariable:K2 "k2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -1885,7 +1961,8 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8.validLong (DLorg/nlogo/nvm/Context;)J
           L2D
          L18
           ALOAD 1
@@ -1964,7 +2041,8 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8.validLong (DLorg/nlogo/nvm/Context;)J
           L2D
          L25
           DSTORE 4
@@ -1986,9 +2064,6 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L9
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L27
          L10
          FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -2003,8 +2078,13 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           ATHROW
          L27
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L28
           RETURN
 [7]_asm_procedurefindnewstate_goto_9 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 10
@@ -2015,6 +2095,13 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
       _plus "+" double,double => double
         _patchvariable:STATE "state" => Object
         _nsum:STATE "sum" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -2065,10 +2152,8 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           IFEQ L7
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L8
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent] [D]
@@ -2077,46 +2162,48 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           IFEQ L9
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent T org/nlogo/agent/Patch] [D]
-          ALOAD 5
           ASTORE 2
+          GOTO L8
+         L9
+         FRAME SAME1 D
+          NEW scala/MatchError
+          DUP
+          ALOAD 3
+          INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
+          ATHROW
+         L8
+         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] [D]
           DCONST_0
-          DSTORE 7
+          DSTORE 4
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/AgentSet;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.iterator ()Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 6
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T D org/nlogo/agent/AgentIterator] [D]
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent D org/nlogo/agent/AgentIterator] [D]
+          ALOAD 6
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L11
-          ALOAD 9
+          ALOAD 6
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Patch
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariable (I)Ljava/lang/Object;
-          ASTORE 10
-          ALOAD 10
+          ASTORE 7
+          ALOAD 7
           INSTANCEOF java/lang/Double
           IFEQ L12
-          ALOAD 10
+          ALOAD 7
           CHECKCAST java/lang/Double
-          ASTORE 11
-          DLOAD 7
-          ALOAD 11
+          ASTORE 8
+          DLOAD 4
+          ALOAD 8
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DADD
-          DSTORE 7
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 12
+          DSTORE 4
           GOTO L10
          L12
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T D org/nlogo/agent/AgentIterator java/lang/Object] [D]
+         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent D org/nlogo/agent/AgentIterator java/lang/Object] [D]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2130,14 +2217,14 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           DUP
           ICONST_0
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
-          ALOAD 10
+          ALOAD 7
           INVOKEVIRTUAL org/nlogo/api/Dump$.logoObject (Ljava/lang/Object;)Ljava/lang/String;
           INVOKEVIRTUAL java/lang/String.toString ()Ljava/lang/String;
           AASTORE
           DUP
           ICONST_1
           GETSTATIC org/nlogo/api/TypeNames$.MODULE$ : Lorg/nlogo/api/TypeNames$;
-          ALOAD 10
+          ALOAD 7
           INVOKEVIRTUAL org/nlogo/api/TypeNames$.name (Ljava/lang/Object;)Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -2145,20 +2232,12 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T D org/nlogo/agent/AgentIterator] [D]
+         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent D org/nlogo/agent/AgentIterator] [D]
           ALOAD 0
-          DLOAD 7
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10.validDouble (D)D
-          GOTO L13
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent] [D]
-          NEW scala/MatchError
-          DUP
-          ALOAD 3
-          INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
-          ATHROW
+          DLOAD 4
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T D org/nlogo/agent/AgentIterator] [D D]
           DSTORE 4
           DSTORE 2
           DLOAD 2
@@ -2193,6 +2272,24 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
                 _procedurevariable:B "b" => Object
               _constdouble:1.0 "1" => double
         _observervariable:G "g" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -2315,7 +2412,8 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_11.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_11.validLong (DLorg/nlogo/nvm/Context;)J
           L2D
          L23
           ALOAD 0
@@ -2363,9 +2461,6 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L9
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L27
          L10
          FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_11 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -2380,11 +2475,22 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           ATHROW
          L27
          FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L28
           RETURN
 [10]_asm_procedurefindnewstate_if_12 "if" boolean => void
       _greaterthan ">" Object,Object => boolean
         _patchvariable:NEW-STATE "new-state" => Object
         _observervariable:N "n" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  o1
+          // parameter final  o2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -2433,40 +2539,36 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
          L6
          FRAME APPEND [java/lang/Object java/lang/Object]
           ICONST_0
-         L7
-         FRAME SAME1 I
-          GOTO L8
+          GOTO L7
          L5
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L9
+          IFEQ L8
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L9
+          IFEQ L8
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
           ICONST_0
-          IF_ICMPLE L10
+          IF_ICMPLE L9
           ICONST_1
-          GOTO L11
-         L10
+          GOTO L7
+         L9
          FRAME SAME
           ICONST_0
-         L11
-         FRAME SAME1 I
-          GOTO L8
-         L9
+          GOTO L7
+         L8
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L12
+          IFEQ L10
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L12
+          IFEQ L10
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -2477,21 +2579,19 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L12
+          IF_ICMPNE L10
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
           ICONST_0
-          IF_ICMPLE L13
+          IF_ICMPLE L11
           ICONST_1
-          GOTO L14
-         L13
+          GOTO L7
+         L11
          FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
           ICONST_0
-         L14
-         FRAME SAME1 I
-          GOTO L8
-         L12
+          GOTO L7
+         L10
          FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -2519,24 +2619,27 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L8
+         L7
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L15
+          IFEQ L12
           BIPUSH 11
-          GOTO L16
-         L15
+          GOTO L13
+         L12
          FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_if_12 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
           BIPUSH 12
-         L16
+         L13
          FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_if_12 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L17
+         L14
           RETURN
 [11]_asm_procedurefindnewstate_setpatchvariable_13 "set" Object => void
       _observervariable:N "n" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2553,9 +2656,6 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 12
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_13 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -2570,8 +2670,13 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 12
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [12]_asm_procedurefindnewstate_return_14 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V

--- a/netlogo-headless/test/benchdumps/Bureaucrats.txt
+++ b/netlogo-headless/test/benchdumps/Bureaucrats.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           DCONST_0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -77,6 +80,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:5000.0 "5000" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 5000.0
          L1
@@ -89,7 +95,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -116,6 +123,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -149,6 +157,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -170,9 +181,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -187,8 +195,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -202,6 +215,9 @@ procedure SETUP:[]{O---}:
 [0]_clearall "clear-all"
 [1]_asm_proceduresetup_ask_0 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_0.world : Lorg/nlogo/agent/World;
@@ -257,6 +273,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [2]_asm_proceduresetup_setpatchvariable_1 "set" Object => void
       _constdouble:2.0 "2" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -270,9 +289,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -287,6 +303,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_proceduresetup_call_2 "colorize"
          L0
@@ -307,6 +327,7 @@ procedure SETUP:[]{O---}:
          L1
           RETURN
 [4]_asm_proceduresetup_done_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -318,6 +339,15 @@ procedure SETUP:[]{O---}:
         _constdouble:2.0 "2" => double
         _count "count" AgentSet => double
           _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           LDC 2.0
@@ -351,9 +381,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L8
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_4 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -368,9 +395,14 @@ procedure SETUP:[]{O---}:
           ATHROW
          L8
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L9
           RETURN
 [6]_resetticks "reset-ticks"
 [7]_asm_proceduresetup_return_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -385,6 +417,9 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
       _patchset "patch-set"
         _asm_procedurego_oneof_1 "one-of" AgentSet => Object
           _patches "patches" => AgentSet
+              // parameter final  context
+              // parameter final  context
+              // parameter final  agents
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurego_oneof_1.world : Lorg/nlogo/agent/World;
@@ -412,6 +447,8 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
              L3
              FRAME SAME1 java/lang/Object
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_setprocedurevariable_0.keptinstr2 : Lorg/nlogo/prim/etc/_patchset;
           ALOAD 1
@@ -431,6 +468,9 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           RETURN
 [1]_asm_procedurego_ask_2 "ask" Object => void
       _procedurevariable:ACTIVE-PATCHES "active-patches" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -440,18 +480,16 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_2.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -467,8 +505,8 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_2.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -485,18 +523,18 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -513,7 +551,7 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -523,23 +561,12 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_2
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -553,13 +580,28 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          ICONST_2
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_2 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [2]_asm_procedurego_setpatchvariable_3 "set" Object => void
       _plus "+" double,double => double
         _patchvariable:N "n" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -624,9 +666,6 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_3 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -641,11 +680,22 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [3]_asm_procedurego_setobservervariable_4 "set" Object => void
       _plus "+" double,double => double
         _observervariable:TOTAL "total" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -697,9 +747,6 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L10
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setobservervariable_4 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -714,6 +761,10 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ATHROW
          L10
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [4]_asm_procedurego_call_5 "colorize"
          L0
@@ -734,6 +785,7 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
          L1
           RETURN
 [5]_asm_procedurego_done_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -741,6 +793,7 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
          L1
           RETURN
 [6]_asm_procedurego_goto_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 19
@@ -753,6 +806,11 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
         _asm_procedurego_greaterthan_9 ">" Object,double => boolean
           _patchvariable:N "n" => Object
           _constdouble:3.0 "3" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  arg1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -779,14 +837,10 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
-              ASTORE 6
-              ALOAD 6
               INVOKEVIRTUAL java/lang/Double.doubleValue ()D
               DLOAD 3
               DCMPL
@@ -794,15 +848,14 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_procedurego_greaterthan_9 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME APPEND [java/lang/Object D]
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
-              ILOAD 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME SAME
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
@@ -831,16 +884,24 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
               INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
               ATHROW
              L8
-             FRAME FULL [org/nlogo/prim/_asm_procedurego_greaterthan_9 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
-              IFEQ L9
-              GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
-              GOTO L10
+             FRAME APPEND [I]
+              ILOAD 5
              L9
+              IFEQ L10
+              GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
+              GOTO L11
+             L10
              FRAME SAME
               GETSTATIC java/lang/Boolean.FALSE : Ljava/lang/Boolean;
-             L10
+             L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -908,25 +969,15 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           IFEQ L7
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L8
+          IFEQ L5
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L9
-         L8
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L9
-         FRAME SAME1 java/lang/Object
-          ASTORE 10
-          ALOAD 10
           POP
           GOTO L5
          L7
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -969,7 +1020,7 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L10
+         L8
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -980,10 +1031,13 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ALOAD 1
           BIPUSH 8
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L11
+         L9
           RETURN
 [8]_asm_procedurego_ask_10 "ask" Object => void
       _procedurevariable:OVERLOADED-PATCHES "overloaded-patches" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -993,18 +1047,16 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_10.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -1020,8 +1072,8 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_10 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_10.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -1038,18 +1090,18 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -1066,7 +1118,7 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -1076,23 +1128,12 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_10 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 9
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 18
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -1106,13 +1147,28 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 9
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 18
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_10 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [9]_asm_procedurego_setpatchvariable_11 "set" Object => void
       _minus "-" double,double => double
         _patchvariable:N "n" => Object
         _constdouble:4.0 "4" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -1177,9 +1233,6 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_11 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1194,11 +1247,22 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [10]_asm_procedurego_setobservervariable_12 "set" Object => void
       _minus "-" double,double => double
         _observervariable:TOTAL "total" => Object
         _constdouble:4.0 "4" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -1250,9 +1314,6 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 11
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L10
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setobservervariable_12 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1267,6 +1328,10 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ATHROW
          L10
          FRAME SAME
+          ALOAD 1
+          BIPUSH 11
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [11]_asm_procedurego_call_13 "colorize"
          L0
@@ -1288,44 +1353,42 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           RETURN
 [12]_asm_procedurego_ask_14 "ask" AgentSet => void
       _neighbors4 "neighbors4" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-          ASTORE 2
-          ALOAD 2
-          INSTANCEOF org/nlogo/agent/Turtle
-          IFEQ L1
-          ALOAD 2
-          CHECKCAST org/nlogo/agent/Turtle
           ASTORE 3
           ALOAD 3
+          INSTANCEOF org/nlogo/agent/Turtle
+          IFEQ L1
+          ALOAD 3
+          CHECKCAST org/nlogo/agent/Turtle
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 4
+          ASTORE 2
           GOTO L2
          L1
-         FRAME APPEND [org/nlogo/agent/Agent]
-          ALOAD 2
+         FRAME APPEND [T org/nlogo/agent/Agent]
+          ALOAD 3
           INSTANCEOF org/nlogo/agent/Patch
           IFEQ L3
-          ALOAD 2
+          ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 5
-          ALOAD 5
-          ASTORE 4
-         L2
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 4
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors4 ()Lorg/nlogo/agent/AgentSet;
-          GOTO L4
+          ASTORE 2
+          GOTO L2
          L3
-         FRAME CHOP 2
+         FRAME SAME
           NEW scala/MatchError
           DUP
-          ALOAD 2
+          ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L2
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_14 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 2
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors4 ()Lorg/nlogo/agent/AgentSet;
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_14 org/nlogo/nvm/Context org/nlogo/agent/Agent T org/nlogo/agent/Patch] [org/nlogo/agent/AgentSet]
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -1347,7 +1410,7 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_14 org/nlogo/nvm/Context org/nlogo/agent/AgentSet T org/nlogo/agent/Patch] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_14 org/nlogo/nvm/Context org/nlogo/agent/AgentSet org/nlogo/agent/Agent] []
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_14.world : Lorg/nlogo/agent/World;
@@ -1378,6 +1441,13 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
       _plus "+" double,double => double
         _patchvariable:N "n" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -1442,9 +1512,6 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          BIPUSH 14
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_15 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1459,11 +1526,22 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          BIPUSH 14
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [14]_asm_procedurego_setobservervariable_16 "set" Object => void
       _plus "+" double,double => double
         _observervariable:TOTAL "total" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -1515,9 +1593,6 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 15
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L10
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setobservervariable_16 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1532,6 +1607,10 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ATHROW
          L10
          FRAME SAME
+          ALOAD 1
+          BIPUSH 15
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [15]_asm_procedurego_call_17 "colorize"
          L0
@@ -1552,6 +1631,7 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
          L1
           RETURN
 [16]_asm_procedurego_done_18 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1559,6 +1639,7 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
          L1
           RETURN
 [17]_asm_procedurego_done_19 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1569,46 +1650,43 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
       _patchset "patch-set"
         _of "of"
           _asm_procedurego_neighbors4_21 "neighbors4" => AgentSet
+                // parameter final  context
                L0
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-                ASTORE 2
-                ALOAD 2
-                INSTANCEOF org/nlogo/agent/Turtle
-                IFEQ L1
-                ALOAD 2
-                CHECKCAST org/nlogo/agent/Turtle
                 ASTORE 3
                 ALOAD 3
+                INSTANCEOF org/nlogo/agent/Turtle
+                IFEQ L1
+                ALOAD 3
+                CHECKCAST org/nlogo/agent/Turtle
                 INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-                ASTORE 4
+                ASTORE 2
                 GOTO L2
                L1
-               FRAME APPEND [org/nlogo/agent/Agent]
-                ALOAD 2
+               FRAME APPEND [T org/nlogo/agent/Agent]
+                ALOAD 3
                 INSTANCEOF org/nlogo/agent/Patch
                 IFEQ L3
-                ALOAD 2
+                ALOAD 3
                 CHECKCAST org/nlogo/agent/Patch
-                ASTORE 5
-                ALOAD 5
-                ASTORE 4
-               L2
-               FRAME APPEND [T org/nlogo/agent/Patch]
-                ALOAD 4
-                INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors4 ()Lorg/nlogo/agent/AgentSet;
-                GOTO L4
+                ASTORE 2
+                GOTO L2
                L3
-               FRAME CHOP 2
+               FRAME SAME
                 NEW scala/MatchError
                 DUP
-                ALOAD 2
+                ALOAD 3
                 INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
                 ATHROW
+               L2
+               FRAME FULL [org/nlogo/prim/_asm_procedurego_neighbors4_21 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+                ALOAD 2
+                INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors4 ()Lorg/nlogo/agent/AgentSet;
                L4
-               FRAME FULL [org/nlogo/prim/_asm_procedurego_neighbors4_21 org/nlogo/nvm/Context org/nlogo/agent/Agent T org/nlogo/agent/Patch] [org/nlogo/agent/AgentSet]
                 ARETURN
           _asm_procedurego_procedurevariable_22 "overloaded-patches" => Object
+                // parameter final  context
                L0
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -1617,6 +1695,8 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
                 AALOAD
                L1
                 ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_setprocedurevariable_20.keptinstr2 : Lorg/nlogo/prim/etc/_patchset;
           ALOAD 1
@@ -1637,6 +1717,9 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
 [19]_asm_procedurego_while_23 "while" boolean => void
       _any "any?" AgentSet => boolean
         _procedurevariable:ACTIVE-PATCHES "active-patches" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -1667,12 +1750,12 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           ASTORE 2
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.isEmpty ()Z
-          IFEQ L5
-          ICONST_0
+          IFNE L5
+          ICONST_1
           GOTO L6
          L5
          FRAME FULL [org/nlogo/prim/_asm_procedurego_while_23 org/nlogo/nvm/Context org/nlogo/agent/AgentSet] []
-          ICONST_1
+          ICONST_0
          L6
          FRAME SAME1 I
           ISTORE 2
@@ -1691,6 +1774,7 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           RETURN
 [20]_tick "tick"
 [21]_asm_procedurego_return_24 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1705,6 +1789,10 @@ procedure COLORIZE:[]{-TP-}:
       _lessorequal "<=" Object,double => boolean
         _patchvariable:N "n" => Object
         _constdouble:3.0 "3" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1790,6 +1878,7 @@ procedure COLORIZE:[]{-TP-}:
 [1]_asm_procedurecolorize_setpatchvariable_1 "set" Object => void
       _item "item"
         _asm_procedurecolorize_patchvariable_2 "n" => Object
+              // parameter final  context
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -1813,11 +1902,14 @@ procedure COLORIZE:[]{-TP-}:
              FRAME SAME1 java/lang/Object
               ARETURN
         _asm_procedurecolorize_constlist_3 "[83 54 45 25]" => LogoList
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurecolorize_constlist_3.kept1_value : Lorg/nlogo/core/LogoList;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecolorize_setpatchvariable_1.keptinstr2 : Lorg/nlogo/prim/etc/_item;
@@ -1832,9 +1924,6 @@ procedure COLORIZE:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L4
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecolorize_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -1849,8 +1938,13 @@ procedure COLORIZE:[]{-TP-}:
           ATHROW
          L4
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L5
           RETURN
 [2]_asm_procedurecolorize_goto_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_4
@@ -1859,6 +1953,9 @@ procedure COLORIZE:[]{-TP-}:
           RETURN
 [3]_asm_procedurecolorize_setpatchvariable_5 "set" Object => void
       _constdouble:15.0 "red" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1872,9 +1969,6 @@ procedure COLORIZE:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecolorize_setpatchvariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1889,8 +1983,13 @@ procedure COLORIZE:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_procedurecolorize_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V

--- a/netlogo-headless/test/benchdumps/CA1D.txt
+++ b/netlogo-headless/test/benchdumps/CA1D.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure STARTUP:[]{OTPL}:
 [0]_asm_procedurestartup_setobservervariable_0 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -23,9 +26,6 @@ procedure STARTUP:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurestartup_setobservervariable_0 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -40,9 +40,16 @@ procedure STARTUP:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [1]_asm_procedurestartup_setobservervariable_1 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -57,9 +64,6 @@ procedure STARTUP:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurestartup_setobservervariable_1 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -74,9 +78,16 @@ procedure STARTUP:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedurestartup_setobservervariable_2 "set" Object => void
       _observervariable:RULE "rule" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -94,9 +105,6 @@ procedure STARTUP:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurestartup_setobservervariable_2 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -111,8 +119,13 @@ procedure STARTUP:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_procedurestartup_return_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -125,6 +138,9 @@ procedure STARTUP:[]{OTPL}:
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:4378.0 "4378" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 4378.0
          L1
@@ -146,16 +162,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -195,6 +211,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
       _mult "*" double,double => double
         _constdouble:10.0 "10" => double
         _worldheight "world-height" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 10.0
          L1
@@ -218,7 +241,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -245,6 +269,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -278,6 +303,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -299,9 +327,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -316,8 +341,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -332,6 +362,9 @@ procedure SETUP-GENERAL:[]{O---}:
 [1]_clearturtles "ct"
 [2]_asm_proceduresetupgeneral_setobservervariable_0 "set" Object => void
       _maxpycor "max-pycor" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -347,9 +380,6 @@ procedure SETUP-GENERAL:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupgeneral_setobservervariable_0 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -364,6 +394,10 @@ procedure SETUP-GENERAL:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_proceduresetupgeneral_call_1 "refresh-rules"
          L0
@@ -385,6 +419,9 @@ procedure SETUP-GENERAL:[]{O---}:
           RETURN
 [4]_asm_proceduresetupgeneral_setobservervariable_2 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -399,9 +436,6 @@ procedure SETUP-GENERAL:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupgeneral_setobservervariable_2 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -416,9 +450,16 @@ procedure SETUP-GENERAL:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [5]_asm_proceduresetupgeneral_setobservervariable_3 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -433,9 +474,6 @@ procedure SETUP-GENERAL:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupgeneral_setobservervariable_3 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -450,8 +488,13 @@ procedure SETUP-GENERAL:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [6]_asm_proceduresetupgeneral_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -483,6 +526,7 @@ procedure SINGLE-CELL:[]{O---}:
 [1]_asm_proceduresinglecell_ask_1 "ask" Object => void
       _patchrow "with"
         _asm_proceduresinglecell_observervariable_2 "row" => Object
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_proceduresinglecell_observervariable_2.world : Lorg/nlogo/agent/World;
@@ -491,6 +535,8 @@ procedure SINGLE-CELL:[]{O---}:
               INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  target
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresinglecell_ask_1.keptinstr2 : Lorg/nlogo/prim/_patchrow;
           ALOAD 1
@@ -498,18 +544,16 @@ procedure SINGLE-CELL:[]{O---}:
          L0
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L1
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L2
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresinglecell_ask_1.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -525,8 +569,8 @@ procedure SINGLE-CELL:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
-         FRAME FULL [org/nlogo/prim/_asm_proceduresinglecell_ask_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresinglecell_ask_1.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -543,18 +587,18 @@ procedure SINGLE-CELL:[]{O---}:
           ATHROW
          L2
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L4
          L1
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L5
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -571,7 +615,7 @@ procedure SINGLE-CELL:[]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -581,23 +625,12 @@ procedure SINGLE-CELL:[]{O---}:
          L6
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduresinglecell_ask_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_2
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
+          GOTO L4
          L5
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -611,11 +644,22 @@ procedure SINGLE-CELL:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L4
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          ICONST_2
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduresinglecell_ask_1 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [2]_asm_proceduresinglecell_setpatchvariable_3 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -629,9 +673,6 @@ procedure SINGLE-CELL:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresinglecell_setpatchvariable_3 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -646,9 +687,16 @@ procedure SINGLE-CELL:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_proceduresinglecell_setpatchvariable_4 "set" Object => void
       _observervariable:BACKGROUND "background" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -665,9 +713,6 @@ procedure SINGLE-CELL:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresinglecell_setpatchvariable_4 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -682,8 +727,13 @@ procedure SINGLE-CELL:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduresinglecell_done_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -693,12 +743,14 @@ procedure SINGLE-CELL:[]{O---}:
 [5]_asm_proceduresinglecell_ask_6 "ask" Object => void
       _patch "patch"
         _asm_proceduresinglecell_constdouble_7 "0" => Double
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_proceduresinglecell_constdouble_7.kept1_value : Ljava/lang/Double;
              L1
               ARETURN
         _asm_proceduresinglecell_observervariable_8 "row" => Object
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_proceduresinglecell_observervariable_8.world : Lorg/nlogo/agent/World;
@@ -707,6 +759,8 @@ procedure SINGLE-CELL:[]{O---}:
               INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  target
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresinglecell_ask_6.keptinstr2 : Lorg/nlogo/prim/etc/_patch;
           ALOAD 1
@@ -714,18 +768,16 @@ procedure SINGLE-CELL:[]{O---}:
          L0
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L1
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L2
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresinglecell_ask_6.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -741,8 +793,8 @@ procedure SINGLE-CELL:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
-         FRAME FULL [org/nlogo/prim/_asm_proceduresinglecell_ask_6 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresinglecell_ask_6.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -759,18 +811,18 @@ procedure SINGLE-CELL:[]{O---}:
           ATHROW
          L2
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L4
          L1
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L5
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -787,7 +839,7 @@ procedure SINGLE-CELL:[]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -797,23 +849,12 @@ procedure SINGLE-CELL:[]{O---}:
          L6
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduresinglecell_ask_6 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 6
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
+          GOTO L4
          L5
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -827,11 +868,22 @@ procedure SINGLE-CELL:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L4
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 6
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduresinglecell_ask_6 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [6]_asm_proceduresinglecell_setpatchvariable_9 "set" Object => void
       _observervariable:FOREGROUND "foreground" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -848,9 +900,6 @@ procedure SINGLE-CELL:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresinglecell_setpatchvariable_9 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -865,9 +914,16 @@ procedure SINGLE-CELL:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_proceduresinglecell_setpatchvariable_10 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -881,9 +937,6 @@ procedure SINGLE-CELL:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresinglecell_setpatchvariable_10 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -898,8 +951,13 @@ procedure SINGLE-CELL:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [8]_asm_proceduresinglecell_done_11 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -908,6 +966,7 @@ procedure SINGLE-CELL:[]{O---}:
           RETURN
 [9]_resetticks "reset-ticks"
 [10]_asm_proceduresinglecell_return_12 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -939,6 +998,7 @@ procedure SETUP-RANDOM:[]{O---}:
 [1]_asm_proceduresetuprandom_ask_1 "ask" Object => void
       _patchrow "with"
         _asm_proceduresetuprandom_observervariable_2 "row" => Object
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_proceduresetuprandom_observervariable_2.world : Lorg/nlogo/agent/World;
@@ -947,6 +1007,8 @@ procedure SETUP-RANDOM:[]{O---}:
               INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  target
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetuprandom_ask_1.keptinstr2 : Lorg/nlogo/prim/_patchrow;
           ALOAD 1
@@ -954,18 +1016,16 @@ procedure SETUP-RANDOM:[]{O---}:
          L0
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L1
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L2
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetuprandom_ask_1.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -981,8 +1041,8 @@ procedure SETUP-RANDOM:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetuprandom_ask_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetuprandom_ask_1.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -999,18 +1059,18 @@ procedure SETUP-RANDOM:[]{O---}:
           ATHROW
          L2
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L4
          L1
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L5
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -1027,7 +1087,7 @@ procedure SETUP-RANDOM:[]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -1037,23 +1097,12 @@ procedure SETUP-RANDOM:[]{O---}:
          L6
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetuprandom_ask_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_2
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
+          GOTO L4
          L5
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -1067,13 +1116,28 @@ procedure SETUP-RANDOM:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L4
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          ICONST_2
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetuprandom_ask_1 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [2]_asm_proceduresetuprandom_setpatchvariable_3 "set" Object => void
       _lessthan "<" double,Object => boolean
         _randomconst:100 "random" => double
         _observervariable:DENSITY "density" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -1092,11 +1156,9 @@ procedure SETUP-RANDOM:[]{O---}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L6
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -1107,15 +1169,14 @@ procedure SETUP-RANDOM:[]{O---}:
           ICONST_1
           GOTO L8
          L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetuprandom_setpatchvariable_3 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetuprandom_setpatchvariable_3 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L8
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L9
          L6
-         FRAME CHOP 1
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1144,14 +1205,16 @@ procedure SETUP-RANDOM:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetuprandom_setpatchvariable_3 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
-          IFEQ L10
-          GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
-          GOTO L11
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
          L10
+          IFEQ L11
+          GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
+          GOTO L12
+         L11
          FRAME SAME
           GETSTATIC java/lang/Boolean.FALSE : Ljava/lang/Boolean;
-         L11
+         L12
          FRAME SAME1 java/lang/Boolean
           ASTORE 2
          L0
@@ -1161,12 +1224,9 @@ procedure SETUP-RANDOM:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L12
+          GOTO L13
          L2
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetuprandom_setpatchvariable_3 org/nlogo/nvm/Context java/lang/Boolean T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/api/AgentException]
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetuprandom_setpatchvariable_3 org/nlogo/nvm/Context java/lang/Boolean T java/lang/Object I java/lang/Double] [org/nlogo/api/AgentException]
           ASTORE 3
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -1176,8 +1236,12 @@ procedure SETUP-RANDOM:[]{O---}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L12
+         L13
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L14
           RETURN
 [3]_asm_proceduresetuprandom_call_4 "color-patch"
          L0
@@ -1198,6 +1262,7 @@ procedure SETUP-RANDOM:[]{O---}:
          L1
           RETURN
 [4]_asm_proceduresetuprandom_done_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1206,6 +1271,7 @@ procedure SETUP-RANDOM:[]{O---}:
           RETURN
 [5]_resetticks "reset-ticks"
 [6]_asm_proceduresetuprandom_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1218,6 +1284,9 @@ procedure SETUP-RANDOM:[]{O---}:
 procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
 [0]_asm_proceduresetupcontinue_setprocedurevariable_0 "let" Object => void
       _constlist:[] "[]" => LogoList
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupcontinue_setprocedurevariable_0.kept2_value : Lorg/nlogo/core/LogoList;
@@ -1237,6 +1306,11 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
 [1]_asm_proceduresetupcontinue_if_1 "if" boolean => void
       _not "not" boolean => boolean
         _observervariable:GONE? "gone?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -1267,12 +1341,12 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L5
-          ICONST_0
+          IFNE L5
+          ICONST_1
           GOTO L6
          L5
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupcontinue_if_1 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L6
          FRAME SAME1 I
           ISTORE 2
@@ -1332,29 +1406,29 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
         _reporterlambda "[[p] -> [on?] of p]"
           _asm_proceduresetupcontinue_patchvariableof_4 "of" Object => Object
             _letvariable(Let(P)) "p" => Object
-                TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-                TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-               L4
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+               L3
                 ALOAD 1
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_proceduresetupcontinue_patchvariableof_4.kept2__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Context.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
-               L5
+               L4
                 ASTORE 2
-               L2
+               L0
                 ALOAD 2
+                INSTANCEOF org/nlogo/agent/Agent
+                IFEQ L5
+                ALOAD 2
+                CHECKCAST org/nlogo/agent/Agent
                 ASTORE 4
                 ALOAD 4
-                INSTANCEOF org/nlogo/agent/Agent
-                IFEQ L6
-                ALOAD 4
-                CHECKCAST org/nlogo/agent/Agent
-                ASTORE 5
-                ALOAD 5
                 INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
                 LDC -1
                 LCMP
-                IFNE L7
+                IFNE L6
                 NEW org/nlogo/nvm/RuntimePrimitiveException
                 DUP
                 ALOAD 1
@@ -1367,45 +1441,45 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
                 ANEWARRAY java/lang/Object
                 DUP
                 ICONST_0
-                ALOAD 5
+                ALOAD 4
                 INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
                 AASTORE
                 INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
                 INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
-               L7
-               FRAME FULL [org/nlogo/prim/_asm_proceduresetupcontinue_patchvariableof_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-                ALOAD 5
+               L6
+               FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+                ALOAD 4
                 ICONST_5
                 INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
-                ASTORE 6
-                GOTO L8
-               L6
-               FRAME CHOP 1
-                ALOAD 4
+                ASTORE 3
+                GOTO L7
+               L5
+               FRAME CHOP 2
+                ALOAD 2
                 INSTANCEOF org/nlogo/agent/AgentSet
-                IFEQ L0
-                ALOAD 4
+                IFEQ L8
+                ALOAD 2
                 CHECKCAST org/nlogo/agent/AgentSet
-                ASTORE 7
+                ASTORE 5
                 NEW org/nlogo/api/LogoListBuilder
                 DUP
                 INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-                ASTORE 8
-                ALOAD 7
+                ASTORE 6
+                ALOAD 5
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
                 GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
                 INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-                ASTORE 9
+                ASTORE 7
                L9
-               FRAME FULL [org/nlogo/prim/_asm_proceduresetupcontinue_patchvariableof_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-                ALOAD 9
+               FRAME FULL [org/nlogo/prim/_asm_proceduresetupcontinue_patchvariableof_4 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+                ALOAD 7
                 INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
                 IFEQ L10
-                ALOAD 8
-                ALOAD 9
+                ALOAD 6
+                ALOAD 7
                 INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
                 ICONST_5
                 INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
@@ -1413,16 +1487,12 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
                 GOTO L9
                L10
                FRAME SAME
-                ALOAD 8
-                INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-                ASTORE 6
-               L8
-               FRAME FULL [org/nlogo/prim/_asm_proceduresetupcontinue_patchvariableof_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
                 ALOAD 6
-               L3
-                GOTO L11
-               L0
-               FRAME CHOP 2
+                INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+                ASTORE 3
+                GOTO L7
+               L8
+               FRAME FULL [org/nlogo/prim/_asm_proceduresetupcontinue_patchvariableof_4 org/nlogo/nvm/Context java/lang/Object] []
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
                 ALOAD 1
@@ -1439,26 +1509,32 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
                 GETSTATIC org/nlogo/core/Syntax$.MODULE$ : Lorg/nlogo/core/Syntax$;
                 INVOKEVIRTUAL org/nlogo/core/Syntax$.PatchsetType ()I
                 IOR
-                ALOAD 4
+                ALOAD 2
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
+               L7
+               FRAME APPEND [java/lang/Object]
+                ALOAD 3
                L1
+                GOTO L11
+               L2
                FRAME FULL [org/nlogo/prim/_asm_proceduresetupcontinue_patchvariableof_4 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-                ASTORE 3
+                ASTORE 8
                 NEW org/nlogo/nvm/RuntimePrimitiveException
                 DUP
                 ALOAD 1
                 ALOAD 0
-                ALOAD 3
+                ALOAD 8
                 INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
                L11
-               FRAME FULL [org/nlogo/prim/_asm_proceduresetupcontinue_patchvariableof_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_proceduresetupcontinue_patchvariableof_4 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
                 ARETURN
         _asm_proceduresetupcontinue_sort_5 "sort" Object => Object
           _patchrow "with"
             _asm_proceduresetupcontinue_observervariable_6 "row" => Object
+                  // parameter final  context
                  L0
                   ALOAD 0
                   GETFIELD org/nlogo/prim/_asm_proceduresetupcontinue_observervariable_6.world : Lorg/nlogo/agent/World;
@@ -1588,6 +1664,8 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
              L2
              FRAME SAME1 org/nlogo/core/LogoList
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupcontinue_setprocedurevariable_3.keptinstr2 : Lorg/nlogo/prim/etc/_map;
           ALOAD 1
@@ -1626,6 +1704,7 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
 [5]_asm_proceduresetupcontinue_ask_8 "ask" Object => void
       _patchrow "with"
         _asm_proceduresetupcontinue_observervariable_9 "row" => Object
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_proceduresetupcontinue_observervariable_9.world : Lorg/nlogo/agent/World;
@@ -1634,6 +1713,8 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
               INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  target
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupcontinue_ask_8.keptinstr2 : Lorg/nlogo/prim/_patchrow;
           ALOAD 1
@@ -1641,18 +1722,16 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
          L0
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L1
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L2
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupcontinue_ask_8.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -1668,8 +1747,8 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetupcontinue_ask_8 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupcontinue_ask_8.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -1686,18 +1765,18 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
           ATHROW
          L2
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L4
          L1
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L5
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -1714,7 +1793,7 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -1724,23 +1803,12 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
          L6
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetupcontinue_ask_8 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 6
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
+          GOTO L4
          L5
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -1754,14 +1822,27 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L4
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 6
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetupcontinue_ask_8 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [6]_asm_proceduresetupcontinue_setpatchvariable_10 "set" Object => void
       _item "item"
         _asm_proceduresetupcontinue_plus_11 "+" double,double => double
           _patchvariabledouble:PXCOR "pxcor" => double
           _maxpxcor "max-pxcor" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d1
+              // parameter final  d2
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -1771,10 +1852,8 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
               IFEQ L1
               ALOAD 3
               CHECKCAST org/nlogo/agent/Turtle
-              ASTORE 4
-              ALOAD 4
               INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-              ASTORE 5
+              ASTORE 2
               GOTO L2
              L1
              FRAME APPEND [T org/nlogo/agent/Agent]
@@ -1783,26 +1862,21 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
               IFEQ L3
               ALOAD 3
               CHECKCAST org/nlogo/agent/Patch
-              ASTORE 6
-              ALOAD 6
-              ASTORE 5
-             L2
-             FRAME APPEND [T org/nlogo/agent/Patch]
-              ALOAD 5
               ASTORE 2
-              ALOAD 2
-              ICONST_0
-              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-              GOTO L4
+              GOTO L2
              L3
-             FRAME CHOP 2
+             FRAME SAME
               NEW scala/MatchError
               DUP
               ALOAD 3
               INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
               ATHROW
+             L2
+             FRAME FULL [org/nlogo/prim/_asm_proceduresetupcontinue_plus_11 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+              ALOAD 2
+              ICONST_0
+              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
              L4
-             FRAME FULL [org/nlogo/prim/_asm_proceduresetupcontinue_plus_11 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] [D]
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_proceduresetupcontinue_plus_11.world : Lorg/nlogo/agent/World;
               INVOKEVIRTUAL org/nlogo/agent/World.maxPxcor ()I
@@ -1821,6 +1895,7 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
               INVOKESPECIAL java/lang/Double.<init> (D)V
               ARETURN
         _asm_proceduresetupcontinue_procedurevariable_12 "on?-list" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -1829,6 +1904,8 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
               AALOAD
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupcontinue_setpatchvariable_10.keptinstr2 : Lorg/nlogo/prim/etc/_item;
@@ -1843,9 +1920,6 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L4
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupcontinue_setpatchvariable_10 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -1860,6 +1934,10 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
           ATHROW
          L4
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L5
           RETURN
 [7]_asm_proceduresetupcontinue_call_13 "color-patch"
          L0
@@ -1880,6 +1958,7 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
          L1
           RETURN
 [8]_asm_proceduresetupcontinue_done_14 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1888,6 +1967,9 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
           RETURN
 [9]_asm_proceduresetupcontinue_setobservervariable_15 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1902,9 +1984,6 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupcontinue_setobservervariable_15 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -1919,8 +1998,13 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [10]_asm_proceduresetupcontinue_return_16 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1933,6 +2017,9 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
 procedure GO:[]{O---}:
 [0]_asm_procedurego_if_0 "if" boolean => void
       _observervariable:RULES-SHOWN? "rules-shown?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -2017,6 +2104,13 @@ procedure GO:[]{O---}:
       _equal "=" Object,double => boolean
         _observervariable:ROW "row" => Object
         _minpycor "min-pycor" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_if_2.world : Lorg/nlogo/agent/World;
@@ -2032,11 +2126,9 @@ procedure GO:[]{O---}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -2047,19 +2139,19 @@ procedure GO:[]{O---}:
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_2 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_2 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L6
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L7
           ISTORE 2
           ALOAD 1
@@ -2068,15 +2160,18 @@ procedure GO:[]{O---}:
           ICONST_3
           GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_2 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_2 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 8
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_2 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_2 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L10
           RETURN
 [3]_asm_procedurego_ifelse_3 "ifelse" boolean => void
       _observervariable:AUTO-CONTINUE? "auto-continue?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -2139,6 +2234,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [6]_asm_procedurego_goto_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 8
@@ -2186,6 +2282,7 @@ procedure GO:[]{O---}:
 [8]_asm_procedurego_ask_7 "ask" Object => void
       _patchrow "with"
         _asm_procedurego_observervariable_8 "row" => Object
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurego_observervariable_8.world : Lorg/nlogo/agent/World;
@@ -2194,6 +2291,8 @@ procedure GO:[]{O---}:
               INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  target
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_7.keptinstr2 : Lorg/nlogo/prim/_patchrow;
           ALOAD 1
@@ -2201,18 +2300,16 @@ procedure GO:[]{O---}:
          L0
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L1
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L2
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_7.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -2228,8 +2325,8 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_7.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -2246,18 +2343,18 @@ procedure GO:[]{O---}:
           ATHROW
          L2
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L4
          L1
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L5
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -2274,7 +2371,7 @@ procedure GO:[]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -2284,23 +2381,12 @@ procedure GO:[]{O---}:
          L6
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 9
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 11
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
+          GOTO L4
          L5
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -2314,8 +2400,16 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L4
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 9
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 11
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_7 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [9]_asm_procedurego_call_9 "do-rule"
          L0
@@ -2336,6 +2430,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [10]_asm_procedurego_done_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2346,6 +2441,13 @@ procedure GO:[]{O---}:
       _minus "-" double,double => double
         _observervariable:ROW "row" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -2397,9 +2499,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 12
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L10
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setobservervariable_11 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -2414,10 +2513,15 @@ procedure GO:[]{O---}:
           ATHROW
          L10
          FRAME SAME
+          ALOAD 1
+          BIPUSH 12
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [12]_asm_procedurego_ask_12 "ask" Object => void
       _patchrow "with"
         _asm_procedurego_observervariable_13 "row" => Object
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurego_observervariable_13.world : Lorg/nlogo/agent/World;
@@ -2426,6 +2530,8 @@ procedure GO:[]{O---}:
               INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  target
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_12.keptinstr2 : Lorg/nlogo/prim/_patchrow;
           ALOAD 1
@@ -2433,18 +2539,16 @@ procedure GO:[]{O---}:
          L0
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L1
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L2
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_12.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -2460,8 +2564,8 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_12 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_12.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -2478,18 +2582,18 @@ procedure GO:[]{O---}:
           ATHROW
          L2
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L4
          L1
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L5
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -2506,7 +2610,7 @@ procedure GO:[]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -2516,23 +2620,12 @@ procedure GO:[]{O---}:
          L6
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_12 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 13
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 15
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
+          GOTO L4
          L5
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -2546,8 +2639,16 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L4
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 13
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 15
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_12 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [13]_asm_procedurego_call_14 "color-patch"
          L0
@@ -2568,6 +2669,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [14]_asm_procedurego_done_15 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2576,6 +2678,9 @@ procedure GO:[]{O---}:
           RETURN
 [15]_asm_procedurego_setobservervariable_16 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2590,9 +2695,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 16
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setobservervariable_16 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -2607,9 +2709,14 @@ procedure GO:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 16
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [16]_tick "tick"
 [17]_asm_procedurego_return_17 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2623,74 +2730,70 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
 [0]_asm_proceduredorule_setprocedurevariable_0 "let" Object => void
       _patchvariableof:ON? "of" Object => Object
         _patchwest "patch-at" => Object
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-         L4
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+         L3
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.topology ()Lorg/nlogo/agent/Topology;
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-          ASTORE 3
-          ALOAD 3
-          INSTANCEOF org/nlogo/agent/Patch
-          IFEQ L5
-          ALOAD 3
-          CHECKCAST org/nlogo/agent/Patch
           ASTORE 4
           ALOAD 4
-          ASTORE 5
-          GOTO L6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0 org/nlogo/nvm/Context T org/nlogo/agent/Agent] [org/nlogo/agent/Topology]
-          ALOAD 3
-          INSTANCEOF org/nlogo/agent/Turtle
-          IFEQ L7
-          ALOAD 3
-          CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 6
-          ALOAD 6
-          INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
-         L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0 org/nlogo/nvm/Context T org/nlogo/agent/Agent T org/nlogo/agent/Patch] [org/nlogo/agent/Topology]
-          ALOAD 5
-          INVOKEVIRTUAL org/nlogo/agent/Topology.getPW (Lorg/nlogo/agent/Patch;)Lorg/nlogo/agent/Patch;
+          INSTANCEOF org/nlogo/agent/Patch
+          IFEQ L4
+          ALOAD 4
+          CHECKCAST org/nlogo/agent/Patch
           ASTORE 2
-          ALOAD 2
-          IFNONNULL L8
-          GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
-          GOTO L9
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] []
-          ALOAD 2
-         L9
-         FRAME SAME1 java/lang/Object
-          GOTO L10
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0 org/nlogo/nvm/Context T org/nlogo/agent/Agent] [org/nlogo/agent/Topology]
+          GOTO L5
+         L4
+         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0 org/nlogo/nvm/Context T T org/nlogo/agent/Agent] [org/nlogo/agent/Topology]
+          ALOAD 4
+          INSTANCEOF org/nlogo/agent/Turtle
+          IFEQ L6
+          ALOAD 4
+          CHECKCAST org/nlogo/agent/Turtle
+          INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
+          ASTORE 2
+          GOTO L5
+         L6
+         FRAME SAME1 org/nlogo/agent/Topology
           NEW scala/MatchError
           DUP
-          ALOAD 3
+          ALOAD 4
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
-         L10
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] [java/lang/Object]
-          ASTORE 2
-         L2
+         L5
+         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0 org/nlogo/nvm/Context org/nlogo/agent/Patch T org/nlogo/agent/Agent] [org/nlogo/agent/Topology]
           ALOAD 2
+          INVOKEVIRTUAL org/nlogo/agent/Topology.getPW (Lorg/nlogo/agent/Patch;)Lorg/nlogo/agent/Patch;
+          ASTORE 3
+          ALOAD 3
+          IFNONNULL L7
+          GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
+          GOTO L8
+         L7
+         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 3
+         L8
+         FRAME SAME1 java/lang/Object
+          ASTORE 2
+         L0
+          ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L9
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L11
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L12
+          IFNE L10
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2703,62 +2806,58 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L12
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Agent] []
-          ALOAD 5
+         L10
+         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 4
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L13
-         L11
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch] []
-          ALOAD 4
+          ASTORE 3
+          GOTO L11
+         L9
+         FRAME SAME
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L0
-          ALOAD 4
+          IFEQ L12
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
-         L14
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+          ASTORE 7
+         L13
+         FRAME APPEND [org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator]
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-          IFEQ L15
-          ALOAD 8
-          ALOAD 9
+          IFEQ L14
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
           INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
-          GOTO L14
-         L15
+          GOTO L13
+         L14
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L13
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Agent java/lang/Object] []
           ALOAD 6
-         L3
-          GOTO L16
-         L0
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch] []
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L11
+         L12
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -2775,22 +2874,27 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
           GETSTATIC org/nlogo/core/Syntax$.MODULE$ : Lorg/nlogo/core/Syntax$;
           INVOKEVIRTUAL org/nlogo/core/Syntax$.PatchsetType ()I
           IOR
-          ALOAD 4
+          ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L11
+         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object org/nlogo/agent/Agent] []
+          ALOAD 3
          L1
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent T org/nlogo/agent/Agent] [org/nlogo/api/AgentException]
-          ASTORE 3
+          GOTO L15
+         L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L16
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Agent java/lang/Object] [java/lang/Object]
+         L15
+         FRAME SAME1 java/lang/Object
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -2801,79 +2905,75 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
           ALOAD 1
           ICONST_1
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L17
+         L16
           RETURN
 [1]_asm_proceduredorule_setprocedurevariable_1 "let" Object => void
       _patchvariableof:ON? "of" Object => Object
         _patcheast "patch-at" => Object
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-         L4
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+         L3
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.topology ()Lorg/nlogo/agent/Topology;
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-          ASTORE 3
-          ALOAD 3
-          INSTANCEOF org/nlogo/agent/Patch
-          IFEQ L5
-          ALOAD 3
-          CHECKCAST org/nlogo/agent/Patch
           ASTORE 4
           ALOAD 4
-          ASTORE 5
-          GOTO L6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent] [org/nlogo/agent/Topology]
-          ALOAD 3
-          INSTANCEOF org/nlogo/agent/Turtle
-          IFEQ L7
-          ALOAD 3
-          CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 6
-          ALOAD 6
-          INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
-         L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent T org/nlogo/agent/Patch] [org/nlogo/agent/Topology]
-          ALOAD 5
-          INVOKEVIRTUAL org/nlogo/agent/Topology.getPE (Lorg/nlogo/agent/Patch;)Lorg/nlogo/agent/Patch;
+          INSTANCEOF org/nlogo/agent/Patch
+          IFEQ L4
+          ALOAD 4
+          CHECKCAST org/nlogo/agent/Patch
           ASTORE 2
-          ALOAD 2
-          IFNONNULL L8
-          GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
-          GOTO L9
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] []
-          ALOAD 2
-         L9
-         FRAME SAME1 java/lang/Object
-          GOTO L10
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent] [org/nlogo/agent/Topology]
+          GOTO L5
+         L4
+         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1 org/nlogo/nvm/Context T T org/nlogo/agent/Agent] [org/nlogo/agent/Topology]
+          ALOAD 4
+          INSTANCEOF org/nlogo/agent/Turtle
+          IFEQ L6
+          ALOAD 4
+          CHECKCAST org/nlogo/agent/Turtle
+          INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
+          ASTORE 2
+          GOTO L5
+         L6
+         FRAME SAME1 org/nlogo/agent/Topology
           NEW scala/MatchError
           DUP
-          ALOAD 3
+          ALOAD 4
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
-         L10
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] [java/lang/Object]
-          ASTORE 2
-         L2
+         L5
+         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1 org/nlogo/nvm/Context org/nlogo/agent/Patch T org/nlogo/agent/Agent] [org/nlogo/agent/Topology]
           ALOAD 2
+          INVOKEVIRTUAL org/nlogo/agent/Topology.getPE (Lorg/nlogo/agent/Patch;)Lorg/nlogo/agent/Patch;
+          ASTORE 3
+          ALOAD 3
+          IFNONNULL L7
+          GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
+          GOTO L8
+         L7
+         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 3
+         L8
+         FRAME SAME1 java/lang/Object
+          ASTORE 2
+         L0
+          ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L9
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L11
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L12
+          IFNE L10
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2886,62 +2986,58 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L12
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Agent] []
-          ALOAD 5
+         L10
+         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 4
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L13
-         L11
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch] []
-          ALOAD 4
+          ASTORE 3
+          GOTO L11
+         L9
+         FRAME SAME
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L0
-          ALOAD 4
+          IFEQ L12
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
-         L14
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+          ASTORE 7
+         L13
+         FRAME APPEND [org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator]
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-          IFEQ L15
-          ALOAD 8
-          ALOAD 9
+          IFEQ L14
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
           INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
-          GOTO L14
-         L15
+          GOTO L13
+         L14
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L13
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Agent java/lang/Object] []
           ALOAD 6
-         L3
-          GOTO L16
-         L0
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch] []
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L11
+         L12
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -2958,22 +3054,27 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
           GETSTATIC org/nlogo/core/Syntax$.MODULE$ : Lorg/nlogo/core/Syntax$;
           INVOKEVIRTUAL org/nlogo/core/Syntax$.PatchsetType ()I
           IOR
-          ALOAD 4
+          ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L11
+         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object java/lang/Object org/nlogo/agent/Agent] []
+          ALOAD 3
          L1
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent T org/nlogo/agent/Agent] [org/nlogo/api/AgentException]
-          ASTORE 3
+          GOTO L15
+         L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L16
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_1 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Agent java/lang/Object] [java/lang/Object]
+         L15
+         FRAME SAME1 java/lang/Object
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -2984,7 +3085,7 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
           ALOAD 1
           ICONST_2
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L17
+         L16
           RETURN
 [2]_asm_proceduredorule_setprocedurevariable_2 "let" Object => void
       _or "or"
@@ -3062,6 +3163,64 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
               _patchvariable:ON? "on?" => Object
           _not "not" boolean => boolean
             _procedurevariable:RIGHT-ON? "right-on?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L6 org/nlogo/api/AgentException
@@ -3383,12 +3542,12 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L122
-          ICONST_0
+          IFNE L122
+          ICONST_1
           GOTO L123
          L122
          FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_2 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L123
          FRAME SAME1 I
           GOTO L124
@@ -3508,12 +3667,12 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L138
-          ICONST_0
+          IFNE L138
+          ICONST_1
           GOTO L139
          L138
          FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_2 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L139
          FRAME SAME1 I
           GOTO L140
@@ -3667,12 +3826,12 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L159
-          ICONST_0
+          IFNE L159
+          ICONST_1
           GOTO L160
          L159
          FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_2 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L160
          FRAME SAME1 I
           GOTO L161
@@ -3711,12 +3870,12 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L166
-          ICONST_0
+          IFNE L166
+          ICONST_1
           GOTO L167
          L166
          FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_2 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L167
          FRAME SAME1 I
           GOTO L168
@@ -3789,12 +3948,12 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L178
-          ICONST_0
+          IFNE L178
+          ICONST_1
           GOTO L179
          L178
          FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_2 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L179
          FRAME SAME1 I
           GOTO L180
@@ -3948,12 +4107,12 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L199
-          ICONST_0
+          IFNE L199
+          ICONST_1
           GOTO L200
          L199
          FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_2 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L200
          FRAME SAME1 I
           GOTO L201
@@ -4039,12 +4198,12 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L210
-          ICONST_0
+          IFNE L210
+          ICONST_1
           GOTO L211
          L210
          FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_2 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L211
          FRAME SAME1 I
           GOTO L212
@@ -4117,12 +4276,12 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L222
-          ICONST_0
+          IFNE L222
+          ICONST_1
           GOTO L223
          L222
          FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_2 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L223
          FRAME SAME1 I
           GOTO L224
@@ -4174,12 +4333,12 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L228
-          ICONST_0
+          IFNE L228
+          ICONST_1
           GOTO L229
          L228
          FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_2 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L229
          FRAME SAME1 I
           GOTO L230
@@ -4286,12 +4445,12 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L245
-          ICONST_0
+          IFNE L245
+          ICONST_1
           GOTO L246
          L245
          FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_2 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L246
          FRAME SAME1 I
           GOTO L247
@@ -4343,12 +4502,12 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L251
-          ICONST_0
+          IFNE L251
+          ICONST_1
           GOTO L252
          L251
          FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_2 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L252
          FRAME SAME1 I
           GOTO L253
@@ -4387,12 +4546,12 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L258
-          ICONST_0
+          IFNE L258
+          ICONST_1
           GOTO L259
          L258
          FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setprocedurevariable_2 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L259
          FRAME SAME1 I
           GOTO L260
@@ -4429,75 +4588,70 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
           RETURN
 [3]_asm_proceduredorule_ask_3 "ask" Object => void
       _patchsouth "patch-at" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduredorule_ask_3.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.topology ()Lorg/nlogo/agent/Topology;
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-          ASTORE 3
-          ALOAD 3
-          INSTANCEOF org/nlogo/agent/Patch
-          IFEQ L1
-          ALOAD 3
-          CHECKCAST org/nlogo/agent/Patch
           ASTORE 4
           ALOAD 4
-          ASTORE 5
+          INSTANCEOF org/nlogo/agent/Patch
+          IFEQ L1
+          ALOAD 4
+          CHECKCAST org/nlogo/agent/Patch
+          ASTORE 2
           GOTO L2
          L1
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_ask_3 org/nlogo/nvm/Context T org/nlogo/agent/Agent] [org/nlogo/agent/Topology]
-          ALOAD 3
+         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_ask_3 org/nlogo/nvm/Context T T org/nlogo/agent/Agent] [org/nlogo/agent/Topology]
+          ALOAD 4
           INSTANCEOF org/nlogo/agent/Turtle
           IFEQ L3
-          ALOAD 3
+          ALOAD 4
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
-         L2
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_ask_3 org/nlogo/nvm/Context T org/nlogo/agent/Agent T org/nlogo/agent/Patch] [org/nlogo/agent/Topology]
-          ALOAD 5
-          INVOKEVIRTUAL org/nlogo/agent/Topology.getPS (Lorg/nlogo/agent/Patch;)Lorg/nlogo/agent/Patch;
           ASTORE 2
+          GOTO L2
+         L3
+         FRAME SAME1 org/nlogo/agent/Topology
+          NEW scala/MatchError
+          DUP
+          ALOAD 4
+          INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
+          ATHROW
+         L2
+         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_ask_3 org/nlogo/nvm/Context org/nlogo/agent/Patch T org/nlogo/agent/Agent] [org/nlogo/agent/Topology]
           ALOAD 2
+          INVOKEVIRTUAL org/nlogo/agent/Topology.getPS (Lorg/nlogo/agent/Patch;)Lorg/nlogo/agent/Patch;
+          ASTORE 3
+          ALOAD 3
           IFNONNULL L4
           GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_ask_3 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] []
-          ALOAD 2
+         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_ask_3 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 3
          L5
          FRAME SAME1 java/lang/Object
-          GOTO L6
-         L3
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_ask_3 org/nlogo/nvm/Context T org/nlogo/agent/Agent] [org/nlogo/agent/Topology]
-          NEW scala/MatchError
-          DUP
-          ALOAD 3
-          INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
-          ATHROW
-         L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_ask_3 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] [java/lang/Object]
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L7
-          ALOAD 4
+          IFEQ L6
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
-          IFNE L8
-          ALOAD 5
+          IFNE L7
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduredorule_ask_3.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-          IF_ACMPNE L9
+          IF_ACMPNE L8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4508,13 +4662,13 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_ask_3 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         L8
+         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_ask_3 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Patch org/nlogo/agent/AgentSet] []
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduredorule_ask_3.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
-          IF_ACMPNE L8
+          IF_ACMPNE L7
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4525,24 +4679,24 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L8
-         FRAME SAME
-          ALOAD 5
-          ASTORE 6
-          GOTO L10
          L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_ask_3 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch] []
+         FRAME SAME
           ALOAD 4
+          ASTORE 3
+          GOTO L9
+         L6
+         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_ask_3 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L11
-          ALOAD 4
+          IFEQ L10
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L12
+          IFNE L11
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4555,33 +4709,22 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L12
-         FRAME APPEND [T org/nlogo/agent/Agent]
-          GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
-          INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L10
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_ask_3 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent java/lang/Object java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 6
-          ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_4
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L13
          L11
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_ask_3 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch] []
+         FRAME APPEND [org/nlogo/agent/Agent]
+          GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
+          ALOAD 5
+          INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
+          ASTORE 3
+          GOTO L9
+         L10
+         FRAME CHOP 1
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -4595,11 +4738,22 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
-         L13
-         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_ask_3 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object java/lang/Object org/nlogo/agent/AgentSet] []
+         L9
+         FRAME FULL [org/nlogo/prim/_asm_proceduredorule_ask_3 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object] []
+          ALOAD 1
+          ALOAD 3
+          ICONST_4
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [4]_asm_proceduredorule_setpatchvariable_4 "set" Object => void
       _procedurevariable:NEW-VALUE "new-value" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -4616,9 +4770,6 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduredorule_setpatchvariable_4 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -4633,8 +4784,13 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [5]_asm_proceduredorule_done_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -4642,6 +4798,7 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
          L1
           RETURN
 [6]_asm_proceduredorule_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -4654,6 +4811,9 @@ procedure DO-RULE:[LEFT-ON? RIGHT-ON? NEW-VALUE]{-TP-}:
 procedure COLOR-PATCH:[]{-TP-}:
 [0]_asm_procedurecolorpatch_ifelse_0 "ifelse" boolean => void
       _patchvariable:ON? "on?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -4712,6 +4872,9 @@ procedure COLOR-PATCH:[]{-TP-}:
           RETURN
 [1]_asm_procedurecolorpatch_setpatchvariable_1 "set" Object => void
       _observervariable:FOREGROUND "foreground" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -4728,9 +4891,6 @@ procedure COLOR-PATCH:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecolorpatch_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -4745,8 +4905,13 @@ procedure COLOR-PATCH:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedurecolorpatch_goto_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_4
@@ -4755,6 +4920,9 @@ procedure COLOR-PATCH:[]{-TP-}:
           RETURN
 [3]_asm_procedurecolorpatch_setpatchvariable_3 "set" Object => void
       _observervariable:BACKGROUND "background" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -4771,9 +4939,6 @@ procedure COLOR-PATCH:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecolorpatch_setpatchvariable_3 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -4788,8 +4953,13 @@ procedure COLOR-PATCH:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_procedurecolorpatch_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -4804,6 +4974,13 @@ reporter procedure BINDIGIT:[NUMBER POWER-OF-TWO]{OTPL}:
       _equal "=" Object,double => boolean
         _procedurevariable:POWER-OF-TWO "power-of-two" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -4816,11 +4993,9 @@ reporter procedure BINDIGIT:[NUMBER POWER-OF-TWO]{OTPL}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -4831,19 +5006,19 @@ reporter procedure BINDIGIT:[NUMBER POWER-OF-TWO]{OTPL}:
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurebindigit_ifelse_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurebindigit_ifelse_0 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L6
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L7
           ISTORE 2
           ALOAD 1
@@ -4852,10 +5027,10 @@ reporter procedure BINDIGIT:[NUMBER POWER-OF-TWO]{OTPL}:
           ICONST_1
           GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurebindigit_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebindigit_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           ICONST_3
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurebindigit_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebindigit_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L10
           RETURN
@@ -4864,6 +5039,10 @@ reporter procedure BINDIGIT:[NUMBER POWER-OF-TWO]{OTPL}:
         _floor "floor" double => double
           _procedurevariable:NUMBER "number" => Object
         _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -4924,7 +5103,8 @@ reporter procedure BINDIGIT:[NUMBER POWER-OF-TWO]{OTPL}:
           DLOAD 4
           DMUL
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebindigit_report_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebindigit_report_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           DSTORE 2
           NEW java/lang/Double
@@ -4998,6 +5178,7 @@ reporter procedure BINDIGIT:[NUMBER POWER-OF-TWO]{OTPL}:
          FRAME SAME
           RETURN
 [2]_asm_procedurebindigit_goto_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_4
@@ -5013,6 +5194,15 @@ reporter procedure BINDIGIT:[NUMBER POWER-OF-TWO]{OTPL}:
         _minus "-" double,double => double
           _procedurevariable:POWER-OF-TWO "power-of-two" => Object
           _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -5212,6 +5402,7 @@ reporter procedure BINDIGIT:[NUMBER POWER-OF-TWO]{OTPL}:
          FRAME SAME
           RETURN
 [4]_asm_procedurebindigit_returnreport_4 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -5232,6 +5423,13 @@ procedure REFRESH-RULES:[]{OTPL}:
       _equal "=" Object,Object => boolean
         _observervariable:RULE "rule" => Object
         _observervariable:OLD-RULE "old-rule" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerefreshrules_ifelse_0.world : Lorg/nlogo/agent/World;
@@ -5270,6 +5468,12 @@ procedure REFRESH-RULES:[]{OTPL}:
       _notequal "!=" Object,Object => boolean
         _observervariable:RULE "rule" => Object
         _callreport:CALCULATE-RULE "calculate-rule"
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerefreshrules_if_1.world : Lorg/nlogo/agent/World;
@@ -5305,12 +5509,12 @@ procedure REFRESH-RULES:[]{OTPL}:
           ALOAD 2
           ALOAD 3
           INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-          IFEQ L3
-          ICONST_0
+          IFNE L3
+          ICONST_1
           GOTO L4
          L3
          FRAME APPEND [java/lang/Object java/lang/Object]
-          ICONST_1
+          ICONST_0
          L4
          FRAME SAME1 I
           ISTORE 2
@@ -5329,6 +5533,8 @@ procedure REFRESH-RULES:[]{OTPL}:
           RETURN
 [2]_asm_procedurerefreshrules_setobservervariable_2 "set" Object => void
       _callreport:CALCULATE-RULE "calculate-rule"
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           NEW org/nlogo/nvm/Activation
@@ -5362,9 +5568,6 @@ procedure REFRESH-RULES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerefreshrules_setobservervariable_2 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -5379,8 +5582,13 @@ procedure REFRESH-RULES:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_procedurerefreshrules_goto_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_5
@@ -5407,6 +5615,9 @@ procedure REFRESH-RULES:[]{OTPL}:
           RETURN
 [5]_asm_procedurerefreshrules_setobservervariable_5 "set" Object => void
       _observervariable:RULE "rule" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -5424,9 +5635,6 @@ procedure REFRESH-RULES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerefreshrules_setobservervariable_5 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -5441,8 +5649,13 @@ procedure REFRESH-RULES:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [6]_asm_procedurerefreshrules_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -5459,6 +5672,14 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           _observervariable:RULE "rule" => Object
           _constdouble:0.0 "0" => Double
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           NEW org/nlogo/nvm/Activation
@@ -5507,11 +5728,9 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L10
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -5522,19 +5741,19 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ICONST_1
           GOTO L12
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_0 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L12
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L13
          L10
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L13
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L14
           IFEQ L15
           GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -5553,12 +5772,9 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L17
          L2
-         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_0 org/nlogo/nvm/Context java/lang/Boolean D java/lang/Object T I] [org/nlogo/api/AgentException]
+         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_0 org/nlogo/nvm/Context java/lang/Boolean D I] [org/nlogo/api/AgentException]
           ASTORE 3
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -5570,6 +5786,10 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ATHROW
          L17
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [1]_asm_procedureextrapolateswitches_setobservervariable_1 "set" Object => void
       _equal "=" Object,double => boolean
@@ -5577,6 +5797,14 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           _observervariable:RULE "rule" => Object
           _constdouble:1.0 "1" => Double
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           NEW org/nlogo/nvm/Activation
@@ -5625,11 +5853,9 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L10
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -5640,19 +5866,19 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ICONST_1
           GOTO L12
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_1 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_1 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L12
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L13
          L10
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L13
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L14
           IFEQ L15
           GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -5671,12 +5897,9 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L17
          L2
-         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_1 org/nlogo/nvm/Context java/lang/Boolean D java/lang/Object T I] [org/nlogo/api/AgentException]
+         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_1 org/nlogo/nvm/Context java/lang/Boolean D I] [org/nlogo/api/AgentException]
           ASTORE 3
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -5688,6 +5911,10 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ATHROW
          L17
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [2]_asm_procedureextrapolateswitches_setobservervariable_2 "set" Object => void
       _equal "=" Object,double => boolean
@@ -5695,6 +5922,14 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           _observervariable:RULE "rule" => Object
           _constdouble:2.0 "2" => Double
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           NEW org/nlogo/nvm/Activation
@@ -5743,11 +5978,9 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L10
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -5758,19 +5991,19 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ICONST_1
           GOTO L12
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_2 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_2 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L12
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L13
          L10
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L13
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L14
           IFEQ L15
           GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -5789,12 +6022,9 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L17
          L2
-         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_2 org/nlogo/nvm/Context java/lang/Boolean D java/lang/Object T I] [org/nlogo/api/AgentException]
+         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_2 org/nlogo/nvm/Context java/lang/Boolean D I] [org/nlogo/api/AgentException]
           ASTORE 3
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -5806,6 +6036,10 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ATHROW
          L17
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [3]_asm_procedureextrapolateswitches_setobservervariable_3 "set" Object => void
       _equal "=" Object,double => boolean
@@ -5813,6 +6047,14 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           _observervariable:RULE "rule" => Object
           _constdouble:3.0 "3" => Double
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           NEW org/nlogo/nvm/Activation
@@ -5861,11 +6103,9 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L10
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -5876,19 +6116,19 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ICONST_1
           GOTO L12
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_3 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_3 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L12
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L13
          L10
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L13
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L14
           IFEQ L15
           GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -5907,12 +6147,9 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L17
          L2
-         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_3 org/nlogo/nvm/Context java/lang/Boolean D java/lang/Object T I] [org/nlogo/api/AgentException]
+         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_3 org/nlogo/nvm/Context java/lang/Boolean D I] [org/nlogo/api/AgentException]
           ASTORE 3
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -5924,6 +6161,10 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ATHROW
          L17
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [4]_asm_procedureextrapolateswitches_setobservervariable_4 "set" Object => void
       _equal "=" Object,double => boolean
@@ -5931,6 +6172,14 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           _observervariable:RULE "rule" => Object
           _constdouble:4.0 "4" => Double
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           NEW org/nlogo/nvm/Activation
@@ -5979,11 +6228,9 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L10
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -5994,19 +6241,19 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ICONST_1
           GOTO L12
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_4 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_4 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L12
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L13
          L10
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L13
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L14
           IFEQ L15
           GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -6025,12 +6272,9 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L17
          L2
-         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_4 org/nlogo/nvm/Context java/lang/Boolean D java/lang/Object T I] [org/nlogo/api/AgentException]
+         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_4 org/nlogo/nvm/Context java/lang/Boolean D I] [org/nlogo/api/AgentException]
           ASTORE 3
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -6042,6 +6286,10 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ATHROW
          L17
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [5]_asm_procedureextrapolateswitches_setobservervariable_5 "set" Object => void
       _equal "=" Object,double => boolean
@@ -6049,6 +6297,14 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           _observervariable:RULE "rule" => Object
           _constdouble:5.0 "5" => Double
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           NEW org/nlogo/nvm/Activation
@@ -6097,11 +6353,9 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L10
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -6112,19 +6366,19 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ICONST_1
           GOTO L12
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_5 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_5 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L12
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L13
          L10
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L13
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L14
           IFEQ L15
           GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -6143,12 +6397,9 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L17
          L2
-         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_5 org/nlogo/nvm/Context java/lang/Boolean D java/lang/Object T I] [org/nlogo/api/AgentException]
+         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_5 org/nlogo/nvm/Context java/lang/Boolean D I] [org/nlogo/api/AgentException]
           ASTORE 3
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -6160,6 +6411,10 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ATHROW
          L17
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [6]_asm_procedureextrapolateswitches_setobservervariable_6 "set" Object => void
       _equal "=" Object,double => boolean
@@ -6167,6 +6422,14 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           _observervariable:RULE "rule" => Object
           _constdouble:6.0 "6" => Double
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           NEW org/nlogo/nvm/Activation
@@ -6215,11 +6478,9 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L10
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -6230,19 +6491,19 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ICONST_1
           GOTO L12
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_6 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_6 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L12
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L13
          L10
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L13
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L14
           IFEQ L15
           GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -6261,12 +6522,9 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L17
          L2
-         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_6 org/nlogo/nvm/Context java/lang/Boolean D java/lang/Object T I] [org/nlogo/api/AgentException]
+         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_6 org/nlogo/nvm/Context java/lang/Boolean D I] [org/nlogo/api/AgentException]
           ASTORE 3
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -6278,6 +6536,10 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ATHROW
          L17
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [7]_asm_procedureextrapolateswitches_setobservervariable_7 "set" Object => void
       _equal "=" Object,double => boolean
@@ -6285,6 +6547,14 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           _observervariable:RULE "rule" => Object
           _constdouble:7.0 "7" => Double
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           NEW org/nlogo/nvm/Activation
@@ -6333,11 +6603,9 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L10
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -6348,19 +6616,19 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ICONST_1
           GOTO L12
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_7 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_7 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L12
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L13
          L10
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L13
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L14
           IFEQ L15
           GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -6379,12 +6647,9 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L17
          L2
-         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_7 org/nlogo/nvm/Context java/lang/Boolean D java/lang/Object T I] [org/nlogo/api/AgentException]
+         FRAME FULL [org/nlogo/prim/_asm_procedureextrapolateswitches_setobservervariable_7 org/nlogo/nvm/Context java/lang/Boolean D I] [org/nlogo/api/AgentException]
           ASTORE 3
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -6396,8 +6661,13 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
           ATHROW
          L17
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [8]_asm_procedureextrapolateswitches_return_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -6410,6 +6680,9 @@ procedure EXTRAPOLATE-SWITCHES:[]{OTPL}:
 reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
 [0]_asm_procedurecalculaterule_setprocedurevariable_0 "let" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_0.kept2_value : Ljava/lang/Double;
@@ -6428,6 +6701,9 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
           RETURN
 [1]_asm_procedurecalculaterule_if_1 "if" boolean => void
       _observervariable:OOO "ooo" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -6474,6 +6750,13 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
       _plus "+" double,double => double
         _procedurevariable:RRESULT "rresult" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -6529,6 +6812,9 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
           RETURN
 [3]_asm_procedurecalculaterule_if_3 "if" boolean => void
       _observervariable:OOI "ooi" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -6575,6 +6861,13 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
       _plus "+" double,double => double
         _procedurevariable:RRESULT "rresult" => Object
         _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -6630,6 +6923,9 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
           RETURN
 [5]_asm_procedurecalculaterule_if_5 "if" boolean => void
       _observervariable:OIO "oio" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -6676,6 +6972,13 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
       _plus "+" double,double => double
         _procedurevariable:RRESULT "rresult" => Object
         _constdouble:4.0 "4" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -6731,6 +7034,9 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
           RETURN
 [7]_asm_procedurecalculaterule_if_7 "if" boolean => void
       _observervariable:OII "oii" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -6777,6 +7083,13 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
       _plus "+" double,double => double
         _procedurevariable:RRESULT "rresult" => Object
         _constdouble:8.0 "8" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -6832,6 +7145,9 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
           RETURN
 [9]_asm_procedurecalculaterule_if_9 "if" boolean => void
       _observervariable:IOO "ioo" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -6878,6 +7194,13 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
       _plus "+" double,double => double
         _procedurevariable:RRESULT "rresult" => Object
         _constdouble:16.0 "16" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -6933,6 +7256,9 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
           RETURN
 [11]_asm_procedurecalculaterule_if_11 "if" boolean => void
       _observervariable:IOI "ioi" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -6979,6 +7305,13 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
       _plus "+" double,double => double
         _procedurevariable:RRESULT "rresult" => Object
         _constdouble:32.0 "32" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -7034,6 +7367,9 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
           RETURN
 [13]_asm_procedurecalculaterule_if_13 "if" boolean => void
       _observervariable:IIO "iio" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -7080,6 +7416,13 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
       _plus "+" double,double => double
         _procedurevariable:RRESULT "rresult" => Object
         _constdouble:64.0 "64" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -7135,6 +7478,9 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
           RETURN
 [15]_asm_procedurecalculaterule_if_15 "if" boolean => void
       _observervariable:III "iii" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -7181,6 +7527,13 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
       _plus "+" double,double => double
         _procedurevariable:RRESULT "rresult" => Object
         _constdouble:128.0 "128" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -7236,6 +7589,7 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
           RETURN
 [17]_asm_procedurecalculaterule_report_17 "report" Object => void
       _procedurevariable:RRESULT "rresult" => Object
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7310,6 +7664,7 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
          FRAME SAME
           RETURN
 [18]_asm_procedurecalculaterule_returnreport_18 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -7346,6 +7701,8 @@ procedure SHOW-RULES:[RULES]{O---}:
           RETURN
 [1]_asm_procedureshowrules_setprocedurevariable_1 "let" Object => void
       _callreport:LIST-RULES "list-rules"
+          // parameter final  context
+          // parameter final  arg0
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -7389,6 +7746,15 @@ procedure SHOW-RULES:[RULES]{O---}:
           _minus "-" double,double => double
             _maxpycor "max-pycor" => double
             _constdouble:5.0 "5" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d0
+              // parameter final  d1
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  arg1
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -7398,10 +7764,8 @@ procedure SHOW-RULES:[RULES]{O---}:
               IFEQ L1
               ALOAD 3
               CHECKCAST org/nlogo/agent/Turtle
-              ASTORE 4
-              ALOAD 4
               INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-              ASTORE 5
+              ASTORE 2
               GOTO L2
              L1
              FRAME APPEND [T org/nlogo/agent/Agent]
@@ -7410,26 +7774,21 @@ procedure SHOW-RULES:[RULES]{O---}:
               IFEQ L3
               ALOAD 3
               CHECKCAST org/nlogo/agent/Patch
-              ASTORE 6
-              ALOAD 6
-              ASTORE 5
-             L2
-             FRAME APPEND [T org/nlogo/agent/Patch]
-              ALOAD 5
               ASTORE 2
-              ALOAD 2
-              ICONST_1
-              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-              GOTO L4
+              GOTO L2
              L3
-             FRAME CHOP 2
+             FRAME SAME
               NEW scala/MatchError
               DUP
               ALOAD 3
               INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
               ATHROW
+             L2
+             FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_greaterthan_3 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+              ALOAD 2
+              ICONST_1
+              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
              L4
-             FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_greaterthan_3 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] [D]
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedureshowrules_greaterthan_3.world : Lorg/nlogo/agent/World;
               INVOKEVIRTUAL org/nlogo/agent/World.maxPycor ()I
@@ -7465,6 +7824,12 @@ procedure SHOW-RULES:[RULES]{O---}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureshowrules_ask_2.world : Lorg/nlogo/agent/World;
@@ -7510,25 +7875,15 @@ procedure SHOW-RULES:[RULES]{O---}:
           IFEQ L4
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L5
+          IFEQ L2
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L6
-         FRAME SAME1 java/lang/Object
-          ASTORE 10
-          ALOAD 10
           POP
           GOTO L2
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -7571,17 +7926,17 @@ procedure SHOW-RULES:[RULES]{O---}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L7
+         L5
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
-          IFNE L8
+          IFNE L6
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureshowrules_ask_2.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-          IF_ACMPNE L9
+          IF_ACMPNE L7
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -7592,13 +7947,13 @@ procedure SHOW-RULES:[RULES]{O---}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
+         L7
          FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_ask_2 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureshowrules_ask_2.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
-          IF_ACMPNE L8
+          IF_ACMPNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -7609,7 +7964,7 @@ procedure SHOW-RULES:[RULES]{O---}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L8
+         L6
          FRAME SAME
           ALOAD 1
           ALOAD 2
@@ -7618,10 +7973,13 @@ procedure SHOW-RULES:[RULES]{O---}:
           ALOAD 1
           ICONST_5
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L10
+         L8
           RETURN
 [3]_asm_procedureshowrules_setpatchvariable_4 "set" Object => void
       _constdouble:5.0 "gray" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -7635,9 +7993,6 @@ procedure SHOW-RULES:[RULES]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_setpatchvariable_4 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -7652,8 +8007,13 @@ procedure SHOW-RULES:[RULES]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_procedureshowrules_done_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -7677,6 +8037,24 @@ procedure SHOW-RULES:[RULES]{O---}:
                   _worldwidth "world-width" => double
                   _constdouble:8.0 "8" => double
             _constdouble:0.0 "0" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d0
+              // parameter final  d1
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d1
+              // parameter final  d2
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d0
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d0
+              // parameter final  d1
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -7686,10 +8064,8 @@ procedure SHOW-RULES:[RULES]{O---}:
               IFEQ L1
               ALOAD 3
               CHECKCAST org/nlogo/agent/Turtle
-              ASTORE 4
-              ALOAD 4
               INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-              ASTORE 5
+              ASTORE 2
               GOTO L2
              L1
              FRAME APPEND [T org/nlogo/agent/Agent]
@@ -7698,26 +8074,21 @@ procedure SHOW-RULES:[RULES]{O---}:
               IFEQ L3
               ALOAD 3
               CHECKCAST org/nlogo/agent/Patch
-              ASTORE 6
-              ALOAD 6
-              ASTORE 5
-             L2
-             FRAME APPEND [T org/nlogo/agent/Patch]
-              ALOAD 5
               ASTORE 2
-              ALOAD 2
-              ICONST_1
-              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-              GOTO L4
+              GOTO L2
              L3
-             FRAME CHOP 2
+             FRAME SAME
               NEW scala/MatchError
               DUP
               ALOAD 3
               INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
               ATHROW
+             L2
+             FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_and_7 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+              ALOAD 2
+              ICONST_1
+              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
              L4
-             FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_and_7 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] [D]
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedureshowrules_and_7.world : Lorg/nlogo/agent/World;
               INVOKEVIRTUAL org/nlogo/agent/World.maxPycor ()I
@@ -7746,10 +8117,8 @@ procedure SHOW-RULES:[RULES]{O---}:
               IFEQ L10
               ALOAD 3
               CHECKCAST org/nlogo/agent/Turtle
-              ASTORE 4
-              ALOAD 4
               INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-              ASTORE 5
+              ASTORE 2
               GOTO L11
              L10
              FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_and_7 org/nlogo/nvm/Context T org/nlogo/agent/Agent D] []
@@ -7758,26 +8127,21 @@ procedure SHOW-RULES:[RULES]{O---}:
               IFEQ L12
               ALOAD 3
               CHECKCAST org/nlogo/agent/Patch
-              ASTORE 6
-              ALOAD 6
-              ASTORE 5
-             L11
-             FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_and_7 org/nlogo/nvm/Context T org/nlogo/agent/Agent T org/nlogo/agent/Patch] []
-              ALOAD 5
               ASTORE 2
-              ALOAD 2
-              ICONST_0
-              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-              GOTO L13
+              GOTO L11
              L12
-             FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_and_7 org/nlogo/nvm/Context T org/nlogo/agent/Agent D] []
+             FRAME SAME
               NEW scala/MatchError
               DUP
               ALOAD 3
               INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
               ATHROW
+             L11
+             FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_and_7 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent D] []
+              ALOAD 2
+              ICONST_0
+              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
              L13
-             FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_and_7 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] [D]
               DCONST_1
              L14
               DSTORE 4
@@ -7844,7 +8208,8 @@ procedure SHOW-RULES:[RULES]{O---}:
               DLOAD 4
               DMUL
               DSUB
-              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureshowrules_and_7.validDouble (D)D
+              ALOAD 1
+              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureshowrules_and_7.validDouble (DLorg/nlogo/nvm/Context;)D
              L22
               DCONST_0
              L23
@@ -7876,6 +8241,12 @@ procedure SHOW-RULES:[RULES]{O---}:
              L28
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureshowrules_ask_6.world : Lorg/nlogo/agent/World;
@@ -7921,25 +8292,15 @@ procedure SHOW-RULES:[RULES]{O---}:
           IFEQ L4
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L5
+          IFEQ L2
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L6
-         FRAME SAME1 java/lang/Object
-          ASTORE 10
-          ALOAD 10
           POP
           GOTO L2
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -7982,17 +8343,17 @@ procedure SHOW-RULES:[RULES]{O---}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L7
+         L5
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
-          IFNE L8
+          IFNE L6
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureshowrules_ask_6.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-          IF_ACMPNE L9
+          IF_ACMPNE L7
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -8003,13 +8364,13 @@ procedure SHOW-RULES:[RULES]{O---}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
+         L7
          FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_ask_6 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureshowrules_ask_6.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
-          IF_ACMPNE L8
+          IF_ACMPNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -8020,7 +8381,7 @@ procedure SHOW-RULES:[RULES]{O---}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L8
+         L6
          FRAME SAME
           ALOAD 1
           ALOAD 2
@@ -8029,10 +8390,11 @@ procedure SHOW-RULES:[RULES]{O---}:
           ALOAD 1
           BIPUSH 27
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L10
+         L8
           RETURN
 [6]_sprout:,+26 "sprout"
       _asm_procedureshowrules_constdouble_8 "1" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureshowrules_constdouble_8.kept1_value : Ljava/lang/Double;
@@ -8040,6 +8402,9 @@ procedure SHOW-RULES:[RULES]{O---}:
             ARETURN
 [7]_asm_procedureshowrules_setturtlevariable_9 "set" Object => void
       _constdouble:270.0 "270" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -8053,9 +8418,6 @@ procedure SHOW-RULES:[RULES]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_setturtlevariable_9 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -8070,9 +8432,16 @@ procedure SHOW-RULES:[RULES]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [8]_asm_procedureshowrules_fd_10 "fd" double => void
       _constdouble:18.0 "18" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
          L0
           LDC 18.0
          L1
@@ -8091,9 +8460,10 @@ procedure SHOW-RULES:[RULES]{O---}:
          L2
           RETURN
 [9]_asm_procedureshowrules_fdinternal_11 => void
+          // parameter final  context
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L3 L4 L1 org/nlogo/api/AgentException
-         L5
+          TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
+         L6
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
@@ -8114,38 +8484,48 @@ procedure SHOW-RULES:[RULES]{O---}:
           GETSTATIC org/nlogo/api/Numbers$.MODULE$ : Lorg/nlogo/api/Numbers$;
           INVOKEVIRTUAL org/nlogo/api/Numbers$.Infinitesimal ()D
           DCMPG
-          IFGT L6
+          IFGT L7
           ALOAD 1
           BIPUSH 10
           PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
-         L6
+          GOTO L8
+         L7
          FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_fdinternal_11 org/nlogo/nvm/Context org/nlogo/agent/Turtle org/nlogo/nvm/MutableDouble D D] []
           DLOAD 6
           DCONST_1
           DCMPG
-          IFGT L4
-         L3
+          IFGT L9
+         L0
           ALOAD 2
           DLOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
+         L1
+          GOTO L10
+         L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L10
+         FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L8
-         L4
+         L9
          FRAME SAME
           DLOAD 4
           ICONST_0
           I2D
           DCMPL
-          IFLE L9
+          IFLE L11
           ICONST_1
-          GOTO L10
-         L9
+          GOTO L12
+         L11
          FRAME SAME
           ICONST_M1
-         L10
+         L12
          FRAME SAME1 I
           ISTORE 8
-         L0
+         L3
           ALOAD 2
           ILOAD 8
           I2D
@@ -8157,28 +8537,21 @@ procedure SHOW-RULES:[RULES]{O---}:
           I2D
           DSUB
           INVOKEVIRTUAL org/nlogo/nvm/MutableDouble.value_$eq (D)V
-          GOTO L7
-         L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          POP
-         L8
-         FRAME SAME
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
-         L2
+         L4
+          GOTO L8
+         L5
          FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_fdinternal_11 org/nlogo/nvm/Context org/nlogo/agent/Turtle org/nlogo/nvm/MutableDouble D D I] [org/nlogo/api/AgentException]
           POP
           ALOAD 1
           BIPUSH 10
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L7
+         L8
          FRAME CHOP 1
           RETURN
 [10]_asm_procedureshowrules_call_12 "print-block"
       _item "item"
         _asm_procedureshowrules_constdouble_13 "0" => Double
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedureshowrules_constdouble_13.kept1_value : Ljava/lang/Double;
@@ -8186,6 +8559,7 @@ procedure SHOW-RULES:[RULES]{O---}:
               ARETURN
         _item "item"
           _asm_procedureshowrules_turtlevariabledouble_14 "who" => Double
+                // parameter final  context
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -8210,6 +8584,7 @@ procedure SHOW-RULES:[RULES]{O---}:
                FRAME SAME1 java/lang/Double
                 ARETURN
           _asm_procedureshowrules_procedurevariable_15 "rules" => Object
+                // parameter final  context
                L0
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -8245,6 +8620,9 @@ procedure SHOW-RULES:[RULES]{O---}:
           RETURN
 [11]_asm_procedureshowrules_fd_16 "fd" double => void
       _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
          L0
           LDC 2.0
          L1
@@ -8263,9 +8641,10 @@ procedure SHOW-RULES:[RULES]{O---}:
          L2
           RETURN
 [12]_asm_procedureshowrules_fdinternal_17 => void
+          // parameter final  context
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L3 L4 L1 org/nlogo/api/AgentException
-         L5
+          TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
+         L6
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
@@ -8286,38 +8665,48 @@ procedure SHOW-RULES:[RULES]{O---}:
           GETSTATIC org/nlogo/api/Numbers$.MODULE$ : Lorg/nlogo/api/Numbers$;
           INVOKEVIRTUAL org/nlogo/api/Numbers$.Infinitesimal ()D
           DCMPG
-          IFGT L6
+          IFGT L7
           ALOAD 1
           BIPUSH 13
           PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
-         L6
+          GOTO L8
+         L7
          FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_fdinternal_17 org/nlogo/nvm/Context org/nlogo/agent/Turtle org/nlogo/nvm/MutableDouble D D] []
           DLOAD 6
           DCONST_1
           DCMPG
-          IFGT L4
-         L3
+          IFGT L9
+         L0
           ALOAD 2
           DLOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
+         L1
+          GOTO L10
+         L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L10
+         FRAME SAME
+          ALOAD 1
+          BIPUSH 13
+          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L8
-         L4
+         L9
          FRAME SAME
           DLOAD 4
           ICONST_0
           I2D
           DCMPL
-          IFLE L9
+          IFLE L11
           ICONST_1
-          GOTO L10
-         L9
+          GOTO L12
+         L11
          FRAME SAME
           ICONST_M1
-         L10
+         L12
          FRAME SAME1 I
           ISTORE 8
-         L0
+         L3
           ALOAD 2
           ILOAD 8
           I2D
@@ -8329,28 +8718,21 @@ procedure SHOW-RULES:[RULES]{O---}:
           I2D
           DSUB
           INVOKEVIRTUAL org/nlogo/nvm/MutableDouble.value_$eq (D)V
-          GOTO L7
-         L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          POP
-         L8
-         FRAME SAME
-          ALOAD 1
-          BIPUSH 13
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
-         L2
+         L4
+          GOTO L8
+         L5
          FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_fdinternal_17 org/nlogo/nvm/Context org/nlogo/agent/Turtle org/nlogo/nvm/MutableDouble D D I] [org/nlogo/api/AgentException]
           POP
           ALOAD 1
           BIPUSH 13
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L7
+         L8
          FRAME CHOP 1
           RETURN
 [13]_asm_procedureshowrules_call_18 "print-block"
       _item "item"
         _asm_procedureshowrules_constdouble_19 "1" => Double
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedureshowrules_constdouble_19.kept1_value : Ljava/lang/Double;
@@ -8358,6 +8740,7 @@ procedure SHOW-RULES:[RULES]{O---}:
               ARETURN
         _item "item"
           _asm_procedureshowrules_turtlevariabledouble_20 "who" => Double
+                // parameter final  context
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -8382,6 +8765,7 @@ procedure SHOW-RULES:[RULES]{O---}:
                FRAME SAME1 java/lang/Double
                 ARETURN
           _asm_procedureshowrules_procedurevariable_21 "rules" => Object
+                // parameter final  context
                L0
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -8417,6 +8801,9 @@ procedure SHOW-RULES:[RULES]{O---}:
           RETURN
 [14]_asm_procedureshowrules_fd_22 "fd" double => void
       _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
          L0
           LDC 2.0
          L1
@@ -8435,9 +8822,10 @@ procedure SHOW-RULES:[RULES]{O---}:
          L2
           RETURN
 [15]_asm_procedureshowrules_fdinternal_23 => void
+          // parameter final  context
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L3 L4 L1 org/nlogo/api/AgentException
-         L5
+          TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
+         L6
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
@@ -8458,38 +8846,48 @@ procedure SHOW-RULES:[RULES]{O---}:
           GETSTATIC org/nlogo/api/Numbers$.MODULE$ : Lorg/nlogo/api/Numbers$;
           INVOKEVIRTUAL org/nlogo/api/Numbers$.Infinitesimal ()D
           DCMPG
-          IFGT L6
+          IFGT L7
           ALOAD 1
           BIPUSH 16
           PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
-         L6
+          GOTO L8
+         L7
          FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_fdinternal_23 org/nlogo/nvm/Context org/nlogo/agent/Turtle org/nlogo/nvm/MutableDouble D D] []
           DLOAD 6
           DCONST_1
           DCMPG
-          IFGT L4
-         L3
+          IFGT L9
+         L0
           ALOAD 2
           DLOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
+         L1
+          GOTO L10
+         L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L10
+         FRAME SAME
+          ALOAD 1
+          BIPUSH 16
+          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L8
-         L4
+         L9
          FRAME SAME
           DLOAD 4
           ICONST_0
           I2D
           DCMPL
-          IFLE L9
+          IFLE L11
           ICONST_1
-          GOTO L10
-         L9
+          GOTO L12
+         L11
          FRAME SAME
           ICONST_M1
-         L10
+         L12
          FRAME SAME1 I
           ISTORE 8
-         L0
+         L3
           ALOAD 2
           ILOAD 8
           I2D
@@ -8501,28 +8899,21 @@ procedure SHOW-RULES:[RULES]{O---}:
           I2D
           DSUB
           INVOKEVIRTUAL org/nlogo/nvm/MutableDouble.value_$eq (D)V
-          GOTO L7
-         L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          POP
-         L8
-         FRAME SAME
-          ALOAD 1
-          BIPUSH 16
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
-         L2
+         L4
+          GOTO L8
+         L5
          FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_fdinternal_23 org/nlogo/nvm/Context org/nlogo/agent/Turtle org/nlogo/nvm/MutableDouble D D I] [org/nlogo/api/AgentException]
           POP
           ALOAD 1
           BIPUSH 16
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L7
+         L8
          FRAME CHOP 1
           RETURN
 [16]_asm_procedureshowrules_call_24 "print-block"
       _item "item"
         _asm_procedureshowrules_constdouble_25 "2" => Double
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedureshowrules_constdouble_25.kept1_value : Ljava/lang/Double;
@@ -8530,6 +8921,7 @@ procedure SHOW-RULES:[RULES]{O---}:
               ARETURN
         _item "item"
           _asm_procedureshowrules_turtlevariabledouble_26 "who" => Double
+                // parameter final  context
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -8554,6 +8946,7 @@ procedure SHOW-RULES:[RULES]{O---}:
                FRAME SAME1 java/lang/Double
                 ARETURN
           _asm_procedureshowrules_procedurevariable_27 "rules" => Object
+                // parameter final  context
                L0
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -8589,6 +8982,9 @@ procedure SHOW-RULES:[RULES]{O---}:
           RETURN
 [17]_asm_procedureshowrules_bk_28 "bk" double => void
       _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
          L0
           LDC 2.0
          L1
@@ -8608,9 +9004,10 @@ procedure SHOW-RULES:[RULES]{O---}:
          L2
           RETURN
 [18]_asm_procedureshowrules_fdinternal_29 => void
+          // parameter final  context
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L3 L4 L1 org/nlogo/api/AgentException
-         L5
+          TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
+         L6
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
@@ -8631,38 +9028,48 @@ procedure SHOW-RULES:[RULES]{O---}:
           GETSTATIC org/nlogo/api/Numbers$.MODULE$ : Lorg/nlogo/api/Numbers$;
           INVOKEVIRTUAL org/nlogo/api/Numbers$.Infinitesimal ()D
           DCMPG
-          IFGT L6
+          IFGT L7
           ALOAD 1
           BIPUSH 19
           PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
-         L6
+          GOTO L8
+         L7
          FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_fdinternal_29 org/nlogo/nvm/Context org/nlogo/agent/Turtle org/nlogo/nvm/MutableDouble D D] []
           DLOAD 6
           DCONST_1
           DCMPG
-          IFGT L4
-         L3
+          IFGT L9
+         L0
           ALOAD 2
           DLOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
+         L1
+          GOTO L10
+         L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L10
+         FRAME SAME
+          ALOAD 1
+          BIPUSH 19
+          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L8
-         L4
+         L9
          FRAME SAME
           DLOAD 4
           ICONST_0
           I2D
           DCMPL
-          IFLE L9
+          IFLE L11
           ICONST_1
-          GOTO L10
-         L9
+          GOTO L12
+         L11
          FRAME SAME
           ICONST_M1
-         L10
+         L12
          FRAME SAME1 I
           ISTORE 8
-         L0
+         L3
           ALOAD 2
           ILOAD 8
           I2D
@@ -8674,27 +9081,22 @@ procedure SHOW-RULES:[RULES]{O---}:
           I2D
           DSUB
           INVOKEVIRTUAL org/nlogo/nvm/MutableDouble.value_$eq (D)V
-          GOTO L7
-         L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          POP
-         L8
-         FRAME SAME
-          ALOAD 1
-          BIPUSH 19
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
-         L2
+         L4
+          GOTO L8
+         L5
          FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_fdinternal_29 org/nlogo/nvm/Context org/nlogo/agent/Turtle org/nlogo/nvm/MutableDouble D D I] [org/nlogo/api/AgentException]
           POP
           ALOAD 1
           BIPUSH 19
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L7
+         L8
          FRAME CHOP 1
           RETURN
 [19]_asm_procedureshowrules_setturtlevariable_30 "set" Object => void
       _constdouble:180.0 "180" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -8708,9 +9110,6 @@ procedure SHOW-RULES:[RULES]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 20
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_setturtlevariable_30 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -8725,9 +9124,16 @@ procedure SHOW-RULES:[RULES]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 20
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [20]_asm_procedureshowrules_fd_31 "fd" double => void
       _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
          L0
           LDC 2.0
          L1
@@ -8746,9 +9152,10 @@ procedure SHOW-RULES:[RULES]{O---}:
          L2
           RETURN
 [21]_asm_procedureshowrules_fdinternal_32 => void
+          // parameter final  context
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L3 L4 L1 org/nlogo/api/AgentException
-         L5
+          TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
+         L6
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
@@ -8769,38 +9176,48 @@ procedure SHOW-RULES:[RULES]{O---}:
           GETSTATIC org/nlogo/api/Numbers$.MODULE$ : Lorg/nlogo/api/Numbers$;
           INVOKEVIRTUAL org/nlogo/api/Numbers$.Infinitesimal ()D
           DCMPG
-          IFGT L6
+          IFGT L7
           ALOAD 1
           BIPUSH 22
           PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
-         L6
+          GOTO L8
+         L7
          FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_fdinternal_32 org/nlogo/nvm/Context org/nlogo/agent/Turtle org/nlogo/nvm/MutableDouble D D] []
           DLOAD 6
           DCONST_1
           DCMPG
-          IFGT L4
-         L3
+          IFGT L9
+         L0
           ALOAD 2
           DLOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
+         L1
+          GOTO L10
+         L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L10
+         FRAME SAME
+          ALOAD 1
+          BIPUSH 22
+          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L8
-         L4
+         L9
          FRAME SAME
           DLOAD 4
           ICONST_0
           I2D
           DCMPL
-          IFLE L9
+          IFLE L11
           ICONST_1
-          GOTO L10
-         L9
+          GOTO L12
+         L11
          FRAME SAME
           ICONST_M1
-         L10
+         L12
          FRAME SAME1 I
           ISTORE 8
-         L0
+         L3
           ALOAD 2
           ILOAD 8
           I2D
@@ -8812,27 +9229,22 @@ procedure SHOW-RULES:[RULES]{O---}:
           I2D
           DSUB
           INVOKEVIRTUAL org/nlogo/nvm/MutableDouble.value_$eq (D)V
-          GOTO L7
-         L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          POP
-         L8
-         FRAME SAME
-          ALOAD 1
-          BIPUSH 22
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
-         L2
+         L4
+          GOTO L8
+         L5
          FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_fdinternal_32 org/nlogo/nvm/Context org/nlogo/agent/Turtle org/nlogo/nvm/MutableDouble D D I] [org/nlogo/api/AgentException]
           POP
           ALOAD 1
           BIPUSH 22
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L7
+         L8
          FRAME CHOP 1
           RETURN
 [22]_asm_procedureshowrules_setturtlevariable_33 "set" Object => void
       _constdouble:90.0 "90" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -8846,9 +9258,6 @@ procedure SHOW-RULES:[RULES]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 23
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_setturtlevariable_33 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -8863,10 +9272,15 @@ procedure SHOW-RULES:[RULES]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 23
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [23]_asm_procedureshowrules_call_34 "print-block"
       _item "item"
         _asm_procedureshowrules_constdouble_35 "3" => Double
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedureshowrules_constdouble_35.kept1_value : Ljava/lang/Double;
@@ -8874,6 +9288,7 @@ procedure SHOW-RULES:[RULES]{O---}:
               ARETURN
         _item "item"
           _asm_procedureshowrules_turtlevariabledouble_36 "who" => Double
+                // parameter final  context
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -8898,6 +9313,7 @@ procedure SHOW-RULES:[RULES]{O---}:
                FRAME SAME1 java/lang/Double
                 ARETURN
           _asm_procedureshowrules_procedurevariable_37 "rules" => Object
+                // parameter final  context
                L0
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -8956,6 +9372,7 @@ procedure SHOW-RULES:[RULES]{O---}:
          L3
           RETURN
 [25]_asm_procedureshowrules_done_39 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -8963,6 +9380,7 @@ procedure SHOW-RULES:[RULES]{O---}:
          L1
           RETURN
 [26]_asm_procedureshowrules_done_40 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -8971,6 +9389,9 @@ procedure SHOW-RULES:[RULES]{O---}:
           RETURN
 [27]_asm_procedureshowrules_setobservervariable_41 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -8985,9 +9406,6 @@ procedure SHOW-RULES:[RULES]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 28
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureshowrules_setobservervariable_41 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -9002,8 +9420,13 @@ procedure SHOW-RULES:[RULES]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 28
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [28]_asm_procedureshowrules_return_42 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -9016,6 +9439,9 @@ procedure SHOW-RULES:[RULES]{O---}:
 procedure PRINT-BLOCK:[STATE _repeatlocal:1]{-T--}:
 [0]_asm_procedureprintblock_ifelse_0 "ifelse" boolean => void
       _procedurevariable:STATE "state" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -9060,6 +9486,9 @@ procedure PRINT-BLOCK:[STATE _repeatlocal:1]{-T--}:
           RETURN
 [1]_asm_procedureprintblock_setturtleorlinkvariable_1 "set" Object => void
       _observervariable:FOREGROUND "foreground" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -9076,9 +9505,6 @@ procedure PRINT-BLOCK:[STATE _repeatlocal:1]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureprintblock_setturtleorlinkvariable_1 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -9093,8 +9519,13 @@ procedure PRINT-BLOCK:[STATE _repeatlocal:1]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedureprintblock_goto_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_4
@@ -9103,6 +9534,9 @@ procedure PRINT-BLOCK:[STATE _repeatlocal:1]{-T--}:
           RETURN
 [3]_asm_procedureprintblock_setturtleorlinkvariable_3 "set" Object => void
       _observervariable:BACKGROUND "background" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -9119,9 +9553,6 @@ procedure PRINT-BLOCK:[STATE _repeatlocal:1]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureprintblock_setturtleorlinkvariable_3 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -9136,9 +9567,16 @@ procedure PRINT-BLOCK:[STATE _repeatlocal:1]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_procedureprintblock_setturtlevariable_4 "set" Object => void
       _constdouble:90.0 "90" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -9152,9 +9590,6 @@ procedure PRINT-BLOCK:[STATE _repeatlocal:1]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureprintblock_setturtlevariable_4 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -9169,9 +9604,16 @@ procedure PRINT-BLOCK:[STATE _repeatlocal:1]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [5]_asm_procedureprintblock_repeatlocal_5 "repeat" double => void
       _constdouble:4.0 "4" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 4.0
          L1
@@ -9184,7 +9626,8 @@ procedure PRINT-BLOCK:[STATE _repeatlocal:1]{-T--}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureprintblock_repeatlocal_5.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureprintblock_repeatlocal_5.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -9194,6 +9637,9 @@ procedure PRINT-BLOCK:[STATE _repeatlocal:1]{-T--}:
           RETURN
 [6]_asm_procedureprintblock_setpatchvariable_6 "set" Object => void
       _turtleorlinkvariable:COLOR "color" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -9224,9 +9670,6 @@ procedure PRINT-BLOCK:[STATE _repeatlocal:1]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L4
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L5
          FRAME FULL [org/nlogo/prim/_asm_procedureprintblock_setpatchvariable_6 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -9241,9 +9684,16 @@ procedure PRINT-BLOCK:[STATE _repeatlocal:1]{-T--}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [7]_asm_procedureprintblock_right_7 "rt" double => void
       _constdouble:90.0 "90" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  delta
          L0
           LDC 90.0
          L1
@@ -9259,25 +9709,28 @@ procedure PRINT-BLOCK:[STATE _repeatlocal:1]{-T--}:
          L2
           RETURN
 [8]_asm_procedureprintblock_fd1_8 "fd" => void
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
+          // parameter final  context
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
           DCONST_1
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L2
          L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          ASTORE 2
+          GOTO L3
          L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L3
          FRAME SAME
           ALOAD 1
           BIPUSH 9
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L3
+         L4
           RETURN
 [9]_asm_procedureprintblock_repeatlocalinternal_9 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9310,6 +9763,7 @@ procedure PRINT-BLOCK:[STATE _repeatlocal:1]{-T--}:
          FRAME SAME
           RETURN
 [10]_asm_procedureprintblock_return_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -9322,6 +9776,9 @@ procedure PRINT-BLOCK:[STATE _repeatlocal:1]{-T--}:
 reporter procedure LIST-RULES:[RULES]{OTPL}:
 [0]_asm_procedurelistrules_setprocedurevariable_0 "let" Object => void
       _constlist:[] "[]" => LogoList
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurelistrules_setprocedurevariable_0.kept2_value : Lorg/nlogo/core/LogoList;
@@ -9342,6 +9799,7 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
       _lput "lput"
         _lput "lput"
           _asm_procedurelistrules_observervariable_2 "ooo" => Object
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurelistrules_observervariable_2.world : Lorg/nlogo/agent/World;
@@ -9351,12 +9809,14 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
                L1
                 ARETURN
           _asm_procedurelistrules_constlist_3 "[false false false]" => LogoList
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurelistrules_constlist_3.kept1_value : Lorg/nlogo/core/LogoList;
                L1
                 ARETURN
         _asm_procedurelistrules_procedurevariable_4 "rules" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9365,6 +9825,8 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
               AALOAD
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurelistrules_setprocedurevariable_1.keptinstr2 : Lorg/nlogo/prim/etc/_lput;
           ALOAD 1
@@ -9386,6 +9848,7 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
       _lput "lput"
         _lput "lput"
           _asm_procedurelistrules_observervariable_6 "ooi" => Object
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurelistrules_observervariable_6.world : Lorg/nlogo/agent/World;
@@ -9395,12 +9858,14 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
                L1
                 ARETURN
           _asm_procedurelistrules_constlist_7 "[false false true ]" => LogoList
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurelistrules_constlist_7.kept1_value : Lorg/nlogo/core/LogoList;
                L1
                 ARETURN
         _asm_procedurelistrules_procedurevariable_8 "rules" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9409,6 +9874,8 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
               AALOAD
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurelistrules_setprocedurevariable_5.keptinstr2 : Lorg/nlogo/prim/etc/_lput;
           ALOAD 1
@@ -9430,6 +9897,7 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
       _lput "lput"
         _lput "lput"
           _asm_procedurelistrules_observervariable_10 "oio" => Object
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurelistrules_observervariable_10.world : Lorg/nlogo/agent/World;
@@ -9439,12 +9907,14 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
                L1
                 ARETURN
           _asm_procedurelistrules_constlist_11 "[false true  false]" => LogoList
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurelistrules_constlist_11.kept1_value : Lorg/nlogo/core/LogoList;
                L1
                 ARETURN
         _asm_procedurelistrules_procedurevariable_12 "rules" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9453,6 +9923,8 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
               AALOAD
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurelistrules_setprocedurevariable_9.keptinstr2 : Lorg/nlogo/prim/etc/_lput;
           ALOAD 1
@@ -9474,6 +9946,7 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
       _lput "lput"
         _lput "lput"
           _asm_procedurelistrules_observervariable_14 "oii" => Object
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurelistrules_observervariable_14.world : Lorg/nlogo/agent/World;
@@ -9483,12 +9956,14 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
                L1
                 ARETURN
           _asm_procedurelistrules_constlist_15 "[false true  true ]" => LogoList
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurelistrules_constlist_15.kept1_value : Lorg/nlogo/core/LogoList;
                L1
                 ARETURN
         _asm_procedurelistrules_procedurevariable_16 "rules" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9497,6 +9972,8 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
               AALOAD
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurelistrules_setprocedurevariable_13.keptinstr2 : Lorg/nlogo/prim/etc/_lput;
           ALOAD 1
@@ -9518,6 +9995,7 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
       _lput "lput"
         _lput "lput"
           _asm_procedurelistrules_observervariable_18 "ioo" => Object
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurelistrules_observervariable_18.world : Lorg/nlogo/agent/World;
@@ -9527,12 +10005,14 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
                L1
                 ARETURN
           _asm_procedurelistrules_constlist_19 "[true  false false]" => LogoList
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurelistrules_constlist_19.kept1_value : Lorg/nlogo/core/LogoList;
                L1
                 ARETURN
         _asm_procedurelistrules_procedurevariable_20 "rules" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9541,6 +10021,8 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
               AALOAD
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurelistrules_setprocedurevariable_17.keptinstr2 : Lorg/nlogo/prim/etc/_lput;
           ALOAD 1
@@ -9562,6 +10044,7 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
       _lput "lput"
         _lput "lput"
           _asm_procedurelistrules_observervariable_22 "ioi" => Object
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurelistrules_observervariable_22.world : Lorg/nlogo/agent/World;
@@ -9571,12 +10054,14 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
                L1
                 ARETURN
           _asm_procedurelistrules_constlist_23 "[true  false true ]" => LogoList
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurelistrules_constlist_23.kept1_value : Lorg/nlogo/core/LogoList;
                L1
                 ARETURN
         _asm_procedurelistrules_procedurevariable_24 "rules" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9585,6 +10070,8 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
               AALOAD
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurelistrules_setprocedurevariable_21.keptinstr2 : Lorg/nlogo/prim/etc/_lput;
           ALOAD 1
@@ -9606,6 +10093,7 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
       _lput "lput"
         _lput "lput"
           _asm_procedurelistrules_observervariable_26 "iio" => Object
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurelistrules_observervariable_26.world : Lorg/nlogo/agent/World;
@@ -9615,12 +10103,14 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
                L1
                 ARETURN
           _asm_procedurelistrules_constlist_27 "[true  true  false]" => LogoList
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurelistrules_constlist_27.kept1_value : Lorg/nlogo/core/LogoList;
                L1
                 ARETURN
         _asm_procedurelistrules_procedurevariable_28 "rules" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9629,6 +10119,8 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
               AALOAD
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurelistrules_setprocedurevariable_25.keptinstr2 : Lorg/nlogo/prim/etc/_lput;
           ALOAD 1
@@ -9650,6 +10142,7 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
       _lput "lput"
         _lput "lput"
           _asm_procedurelistrules_observervariable_30 "iii" => Object
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurelistrules_observervariable_30.world : Lorg/nlogo/agent/World;
@@ -9659,12 +10152,14 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
                L1
                 ARETURN
           _asm_procedurelistrules_constlist_31 "[true  true  true ]" => LogoList
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurelistrules_constlist_31.kept1_value : Lorg/nlogo/core/LogoList;
                L1
                 ARETURN
         _asm_procedurelistrules_procedurevariable_32 "rules" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9673,6 +10168,8 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
               AALOAD
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurelistrules_setprocedurevariable_29.keptinstr2 : Lorg/nlogo/prim/etc/_lput;
           ALOAD 1
@@ -9692,6 +10189,7 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
           RETURN
 [9]_asm_procedurelistrules_report_33 "report" Object => void
       _procedurevariable:RULES "rules" => Object
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9766,6 +10264,7 @@ reporter procedure LIST-RULES:[RULES]{OTPL}:
          FRAME SAME
           RETURN
 [10]_asm_procedurelistrules_returnreport_34 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP

--- a/netlogo-headless/test/benchdumps/Erosion.txt
+++ b/netlogo-headless/test/benchdumps/Erosion.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:19192.0 "19192" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 19192.0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -77,6 +80,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:250.0 "250" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 250.0
          L1
@@ -89,7 +95,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -116,6 +123,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -149,6 +157,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -170,9 +181,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -187,8 +195,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -203,6 +216,9 @@ procedure SETUP:[_repeatlocal:0]{O---}:
 [1]_resetticks "reset-ticks"
 [2]_asm_proceduresetup_setobservervariable_0 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -217,9 +233,6 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_0 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -234,9 +247,16 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_proceduresetup_ask_1 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_1.world : Lorg/nlogo/agent/World;
@@ -292,6 +312,9 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           RETURN
 [4]_asm_proceduresetup_ifelse_2 "ifelse" boolean => void
       _observervariable:BUMPY? "bumpy?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -336,6 +359,9 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           RETURN
 [5]_asm_proceduresetup_ifelse_3 "ifelse" boolean => void
       _observervariable:HILL? "hill?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -390,6 +416,26 @@ procedure SETUP:[_repeatlocal:0]{O---}:
               _maxpxcor "max-pxcor" => double
           _constdouble:100.0 "100" => double
         _randomconst:100 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           LDC -100.0
@@ -476,9 +522,6 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L16
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -493,8 +536,13 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ATHROW
          L16
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L17
           RETURN
 [7]_asm_proceduresetup_goto_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 9
@@ -503,6 +551,9 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           RETURN
 [8]_asm_proceduresetup_setpatchvariable_6 "set" Object => void
       _randomconst:125 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -525,9 +576,6 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_6 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -542,8 +590,13 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [9]_asm_proceduresetup_goto_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 11
@@ -552,6 +605,9 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           RETURN
 [10]_asm_proceduresetup_setpatchvariable_8 "set" Object => void
       _constdouble:100.0 "100" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -565,9 +621,6 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 11
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_8 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -582,9 +635,16 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 11
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [11]_asm_proceduresetup_setpatchvariable_9 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -598,9 +658,6 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 12
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_9 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -615,9 +672,16 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 12
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [12]_asm_proceduresetup_setpatchvariable_10 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -631,9 +695,6 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 13
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_10 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -648,8 +709,13 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 13
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [13]_asm_proceduresetup_done_11 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -658,6 +724,9 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           RETURN
 [14]_asm_proceduresetup_if_12 "if" boolean => void
       _observervariable:BUMPY? "bumpy?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -702,6 +771,9 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           RETURN
 [15]_asm_proceduresetup_repeatlocal_13 "repeat" double => void
       _observervariable:TERRAIN-SMOOTHNESS "terrain-smoothness" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -739,7 +811,8 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_repeatlocal_13.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_repeatlocal_13.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -749,12 +822,14 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           RETURN
 [16]_diffuse:ELEVATION "diffuse"
       _asm_proceduresetup_constdouble_14 "0.5" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetup_constdouble_14.kept1_value : Ljava/lang/Double;
            L1
             ARETURN
 [17]_asm_proceduresetup_repeatlocalinternal_15 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -793,44 +868,46 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           _count "count" AgentSet => double
             _neighbors "neighbors" => AgentSet
           _constdouble:8.0 "8" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d0
+              // parameter final  d1
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-              ASTORE 2
-              ALOAD 2
-              INSTANCEOF org/nlogo/agent/Turtle
-              IFEQ L1
-              ALOAD 2
-              CHECKCAST org/nlogo/agent/Turtle
               ASTORE 3
               ALOAD 3
+              INSTANCEOF org/nlogo/agent/Turtle
+              IFEQ L1
+              ALOAD 3
+              CHECKCAST org/nlogo/agent/Turtle
               INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-              ASTORE 4
+              ASTORE 2
               GOTO L2
              L1
-             FRAME APPEND [org/nlogo/agent/Agent]
-              ALOAD 2
+             FRAME APPEND [T org/nlogo/agent/Agent]
+              ALOAD 3
               INSTANCEOF org/nlogo/agent/Patch
               IFEQ L3
-              ALOAD 2
+              ALOAD 3
               CHECKCAST org/nlogo/agent/Patch
-              ASTORE 5
-              ALOAD 5
-              ASTORE 4
-             L2
-             FRAME APPEND [T org/nlogo/agent/Patch]
-              ALOAD 4
-              INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/AgentSet;
-              GOTO L4
+              ASTORE 2
+              GOTO L2
              L3
-             FRAME CHOP 2
+             FRAME SAME
               NEW scala/MatchError
               DUP
-              ALOAD 2
+              ALOAD 3
               INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
               ATHROW
+             L2
+             FRAME FULL [org/nlogo/prim/_asm_proceduresetup_notequal_17 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+              ALOAD 2
+              INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/AgentSet;
              L4
-             FRAME FULL [org/nlogo/prim/_asm_proceduresetup_notequal_17 org/nlogo/nvm/Context org/nlogo/agent/Agent T org/nlogo/agent/Patch] [org/nlogo/agent/AgentSet]
               ASTORE 2
               ALOAD 2
               INVOKEVIRTUAL org/nlogo/agent/AgentSet.count ()I
@@ -860,6 +937,12 @@ procedure SETUP:[_repeatlocal:0]{O---}:
              L10
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_16.world : Lorg/nlogo/agent/World;
@@ -905,25 +988,15 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           IFEQ L4
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L5
+          IFEQ L2
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L6
-         FRAME SAME1 java/lang/Object
-          ASTORE 10
-          ALOAD 10
           POP
           GOTO L2
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -966,17 +1039,17 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L7
+         L5
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
-          IFNE L8
+          IFNE L6
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_16.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-          IF_ACMPNE L9
+          IF_ACMPNE L7
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -987,13 +1060,13 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
+         L7
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_ask_16 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_16.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
-          IF_ACMPNE L8
+          IF_ACMPNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1004,7 +1077,7 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L8
+         L6
          FRAME SAME
           ALOAD 1
           ALOAD 2
@@ -1013,10 +1086,13 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ALOAD 1
           BIPUSH 22
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L10
+         L8
           RETURN
 [19]_asm_proceduresetup_setpatchvariable_18 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1030,9 +1106,6 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 20
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_18 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -1047,9 +1120,16 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 20
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [20]_asm_proceduresetup_setpatchvariable_19 "set" Object => void
       _constdouble:-1.0E7 "-10000000" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1063,9 +1143,6 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 21
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_19 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1080,8 +1157,13 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 21
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [21]_asm_proceduresetup_done_20 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1092,6 +1174,7 @@ procedure SETUP:[_repeatlocal:0]{O---}:
       _with "with" AgentSet,Reporter => AgentSet
         _patches "patches" => AgentSet
         _asm_proceduresetup_patchvariable_22 "drain?" => Object
+              // parameter final  context
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -1114,6 +1197,12 @@ procedure SETUP:[_repeatlocal:0]{O---}:
              L3
              FRAME SAME1 java/lang/Object
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1160,25 +1249,15 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           IFEQ L7
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L8
+          IFEQ L5
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L9
-         L8
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L9
-         FRAME SAME1 java/lang/Object
-          ASTORE 10
-          ALOAD 10
           POP
           GOTO L5
          L7
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1221,7 +1300,7 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L10
+         L8
           ASTORE 2
          L0
           ALOAD 0
@@ -1231,10 +1310,7 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 23
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L11
+          GOTO L9
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_21 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] [org/nlogo/api/AgentException]
           ASTORE 3
@@ -1246,14 +1322,21 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L11
+         L9
          FRAME SAME
+          ALOAD 1
+          BIPUSH 23
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [23]_asm_proceduresetup_setobservervariable_23 "set" Object => void
       _with "with" AgentSet,Reporter => AgentSet
         _patches "patches" => AgentSet
         _asm_proceduresetup_not_24 "not" boolean => boolean
           _patchvariable:DRAIN? "drain?" => Object
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
               TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
              L0
@@ -1298,12 +1381,12 @@ procedure SETUP:[_repeatlocal:0]{O---}:
              FRAME SAME1 I
               ISTORE 2
               ILOAD 2
-              IFEQ L7
-              ICONST_0
+              IFNE L7
+              ICONST_1
               GOTO L8
              L7
              FRAME FULL [org/nlogo/prim/_asm_proceduresetup_not_24 org/nlogo/nvm/Context I] []
-              ICONST_1
+              ICONST_0
              L8
              FRAME SAME1 I
               IFEQ L9
@@ -1315,6 +1398,12 @@ procedure SETUP:[_repeatlocal:0]{O---}:
              L10
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1361,25 +1450,15 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           IFEQ L7
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L8
+          IFEQ L5
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L9
-         L8
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L9
-         FRAME SAME1 java/lang/Object
-          ASTORE 10
-          ALOAD 10
           POP
           GOTO L5
          L7
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1422,7 +1501,7 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L10
+         L8
           ASTORE 2
          L0
           ALOAD 0
@@ -1432,10 +1511,7 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 24
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L11
+          GOTO L9
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_23 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] [org/nlogo/api/AgentException]
           ASTORE 3
@@ -1447,11 +1523,18 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L11
+         L9
          FRAME SAME
+          ALOAD 1
+          BIPUSH 24
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [24]_asm_proceduresetup_ask_25 "ask" Object => void
       _observervariable:LAND "land" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_25.world : Lorg/nlogo/agent/World;
@@ -1461,18 +1544,16 @@ procedure SETUP:[_repeatlocal:0]{O---}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_25.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -1488,8 +1569,8 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_ask_25 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_25.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -1506,18 +1587,18 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -1534,7 +1615,7 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -1544,23 +1625,12 @@ procedure SETUP:[_repeatlocal:0]{O---}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_ask_25 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 25
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 27
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -1574,8 +1644,16 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 25
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 27
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_ask_25 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [25]_asm_proceduresetup_call_26 "recolor"
          L0
@@ -1596,6 +1674,7 @@ procedure SETUP:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [26]_asm_proceduresetup_done_27 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1603,6 +1682,7 @@ procedure SETUP:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [27]_asm_proceduresetup_return_28 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1620,6 +1700,16 @@ procedure RECOLOR:[]{-TP-}:
           _constdouble:0.0 "0" => double
         _not "not" boolean => boolean
           _observervariable:SHOW-WATER? "show-water?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -1647,11 +1737,9 @@ procedure RECOLOR:[]{-TP-}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L7
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -1662,19 +1750,19 @@ procedure RECOLOR:[]{-TP-}:
           ICONST_1
           GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L9
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L10
          L7
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L10
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L11
           IFNE L12
          L13
@@ -1706,20 +1794,20 @@ procedure RECOLOR:[]{-TP-}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L16
-          ICONST_0
+          IFNE L16
+          ICONST_1
           GOTO L17
          L16
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object T I] []
-          ICONST_1
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context I D I] []
+          ICONST_0
          L17
          FRAME SAME1 I
           GOTO L18
          L12
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object T I] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context java/lang/Object D I] []
           ICONST_1
          L18
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context T D java/lang/Object T I] [I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context T D I] [I]
           ISTORE 2
           ALOAD 1
           ILOAD 2
@@ -1727,10 +1815,10 @@ procedure RECOLOR:[]{-TP-}:
           ICONST_1
           GOTO L20
          L19
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           ICONST_3
          L20
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L21
           RETURN
@@ -1740,6 +1828,12 @@ procedure RECOLOR:[]{-TP-}:
         _patchvariable:ELEVATION "elevation" => Object
         _constdouble:-250.0 "-250" => double
         _constdouble:100.0 "100" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -1894,7 +1988,8 @@ procedure RECOLOR:[]{-TP-}:
           DLOAD 2
           DLOAD 10
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolor_setpatchvariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolor_setpatchvariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L21
           DSTORE 2
           NEW java/lang/Double
@@ -1909,9 +2004,6 @@ procedure RECOLOR:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L22
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double T D D D D] [org/nlogo/api/AgentException]
@@ -1926,8 +2018,13 @@ procedure RECOLOR:[]{-TP-}:
           ATHROW
          L22
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L23
           RETURN
 [2]_asm_procedurerecolor_goto_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_4
@@ -1943,6 +2040,13 @@ procedure RECOLOR:[]{-TP-}:
             _constdouble:75.0 "75" => Double
         _constdouble:100.0 "100" => double
         _constdouble:-10.0 "-10" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L6
@@ -2156,7 +2260,8 @@ procedure RECOLOR:[]{-TP-}:
           DLOAD 2
           DLOAD 10
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolor_setpatchvariable_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolor_setpatchvariable_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L28
           DSTORE 2
           NEW java/lang/Double
@@ -2171,9 +2276,6 @@ procedure RECOLOR:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L4
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L29
          L5
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_setpatchvariable_3 org/nlogo/nvm/Context java/lang/Double T D D D D] [org/nlogo/api/AgentException]
@@ -2188,8 +2290,13 @@ procedure RECOLOR:[]{-TP-}:
           ATHROW
          L29
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L30
           RETURN
 [4]_asm_procedurerecolor_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2202,6 +2309,9 @@ procedure RECOLOR:[]{-TP-}:
 procedure SHOW-WATER:[]{OTPL}:
 [0]_asm_procedureshowwater_setobservervariable_0 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2216,9 +2326,6 @@ procedure SHOW-WATER:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureshowwater_setobservervariable_0 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -2233,9 +2340,16 @@ procedure SHOW-WATER:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [1]_asm_procedureshowwater_ask_1 "ask" Object => void
       _observervariable:LAND "land" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureshowwater_ask_1.world : Lorg/nlogo/agent/World;
@@ -2245,18 +2359,16 @@ procedure SHOW-WATER:[]{OTPL}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureshowwater_ask_1.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -2272,8 +2384,8 @@ procedure SHOW-WATER:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedureshowwater_ask_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureshowwater_ask_1.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -2290,18 +2402,18 @@ procedure SHOW-WATER:[]{OTPL}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -2318,7 +2430,7 @@ procedure SHOW-WATER:[]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -2328,23 +2440,12 @@ procedure SHOW-WATER:[]{OTPL}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedureshowwater_ask_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_2
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -2358,8 +2459,16 @@ procedure SHOW-WATER:[]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          ICONST_2
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedureshowwater_ask_1 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [2]_asm_procedureshowwater_call_2 "recolor"
          L0
@@ -2380,6 +2489,7 @@ procedure SHOW-WATER:[]{OTPL}:
          L1
           RETURN
 [3]_asm_procedureshowwater_done_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2387,6 +2497,7 @@ procedure SHOW-WATER:[]{OTPL}:
          L1
           RETURN
 [4]_asm_procedureshowwater_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2399,6 +2510,9 @@ procedure SHOW-WATER:[]{OTPL}:
 procedure HIDE-WATER:[]{OTPL}:
 [0]_asm_procedurehidewater_setobservervariable_0 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2413,9 +2527,6 @@ procedure HIDE-WATER:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurehidewater_setobservervariable_0 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -2430,9 +2541,16 @@ procedure HIDE-WATER:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [1]_asm_procedurehidewater_ask_1 "ask" Object => void
       _observervariable:LAND "land" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurehidewater_ask_1.world : Lorg/nlogo/agent/World;
@@ -2442,18 +2560,16 @@ procedure HIDE-WATER:[]{OTPL}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurehidewater_ask_1.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -2469,8 +2585,8 @@ procedure HIDE-WATER:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurehidewater_ask_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurehidewater_ask_1.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -2487,18 +2603,18 @@ procedure HIDE-WATER:[]{OTPL}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -2515,7 +2631,7 @@ procedure HIDE-WATER:[]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -2525,23 +2641,12 @@ procedure HIDE-WATER:[]{OTPL}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurehidewater_ask_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_2
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -2555,8 +2660,16 @@ procedure HIDE-WATER:[]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          ICONST_2
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurehidewater_ask_1 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [2]_asm_procedurehidewater_call_2 "recolor"
          L0
@@ -2577,6 +2690,7 @@ procedure HIDE-WATER:[]{OTPL}:
          L1
           RETURN
 [3]_asm_procedurehidewater_done_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2584,6 +2698,7 @@ procedure HIDE-WATER:[]{OTPL}:
          L1
           RETURN
 [4]_asm_procedurehidewater_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2596,6 +2711,9 @@ procedure HIDE-WATER:[]{OTPL}:
 procedure GO:[]{O---}:
 [0]_asm_procedurego_ask_0 "ask" Object => void
       _observervariable:LAND "land" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_0.world : Lorg/nlogo/agent/World;
@@ -2605,18 +2723,16 @@ procedure GO:[]{O---}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -2632,8 +2748,8 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_0 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -2650,18 +2766,18 @@ procedure GO:[]{O---}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -2678,7 +2794,7 @@ procedure GO:[]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -2688,23 +2804,12 @@ procedure GO:[]{O---}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_0 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_1
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -2718,14 +2823,31 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          ICONST_1
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [1]_asm_procedurego_if_1 "if" boolean => void
       _lessthan "<" double,Object => boolean
         _randomfloat "random-float" double => double
           _constdouble:1.0 "1.0" => double
         _observervariable:RAINFALL "rainfall" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           DCONST_1
          L1
@@ -2746,11 +2868,9 @@ procedure GO:[]{O---}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L4
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -2761,15 +2881,14 @@ procedure GO:[]{O---}:
           ICONST_1
           GOTO L6
          L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_1 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_1 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L6
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L7
          L4
-         FRAME CHOP 1
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2798,25 +2917,34 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_1 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
+         L8
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L8
+          IFEQ L9
           ICONST_2
-          GOTO L9
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_1 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          ICONST_3
+          GOTO L10
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_1 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_1 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context]
+          ICONST_3
          L10
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_1 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [2]_asm_procedurego_setpatchvariable_2 "set" Object => void
       _plus "+" double,double => double
         _patchvariable:WATER "water" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -2881,9 +3009,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_2 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -2898,8 +3023,13 @@ procedure GO:[]{O---}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [3]_asm_procedurego_done_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2908,6 +3038,9 @@ procedure GO:[]{O---}:
           RETURN
 [4]_asm_procedurego_ask_4 "ask" Object => void
       _observervariable:LAND "land" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_4.world : Lorg/nlogo/agent/World;
@@ -2917,18 +3050,16 @@ procedure GO:[]{O---}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_4.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -2944,8 +3075,8 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_4.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -2962,18 +3093,18 @@ procedure GO:[]{O---}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -2990,7 +3121,7 @@ procedure GO:[]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -3000,23 +3131,12 @@ procedure GO:[]{O---}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_5
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -3030,13 +3150,28 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          ICONST_5
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_4 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [5]_asm_procedurego_if_5 "if" boolean => void
       _greaterthan ">" Object,double => boolean
         _patchvariable:WATER "water" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -3063,14 +3198,10 @@ procedure GO:[]{O---}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -3078,15 +3209,14 @@ procedure GO:[]{O---}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_5 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3115,20 +3245,22 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_5 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L9
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L9
+          IFEQ L10
           BIPUSH 6
-          GOTO L10
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_5 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 7
+          GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_5 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_5 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 7
          L11
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_5 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [6]_asm_procedurego_call_6 "flow"
          L0
@@ -3149,6 +3281,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [7]_asm_procedurego_done_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -3157,6 +3290,9 @@ procedure GO:[]{O---}:
           RETURN
 [8]_asm_procedurego_ask_8 "ask" Object => void
       _observervariable:DRAINS "drains" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_8.world : Lorg/nlogo/agent/World;
@@ -3166,18 +3302,16 @@ procedure GO:[]{O---}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_8.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -3193,8 +3327,8 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_8 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_8.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -3211,18 +3345,18 @@ procedure GO:[]{O---}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -3239,7 +3373,7 @@ procedure GO:[]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -3249,23 +3383,12 @@ procedure GO:[]{O---}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_8 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 9
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 12
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -3279,11 +3402,22 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 9
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 12
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_8 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [9]_asm_procedurego_setpatchvariable_9 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3297,9 +3431,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_9 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -3314,9 +3445,16 @@ procedure GO:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [10]_asm_procedurego_setpatchvariable_10 "set" Object => void
       _constdouble:-1.0E7 "-10000000" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3330,9 +3468,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 11
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_10 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -3347,8 +3482,13 @@ procedure GO:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 11
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [11]_asm_procedurego_done_11 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -3357,6 +3497,9 @@ procedure GO:[]{O---}:
           RETURN
 [12]_asm_procedurego_ask_12 "ask" Object => void
       _observervariable:LAND "land" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_12.world : Lorg/nlogo/agent/World;
@@ -3366,18 +3509,16 @@ procedure GO:[]{O---}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_12.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -3393,8 +3534,8 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_12 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_12.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -3411,18 +3552,18 @@ procedure GO:[]{O---}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -3439,7 +3580,7 @@ procedure GO:[]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -3449,23 +3590,12 @@ procedure GO:[]{O---}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_12 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 13
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 15
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -3479,8 +3609,16 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 13
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 15
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_12 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [13]_asm_procedurego_call_13 "recolor"
          L0
@@ -3501,6 +3639,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [14]_asm_procedurego_done_14 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -3509,6 +3648,7 @@ procedure GO:[]{O---}:
           RETURN
 [15]_tick "tick"
 [16]_asm_procedurego_return_15 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -3522,48 +3662,49 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
 [0]_asm_procedureflow_setprocedurevariable_0 "let" Object => void
       _minoneof "min-one-of"
         _asm_procedureflow_neighbors_1 "neighbors" => AgentSet
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-              ASTORE 2
-              ALOAD 2
-              INSTANCEOF org/nlogo/agent/Turtle
-              IFEQ L1
-              ALOAD 2
-              CHECKCAST org/nlogo/agent/Turtle
               ASTORE 3
               ALOAD 3
+              INSTANCEOF org/nlogo/agent/Turtle
+              IFEQ L1
+              ALOAD 3
+              CHECKCAST org/nlogo/agent/Turtle
               INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-              ASTORE 4
+              ASTORE 2
               GOTO L2
              L1
-             FRAME APPEND [org/nlogo/agent/Agent]
-              ALOAD 2
+             FRAME APPEND [T org/nlogo/agent/Agent]
+              ALOAD 3
               INSTANCEOF org/nlogo/agent/Patch
               IFEQ L3
-              ALOAD 2
+              ALOAD 3
               CHECKCAST org/nlogo/agent/Patch
-              ASTORE 5
-              ALOAD 5
-              ASTORE 4
-             L2
-             FRAME APPEND [T org/nlogo/agent/Patch]
-              ALOAD 4
-              INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/AgentSet;
-              GOTO L4
+              ASTORE 2
+              GOTO L2
              L3
-             FRAME CHOP 2
+             FRAME SAME
               NEW scala/MatchError
               DUP
-              ALOAD 2
+              ALOAD 3
               INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
               ATHROW
+             L2
+             FRAME FULL [org/nlogo/prim/_asm_procedureflow_neighbors_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+              ALOAD 2
+              INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/AgentSet;
              L4
-             FRAME FULL [org/nlogo/prim/_asm_procedureflow_neighbors_1 org/nlogo/nvm/Context org/nlogo/agent/Agent T org/nlogo/agent/Patch] [org/nlogo/agent/AgentSet]
               ARETURN
         _asm_procedureflow_plus_2 "+" double,double => double
           _patchvariable:ELEVATION "elevation" => Object
           _patchvariable:WATER "water" => Object
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d1
+              // parameter final  d2
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
               TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
               TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -3659,6 +3800,8 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
               DLOAD 2
               INVOKESPECIAL java/lang/Double.<init> (D)V
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureflow_setprocedurevariable_0.keptinstr2 : Lorg/nlogo/prim/etc/_minoneof;
           ALOAD 1
@@ -3691,18 +3834,40 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
                   _procedurevariable:TARGET "target" => Object
               _patchvariableof:WATER "of" Object => Object
                 _procedurevariable:TARGET "target" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
           TRYCATCHBLOCK L6 L7 L7 java/lang/ClassCastException
           TRYCATCHBLOCK L8 L9 L10 org/nlogo/api/AgentException
           TRYCATCHBLOCK L11 L12 L12 java/lang/ClassCastException
-          TRYCATCHBLOCK L13 L14 L14 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L15 L16 L14 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L17 L18 L18 java/lang/ClassCastException
-          TRYCATCHBLOCK L19 L20 L20 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L21 L22 L20 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L23 L24 L24 java/lang/ClassCastException
-         L25
+          TRYCATCHBLOCK L13 L14 L15 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L16 L17 L17 java/lang/ClassCastException
+          TRYCATCHBLOCK L18 L19 L20 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L21 L22 L22 java/lang/ClassCastException
+         L23
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
@@ -3713,7 +3878,7 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           BIPUSH 6
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
          L1
-          GOTO L26
+          GOTO L24
          L2
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -3725,11 +3890,11 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L26
+         L24
          FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder java/lang/Object]
           INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
           DUP
-         L27
+         L25
           LDC 0.5
          L3
           ALOAD 1
@@ -3737,7 +3902,7 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
          L4
-          GOTO L28
+          GOTO L26
          L5
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -3749,7 +3914,7 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L28
+         L26
          FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D java/lang/Object]
           ASTORE 2
          L6
@@ -3776,7 +3941,7 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           BIPUSH 6
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
          L9
-          GOTO L29
+          GOTO L27
          L10
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -3788,14 +3953,14 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L29
+         L27
          FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D java/lang/Object]
           ASTORE 2
          L11
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
-          GOTO L30
+          GOTO L28
          L12
          FRAME SAME1 java/lang/ClassCastException
           POP
@@ -3808,35 +3973,33 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
-         L30
+         L28
          FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D D]
           DSTORE 4
           DSTORE 2
           DLOAD 2
           DLOAD 4
           DADD
-         L31
+         L29
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_0
           AALOAD
-         L32
+         L30
           ASTORE 2
-         L15
+         L13
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L31
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L33
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L34
+          IFNE L32
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3849,62 +4012,58 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L34
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
-          ALOAD 5
+         L32
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T org/nlogo/agent/Agent] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          ALOAD 4
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L35
-         L33
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
-          ALOAD 4
+          ASTORE 3
+          GOTO L33
+         L31
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T D] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L13
-          ALOAD 4
+          IFEQ L34
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
-         L36
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
-          ALOAD 9
+          ASTORE 7
+         L35
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-          IFEQ L37
-          ALOAD 8
-          ALOAD 9
+          IFEQ L36
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
           INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
-          GOTO L36
-         L37
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L35
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          GOTO L35
+         L36
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
           ALOAD 6
-         L16
-          GOTO L38
-         L13
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L33
+         L34
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T D] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -3921,29 +4080,34 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           GETSTATIC org/nlogo/core/Syntax$.MODULE$ : Lorg/nlogo/core/Syntax$;
           INVOKEVIRTUAL org/nlogo/core/Syntax$.PatchsetType ()I
           IOR
-          ALOAD 4
+          ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L33
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          ALOAD 3
          L14
+          GOTO L37
+         L15
          FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L38
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D java/lang/Object]
+         L37
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D java/lang/Object]
           ASTORE 2
-         L17
+         L16
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
-          GOTO L39
-         L18
+          GOTO L38
+         L17
          FRAME SAME1 java/lang/ClassCastException
           POP
           NEW org/nlogo/nvm/ArgumentTypeException
@@ -3955,35 +4119,33 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
-         L39
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D D]
+         L38
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D D]
           DSTORE 4
           DSTORE 2
           DLOAD 2
           DLOAD 4
           DSUB
-         L40
+         L39
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_0
           AALOAD
-         L41
+         L40
           ASTORE 2
-         L21
+         L18
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L41
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L42
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L43
+          IFNE L42
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3996,62 +4158,58 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L43
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
-          ALOAD 5
+         L42
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T org/nlogo/agent/Agent] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          ALOAD 4
           BIPUSH 6
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L44
-         L42
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
-          ALOAD 4
+          ASTORE 3
+          GOTO L43
+         L41
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T D] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L19
-          ALOAD 4
+          IFEQ L44
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L45
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L46
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           BIPUSH 6
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
           INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
           GOTO L45
          L46
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L44
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
           ALOAD 6
-         L22
-          GOTO L47
-         L19
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L43
+         L44
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T D] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -4068,29 +4226,34 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           GETSTATIC org/nlogo/core/Syntax$.MODULE$ : Lorg/nlogo/core/Syntax$;
           INVOKEVIRTUAL org/nlogo/core/Syntax$.PatchsetType ()I
           IOR
-          ALOAD 4
+          ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L43
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          ALOAD 3
+         L19
+          GOTO L47
          L20
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T T T java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L47
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D java/lang/Object]
           ASTORE 2
-         L23
+         L21
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           GOTO L48
-         L24
+         L22
          FRAME SAME1 java/lang/ClassCastException
           POP
           NEW org/nlogo/nvm/ArgumentTypeException
@@ -4103,7 +4266,7 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
          L48
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D D]
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D D]
           DSTORE 4
           DSTORE 2
           DLOAD 2
@@ -4211,6 +4374,13 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
       _greaterthan ">" Object,double => boolean
         _procedurevariable:AMOUNT "amount" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -4223,14 +4393,10 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -4238,15 +4404,14 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_if_4 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4275,20 +4440,22 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_if_4 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L7
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L7
+          IFEQ L8
           ICONST_3
-          GOTO L8
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_if_4 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 10
+          GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_if_4 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_if_4 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 10
          L9
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_if_4 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [3]_asm_procedureflow_setprocedurevariable_5 "let" Object => void
       _mult "*" double,double => double
@@ -4296,6 +4463,17 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
         _minus "-" double,double => double
           _constdouble:1.0 "1" => double
           _observervariable:SOIL-HARDNESS "soil-hardness" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -4386,6 +4564,13 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
       _minus "-" double,double => double
         _patchvariable:ELEVATION "elevation" => Object
         _procedurevariable:EROSION "erosion" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -4475,9 +4660,6 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L8
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L15
          L9
          FRAME FULL [org/nlogo/prim/_asm_procedureflow_setpatchvariable_6 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -4492,6 +4674,10 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ATHROW
          L15
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L16
           RETURN
 [5]_asm_procedureflow_setprocedurevariable_7 "set" Object => void
       _min "min" LogoList => double
@@ -4508,18 +4694,40 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
                   _procedurevariable:TARGET "target" => Object
               _patchvariableof:WATER "of" Object => Object
                 _procedurevariable:TARGET "target" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
           TRYCATCHBLOCK L6 L7 L7 java/lang/ClassCastException
           TRYCATCHBLOCK L8 L9 L10 org/nlogo/api/AgentException
           TRYCATCHBLOCK L11 L12 L12 java/lang/ClassCastException
-          TRYCATCHBLOCK L13 L14 L14 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L15 L16 L14 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L17 L18 L18 java/lang/ClassCastException
-          TRYCATCHBLOCK L19 L20 L20 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L21 L22 L20 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L23 L24 L24 java/lang/ClassCastException
-         L25
+          TRYCATCHBLOCK L13 L14 L15 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L16 L17 L17 java/lang/ClassCastException
+          TRYCATCHBLOCK L18 L19 L20 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L21 L22 L22 java/lang/ClassCastException
+         L23
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
@@ -4530,7 +4738,7 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           BIPUSH 6
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
          L1
-          GOTO L26
+          GOTO L24
          L2
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -4542,11 +4750,11 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L26
+         L24
          FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder java/lang/Object]
           INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
           DUP
-         L27
+         L25
           LDC 0.5
          L3
           ALOAD 1
@@ -4554,7 +4762,7 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
          L4
-          GOTO L28
+          GOTO L26
          L5
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -4566,7 +4774,7 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L28
+         L26
          FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D java/lang/Object]
           ASTORE 2
          L6
@@ -4593,7 +4801,7 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           BIPUSH 6
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
          L9
-          GOTO L29
+          GOTO L27
          L10
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -4605,14 +4813,14 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L29
+         L27
          FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D java/lang/Object]
           ASTORE 2
          L11
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
-          GOTO L30
+          GOTO L28
          L12
          FRAME SAME1 java/lang/ClassCastException
           POP
@@ -4625,35 +4833,33 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
-         L30
+         L28
          FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D D]
           DSTORE 4
           DSTORE 2
           DLOAD 2
           DLOAD 4
           DADD
-         L31
+         L29
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_0
           AALOAD
-         L32
+         L30
           ASTORE 2
-         L15
+         L13
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L31
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L33
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L34
+          IFNE L32
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4666,62 +4872,58 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L34
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
-          ALOAD 5
+         L32
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T org/nlogo/agent/Agent] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          ALOAD 4
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L35
-         L33
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
-          ALOAD 4
+          ASTORE 3
+          GOTO L33
+         L31
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T D] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L13
-          ALOAD 4
+          IFEQ L34
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
-         L36
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
-          ALOAD 9
+          ASTORE 7
+         L35
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-          IFEQ L37
-          ALOAD 8
-          ALOAD 9
+          IFEQ L36
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
           INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
-          GOTO L36
-         L37
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L35
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          GOTO L35
+         L36
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
           ALOAD 6
-         L16
-          GOTO L38
-         L13
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L33
+         L34
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T D] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -4738,29 +4940,34 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           GETSTATIC org/nlogo/core/Syntax$.MODULE$ : Lorg/nlogo/core/Syntax$;
           INVOKEVIRTUAL org/nlogo/core/Syntax$.PatchsetType ()I
           IOR
-          ALOAD 4
+          ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L33
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          ALOAD 3
          L14
+          GOTO L37
+         L15
          FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L38
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D java/lang/Object]
+         L37
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D java/lang/Object]
           ASTORE 2
-         L17
+         L16
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
-          GOTO L39
-         L18
+          GOTO L38
+         L17
          FRAME SAME1 java/lang/ClassCastException
           POP
           NEW org/nlogo/nvm/ArgumentTypeException
@@ -4772,35 +4979,33 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
-         L39
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D D]
+         L38
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D D]
           DSTORE 4
           DSTORE 2
           DLOAD 2
           DLOAD 4
           DSUB
-         L40
+         L39
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_0
           AALOAD
-         L41
+         L40
           ASTORE 2
-         L21
+         L18
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L41
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L42
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L43
+          IFNE L42
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4813,62 +5018,58 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L43
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
-          ALOAD 5
+         L42
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T org/nlogo/agent/Agent] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          ALOAD 4
           BIPUSH 6
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L44
-         L42
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
-          ALOAD 4
+          ASTORE 3
+          GOTO L43
+         L41
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T D] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L19
-          ALOAD 4
+          IFEQ L44
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L45
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L46
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           BIPUSH 6
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
           INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
           GOTO L45
          L46
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L44
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
           ALOAD 6
-         L22
-          GOTO L47
-         L19
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L43
+         L44
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T D] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -4885,29 +5086,34 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           GETSTATIC org/nlogo/core/Syntax$.MODULE$ : Lorg/nlogo/core/Syntax$;
           INVOKEVIRTUAL org/nlogo/core/Syntax$.PatchsetType ()I
           IOR
-          ALOAD 4
+          ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L43
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D]
+          ALOAD 3
+         L19
+          GOTO L47
          L20
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T T T java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L47
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D java/lang/Object]
           ASTORE 2
-         L23
+         L21
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           GOTO L48
-         L24
+         L22
          FRAME SAME1 java/lang/ClassCastException
           POP
           NEW org/nlogo/nvm/ArgumentTypeException
@@ -4920,7 +5126,7 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
          L48
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D D]
+         FRAME FULL [org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [org/nlogo/api/LogoListBuilder org/nlogo/api/LogoListBuilder D D D]
           DSTORE 4
           DSTORE 2
           DLOAD 2
@@ -5028,6 +5234,13 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
       _minus "-" double,double => double
         _patchvariable:WATER "water" => Object
         _procedurevariable:AMOUNT "amount" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -5117,9 +5330,6 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L8
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L15
          L9
          FRAME FULL [org/nlogo/prim/_asm_procedureflow_setpatchvariable_8 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -5134,9 +5344,16 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ATHROW
          L15
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L16
           RETURN
 [7]_asm_procedureflow_ask_9 "ask" Object => void
       _procedurevariable:TARGET "target" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5146,18 +5363,16 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureflow_ask_9.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -5173,8 +5388,8 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_ask_9 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureflow_ask_9.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -5191,18 +5406,18 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -5219,7 +5434,7 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -5229,23 +5444,12 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_ask_9 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 8
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -5259,13 +5463,28 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 8
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedureflow_ask_9 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [8]_asm_procedureflow_setpatchvariable_10 "set" Object => void
       _plus "+" double,double => double
         _patchvariable:WATER "water" => Object
         _procedurevariable:AMOUNT "amount" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -5355,9 +5574,6 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L8
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L15
          L9
          FRAME FULL [org/nlogo/prim/_asm_procedureflow_setpatchvariable_10 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -5372,8 +5588,13 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           ATHROW
          L15
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L16
           RETURN
 [9]_asm_procedureflow_done_11 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -5381,6 +5602,7 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
          L1
           RETURN
 [10]_asm_procedureflow_return_12 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V

--- a/netlogo-headless/test/benchdumps/Fire.txt
+++ b/netlogo-headless/test/benchdumps/Fire.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:362.0 "362" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 362.0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -77,6 +80,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:100.0 "100" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 100.0
          L1
@@ -89,7 +95,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -116,6 +123,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -149,6 +157,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -170,9 +181,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -187,8 +195,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -203,6 +216,9 @@ procedure SETUP:[]{O---}:
 [1]_resetticks "reset-ticks"
 [2]_asm_proceduresetup_ask_0 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_0.world : Lorg/nlogo/agent/World;
@@ -258,6 +274,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [3]_asm_proceduresetup_setpatchvariable_1 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -271,9 +290,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -288,6 +304,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduresetup_if_2 "if" boolean => void
       _greaterthan ">" double,double => boolean
@@ -295,6 +315,17 @@ procedure SETUP:[]{O---}:
         _plus "+" double,double => double
           _constdouble:1.0 "1" => double
           _minpxcor "min-pxcor" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -304,10 +335,8 @@ procedure SETUP:[]{O---}:
           IFEQ L1
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L2
          L1
          FRAME APPEND [T org/nlogo/agent/Agent]
@@ -316,26 +345,21 @@ procedure SETUP:[]{O---}:
           IFEQ L3
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L2
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 5
           ASTORE 2
-          ALOAD 2
-          ICONST_0
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-          GOTO L4
+          GOTO L2
          L3
-         FRAME CHOP 2
+         FRAME SAME
           NEW scala/MatchError
           DUP
           ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L2
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 2
+          ICONST_0
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
          L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] [D]
           DCONST_1
          L5
           ALOAD 0
@@ -380,6 +404,13 @@ procedure SETUP:[]{O---}:
       _lessthan "<" double,Object => boolean
         _randomconst:100 "random" => double
         _observervariable:DENSITY "density" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -397,11 +428,9 @@ procedure SETUP:[]{O---}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -412,15 +441,14 @@ procedure SETUP:[]{O---}:
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_3 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_3 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -449,23 +477,28 @@ procedure SETUP:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_3 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
+         L7
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L7
+          IFEQ L8
           BIPUSH 6
-          GOTO L8
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_3 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 7
+          GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_3 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_3 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context]
+          BIPUSH 7
          L9
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_3 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [6]_asm_proceduresetup_setpatchvariable_4 "set" Object => void
       _constdouble:55.0 "green" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -479,9 +512,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -496,6 +526,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_proceduresetup_if_5 "if" boolean => void
       _equal "=" double,double => boolean
@@ -503,6 +537,17 @@ procedure SETUP:[]{O---}:
         _plus "+" double,double => double
           _constdouble:1.0 "1" => double
           _minpycor "min-pycor" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -512,10 +557,8 @@ procedure SETUP:[]{O---}:
           IFEQ L1
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L2
          L1
          FRAME APPEND [T org/nlogo/agent/Agent]
@@ -524,26 +567,21 @@ procedure SETUP:[]{O---}:
           IFEQ L3
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L2
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 5
           ASTORE 2
-          ALOAD 2
-          ICONST_0
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-          GOTO L4
+          GOTO L2
          L3
-         FRAME CHOP 2
+         FRAME SAME
           NEW scala/MatchError
           DUP
           ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L2
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_5 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 2
+          ICONST_0
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
          L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_5 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] [D]
           DCONST_1
          L5
           ALOAD 0
@@ -586,6 +624,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [8]_asm_proceduresetup_setpatchvariable_6 "set" Object => void
       _constdouble:15.0 "red" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -599,9 +640,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_6 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -616,9 +654,16 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [9]_asm_proceduresetup_setpatchvariable_7 "set" Object => void
       _constdouble:1.0 "1" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -632,9 +677,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_7 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -649,8 +691,13 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [10]_asm_proceduresetup_done_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -663,6 +710,11 @@ procedure SETUP:[]{O---}:
         _asm_proceduresetup_equal_10 "=" Object,double => boolean
           _patchvariable:PCOLOR "pcolor" => Object
           _constdouble:55.0 "green" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -689,11 +741,9 @@ procedure SETUP:[]{O---}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -704,19 +754,19 @@ procedure SETUP:[]{O---}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_proceduresetup_equal_10 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduresetup_equal_10 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -727,6 +777,12 @@ procedure SETUP:[]{O---}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  block
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -770,25 +826,15 @@ procedure SETUP:[]{O---}:
           IFEQ L7
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L8
+          IFEQ L5
           ILOAD 5
           ICONST_1
           IADD
           ISTORE 5
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          GOTO L9
-         L8
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L9
-         FRAME SAME1 scala/runtime/BoxedUnit
-          ASTORE 10
           GOTO L5
          L7
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -823,7 +869,7 @@ procedure SETUP:[]{O---}:
          FRAME CHOP 2
           ILOAD 5
           I2D
-         L10
+         L8
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -838,10 +884,7 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 12
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L11
+          GOTO L9
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_9 org/nlogo/nvm/Context java/lang/Double T org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator] [org/nlogo/api/AgentException]
           ASTORE 3
@@ -853,11 +896,18 @@ procedure SETUP:[]{O---}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L11
+         L9
          FRAME SAME
+          ALOAD 1
+          BIPUSH 12
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [12]_asm_proceduresetup_setobservervariable_11 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -872,9 +922,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 13
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_11 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -889,8 +936,13 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 13
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [13]_asm_proceduresetup_return_12 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -930,6 +982,14 @@ procedure GO:[]{O---}:
                L1
                FRAME SAME1 java/lang/Object
                 ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_if_0.world : Lorg/nlogo/agent/World;
@@ -974,16 +1034,11 @@ procedure GO:[]{O---}:
           GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
           ALOAD 8
           INVOKEVIRTUAL scala/Predef$.Boolean2boolean (Ljava/lang/Boolean;)Z
-          IFEQ L5
+          IFEQ L2
           ICONST_1
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 9
-          GOTO L2
+          GOTO L5
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1013,31 +1068,31 @@ procedure GO:[]{O---}:
          L3
          FRAME CHOP 2
           ICONST_0
-         L6
+         L5
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L7
-          ICONST_0
-          GOTO L8
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_0 org/nlogo/nvm/Context I org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentIterator] []
+          IFNE L6
           ICONST_1
-         L8
+          GOTO L7
+         L6
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_0 org/nlogo/nvm/Context I org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentIterator] []
+          ICONST_0
+         L7
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L9
+          IFEQ L8
           ICONST_1
-          GOTO L10
-         L9
+          GOTO L9
+         L8
          FRAME SAME1 org/nlogo/nvm/Context
           ICONST_2
-         L10
+         L9
          FRAME FULL [org/nlogo/prim/_asm_procedurego_if_0 org/nlogo/nvm/Context I org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentIterator] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L11
+         L10
           RETURN
 [1]_asm_procedurego_stop_2 "stop" => void
          L0
@@ -1079,6 +1134,9 @@ procedure GO:[]{O---}:
           RETURN
 [2]_asm_procedurego_ask_3 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_3.world : Lorg/nlogo/agent/World;
@@ -1136,6 +1194,13 @@ procedure GO:[]{O---}:
       _equal "=" Object,double => boolean
         _patchvariable:PCOLOR "pcolor" => Object
         _constdouble:55.0 "green" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1162,11 +1227,9 @@ procedure GO:[]{O---}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -1177,19 +1240,19 @@ procedure GO:[]{O---}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_4 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_4 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -1198,15 +1261,18 @@ procedure GO:[]{O---}:
           ICONST_4
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_4 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_4 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           ICONST_5
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_4 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_4 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
 [4]_asm_procedurego_setpatchvariable_5 "set" Object => void
       _nsum4:FIRE "sum" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -1217,10 +1283,8 @@ procedure GO:[]{O---}:
           IFEQ L4
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L5
          L4
          FRAME APPEND [T org/nlogo/agent/Agent]
@@ -1229,43 +1293,45 @@ procedure GO:[]{O---}:
           IFEQ L6
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L5
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 5
           ASTORE 2
+          GOTO L5
+         L6
+         FRAME SAME
+          NEW scala/MatchError
+          DUP
+          ALOAD 3
+          INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
+          ATHROW
+         L5
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_5 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
           DCONST_0
-          DSTORE 7
+          DSTORE 4
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors4 ()Lorg/nlogo/agent/AgentSet;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.iterator ()Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 6
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_5 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T D org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+         FRAME APPEND [D org/nlogo/agent/AgentIterator]
+          ALOAD 6
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L8
-          ALOAD 9
+          ALOAD 6
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Patch
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariable (I)Ljava/lang/Object;
-          ASTORE 10
-          ALOAD 10
+          ASTORE 7
+          ALOAD 7
           INSTANCEOF java/lang/Double
           IFEQ L9
-          ALOAD 10
+          ALOAD 7
           CHECKCAST java/lang/Double
-          ASTORE 11
-          DLOAD 7
-          ALOAD 11
+          ASTORE 8
+          DLOAD 4
+          ALOAD 8
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DADD
-          DSTORE 7
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 12
+          DSTORE 4
           GOTO L7
          L9
          FRAME APPEND [java/lang/Object]
@@ -1282,14 +1348,14 @@ procedure GO:[]{O---}:
           DUP
           ICONST_0
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
-          ALOAD 10
+          ALOAD 7
           INVOKEVIRTUAL org/nlogo/api/Dump$.logoObject (Ljava/lang/Object;)Ljava/lang/String;
           INVOKEVIRTUAL java/lang/String.toString ()Ljava/lang/String;
           AASTORE
           DUP
           ICONST_1
           GETSTATIC org/nlogo/api/TypeNames$.MODULE$ : Lorg/nlogo/api/TypeNames$;
-          ALOAD 10
+          ALOAD 7
           INVOKEVIRTUAL org/nlogo/api/TypeNames$.name (Ljava/lang/Object;)Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -1299,18 +1365,10 @@ procedure GO:[]{O---}:
          L8
          FRAME CHOP 1
           ALOAD 0
-          DLOAD 7
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_5.validDouble (D)D
-          GOTO L10
-         L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_5 org/nlogo/nvm/Context T org/nlogo/agent/Agent] []
-          NEW scala/MatchError
-          DUP
-          ALOAD 3
-          INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
-          ATHROW
+          DLOAD 4
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_5 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T D org/nlogo/agent/AgentIterator] [D]
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -1324,12 +1382,9 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L11
          L2
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_5 org/nlogo/nvm/Context java/lang/Double T T org/nlogo/agent/Patch T D org/nlogo/agent/AgentIterator] [org/nlogo/api/AgentException]
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_5 org/nlogo/nvm/Context java/lang/Double T D org/nlogo/agent/AgentIterator] [org/nlogo/api/AgentException]
           ASTORE 3
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -1341,8 +1396,13 @@ procedure GO:[]{O---}:
           ATHROW
          L11
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [5]_asm_procedurego_done_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1351,6 +1411,9 @@ procedure GO:[]{O---}:
           RETURN
 [6]_asm_procedurego_ask_7 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_7.world : Lorg/nlogo/agent/World;
@@ -1408,6 +1471,13 @@ procedure GO:[]{O---}:
       _equal "=" Object,double => boolean
         _patchvariable:PCOLOR "pcolor" => Object
         _constdouble:55.0 "green" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1434,11 +1504,9 @@ procedure GO:[]{O---}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -1449,19 +1517,19 @@ procedure GO:[]{O---}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_8 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_8 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -1470,10 +1538,10 @@ procedure GO:[]{O---}:
           BIPUSH 8
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_8 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_8 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 13
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_8 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_8 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
@@ -1481,6 +1549,13 @@ procedure GO:[]{O---}:
       _greaterthan ">" Object,double => boolean
         _patchvariable:COUNTS "counts" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1507,14 +1582,10 @@ procedure GO:[]{O---}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -1522,15 +1593,14 @@ procedure GO:[]{O---}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_9 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1559,23 +1629,28 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_9 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L9
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L9
+          IFEQ L10
           BIPUSH 9
-          GOTO L10
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_9 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 12
+          GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_9 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_9 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 12
          L11
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_9 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [9]_asm_procedurego_setpatchvariable_10 "set" Object => void
       _constdouble:1.0 "1" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1589,9 +1664,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_10 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1606,9 +1678,16 @@ procedure GO:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [10]_asm_procedurego_setpatchvariable_11 "set" Object => void
       _constdouble:15.0 "red" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1622,9 +1701,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 11
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_11 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1639,11 +1715,22 @@ procedure GO:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 11
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [11]_asm_procedurego_setobservervariable_12 "set" Object => void
       _plus "+" double,double => double
         _observervariable:BURNED-TREES "burned-trees" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -1695,9 +1782,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 12
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L10
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setobservervariable_12 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1712,8 +1796,13 @@ procedure GO:[]{O---}:
           ATHROW
          L10
          FRAME SAME
+          ALOAD 1
+          BIPUSH 12
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [12]_asm_procedurego_goto_13 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 15
@@ -1722,6 +1811,8 @@ procedure GO:[]{O---}:
           RETURN
 [13]_asm_procedurego_if_14 "if" boolean => void
       _callreport:BURNING? "burning?"
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           NEW org/nlogo/nvm/Activation
@@ -1784,6 +1875,13 @@ procedure GO:[]{O---}:
       _minus "-" double,double => double
         _patchvariable:PCOLOR "pcolor" => Object
         _constdouble:0.3 "0.3" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -1848,9 +1946,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          BIPUSH 15
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_15 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1865,8 +1960,13 @@ procedure GO:[]{O---}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          BIPUSH 15
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [15]_asm_procedurego_done_16 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1875,6 +1975,7 @@ procedure GO:[]{O---}:
           RETURN
 [16]_tick "tick"
 [17]_asm_procedurego_return_17 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1893,6 +1994,16 @@ reporter procedure BURNING?:[]{-TP-}:
         _lessthan "<" Object,double => boolean
           _patchvariable:PCOLOR "pcolor" => Object
           _constdouble:16.0 "+" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -1920,14 +2031,10 @@ reporter procedure BURNING?:[]{-TP-}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L8
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -1935,15 +2042,14 @@ reporter procedure BURNING?:[]{-TP-}:
           ICONST_1
           GOTO L10
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedureburning_report_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L10
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L11
          L8
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1972,15 +2078,17 @@ reporter procedure BURNING?:[]{-TP-}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureburning_report_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
-          IFEQ L12
+         FRAME APPEND [I]
+          ILOAD 5
+         L12
+          IFEQ L13
          L3
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           ICONST_2
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
          L4
-          GOTO L13
+          GOTO L14
          L5
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -1992,36 +2100,31 @@ reporter procedure BURNING?:[]{-TP-}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L13
+         L14
          FRAME SAME1 java/lang/Object
           LDC 16.0
-         L14
+         L15
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
-          IFEQ L15
-          ALOAD 5
+          IFEQ L16
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
-          IFGE L16
+          IFGE L17
           ICONST_1
-          GOTO L17
-         L16
+          GOTO L18
+         L17
          FRAME SAME
           ICONST_0
-         L17
+         L18
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
-          GOTO L18
-         L15
+          ISTORE 5
+          GOTO L19
+         L16
          FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -2050,21 +2153,23 @@ reporter procedure BURNING?:[]{-TP-}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L18
-         FRAME SAME1 I
-          GOTO L19
-         L12
+         L19
+         FRAME SAME
+          ILOAD 5
+         L20
+          GOTO L21
+         L13
          FRAME SAME
           ICONST_0
-         L19
+         L21
          FRAME SAME1 I
-          IFEQ L20
+          IFEQ L22
           GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
-          GOTO L21
-         L20
+          GOTO L23
+         L22
          FRAME SAME
           GETSTATIC java/lang/Boolean.FALSE : Ljava/lang/Boolean;
-         L21
+         L23
          FRAME SAME1 java/lang/Boolean
           ASTORE 2
           ALOAD 1
@@ -2082,7 +2187,7 @@ reporter procedure BURNING?:[]{-TP-}:
           INVOKEVIRTUAL org/nlogo/nvm/Activation.nonLambdaActivation ()Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.procedure ()Lorg/nlogo/nvm/Procedure;
           INVOKEVIRTUAL org/nlogo/nvm/Procedure.isReporter ()Z
-          IFNE L22
+          IFNE L24
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2098,22 +2203,22 @@ reporter procedure BURNING?:[]{-TP-}:
           INVOKEINTERFACE org/nlogo/core/I18NJava.getN (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L22
-         FRAME FULL [org/nlogo/prim/_asm_procedureburning_report_0 org/nlogo/nvm/Context java/lang/Boolean D java/lang/Object java/lang/Double I] []
+         L24
+         FRAME FULL [org/nlogo/prim/_asm_procedureburning_report_0 org/nlogo/nvm/Context java/lang/Boolean D I] []
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.procedure ()Lorg/nlogo/nvm/Procedure;
           INVOKEVIRTUAL org/nlogo/nvm/Procedure.isLambda ()Z
-          IFEQ L23
+          IFEQ L25
           NEW org/nlogo/nvm/NonLocalExit
           DUP
           INVOKESPECIAL org/nlogo/nvm/NonLocalExit.<init> ()V
           ATHROW
-         L23
+         L25
          FRAME SAME
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.atTopActivation ()Z
-          IFNE L24
+          IFNE L26
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2129,10 +2234,11 @@ reporter procedure BURNING?:[]{-TP-}:
           INVOKEINTERFACE org/nlogo/core/I18NJava.getN (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L24
+         L26
          FRAME SAME
           RETURN
 [1]_asm_procedureburning_returnreport_1 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -2153,6 +2259,13 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
       _greaterthan ">" Object,double => boolean
         _observervariable:INITIAL-TREES "initial-trees" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurepercentburned_ifelse_0.world : Lorg/nlogo/agent/World;
@@ -2165,14 +2278,10 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -2180,15 +2289,14 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurepercentburned_ifelse_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2217,20 +2325,22 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurepercentburned_ifelse_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L7
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L7
+          IFEQ L8
           ICONST_1
-          GOTO L8
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurepercentburned_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          ICONST_3
+          GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurepercentburned_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurepercentburned_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          ICONST_3
          L9
+         FRAME FULL [org/nlogo/prim/_asm_procedurepercentburned_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [1]_asm_procedurepercentburned_report_1 "report" Object => void
       _mult "*" double,double => double
@@ -2238,6 +2348,12 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
           _observervariable:BURNED-TREES "burned-trees" => Object
           _observervariable:INITIAL-TREES "initial-trees" => Object
         _constdouble:100.0 "100" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -2394,6 +2510,7 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
          FRAME SAME
           RETURN
 [2]_asm_procedurepercentburned_goto_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_4
@@ -2402,6 +2519,7 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
           RETURN
 [3]_asm_procedurepercentburned_report_3 "report" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurepercentburned_report_3.kept2_value : Ljava/lang/Double;
@@ -2473,6 +2591,7 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
          FRAME SAME
           RETURN
 [4]_asm_procedurepercentburned_returnreport_4 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP

--- a/netlogo-headless/test/benchdumps/FireBig.txt
+++ b/netlogo-headless/test/benchdumps/FireBig.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:362.0 "362" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 362.0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -77,6 +80,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:100.0 "100" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 100.0
          L1
@@ -89,7 +95,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -116,6 +123,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -149,6 +157,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -170,9 +181,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -187,8 +195,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -203,6 +216,9 @@ procedure SETUP:[]{O---}:
 [1]_resetticks "reset-ticks"
 [2]_asm_proceduresetup_ask_0 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_0.world : Lorg/nlogo/agent/World;
@@ -258,6 +274,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [3]_asm_proceduresetup_setpatchvariable_1 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -271,9 +290,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -288,6 +304,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduresetup_if_2 "if" boolean => void
       _greaterthan ">" double,double => boolean
@@ -295,6 +315,17 @@ procedure SETUP:[]{O---}:
         _plus "+" double,double => double
           _constdouble:1.0 "1" => double
           _minpxcor "min-pxcor" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -304,10 +335,8 @@ procedure SETUP:[]{O---}:
           IFEQ L1
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L2
          L1
          FRAME APPEND [T org/nlogo/agent/Agent]
@@ -316,26 +345,21 @@ procedure SETUP:[]{O---}:
           IFEQ L3
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L2
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 5
           ASTORE 2
-          ALOAD 2
-          ICONST_0
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-          GOTO L4
+          GOTO L2
          L3
-         FRAME CHOP 2
+         FRAME SAME
           NEW scala/MatchError
           DUP
           ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L2
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 2
+          ICONST_0
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
          L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] [D]
           DCONST_1
          L5
           ALOAD 0
@@ -380,6 +404,13 @@ procedure SETUP:[]{O---}:
       _lessthan "<" double,Object => boolean
         _randomconst:100 "random" => double
         _observervariable:DENSITY "density" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -397,11 +428,9 @@ procedure SETUP:[]{O---}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -412,15 +441,14 @@ procedure SETUP:[]{O---}:
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_3 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_3 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -449,23 +477,28 @@ procedure SETUP:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_3 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
+         L7
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L7
+          IFEQ L8
           BIPUSH 6
-          GOTO L8
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_3 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 7
+          GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_3 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_3 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context]
+          BIPUSH 7
          L9
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_3 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [6]_asm_proceduresetup_setpatchvariable_4 "set" Object => void
       _constdouble:55.0 "green" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -479,9 +512,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -496,6 +526,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_proceduresetup_if_5 "if" boolean => void
       _equal "=" double,double => boolean
@@ -503,6 +537,17 @@ procedure SETUP:[]{O---}:
         _plus "+" double,double => double
           _constdouble:1.0 "1" => double
           _minpycor "min-pycor" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -512,10 +557,8 @@ procedure SETUP:[]{O---}:
           IFEQ L1
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L2
          L1
          FRAME APPEND [T org/nlogo/agent/Agent]
@@ -524,26 +567,21 @@ procedure SETUP:[]{O---}:
           IFEQ L3
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L2
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 5
           ASTORE 2
-          ALOAD 2
-          ICONST_0
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-          GOTO L4
+          GOTO L2
          L3
-         FRAME CHOP 2
+         FRAME SAME
           NEW scala/MatchError
           DUP
           ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L2
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_5 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 2
+          ICONST_0
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
          L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_5 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] [D]
           DCONST_1
          L5
           ALOAD 0
@@ -586,6 +624,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [8]_asm_proceduresetup_setpatchvariable_6 "set" Object => void
       _constdouble:15.0 "red" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -599,9 +640,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_6 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -616,9 +654,16 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [9]_asm_proceduresetup_setpatchvariable_7 "set" Object => void
       _constdouble:1.0 "1" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -632,9 +677,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_7 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -649,8 +691,13 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [10]_asm_proceduresetup_done_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -663,6 +710,11 @@ procedure SETUP:[]{O---}:
         _asm_proceduresetup_equal_10 "=" Object,double => boolean
           _patchvariable:PCOLOR "pcolor" => Object
           _constdouble:55.0 "green" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -689,11 +741,9 @@ procedure SETUP:[]{O---}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -704,19 +754,19 @@ procedure SETUP:[]{O---}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_proceduresetup_equal_10 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduresetup_equal_10 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -727,6 +777,12 @@ procedure SETUP:[]{O---}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  block
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -770,25 +826,15 @@ procedure SETUP:[]{O---}:
           IFEQ L7
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L8
+          IFEQ L5
           ILOAD 5
           ICONST_1
           IADD
           ISTORE 5
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          GOTO L9
-         L8
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L9
-         FRAME SAME1 scala/runtime/BoxedUnit
-          ASTORE 10
           GOTO L5
          L7
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -823,7 +869,7 @@ procedure SETUP:[]{O---}:
          FRAME CHOP 2
           ILOAD 5
           I2D
-         L10
+         L8
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -838,10 +884,7 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 12
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L11
+          GOTO L9
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_9 org/nlogo/nvm/Context java/lang/Double T org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator] [org/nlogo/api/AgentException]
           ASTORE 3
@@ -853,11 +896,18 @@ procedure SETUP:[]{O---}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L11
+         L9
          FRAME SAME
+          ALOAD 1
+          BIPUSH 12
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [12]_asm_proceduresetup_setobservervariable_11 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -872,9 +922,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 13
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_11 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -889,8 +936,13 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 13
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [13]_asm_proceduresetup_return_12 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -930,6 +982,14 @@ procedure GO:[]{O---}:
                L1
                FRAME SAME1 java/lang/Object
                 ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_if_0.world : Lorg/nlogo/agent/World;
@@ -974,16 +1034,11 @@ procedure GO:[]{O---}:
           GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
           ALOAD 8
           INVOKEVIRTUAL scala/Predef$.Boolean2boolean (Ljava/lang/Boolean;)Z
-          IFEQ L5
+          IFEQ L2
           ICONST_1
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 9
-          GOTO L2
+          GOTO L5
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1013,31 +1068,31 @@ procedure GO:[]{O---}:
          L3
          FRAME CHOP 2
           ICONST_0
-         L6
+         L5
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L7
-          ICONST_0
-          GOTO L8
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_0 org/nlogo/nvm/Context I org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentIterator] []
+          IFNE L6
           ICONST_1
-         L8
+          GOTO L7
+         L6
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_0 org/nlogo/nvm/Context I org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentIterator] []
+          ICONST_0
+         L7
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L9
+          IFEQ L8
           ICONST_1
-          GOTO L10
-         L9
+          GOTO L9
+         L8
          FRAME SAME1 org/nlogo/nvm/Context
           ICONST_2
-         L10
+         L9
          FRAME FULL [org/nlogo/prim/_asm_procedurego_if_0 org/nlogo/nvm/Context I org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentIterator] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L11
+         L10
           RETURN
 [1]_asm_procedurego_stop_2 "stop" => void
          L0
@@ -1079,6 +1134,9 @@ procedure GO:[]{O---}:
           RETURN
 [2]_asm_procedurego_ask_3 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_3.world : Lorg/nlogo/agent/World;
@@ -1136,6 +1194,13 @@ procedure GO:[]{O---}:
       _equal "=" Object,double => boolean
         _patchvariable:PCOLOR "pcolor" => Object
         _constdouble:55.0 "green" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1162,11 +1227,9 @@ procedure GO:[]{O---}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -1177,19 +1240,19 @@ procedure GO:[]{O---}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_4 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_4 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -1198,15 +1261,18 @@ procedure GO:[]{O---}:
           ICONST_4
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_4 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_4 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           ICONST_5
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_4 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_4 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
 [4]_asm_procedurego_setpatchvariable_5 "set" Object => void
       _nsum4:FIRE "sum" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -1217,10 +1283,8 @@ procedure GO:[]{O---}:
           IFEQ L4
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L5
          L4
          FRAME APPEND [T org/nlogo/agent/Agent]
@@ -1229,43 +1293,45 @@ procedure GO:[]{O---}:
           IFEQ L6
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L5
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 5
           ASTORE 2
+          GOTO L5
+         L6
+         FRAME SAME
+          NEW scala/MatchError
+          DUP
+          ALOAD 3
+          INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
+          ATHROW
+         L5
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_5 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
           DCONST_0
-          DSTORE 7
+          DSTORE 4
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors4 ()Lorg/nlogo/agent/AgentSet;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.iterator ()Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 6
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_5 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T D org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+         FRAME APPEND [D org/nlogo/agent/AgentIterator]
+          ALOAD 6
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L8
-          ALOAD 9
+          ALOAD 6
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Patch
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariable (I)Ljava/lang/Object;
-          ASTORE 10
-          ALOAD 10
+          ASTORE 7
+          ALOAD 7
           INSTANCEOF java/lang/Double
           IFEQ L9
-          ALOAD 10
+          ALOAD 7
           CHECKCAST java/lang/Double
-          ASTORE 11
-          DLOAD 7
-          ALOAD 11
+          ASTORE 8
+          DLOAD 4
+          ALOAD 8
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DADD
-          DSTORE 7
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 12
+          DSTORE 4
           GOTO L7
          L9
          FRAME APPEND [java/lang/Object]
@@ -1282,14 +1348,14 @@ procedure GO:[]{O---}:
           DUP
           ICONST_0
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
-          ALOAD 10
+          ALOAD 7
           INVOKEVIRTUAL org/nlogo/api/Dump$.logoObject (Ljava/lang/Object;)Ljava/lang/String;
           INVOKEVIRTUAL java/lang/String.toString ()Ljava/lang/String;
           AASTORE
           DUP
           ICONST_1
           GETSTATIC org/nlogo/api/TypeNames$.MODULE$ : Lorg/nlogo/api/TypeNames$;
-          ALOAD 10
+          ALOAD 7
           INVOKEVIRTUAL org/nlogo/api/TypeNames$.name (Ljava/lang/Object;)Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -1299,18 +1365,10 @@ procedure GO:[]{O---}:
          L8
          FRAME CHOP 1
           ALOAD 0
-          DLOAD 7
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_5.validDouble (D)D
-          GOTO L10
-         L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_5 org/nlogo/nvm/Context T org/nlogo/agent/Agent] []
-          NEW scala/MatchError
-          DUP
-          ALOAD 3
-          INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
-          ATHROW
+          DLOAD 4
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_5 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T D org/nlogo/agent/AgentIterator] [D]
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -1324,12 +1382,9 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L11
          L2
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_5 org/nlogo/nvm/Context java/lang/Double T T org/nlogo/agent/Patch T D org/nlogo/agent/AgentIterator] [org/nlogo/api/AgentException]
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_5 org/nlogo/nvm/Context java/lang/Double T D org/nlogo/agent/AgentIterator] [org/nlogo/api/AgentException]
           ASTORE 3
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -1341,8 +1396,13 @@ procedure GO:[]{O---}:
           ATHROW
          L11
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [5]_asm_procedurego_done_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1351,6 +1411,9 @@ procedure GO:[]{O---}:
           RETURN
 [6]_asm_procedurego_ask_7 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_7.world : Lorg/nlogo/agent/World;
@@ -1408,6 +1471,13 @@ procedure GO:[]{O---}:
       _equal "=" Object,double => boolean
         _patchvariable:PCOLOR "pcolor" => Object
         _constdouble:55.0 "green" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1434,11 +1504,9 @@ procedure GO:[]{O---}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -1449,19 +1517,19 @@ procedure GO:[]{O---}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_8 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_8 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -1470,10 +1538,10 @@ procedure GO:[]{O---}:
           BIPUSH 8
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_8 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_8 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 13
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_8 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_8 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
@@ -1481,6 +1549,13 @@ procedure GO:[]{O---}:
       _greaterthan ">" Object,double => boolean
         _patchvariable:COUNTS "counts" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1507,14 +1582,10 @@ procedure GO:[]{O---}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -1522,15 +1593,14 @@ procedure GO:[]{O---}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_9 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1559,23 +1629,28 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_9 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L9
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L9
+          IFEQ L10
           BIPUSH 9
-          GOTO L10
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_9 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 12
+          GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_9 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_9 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 12
          L11
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_9 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [9]_asm_procedurego_setpatchvariable_10 "set" Object => void
       _constdouble:1.0 "1" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1589,9 +1664,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_10 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1606,9 +1678,16 @@ procedure GO:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [10]_asm_procedurego_setpatchvariable_11 "set" Object => void
       _constdouble:15.0 "red" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1622,9 +1701,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 11
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_11 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1639,11 +1715,22 @@ procedure GO:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 11
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [11]_asm_procedurego_setobservervariable_12 "set" Object => void
       _plus "+" double,double => double
         _observervariable:BURNED-TREES "burned-trees" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -1695,9 +1782,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 12
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L10
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setobservervariable_12 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1712,8 +1796,13 @@ procedure GO:[]{O---}:
           ATHROW
          L10
          FRAME SAME
+          ALOAD 1
+          BIPUSH 12
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [12]_asm_procedurego_goto_13 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 15
@@ -1722,6 +1811,8 @@ procedure GO:[]{O---}:
           RETURN
 [13]_asm_procedurego_if_14 "if" boolean => void
       _callreport:BURNING? "burning?"
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           NEW org/nlogo/nvm/Activation
@@ -1784,6 +1875,13 @@ procedure GO:[]{O---}:
       _minus "-" double,double => double
         _patchvariable:PCOLOR "pcolor" => Object
         _constdouble:0.3 "0.3" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -1848,9 +1946,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          BIPUSH 15
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_15 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1865,8 +1960,13 @@ procedure GO:[]{O---}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          BIPUSH 15
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [15]_asm_procedurego_done_16 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1875,6 +1975,7 @@ procedure GO:[]{O---}:
           RETURN
 [16]_tick "tick"
 [17]_asm_procedurego_return_17 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1893,6 +1994,16 @@ reporter procedure BURNING?:[]{-TP-}:
         _lessthan "<" Object,double => boolean
           _patchvariable:PCOLOR "pcolor" => Object
           _constdouble:16.0 "+" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -1920,14 +2031,10 @@ reporter procedure BURNING?:[]{-TP-}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L8
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -1935,15 +2042,14 @@ reporter procedure BURNING?:[]{-TP-}:
           ICONST_1
           GOTO L10
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedureburning_report_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L10
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L11
          L8
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1972,15 +2078,17 @@ reporter procedure BURNING?:[]{-TP-}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureburning_report_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
-          IFEQ L12
+         FRAME APPEND [I]
+          ILOAD 5
+         L12
+          IFEQ L13
          L3
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           ICONST_2
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
          L4
-          GOTO L13
+          GOTO L14
          L5
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -1992,36 +2100,31 @@ reporter procedure BURNING?:[]{-TP-}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L13
+         L14
          FRAME SAME1 java/lang/Object
           LDC 16.0
-         L14
+         L15
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
-          IFEQ L15
-          ALOAD 5
+          IFEQ L16
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
-          IFGE L16
+          IFGE L17
           ICONST_1
-          GOTO L17
-         L16
+          GOTO L18
+         L17
          FRAME SAME
           ICONST_0
-         L17
+         L18
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
-          GOTO L18
-         L15
+          ISTORE 5
+          GOTO L19
+         L16
          FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -2050,21 +2153,23 @@ reporter procedure BURNING?:[]{-TP-}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L18
-         FRAME SAME1 I
-          GOTO L19
-         L12
+         L19
+         FRAME SAME
+          ILOAD 5
+         L20
+          GOTO L21
+         L13
          FRAME SAME
           ICONST_0
-         L19
+         L21
          FRAME SAME1 I
-          IFEQ L20
+          IFEQ L22
           GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
-          GOTO L21
-         L20
+          GOTO L23
+         L22
          FRAME SAME
           GETSTATIC java/lang/Boolean.FALSE : Ljava/lang/Boolean;
-         L21
+         L23
          FRAME SAME1 java/lang/Boolean
           ASTORE 2
           ALOAD 1
@@ -2082,7 +2187,7 @@ reporter procedure BURNING?:[]{-TP-}:
           INVOKEVIRTUAL org/nlogo/nvm/Activation.nonLambdaActivation ()Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.procedure ()Lorg/nlogo/nvm/Procedure;
           INVOKEVIRTUAL org/nlogo/nvm/Procedure.isReporter ()Z
-          IFNE L22
+          IFNE L24
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2098,22 +2203,22 @@ reporter procedure BURNING?:[]{-TP-}:
           INVOKEINTERFACE org/nlogo/core/I18NJava.getN (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L22
-         FRAME FULL [org/nlogo/prim/_asm_procedureburning_report_0 org/nlogo/nvm/Context java/lang/Boolean D java/lang/Object java/lang/Double I] []
+         L24
+         FRAME FULL [org/nlogo/prim/_asm_procedureburning_report_0 org/nlogo/nvm/Context java/lang/Boolean D I] []
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.procedure ()Lorg/nlogo/nvm/Procedure;
           INVOKEVIRTUAL org/nlogo/nvm/Procedure.isLambda ()Z
-          IFEQ L23
+          IFEQ L25
           NEW org/nlogo/nvm/NonLocalExit
           DUP
           INVOKESPECIAL org/nlogo/nvm/NonLocalExit.<init> ()V
           ATHROW
-         L23
+         L25
          FRAME SAME
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.atTopActivation ()Z
-          IFNE L24
+          IFNE L26
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2129,10 +2234,11 @@ reporter procedure BURNING?:[]{-TP-}:
           INVOKEINTERFACE org/nlogo/core/I18NJava.getN (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L24
+         L26
          FRAME SAME
           RETURN
 [1]_asm_procedureburning_returnreport_1 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -2153,6 +2259,13 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
       _greaterthan ">" Object,double => boolean
         _observervariable:INITIAL-TREES "initial-trees" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurepercentburned_ifelse_0.world : Lorg/nlogo/agent/World;
@@ -2165,14 +2278,10 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -2180,15 +2289,14 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurepercentburned_ifelse_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2217,20 +2325,22 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurepercentburned_ifelse_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L7
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L7
+          IFEQ L8
           ICONST_1
-          GOTO L8
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurepercentburned_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          ICONST_3
+          GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurepercentburned_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurepercentburned_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          ICONST_3
          L9
+         FRAME FULL [org/nlogo/prim/_asm_procedurepercentburned_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [1]_asm_procedurepercentburned_report_1 "report" Object => void
       _mult "*" double,double => double
@@ -2238,6 +2348,12 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
           _observervariable:BURNED-TREES "burned-trees" => Object
           _observervariable:INITIAL-TREES "initial-trees" => Object
         _constdouble:100.0 "100" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -2394,6 +2510,7 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
          FRAME SAME
           RETURN
 [2]_asm_procedurepercentburned_goto_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_4
@@ -2402,6 +2519,7 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
           RETURN
 [3]_asm_procedurepercentburned_report_3 "report" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurepercentburned_report_3.kept2_value : Ljava/lang/Double;
@@ -2473,6 +2591,7 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
          FRAME SAME
           RETURN
 [4]_asm_procedurepercentburned_returnreport_4 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP

--- a/netlogo-headless/test/benchdumps/Flocking.txt
+++ b/netlogo-headless/test/benchdumps/Flocking.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:5454.0 "5454" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 5454.0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -77,6 +80,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:700.0 "700" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 700.0
          L1
@@ -89,7 +95,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -116,6 +123,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -149,6 +157,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -170,9 +181,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -187,8 +195,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -203,6 +216,7 @@ procedure SETUP:[]{O---}:
 [1]_resetticks "reset-ticks"
 [2]_createorderedturtles:,+7 "cro"
       _asm_proceduresetup_observervariable_0 "population" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetup_observervariable_0.world : Lorg/nlogo/agent/World;
@@ -215,6 +229,13 @@ procedure SETUP:[]{O---}:
       _plus "+" double,double => double
         _constdouble:43.0 "-" => double
         _randomconst:7 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           LDC 43.0
@@ -245,9 +266,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtleorlinkvariable_1 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -262,12 +280,22 @@ procedure SETUP:[]{O---}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [4]_asm_proceduresetup_setxy_2 "setxy" double,double => void
       _randomfloat "random-float" double => double
         _worldwidth "world-width" => double
       _randomfloat "random-float" double => double
         _worldheight "world-height" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -347,6 +375,11 @@ procedure SETUP:[]{O---}:
 [5]_asm_proceduresetup_right_3 "rt" double => void
       _randomfloat "random-float" double => double
         _constdouble:360.0 "360" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  delta
          L0
           LDC 360.0
          L1
@@ -370,6 +403,7 @@ procedure SETUP:[]{O---}:
          L3
           RETURN
 [6]_asm_proceduresetup_done_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -377,6 +411,7 @@ procedure SETUP:[]{O---}:
          L1
           RETURN
 [7]_asm_proceduresetup_return_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -389,6 +424,9 @@ procedure SETUP:[]{O---}:
 procedure GO:[]{O---}:
 [0]_asm_procedurego_ask_0 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_0.world : Lorg/nlogo/agent/World;
@@ -461,6 +499,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [2]_asm_procedurego_done_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -469,6 +508,7 @@ procedure GO:[]{O---}:
           RETURN
 [3]_tick "tick"
 [4]_asm_procedurego_return_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -500,6 +540,11 @@ procedure FLOCK:[]{-T--}:
 [1]_asm_procedureflock_if_1 "if" boolean => void
       _any "any?" AgentSet => boolean
         _turtlevariable:FLOCKMATES "flockmates" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -544,12 +589,12 @@ procedure FLOCK:[]{-T--}:
           ASTORE 2
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.isEmpty ()Z
-          IFEQ L7
-          ICONST_0
+          IFNE L7
+          ICONST_1
           GOTO L8
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedureflock_if_1 org/nlogo/nvm/Context org/nlogo/agent/AgentSet] []
-          ICONST_1
+          ICONST_0
          L8
          FRAME SAME1 I
           ISTORE 2
@@ -589,6 +634,13 @@ procedure FLOCK:[]{-T--}:
         _distance "distance" Agent => double
           _turtlevariable:NEAREST-NEIGHBOR "nearest-neighbor" => Object
         _observervariable:MINIMUM-SEPARATION "minimum-separation" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -686,11 +738,9 @@ procedure FLOCK:[]{-T--}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L11
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -701,15 +751,14 @@ procedure FLOCK:[]{-T--}:
           ICONST_1
           GOTO L13
          L12
-         FRAME FULL [org/nlogo/prim/_asm_procedureflock_ifelse_3 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedureflock_ifelse_3 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L13
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L14
          L11
-         FRAME CHOP 1
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -738,20 +787,22 @@ procedure FLOCK:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L14
-         FRAME FULL [org/nlogo/prim/_asm_procedureflock_ifelse_3 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
+         L15
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L15
+          IFEQ L16
           ICONST_4
-          GOTO L16
-         L15
-         FRAME FULL [org/nlogo/prim/_asm_procedureflock_ifelse_3 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 6
+          GOTO L17
          L16
-         FRAME FULL [org/nlogo/prim/_asm_procedureflock_ifelse_3 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedureflock_ifelse_3 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context]
+          BIPUSH 6
          L17
+         FRAME FULL [org/nlogo/prim/_asm_procedureflock_ifelse_3 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [4]_asm_procedureflock_call_4 "separate"
          L0
@@ -772,6 +823,7 @@ procedure FLOCK:[]{-T--}:
          L1
           RETURN
 [5]_asm_procedureflock_goto_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 8
@@ -815,25 +867,28 @@ procedure FLOCK:[]{-T--}:
          L1
           RETURN
 [8]_asm_procedureflock_fd1_8 "fd" => void
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
+          // parameter final  context
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
           DCONST_1
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L2
          L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          ASTORE 2
+          GOTO L3
          L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L3
          FRAME SAME
           ALOAD 1
           BIPUSH 9
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L3
+         L4
           RETURN
 [9]_asm_procedureflock_return_9 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -848,6 +903,7 @@ procedure FIND-FLOCKMATES:[]{-T--}:
       _other "other" AgentSet => AgentSet
         _inradiusboundingbox "in-radius"
           _asm_procedurefindflockmates_turtles_1 "turtles" => AgentSet
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurefindflockmates_turtles_1.world : Lorg/nlogo/agent/World;
@@ -855,6 +911,7 @@ procedure FIND-FLOCKMATES:[]{-T--}:
                L1
                 ARETURN
           _asm_procedurefindflockmates_observervariable_2 "vision" => Object
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurefindflockmates_observervariable_2.world : Lorg/nlogo/agent/World;
@@ -863,6 +920,10 @@ procedure FIND-FLOCKMATES:[]{-T--}:
                 INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
                L1
                 ARETURN
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
           ALOAD 0
@@ -930,9 +991,6 @@ procedure FIND-FLOCKMATES:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L10
          L4
          FRAME SAME1 org/nlogo/api/AgentException
@@ -947,8 +1005,13 @@ procedure FIND-FLOCKMATES:[]{-T--}:
           ATHROW
          L10
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [1]_asm_procedurefindflockmates_return_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -962,6 +1025,7 @@ procedure FIND-NEAREST-NEIGHBOR:[]{-T--}:
 [0]_asm_procedurefindnearestneighbor_setturtlevariable_0 "set" Object => void
       _minoneof "min-one-of"
         _asm_procedurefindnearestneighbor_turtlevariable_1 "flockmates" => Object
+              // parameter final  context
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -1063,6 +1127,8 @@ procedure FIND-NEAREST-NEIGHBOR:[]{-T--}:
               DLOAD 2
               INVOKESPECIAL java/lang/Double.<init> (D)V
               ARETURN
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurefindnearestneighbor_setturtlevariable_0.keptinstr2 : Lorg/nlogo/prim/etc/_minoneof;
@@ -1077,9 +1143,6 @@ procedure FIND-NEAREST-NEIGHBOR:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L4
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurefindnearestneighbor_setturtlevariable_0 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -1094,8 +1157,13 @@ procedure FIND-NEAREST-NEIGHBOR:[]{-T--}:
           ATHROW
          L4
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L5
           RETURN
 [1]_asm_procedurefindnearestneighbor_return_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1110,10 +1178,13 @@ procedure SEPARATE:[]{-T--}:
       _turtlevariableof:HEADING "of" Object => Object
         _turtlevariable:NEAREST-NEIGHBOR "nearest-neighbor" => Object
       _observervariable:MAX-SEPARATE-TURN "max-separate-turn" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agentOrSet
+          // parameter final  context
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L3 L4 L4 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L5 L6 L4 org/nlogo/api/AgentException
-         L7
+          TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
+         L6
           NEW org/nlogo/nvm/Activation
           DUP
           ALOAD 0
@@ -1131,7 +1202,7 @@ procedure SEPARATE:[]{-T--}:
           BIPUSH 14
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
          L1
-          GOTO L8
+          GOTO L7
          L2
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -1143,23 +1214,21 @@ procedure SEPARATE:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L8
+         L7
          FRAME FULL [org/nlogo/prim/_asm_procedureseparate_call_0 org/nlogo/nvm/Context] [org/nlogo/nvm/Activation [Ljava/lang/Object; I java/lang/Object]
           ASTORE 2
-         L5
+         L3
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L8
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L9
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L10
+          IFNE L9
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1172,62 +1241,58 @@ procedure SEPARATE:[]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L10
-         FRAME FULL [org/nlogo/prim/_asm_procedureseparate_call_0 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] [org/nlogo/nvm/Activation [Ljava/lang/Object; I]
-          ALOAD 5
+         L9
+         FRAME FULL [org/nlogo/prim/_asm_procedureseparate_call_0 org/nlogo/nvm/Context java/lang/Object T org/nlogo/agent/Agent] [org/nlogo/nvm/Activation [Ljava/lang/Object; I]
+          ALOAD 4
           ICONST_2
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L11
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_procedureseparate_call_0 org/nlogo/nvm/Context java/lang/Object T java/lang/Object] [org/nlogo/nvm/Activation [Ljava/lang/Object; I]
-          ALOAD 4
+          ASTORE 3
+          GOTO L10
+         L8
+         FRAME FULL [org/nlogo/prim/_asm_procedureseparate_call_0 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/nvm/Activation [Ljava/lang/Object; I]
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L3
-          ALOAD 4
+          IFEQ L11
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L12
-         FRAME FULL [org/nlogo/prim/_asm_procedureseparate_call_0 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/nvm/Activation [Ljava/lang/Object; I]
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedureseparate_call_0 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/nvm/Activation [Ljava/lang/Object; I]
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L13
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           ICONST_2
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
           INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
           GOTO L12
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedureseparate_call_0 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/nvm/Activation [Ljava/lang/Object; I]
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureseparate_call_0 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/nvm/Activation [Ljava/lang/Object; I]
+         FRAME FULL [org/nlogo/prim/_asm_procedureseparate_call_0 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/nvm/Activation [Ljava/lang/Object; I]
           ALOAD 6
-         L6
-          GOTO L14
-         L3
-         FRAME FULL [org/nlogo/prim/_asm_procedureseparate_call_0 org/nlogo/nvm/Context java/lang/Object T java/lang/Object] [org/nlogo/nvm/Activation [Ljava/lang/Object; I]
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L10
+         L11
+         FRAME FULL [org/nlogo/prim/_asm_procedureseparate_call_0 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/nvm/Activation [Ljava/lang/Object; I]
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -1241,19 +1306,24 @@ procedure SEPARATE:[]{-T--}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L10
+         FRAME FULL [org/nlogo/prim/_asm_procedureseparate_call_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [org/nlogo/nvm/Activation [Ljava/lang/Object; I]
+          ALOAD 3
          L4
+          GOTO L14
+         L5
          FRAME FULL [org/nlogo/prim/_asm_procedureseparate_call_0 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L14
-         FRAME FULL [org/nlogo/prim/_asm_procedureseparate_call_0 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/nvm/Activation [Ljava/lang/Object; I java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_procedureseparate_call_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [org/nlogo/nvm/Activation [Ljava/lang/Object; I java/lang/Object]
           AASTORE
           DUP
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
@@ -1275,6 +1345,7 @@ procedure SEPARATE:[]{-T--}:
          L17
           RETURN
 [1]_asm_procedureseparate_return_1 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1288,6 +1359,7 @@ procedure ALIGN:[]{-T--}:
 [0]_asm_procedurealign_call_0 "turn-towards"
       _callreport:AVERAGE-FLOCKMATE-HEADING "average-flockmate-heading"
       _observervariable:MAX-ALIGN-TURN "max-align-turn" => Object
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -1344,6 +1416,7 @@ procedure ALIGN:[]{-T--}:
          L5
           RETURN
 [1]_asm_procedurealign_return_1 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1360,6 +1433,9 @@ reporter procedure AVERAGE-FLOCKMATE-HEADING:[]{-T--}:
           _of "of"
             _asm_procedureaverageflockmateheading_sin_1 "sin" double => double
               _turtlevariabledouble:HEADING "heading" => double
+                  // parameter final  context
+                  // parameter final  context
+                  // parameter final  arg0
                  L0
                   ALOAD 1
                   GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -1379,6 +1455,7 @@ reporter procedure AVERAGE-FLOCKMATE-HEADING:[]{-T--}:
                   INVOKESPECIAL java/lang/Double.<init> (D)V
                   ARETURN
             _asm_procedureaverageflockmateheading_turtlevariable_2 "flockmates" => Object
+                  // parameter final  context
                   TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                  L0
                   ALOAD 1
@@ -1405,6 +1482,9 @@ reporter procedure AVERAGE-FLOCKMATE-HEADING:[]{-T--}:
           _of "of"
             _asm_procedureaverageflockmateheading_cos_3 "cos" double => double
               _turtlevariabledouble:HEADING "heading" => double
+                  // parameter final  context
+                  // parameter final  context
+                  // parameter final  arg0
                  L0
                   ALOAD 1
                   GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -1424,6 +1504,7 @@ reporter procedure AVERAGE-FLOCKMATE-HEADING:[]{-T--}:
                   INVOKESPECIAL java/lang/Double.<init> (D)V
                   ARETURN
             _asm_procedureaverageflockmateheading_turtlevariable_4 "flockmates" => Object
+                  // parameter final  context
                   TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                  L0
                   ALOAD 1
@@ -1446,6 +1527,9 @@ reporter procedure AVERAGE-FLOCKMATE-HEADING:[]{-T--}:
                  L3
                  FRAME SAME1 java/lang/Object
                   ARETURN
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           ALOAD 0
@@ -1542,7 +1626,8 @@ reporter procedure AVERAGE-FLOCKMATE-HEADING:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageflockmateheading_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageflockmateheading_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureaverageflockmateheading_report_0.keptinstr6 : Lorg/nlogo/prim/_of;
@@ -1638,7 +1723,8 @@ reporter procedure AVERAGE-FLOCKMATE-HEADING:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageflockmateheading_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageflockmateheading_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L17
           DSTORE 4
           DSTORE 2
@@ -1700,6 +1786,7 @@ reporter procedure AVERAGE-FLOCKMATE-HEADING:[]{-T--}:
           GOTO L21
          L22
          FRAME SAME
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
@@ -1707,6 +1794,8 @@ reporter procedure AVERAGE-FLOCKMATE-HEADING:[]{-T--}:
           SIPUSH 360
           I2D
           DADD
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageflockmateheading_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
           SIPUSH 360
           I2D
           DREM
@@ -1784,6 +1873,7 @@ reporter procedure AVERAGE-FLOCKMATE-HEADING:[]{-T--}:
          FRAME SAME
           RETURN
 [1]_asm_procedureaverageflockmateheading_returnreport_5 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -1803,6 +1893,7 @@ procedure COHERE:[]{-T--}:
 [0]_asm_procedurecohere_call_0 "turn-towards"
       _callreport:AVERAGE-HEADING-TOWARDS-FLOCKMATES "average-heading-towards-flockmates"
       _observervariable:MAX-COHERE-TURN "max-cohere-turn" => Object
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -1859,6 +1950,7 @@ procedure COHERE:[]{-T--}:
          L5
           RETURN
 [1]_asm_procedurecohere_return_1 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1903,6 +1995,12 @@ reporter procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
                        L3
                         ARETURN
                 _constdouble:180.0 "180" => double
+                  // parameter final  context
+                  // parameter final  context
+                  // parameter final  d1
+                  // parameter final  d2
+                  // parameter final  context
+                  // parameter final  arg0
                   TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
                   ALOAD 0
                   GETFIELD org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_sin_1.keptinstr3 : Lorg/nlogo/prim/etc/_towards;
@@ -1949,6 +2047,7 @@ reporter procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
                   INVOKESPECIAL java/lang/Double.<init> (D)V
                   ARETURN
             _asm_procedureaverageheadingtowardsflockmates_turtlevariable_3 "flockmates" => Object
+                  // parameter final  context
                   TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                  L0
                   ALOAD 1
@@ -2003,6 +2102,12 @@ reporter procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
                        L3
                         ARETURN
                 _constdouble:180.0 "180" => double
+                  // parameter final  context
+                  // parameter final  context
+                  // parameter final  d1
+                  // parameter final  d2
+                  // parameter final  context
+                  // parameter final  arg0
                   TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
                   ALOAD 0
                   GETFIELD org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_cos_4.keptinstr3 : Lorg/nlogo/prim/etc/_towards;
@@ -2049,6 +2154,7 @@ reporter procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
                   INVOKESPECIAL java/lang/Double.<init> (D)V
                   ARETURN
             _asm_procedureaverageheadingtowardsflockmates_turtlevariable_6 "flockmates" => Object
+                  // parameter final  context
                   TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                  L0
                   ALOAD 1
@@ -2071,6 +2177,9 @@ reporter procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
                  L3
                  FRAME SAME1 java/lang/Object
                   ARETURN
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           ALOAD 0
@@ -2167,7 +2276,8 @@ reporter procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_report_0.keptinstr6 : Lorg/nlogo/prim/_of;
@@ -2263,7 +2373,8 @@ reporter procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L17
           DSTORE 4
           DSTORE 2
@@ -2325,6 +2436,7 @@ reporter procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
           GOTO L21
          L22
          FRAME SAME
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
@@ -2332,6 +2444,8 @@ reporter procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
           SIPUSH 360
           I2D
           DADD
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
           SIPUSH 360
           I2D
           DREM
@@ -2409,6 +2523,7 @@ reporter procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
          FRAME SAME
           RETURN
 [1]_asm_procedureaverageheadingtowardsflockmates_returnreport_7 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -2430,6 +2545,9 @@ procedure TURN-TOWARDS:[NEW-HEADING MAX-TURN]{-T--}:
         _procedurevariable:NEW-HEADING "new-heading" => Object
         _turtlevariabledouble:HEADING "heading" => Double
       _procedurevariable:MAX-TURN "max-turn" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           NEW org/nlogo/nvm/Activation
@@ -2523,6 +2641,7 @@ procedure TURN-TOWARDS:[NEW-HEADING MAX-TURN]{-T--}:
          L11
           RETURN
 [1]_asm_procedureturntowards_return_1 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2538,6 +2657,9 @@ procedure TURN-AWAY:[NEW-HEADING MAX-TURN]{-T--}:
         _turtlevariabledouble:HEADING "heading" => Double
         _procedurevariable:NEW-HEADING "new-heading" => Object
       _procedurevariable:MAX-TURN "max-turn" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           NEW org/nlogo/nvm/Activation
@@ -2631,6 +2753,7 @@ procedure TURN-AWAY:[NEW-HEADING MAX-TURN]{-T--}:
          L11
           RETURN
 [1]_asm_procedureturnaway_return_1 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2646,6 +2769,15 @@ procedure TURN-AT-MOST:[TURN MAX-TURN]{-T--}:
         _abs "abs" double => double
           _procedurevariable:TURN "turn" => Object
         _procedurevariable:MAX-TURN "max-turn" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -2697,11 +2829,9 @@ procedure TURN-AT-MOST:[TURN MAX-TURN]{-T--}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L8
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -2712,15 +2842,14 @@ procedure TURN-AT-MOST:[TURN MAX-TURN]{-T--}:
           ICONST_1
           GOTO L10
          L9
-         FRAME APPEND [java/lang/Object java/lang/Object java/lang/Double]
+         FRAME APPEND [java/lang/Object T java/lang/Double]
           ICONST_0
          L10
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L11
          L8
-         FRAME CHOP 1
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2749,25 +2878,34 @@ procedure TURN-AT-MOST:[TURN MAX-TURN]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureturnatmost_ifelse_0 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
+         L12
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L12
+          IFEQ L13
           ICONST_1
-          GOTO L13
-         L12
-         FRAME FULL [org/nlogo/prim/_asm_procedureturnatmost_ifelse_0 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 6
+          GOTO L14
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedureturnatmost_ifelse_0 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedureturnatmost_ifelse_0 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context]
+          BIPUSH 6
          L14
+         FRAME FULL [org/nlogo/prim/_asm_procedureturnatmost_ifelse_0 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L15
           RETURN
 [1]_asm_procedureturnatmost_ifelse_1 "ifelse" boolean => void
       _greaterthan ">" Object,double => boolean
         _procedurevariable:TURN "turn" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -2780,14 +2918,10 @@ procedure TURN-AT-MOST:[TURN MAX-TURN]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -2795,15 +2929,14 @@ procedure TURN-AT-MOST:[TURN MAX-TURN]{-T--}:
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedureturnatmost_ifelse_1 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2832,23 +2965,28 @@ procedure TURN-AT-MOST:[TURN MAX-TURN]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedureturnatmost_ifelse_1 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L7
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L7
+          IFEQ L8
           ICONST_2
-          GOTO L8
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedureturnatmost_ifelse_1 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          ICONST_4
+          GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedureturnatmost_ifelse_1 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedureturnatmost_ifelse_1 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          ICONST_4
          L9
+         FRAME FULL [org/nlogo/prim/_asm_procedureturnatmost_ifelse_1 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [2]_asm_procedureturnatmost_right_2 "rt" double => void
       _procedurevariable:MAX-TURN "max-turn" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  delta
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -2889,6 +3027,7 @@ procedure TURN-AT-MOST:[TURN MAX-TURN]{-T--}:
          L5
           RETURN
 [3]_asm_procedureturnatmost_goto_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_5
@@ -2897,6 +3036,9 @@ procedure TURN-AT-MOST:[TURN MAX-TURN]{-T--}:
           RETURN
 [4]_asm_procedureturnatmost_left_4 "lt" double => void
       _procedurevariable:MAX-TURN "max-turn" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  delta
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -2938,6 +3080,7 @@ procedure TURN-AT-MOST:[TURN MAX-TURN]{-T--}:
          L5
           RETURN
 [5]_asm_procedureturnatmost_goto_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 7
@@ -2946,6 +3089,9 @@ procedure TURN-AT-MOST:[TURN MAX-TURN]{-T--}:
           RETURN
 [6]_asm_procedureturnatmost_right_6 "rt" double => void
       _procedurevariable:TURN "turn" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  delta
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -2986,6 +3132,7 @@ procedure TURN-AT-MOST:[TURN MAX-TURN]{-T--}:
          L5
           RETURN
 [7]_asm_procedureturnatmost_return_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -3003,6 +3150,16 @@ reporter procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
             _procedurevariable:H1 "h1" => Object
             _procedurevariable:H2 "h2" => Object
         _constdouble:180.0 "180" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -3111,6 +3268,11 @@ reporter procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
       _minus "-" double,double => double
         _procedurevariable:H1 "h1" => Object
         _procedurevariable:H2 "h2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -3244,6 +3406,7 @@ reporter procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
          FRAME SAME
           RETURN
 [2]_asm_proceduremysubtractheadings_goto_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 7
@@ -3254,6 +3417,13 @@ reporter procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
       _greaterthan ">" Object,Object => boolean
         _procedurevariable:H1 "h1" => Object
         _procedurevariable:H2 "h2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  o1
+          // parameter final  o2
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -3288,40 +3458,36 @@ reporter procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
          L4
          FRAME APPEND [java/lang/Object java/lang/Object]
           ICONST_0
-         L5
-         FRAME SAME1 I
-          GOTO L6
+          GOTO L5
          L3
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
           ICONST_0
-          IF_ICMPLE L8
+          IF_ICMPLE L7
           ICONST_1
-          GOTO L9
-         L8
+          GOTO L5
+         L7
          FRAME SAME
           ICONST_0
-         L9
-         FRAME SAME1 I
-          GOTO L6
-         L7
+          GOTO L5
+         L6
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -3332,21 +3498,19 @@ reporter procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L10
+          IF_ICMPNE L8
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
           ICONST_0
-          IF_ICMPLE L11
+          IF_ICMPLE L9
           ICONST_1
-          GOTO L12
-         L11
+          GOTO L5
+         L9
          FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
           ICONST_0
-         L12
-         FRAME SAME1 I
-          GOTO L6
-         L10
+          GOTO L5
+         L8
          FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -3374,21 +3538,21 @@ reporter procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L6
+         L5
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L13
+          IFEQ L10
           ICONST_4
-          GOTO L14
-         L13
+          GOTO L11
+         L10
          FRAME FULL [org/nlogo/prim/_asm_proceduremysubtractheadings_ifelse_3 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
           BIPUSH 6
-         L14
+         L11
          FRAME FULL [org/nlogo/prim/_asm_proceduremysubtractheadings_ifelse_3 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L15
+         L12
           RETURN
 [4]_asm_proceduremysubtractheadings_report_4 "report" Object => void
       _minus "-" double,double => double
@@ -3396,6 +3560,15 @@ reporter procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
           _procedurevariable:H1 "h1" => Object
           _procedurevariable:H2 "h2" => Object
         _constdouble:360.0 "360" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -3537,6 +3710,7 @@ reporter procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
          FRAME SAME
           RETURN
 [5]_asm_proceduremysubtractheadings_goto_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 7
@@ -3549,6 +3723,15 @@ reporter procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
           _procedurevariable:H1 "h1" => Object
           _procedurevariable:H2 "h2" => Object
         _constdouble:360.0 "360" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -3690,6 +3873,7 @@ reporter procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
          FRAME SAME
           RETURN
 [7]_asm_proceduremysubtractheadings_returnreport_7 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP

--- a/netlogo-headless/test/benchdumps/GasLabCirc.txt
+++ b/netlogo-headless/test/benchdumps/GasLabCirc.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:12345.0 "12345" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 12345.0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -77,6 +80,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [3]_asm_procedurebenchmark_setobservervariable_2 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -91,9 +97,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_2 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -108,9 +111,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_procedurebenchmark_repeatlocal_3 "repeat" double => void
       _constdouble:3500.0 "3500" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 3500.0
          L1
@@ -123,7 +133,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_3.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_3.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -150,6 +161,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [6]_asm_procedurebenchmark_repeatlocalinternal_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -183,6 +195,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [7]_asm_procedurebenchmark_setobservervariable_6 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -204,9 +219,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_6 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -221,8 +233,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [8]_asm_procedurebenchmark_return_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -237,6 +254,7 @@ procedure SETUP:[]{O---}:
 [1]_resetticks "reset-ticks"
 [2]_setdefaultshape "set-default-shape"
       _asm_proceduresetup_breed_0 "particles" => AgentSet
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetup_breed_0.world : Lorg/nlogo/agent/World;
@@ -245,12 +263,16 @@ procedure SETUP:[]{O---}:
            L1
             ARETURN
       _asm_proceduresetup_conststring_1 ""circle"" => String
+            // parameter final  context
            L0
             LDC "circle"
            L1
             ARETURN
 [3]_asm_proceduresetup_setobservervariable_2 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -265,9 +287,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_2 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -282,9 +301,16 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduresetup_setobservervariable_3 "set" Object => void
       _constdouble:0.2 "0.2" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -299,9 +325,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_3 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -316,11 +339,22 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [5]_asm_proceduresetup_setobservervariable_4 "set" Object => void
       _minus "-" double,double => double
         _maxpxcor "max-pxcor" => double
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -350,9 +384,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_4 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -367,6 +398,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [6]_asm_proceduresetup_call_5 "make-box"
          L0
@@ -411,6 +446,7 @@ procedure SETUP:[]{O---}:
           _max "max"
             _breedvariableof:SPEED "of"
               _asm_proceduresetup_breed_8 "particles" => AgentSet
+                    // parameter final  context
                    L0
                     ALOAD 0
                     GETFIELD org/nlogo/prim/_asm_proceduresetup_breed_8.world : Lorg/nlogo/agent/World;
@@ -418,6 +454,11 @@ procedure SETUP:[]{O---}:
                     INVOKEVIRTUAL org/nlogo/agent/World.getBreed (Ljava/lang/String;)Lorg/nlogo/agent/AgentSet;
                    L1
                     ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -487,9 +528,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L4
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_7 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -504,9 +542,16 @@ procedure SETUP:[]{O---}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [9]_asm_proceduresetup_setobservervariable_9 "set" Object => void
       _observervariable:TICK-LENGTH "tick-length" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -524,9 +569,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_9 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -541,9 +583,16 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [10]_asm_proceduresetup_setobservervariable_10 "set" Object => void
       _nobody "nobody" => Nobody$
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
@@ -557,9 +606,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 11
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_10 org/nlogo/nvm/Context org/nlogo/core/Nobody$] [org/nlogo/api/AgentException]
@@ -574,9 +620,16 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 11
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [11]_asm_proceduresetup_setobservervariable_11 "set" Object => void
       _nobody "nobody" => Nobody$
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
@@ -590,9 +643,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 12
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_11 org/nlogo/nvm/Context org/nlogo/core/Nobody$] [org/nlogo/api/AgentException]
@@ -607,6 +657,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 12
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [12]_asm_proceduresetup_call_12 "rebuild-collision-list"
          L0
@@ -627,6 +681,7 @@ procedure SETUP:[]{O---}:
          L1
           RETURN
 [13]_asm_proceduresetup_return_13 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -639,6 +694,9 @@ procedure SETUP:[]{O---}:
 procedure REBUILD-COLLISION-LIST:[]{OTPL}:
 [0]_asm_procedurerebuildcollisionlist_setobservervariable_0 "set" Object => void
       _constlist:[] "[]" => LogoList
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -653,9 +711,6 @@ procedure REBUILD-COLLISION-LIST:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerebuildcollisionlist_setobservervariable_0 org/nlogo/nvm/Context org/nlogo/core/LogoList] [org/nlogo/api/AgentException]
@@ -670,9 +725,16 @@ procedure REBUILD-COLLISION-LIST:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [1]_asm_procedurerebuildcollisionlist_ask_1 "ask" AgentSet => void
       _breed:PARTICLES "particles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerebuildcollisionlist_ask_1.world : Lorg/nlogo/agent/World;
@@ -746,6 +808,7 @@ procedure REBUILD-COLLISION-LIST:[]{OTPL}:
          L1
           RETURN
 [3]_asm_procedurerebuildcollisionlist_done_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -754,6 +817,9 @@ procedure REBUILD-COLLISION-LIST:[]{OTPL}:
           RETURN
 [4]_asm_procedurerebuildcollisionlist_ask_4 "ask" AgentSet => void
       _breed:PARTICLES "particles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerebuildcollisionlist_ask_4.world : Lorg/nlogo/agent/World;
@@ -827,6 +893,7 @@ procedure REBUILD-COLLISION-LIST:[]{OTPL}:
          L1
           RETURN
 [6]_asm_procedurerebuildcollisionlist_done_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -834,6 +901,7 @@ procedure REBUILD-COLLISION-LIST:[]{OTPL}:
          L1
           RETURN
 [7]_asm_procedurerebuildcollisionlist_return_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -847,6 +915,7 @@ procedure GO:[]{O---}:
 [0]_asm_procedurego_ifelse_0 "ifelse" boolean => void
       _isturtle "is-turtle?"
         _asm_procedurego_observervariable_1 "colliding-particle-2" => Object
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurego_observervariable_1.world : Lorg/nlogo/agent/World;
@@ -855,6 +924,8 @@ procedure GO:[]{O---}:
               INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ifelse_0.keptinstr2 : Lorg/nlogo/prim/etc/_isturtle;
@@ -908,12 +979,14 @@ procedure GO:[]{O---}:
                 _notequal "!=" Object,Object => boolean
                   _item "item"
                     _asm_procedurego_constdouble_4 "1" => Double
+                          // parameter final  context
                          L0
                           ALOAD 0
                           GETFIELD org/nlogo/prim/_asm_procedurego_constdouble_4.kept1_value : Ljava/lang/Double;
                          L1
                           ARETURN
                     _asm_procedurego_letvariable_5 "collision" => Object
+                          // parameter final  context
                          L0
                           ALOAD 1
                           ALOAD 0
@@ -925,12 +998,14 @@ procedure GO:[]{O---}:
                 _notequal "!=" Object,Object => boolean
                   _item "item"
                     _asm_procedurego_constdouble_6 "2" => Double
+                          // parameter final  context
                          L0
                           ALOAD 0
                           GETFIELD org/nlogo/prim/_asm_procedurego_constdouble_6.kept1_value : Ljava/lang/Double;
                          L1
                           ARETURN
                     _asm_procedurego_letvariable_7 "collision" => Object
+                          // parameter final  context
                          L0
                           ALOAD 1
                           ALOAD 0
@@ -942,12 +1017,14 @@ procedure GO:[]{O---}:
               _notequal "!=" Object,Object => boolean
                 _item "item"
                   _asm_procedurego_constdouble_8 "1" => Double
+                        // parameter final  context
                        L0
                         ALOAD 0
                         GETFIELD org/nlogo/prim/_asm_procedurego_constdouble_8.kept1_value : Ljava/lang/Double;
                        L1
                         ARETURN
                   _asm_procedurego_letvariable_9 "collision" => Object
+                        // parameter final  context
                        L0
                         ALOAD 1
                         ALOAD 0
@@ -959,12 +1036,14 @@ procedure GO:[]{O---}:
             _notequal "!=" Object,Object => boolean
               _item "item"
                 _asm_procedurego_constdouble_10 "2" => Double
+                      // parameter final  context
                      L0
                       ALOAD 0
                       GETFIELD org/nlogo/prim/_asm_procedurego_constdouble_10.kept1_value : Ljava/lang/Double;
                      L1
                       ARETURN
                 _asm_procedurego_letvariable_11 "collision" => Object
+                      // parameter final  context
                      L0
                       ALOAD 1
                       ALOAD 0
@@ -973,6 +1052,22 @@ procedure GO:[]{O---}:
                      L1
                       ARETURN
               _observervariable:COLLIDING-PARTICLE-2 "colliding-particle-2" => Object
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  arg1
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  arg1
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  arg1
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  arg1
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurego_and_3.keptinstr5 : Lorg/nlogo/prim/etc/_item;
@@ -991,12 +1086,12 @@ procedure GO:[]{O---}:
                 ALOAD 2
                 ALOAD 3
                 INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-                IFEQ L3
-                ICONST_0
+                IFNE L3
+                ICONST_1
                 GOTO L4
                L3
                FRAME APPEND [java/lang/Object java/lang/Object]
-                ICONST_1
+                ICONST_0
                L4
                FRAME SAME1 I
                 IFEQ L5
@@ -1017,12 +1112,12 @@ procedure GO:[]{O---}:
                 ALOAD 2
                 ALOAD 3
                 INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-                IFEQ L8
-                ICONST_0
+                IFNE L8
+                ICONST_1
                 GOTO L9
                L8
                FRAME SAME
-                ICONST_1
+                ICONST_0
                L9
                FRAME SAME1 I
                 GOTO L10
@@ -1049,12 +1144,12 @@ procedure GO:[]{O---}:
                 ALOAD 2
                 ALOAD 3
                 INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-                IFEQ L14
-                ICONST_0
+                IFNE L14
+                ICONST_1
                 GOTO L15
                L14
                FRAME SAME
-                ICONST_1
+                ICONST_0
                L15
                FRAME SAME1 I
                 GOTO L16
@@ -1081,12 +1176,12 @@ procedure GO:[]{O---}:
                 ALOAD 2
                 ALOAD 3
                 INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-                IFEQ L20
-                ICONST_0
+                IFNE L20
+                ICONST_1
                 GOTO L21
                L20
                FRAME SAME
-                ICONST_1
+                ICONST_0
                L21
                FRAME SAME1 I
                 GOTO L22
@@ -1105,6 +1200,7 @@ procedure GO:[]{O---}:
                FRAME SAME1 java/lang/Boolean
                 ARETURN
         _asm_procedurego_observervariable_12 "colliding-particles" => Object
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurego_observervariable_12.world : Lorg/nlogo/agent/World;
@@ -1113,6 +1209,8 @@ procedure GO:[]{O---}:
               INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_setobservervariable_2.keptinstr2 : Lorg/nlogo/prim/etc/_filter;
@@ -1128,9 +1226,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L4
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setobservervariable_2 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -1145,9 +1240,16 @@ procedure GO:[]{O---}:
           ATHROW
          L4
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L5
           RETURN
 [2]_asm_procedurego_ask_13 "ask" Object => void
       _observervariable:COLLIDING-PARTICLE-2 "colliding-particle-2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_13.world : Lorg/nlogo/agent/World;
@@ -1157,18 +1259,16 @@ procedure GO:[]{O---}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_13.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -1184,8 +1284,8 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_13 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_13.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -1202,18 +1302,18 @@ procedure GO:[]{O---}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -1230,7 +1330,7 @@ procedure GO:[]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -1240,23 +1340,12 @@ procedure GO:[]{O---}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_13 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_3
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -1270,8 +1359,16 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          ICONST_3
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_13 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [3]_asm_procedurego_call_14 "check-for-wall-collision"
          L0
@@ -1292,6 +1389,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [4]_asm_procedurego_done_15 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1300,6 +1398,9 @@ procedure GO:[]{O---}:
           RETURN
 [5]_asm_procedurego_ask_16 "ask" Object => void
       _observervariable:COLLIDING-PARTICLE-2 "colliding-particle-2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_16.world : Lorg/nlogo/agent/World;
@@ -1309,18 +1410,16 @@ procedure GO:[]{O---}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_16.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -1336,8 +1435,8 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_16 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_16.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -1354,18 +1453,18 @@ procedure GO:[]{O---}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -1382,7 +1481,7 @@ procedure GO:[]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -1392,23 +1491,12 @@ procedure GO:[]{O---}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_16 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 6
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -1422,8 +1510,16 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 6
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_16 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [6]_asm_procedurego_call_17 "check-for-particle-collision"
          L0
@@ -1444,6 +1540,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [7]_asm_procedurego_done_18 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1451,6 +1548,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [8]_asm_procedurego_goto_19 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 10
@@ -1466,12 +1564,14 @@ procedure GO:[]{O---}:
             _notequal "!=" Object,Object => boolean
               _item "item"
                 _asm_procedurego_constdouble_22 "1" => Double
+                      // parameter final  context
                      L0
                       ALOAD 0
                       GETFIELD org/nlogo/prim/_asm_procedurego_constdouble_22.kept1_value : Ljava/lang/Double;
                      L1
                       ARETURN
                 _asm_procedurego_letvariable_23 "collision" => Object
+                      // parameter final  context
                      L0
                       ALOAD 1
                       ALOAD 0
@@ -1483,12 +1583,14 @@ procedure GO:[]{O---}:
             _notequal "!=" Object,Object => boolean
               _item "item"
                 _asm_procedurego_constdouble_24 "2" => Double
+                      // parameter final  context
                      L0
                       ALOAD 0
                       GETFIELD org/nlogo/prim/_asm_procedurego_constdouble_24.kept1_value : Ljava/lang/Double;
                      L1
                       ARETURN
                 _asm_procedurego_letvariable_25 "collision" => Object
+                      // parameter final  context
                      L0
                       ALOAD 1
                       ALOAD 0
@@ -1497,6 +1599,14 @@ procedure GO:[]{O---}:
                      L1
                       ARETURN
               _observervariable:COLLIDING-PARTICLE-1 "colliding-particle-1" => Object
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  arg1
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  arg1
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurego_and_21.keptinstr3 : Lorg/nlogo/prim/etc/_item;
@@ -1515,12 +1625,12 @@ procedure GO:[]{O---}:
                 ALOAD 2
                 ALOAD 3
                 INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-                IFEQ L3
-                ICONST_0
+                IFNE L3
+                ICONST_1
                 GOTO L4
                L3
                FRAME APPEND [java/lang/Object java/lang/Object]
-                ICONST_1
+                ICONST_0
                L4
                FRAME SAME1 I
                 IFEQ L5
@@ -1541,12 +1651,12 @@ procedure GO:[]{O---}:
                 ALOAD 2
                 ALOAD 3
                 INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-                IFEQ L8
-                ICONST_0
+                IFNE L8
+                ICONST_1
                 GOTO L9
                L8
                FRAME SAME
-                ICONST_1
+                ICONST_0
                L9
                FRAME SAME1 I
                 GOTO L10
@@ -1565,6 +1675,7 @@ procedure GO:[]{O---}:
                FRAME SAME1 java/lang/Boolean
                 ARETURN
         _asm_procedurego_observervariable_26 "colliding-particles" => Object
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurego_observervariable_26.world : Lorg/nlogo/agent/World;
@@ -1573,6 +1684,8 @@ procedure GO:[]{O---}:
               INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_setobservervariable_20.keptinstr2 : Lorg/nlogo/prim/etc/_filter;
@@ -1588,9 +1701,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L4
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setobservervariable_20 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -1605,11 +1715,22 @@ procedure GO:[]{O---}:
           ATHROW
          L4
          FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L5
           RETURN
 [10]_asm_procedurego_if_27 "if" boolean => void
       _notequal "!=" Object,Object => boolean
         _observervariable:COLLIDING-PARTICLE-1 "colliding-particle-1" => Object
         _nobody "nobody" => Nobody$
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_if_27.world : Lorg/nlogo/agent/World;
@@ -1625,12 +1746,12 @@ procedure GO:[]{O---}:
           ALOAD 2
           ALOAD 3
           INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-          IFEQ L3
-          ICONST_0
+          IFNE L3
+          ICONST_1
           GOTO L4
          L3
          FRAME APPEND [java/lang/Object org/nlogo/core/Nobody$]
-          ICONST_1
+          ICONST_0
          L4
          FRAME SAME1 I
           ISTORE 2
@@ -1649,6 +1770,9 @@ procedure GO:[]{O---}:
           RETURN
 [11]_asm_procedurego_ask_28 "ask" Object => void
       _observervariable:COLLIDING-PARTICLE-1 "colliding-particle-1" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_28.world : Lorg/nlogo/agent/World;
@@ -1658,18 +1782,16 @@ procedure GO:[]{O---}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_28.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -1685,8 +1807,8 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_28 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_28.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -1703,18 +1825,18 @@ procedure GO:[]{O---}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -1731,7 +1853,7 @@ procedure GO:[]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -1741,23 +1863,12 @@ procedure GO:[]{O---}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_28 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 12
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 14
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -1771,8 +1882,16 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 12
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 14
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_28 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [12]_asm_procedurego_call_29 "check-for-wall-collision"
          L0
@@ -1793,6 +1912,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [13]_asm_procedurego_done_30 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1803,6 +1923,13 @@ procedure GO:[]{O---}:
       _notequal "!=" Object,Object => boolean
         _observervariable:COLLIDING-PARTICLE-1 "colliding-particle-1" => Object
         _nobody "nobody" => Nobody$
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_if_31.world : Lorg/nlogo/agent/World;
@@ -1818,12 +1945,12 @@ procedure GO:[]{O---}:
           ALOAD 2
           ALOAD 3
           INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-          IFEQ L3
-          ICONST_0
+          IFNE L3
+          ICONST_1
           GOTO L4
          L3
          FRAME APPEND [java/lang/Object org/nlogo/core/Nobody$]
-          ICONST_1
+          ICONST_0
          L4
          FRAME SAME1 I
           ISTORE 2
@@ -1842,6 +1969,9 @@ procedure GO:[]{O---}:
           RETURN
 [15]_asm_procedurego_ask_32 "ask" Object => void
       _observervariable:COLLIDING-PARTICLE-1 "colliding-particle-1" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_32.world : Lorg/nlogo/agent/World;
@@ -1851,18 +1981,16 @@ procedure GO:[]{O---}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_32.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -1878,8 +2006,8 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_32 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_32.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -1896,18 +2024,18 @@ procedure GO:[]{O---}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -1924,7 +2052,7 @@ procedure GO:[]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -1934,23 +2062,12 @@ procedure GO:[]{O---}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_32 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 16
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 18
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -1964,8 +2081,16 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 16
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 18
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_32 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [16]_asm_procedurego_call_33 "check-for-particle-collision"
          L0
@@ -1986,6 +2111,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [17]_asm_procedurego_done_34 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2012,6 +2138,9 @@ procedure GO:[]{O---}:
           RETURN
 [19]_asm_procedurego_ask_36 "ask" AgentSet => void
       _breed:PARTICLES "particles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_36.world : Lorg/nlogo/agent/World;
@@ -2070,17 +2199,24 @@ procedure GO:[]{O---}:
       _mult "*" double,double => double
         _breedvariable:SPEED "speed" => Object
         _observervariable:TICK-LENGTH "tick-length" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  distance
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
-          TRYCATCHBLOCK L7 L8 L8 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L7 L8 L9 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           LDC "SPEED"
           INVOKEVIRTUAL org/nlogo/agent/Agent.getBreedVariable (Ljava/lang/String;)Ljava/lang/Object;
          L1
-          GOTO L9
+          GOTO L10
          L2
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -2092,14 +2228,14 @@ procedure GO:[]{O---}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
+         L10
          FRAME SAME1 java/lang/Object
           ASTORE 2
          L3
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
-          GOTO L10
+          GOTO L11
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurego_jump_37 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
           POP
@@ -2112,20 +2248,20 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
-         L10
+         L11
          FRAME SAME1 D
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_jump_37.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.observer ()Lorg/nlogo/agent/Observer;
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
-         L11
+         L12
           ASTORE 2
          L5
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
-          GOTO L12
+          GOTO L13
          L6
          FRAME SAME1 java/lang/ClassCastException
           POP
@@ -2138,14 +2274,14 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
-         L12
+         L13
          FRAME FULL [org/nlogo/prim/_asm_procedurego_jump_37 org/nlogo/nvm/Context java/lang/Object] [D D]
           DSTORE 4
           DSTORE 2
           DLOAD 2
           DLOAD 4
           DMUL
-         L13
+         L14
           DSTORE 2
          L7
           ALOAD 1
@@ -2153,18 +2289,20 @@ procedure GO:[]{O---}:
           CHECKCAST org/nlogo/agent/Turtle
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L14
          L8
+          GOTO L15
+         L9
          FRAME FULL [org/nlogo/prim/_asm_procedurego_jump_37 org/nlogo/nvm/Context D D] [org/nlogo/api/AgentException]
-          ASTORE 4
-         L14
-         FRAME CHOP 1
+          POP
+         L15
+         FRAME SAME
           ALOAD 1
           BIPUSH 21
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L15
+         L16
           RETURN
 [21]_asm_procedurego_done_38 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2191,6 +2329,7 @@ procedure GO:[]{O---}:
           RETURN
 [23]_tickadvance "tick-advance"
       _asm_procedurego_observervariable_40 "tick-length" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurego_observervariable_40.world : Lorg/nlogo/agent/World;
@@ -2201,6 +2340,9 @@ procedure GO:[]{O---}:
             ARETURN
 [24]_asm_procedurego_if_41 "if" boolean => void
       _observervariable:MANAGE-VIEW-UPDATES? "manage-view-updates?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -2249,6 +2391,16 @@ procedure GO:[]{O---}:
           _ticks "ticks" => double
           _observervariable:LAST-VIEW-UPDATE "last-view-update" => Object
         _observervariable:VIEW-UPDATE-RATE "view-update-rate" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -2313,11 +2465,9 @@ procedure GO:[]{O---}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L9
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -2328,15 +2478,14 @@ procedure GO:[]{O---}:
           ICONST_1
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_42 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_42 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L11
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L12
          L9
-         FRAME CHOP 1
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2365,24 +2514,28 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L12
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_42 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
+         L13
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L13
+          IFEQ L14
           BIPUSH 26
-          GOTO L14
-         L13
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_42 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 28
+          GOTO L15
          L14
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_42 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_42 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context]
+          BIPUSH 28
          L15
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_42 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L16
           RETURN
 [26]_display "display"
 [27]_asm_procedurego_setobservervariable_43 "set" Object => void
       _ticks "ticks" => double
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2420,9 +2573,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 28
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L6
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setobservervariable_43 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -2437,8 +2587,13 @@ procedure GO:[]{O---}:
           ATHROW
          L6
          FRAME SAME
+          ALOAD 1
+          BIPUSH 28
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L7
           RETURN
 [28]_asm_procedurego_return_44 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2452,6 +2607,9 @@ reporter procedure CONVERT-HEADING-X:[HEADING-ANGLE]{OTPL}:
 [0]_asm_procedureconvertheadingx_report_0 "report" Object => void
       _sin "sin" double => double
         _procedurevariable:HEADING-ANGLE "heading-angle" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -2557,6 +2715,7 @@ reporter procedure CONVERT-HEADING-X:[HEADING-ANGLE]{OTPL}:
          FRAME SAME
           RETURN
 [1]_asm_procedureconvertheadingx_returnreport_1 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -2576,6 +2735,9 @@ reporter procedure CONVERT-HEADING-Y:[HEADING-ANGLE]{OTPL}:
 [0]_asm_procedureconvertheadingy_report_0 "report" Object => void
       _cos "cos" double => double
         _procedurevariable:HEADING-ANGLE "heading-angle" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -2681,6 +2843,7 @@ reporter procedure CONVERT-HEADING-Y:[HEADING-ANGLE]{OTPL}:
          FRAME SAME
           RETURN
 [1]_asm_procedureconvertheadingy_returnreport_1 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -2699,6 +2862,9 @@ reporter procedure CONVERT-HEADING-Y:[HEADING-ANGLE]{OTPL}:
 procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY-Y-SPEED]{-T--}:
 [0]_asm_procedurecheckforparticlecollision_setprocedurevariable_0 "let" Object => void
       _turtlevariabledouble:XCOR "xcor" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -2735,6 +2901,9 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           RETURN
 [1]_asm_procedurecheckforparticlecollision_setprocedurevariable_1 "let" Object => void
       _turtlevariabledouble:YCOR "ycor" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -2771,6 +2940,9 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           RETURN
 [2]_asm_procedurecheckforparticlecollision_setprocedurevariable_2 "let" Object => void
       _turtlevariabledouble:SIZE "size" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -2810,6 +2982,13 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
         _breedvariable:SPEED "speed" => Object
         _callreport:CONVERT-HEADING-X "convert-heading-x"
           _turtlevariabledouble:HEADING "heading" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -2949,6 +3128,13 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
         _breedvariable:SPEED "speed" => Object
         _callreport:CONVERT-HEADING-Y "convert-heading-y"
           _turtlevariabledouble:HEADING "heading" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -3086,6 +3272,11 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
 [5]_asm_procedurecheckforparticlecollision_ask_5 "ask" AgentSet => void
       _other "other" AgentSet => AgentSet
         _breed:PARTICLES "particles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecheckforparticlecollision_ask_5.world : Lorg/nlogo/agent/World;
@@ -3177,6 +3368,13 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
       _minus "-" double,double => double
         _turtlevariabledouble:XCOR "xcor" => double
         _procedurevariable:MY-X "my-x" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -3237,6 +3435,13 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
       _minus "-" double,double => double
         _turtlevariabledouble:YCOR "ycor" => double
         _procedurevariable:MY-Y "my-y" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -3298,6 +3503,13 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
         _breedvariable:SPEED "speed" => Object
         _callreport:CONVERT-HEADING-X "convert-heading-x"
           _turtlevariabledouble:HEADING "heading" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -3436,6 +3648,13 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
         _breedvariable:SPEED "speed" => Object
         _callreport:CONVERT-HEADING-Y "convert-heading-y"
           _turtlevariabledouble:HEADING "heading" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -3573,6 +3792,13 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
       _minus "-" double,double => double
         _letvariable(Let(X-SPEED)) "x-speed" => Object
         _procedurevariable:MY-X-SPEED "my-x-speed" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -3653,6 +3879,13 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
       _minus "-" double,double => double
         _letvariable(Let(Y-SPEED)) "y-speed" => Object
         _procedurevariable:MY-Y-SPEED "my-y-speed" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -3738,6 +3971,17 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           _turtlevariableof:SIZE "of" Agent => Object
             _self "self" => Agent
           _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agent
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -3917,6 +4161,29 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
         _pow "^" double,double => double
           _letvariable(Let(SUM-R)) "sum-r" => Object
           _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -4074,7 +4341,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.pow (DD)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_13.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_13.validDouble (DLorg/nlogo/nvm/Context;)D
          L25
           DSTORE 4
           DSTORE 2
@@ -4108,6 +4376,25 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           _mult "*" double,double => double
             _letvariable(Let(DPY)) "dpy" => Object
             _letvariable(Let(DVY)) "dvy" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -4263,6 +4550,21 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
         _mult "*" double,double => double
           _letvariable(Let(DVY)) "dvy" => Object
           _letvariable(Let(DVY)) "dvy" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -4412,6 +4714,25 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
             _constdouble:4.0 "4" => double
             _letvariable(Let(V-SQUARED)) "v-squared" => Object
           _letvariable(Let(P-SQUARED)) "p-squared" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -4449,7 +4770,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.pow (DD)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_16.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_16.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           LDC 4.0
          L11
@@ -4539,6 +4861,9 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           RETURN
 [17]_asm_procedurecheckforparticlecollision_let_17 "let" Object => void
       _constdouble:-1.0 "-1" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_17.kept2_value : Ljava/lang/Double;
@@ -4558,6 +4883,10 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
       _greaterorequal ">=" Object,double => boolean
         _letvariable(Let(D1)) "D1" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           ALOAD 0
@@ -4635,6 +4964,18 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
         _mult "*" double,double => double
           _constdouble:2.0 "2" => double
           _letvariable(Let(V-SQUARED)) "v-squared" => Object
+            // parameter final  context
+            // parameter final  context
+            // parameter final  d0
+            // parameter final  context
+            // parameter final  context
+            // parameter final  d0
+            // parameter final  d1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
             TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
             TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -4789,6 +5130,13 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
       _greaterthan ">" Object,double => boolean
         _letvariable(Let(TIME-TO-COLLISION)) "time-to-collision" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           ALOAD 0
@@ -4800,14 +5148,10 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -4815,15 +5159,14 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforparticlecollision_if_20 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4852,20 +5195,22 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforparticlecollision_if_20 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L7
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L7
+          IFEQ L8
           BIPUSH 21
-          GOTO L8
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforparticlecollision_if_20 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 23
+          GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforparticlecollision_if_20 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforparticlecollision_if_20 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 23
          L9
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforparticlecollision_if_20 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [21]_asm_procedurecheckforparticlecollision_let_21 "let" Object => void
       _list "list"
@@ -4874,6 +5219,13 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           _ticks "ticks" => double
         _self "self" => Agent
         _myself "myself" => Agent
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           NEW org/nlogo/api/LogoListBuilder
@@ -4988,6 +5340,13 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
       _fput "fput" Object,LogoList => LogoList
         _letvariable(Let(COLLIDING-PAIR)) "colliding-pair" => Object
         _observervariable:COLLIDING-PARTICLES "colliding-particles" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  obj
+          // parameter final  list
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -5036,9 +5395,6 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 23
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L10
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurecheckforparticlecollision_setobservervariable_22 org/nlogo/nvm/Context org/nlogo/core/LogoList org/nlogo/core/LogoList] [org/nlogo/api/AgentException]
@@ -5053,8 +5409,13 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           ATHROW
          L10
          FRAME SAME
+          ALOAD 1
+          BIPUSH 23
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [23]_asm_procedurecheckforparticlecollision_done_23 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -5062,6 +5423,7 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
          L1
           RETURN
 [24]_asm_procedurecheckforparticlecollision_return_24 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -5077,6 +5439,13 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
         _breedvariable:SPEED "speed" => Object
         _callreport:CONVERT-HEADING-X "convert-heading-x"
           _turtlevariabledouble:HEADING "heading" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -5216,6 +5585,13 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
         _breedvariable:SPEED "speed" => Object
         _callreport:CONVERT-HEADING-Y "convert-heading-y"
           _turtlevariabledouble:HEADING "heading" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -5354,6 +5730,13 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _minus "-" double,double => double
         _observervariable:BOX-EDGE "box-edge" => Object
         _constdouble:0.5 "0.5" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -5412,6 +5795,15 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
         _unaryminus "-" double => double
           _observervariable:BOX-EDGE "box-edge" => Object
         _constdouble:0.5 "0.5" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -5473,6 +5865,13 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _minus "-" double,double => double
         _observervariable:BOX-EDGE "box-edge" => Object
         _constdouble:0.5 "0.5" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -5531,6 +5930,15 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
         _unaryminus "-" double => double
           _observervariable:BOX-EDGE "box-edge" => Object
         _constdouble:0.5 "0.5" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -5594,6 +6002,14 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
         _div "/" double,double => double
           _turtlevariabledouble:SIZE "size" => double
           _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -5659,6 +6075,14 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
         _div "/" double,double => double
           _turtlevariabledouble:SIZE "size" => double
           _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -5724,6 +6148,14 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
         _div "/" double,double => double
           _turtlevariabledouble:SIZE "size" => double
           _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -5789,6 +6221,14 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
         _div "/" double,double => double
           _turtlevariabledouble:SIZE "size" => double
           _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -5852,6 +6292,13 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _minus "-" double,double => double
         _procedurevariable:XPOS-PLANE "xpos-plane" => Object
         _procedurevariable:CONTACT-POINT-XPOS "contact-point-xpos" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -5934,6 +6381,13 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _minus "-" double,double => double
         _procedurevariable:XNEG-PLANE "xneg-plane" => Object
         _procedurevariable:CONTACT-POINT-XNEG "contact-point-xneg" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -6016,6 +6470,13 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _minus "-" double,double => double
         _procedurevariable:YPOS-PLANE "ypos-plane" => Object
         _procedurevariable:CONTACT-POINT-YPOS "contact-point-ypos" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -6098,6 +6559,13 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _minus "-" double,double => double
         _procedurevariable:YNEG-PLANE "yneg-plane" => Object
         _procedurevariable:CONTACT-POINT-YNEG "contact-point-yneg" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -6178,6 +6646,9 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           RETURN
 [14]_asm_procedurecheckforwallcollision_setprocedurevariable_14 "let" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_14.kept2_value : Ljava/lang/Double;
@@ -6198,6 +6669,13 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _notequal "!=" Object,double => boolean
         _procedurevariable:X-SPEED "x-speed" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -6210,11 +6688,9 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -6225,19 +6701,19 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_15 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_15 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L6
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L7
           ISTORE 2
           ALOAD 1
@@ -6246,10 +6722,10 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           BIPUSH 16
           GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_15 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_15 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 18
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_15 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_15 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L10
           RETURN
@@ -6257,6 +6733,10 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _div "/" double,double => double
         _procedurevariable:DPXPOS "dpxpos" => Object
         _procedurevariable:X-SPEED "x-speed" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -6351,6 +6831,7 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
          L11
           RETURN
 [17]_asm_procedurecheckforwallcollision_goto_17 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 19
@@ -6359,6 +6840,9 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           RETURN
 [18]_asm_procedurecheckforwallcollision_setprocedurevariable_18 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_18.kept2_value : Ljava/lang/Double;
@@ -6379,6 +6863,13 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _greaterthan ">" Object,double => boolean
         _procedurevariable:T-PLANE-XPOS "t-plane-xpos" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -6391,14 +6882,10 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -6406,15 +6893,14 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_19 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -6443,24 +6929,28 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_19 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L7
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L7
+          IFEQ L8
           BIPUSH 20
-          GOTO L8
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_19 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 21
+          GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_19 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_19 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 21
          L9
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_19 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [20]_asm_procedurecheckforwallcollision_call_20 "assign-colliding-wall"
       _procedurevariable:T-PLANE-XPOS "t-plane-xpos" => Object
       _conststring:"plane-xpos" ""plane-xpos"" => String
+          // parameter final  context
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -6498,6 +6988,9 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           RETURN
 [21]_asm_procedurecheckforwallcollision_setprocedurevariable_21 "let" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_21.kept2_value : Ljava/lang/Double;
@@ -6518,6 +7011,13 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _notequal "!=" Object,double => boolean
         _procedurevariable:X-SPEED "x-speed" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -6530,11 +7030,9 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -6545,19 +7043,19 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_22 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_22 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L6
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L7
           ISTORE 2
           ALOAD 1
@@ -6566,10 +7064,10 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           BIPUSH 23
           GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_22 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_22 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 25
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_22 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_22 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L10
           RETURN
@@ -6577,6 +7075,10 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _div "/" double,double => double
         _procedurevariable:DPXNEG "dpxneg" => Object
         _procedurevariable:X-SPEED "x-speed" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -6671,6 +7173,7 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
          L11
           RETURN
 [24]_asm_procedurecheckforwallcollision_goto_24 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 26
@@ -6679,6 +7182,9 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           RETURN
 [25]_asm_procedurecheckforwallcollision_setprocedurevariable_25 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_25.kept2_value : Ljava/lang/Double;
@@ -6699,6 +7205,13 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _greaterthan ">" Object,double => boolean
         _procedurevariable:T-PLANE-XNEG "t-plane-xneg" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -6711,14 +7224,10 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -6726,15 +7235,14 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_26 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -6763,24 +7271,28 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_26 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L7
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L7
+          IFEQ L8
           BIPUSH 27
-          GOTO L8
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_26 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 28
+          GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_26 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_26 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 28
          L9
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_26 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [27]_asm_procedurecheckforwallcollision_call_27 "assign-colliding-wall"
       _procedurevariable:T-PLANE-XNEG "t-plane-xneg" => Object
       _conststring:"plane-xneg" ""plane-xneg"" => String
+          // parameter final  context
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -6818,6 +7330,9 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           RETURN
 [28]_asm_procedurecheckforwallcollision_setprocedurevariable_28 "let" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_28.kept2_value : Ljava/lang/Double;
@@ -6838,6 +7353,13 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _notequal "!=" Object,double => boolean
         _procedurevariable:Y-SPEED "y-speed" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -6850,11 +7372,9 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -6865,19 +7385,19 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_29 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_29 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L6
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L7
           ISTORE 2
           ALOAD 1
@@ -6886,10 +7406,10 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           BIPUSH 30
           GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_29 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_29 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 32
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_29 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_29 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L10
           RETURN
@@ -6897,6 +7417,10 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _div "/" double,double => double
         _procedurevariable:DPYPOS "dpypos" => Object
         _procedurevariable:Y-SPEED "y-speed" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -6991,6 +7515,7 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
          L11
           RETURN
 [31]_asm_procedurecheckforwallcollision_goto_31 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 33
@@ -6999,6 +7524,9 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           RETURN
 [32]_asm_procedurecheckforwallcollision_setprocedurevariable_32 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_32.kept2_value : Ljava/lang/Double;
@@ -7019,6 +7547,13 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _greaterthan ">" Object,double => boolean
         _procedurevariable:T-PLANE-YPOS "t-plane-ypos" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7031,14 +7566,10 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -7046,15 +7577,14 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_33 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -7083,24 +7613,28 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_33 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L7
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L7
+          IFEQ L8
           BIPUSH 34
-          GOTO L8
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_33 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 35
+          GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_33 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_33 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 35
          L9
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_33 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [34]_asm_procedurecheckforwallcollision_call_34 "assign-colliding-wall"
       _procedurevariable:T-PLANE-YPOS "t-plane-ypos" => Object
       _conststring:"plane-ypos" ""plane-ypos"" => String
+          // parameter final  context
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -7138,6 +7672,9 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           RETURN
 [35]_asm_procedurecheckforwallcollision_setprocedurevariable_35 "let" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_35.kept2_value : Ljava/lang/Double;
@@ -7158,6 +7695,13 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _notequal "!=" Object,double => boolean
         _procedurevariable:Y-SPEED "y-speed" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7170,11 +7714,9 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -7185,19 +7727,19 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_36 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_36 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L6
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L7
           ISTORE 2
           ALOAD 1
@@ -7206,10 +7748,10 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           BIPUSH 37
           GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_36 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_36 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 39
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_36 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_ifelse_36 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L10
           RETURN
@@ -7217,6 +7759,10 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _div "/" double,double => double
         _procedurevariable:DPYNEG "dpyneg" => Object
         _procedurevariable:Y-SPEED "y-speed" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -7311,6 +7857,7 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
          L11
           RETURN
 [38]_asm_procedurecheckforwallcollision_goto_38 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 40
@@ -7319,6 +7866,9 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           RETURN
 [39]_asm_procedurecheckforwallcollision_setprocedurevariable_39 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_39.kept2_value : Ljava/lang/Double;
@@ -7339,6 +7889,13 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
       _greaterthan ">" Object,double => boolean
         _procedurevariable:T-PLANE-YNEG "t-plane-yneg" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7351,14 +7908,10 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -7366,15 +7919,14 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_40 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -7403,24 +7955,28 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_40 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L7
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L7
+          IFEQ L8
           BIPUSH 41
-          GOTO L8
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_40 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 42
+          GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_40 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_40 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 42
          L9
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforwallcollision_if_40 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [41]_asm_procedurecheckforwallcollision_call_41 "assign-colliding-wall"
       _procedurevariable:T-PLANE-YNEG "t-plane-yneg" => Object
       _conststring:"plane-yneg" ""plane-yneg"" => String
+          // parameter final  context
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -7457,6 +8013,7 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
          L5
           RETURN
 [42]_asm_procedurecheckforwallcollision_return_42 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -7474,6 +8031,14 @@ procedure ASSIGN-COLLIDING-WALL:[TIME-TO-COLLISION WALL COLLIDING-PAIR]{-TPL}:
           _ticks "ticks" => double
         _self "self" => Agent
         _procedurevariable:WALL "wall" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           NEW org/nlogo/api/LogoListBuilder
@@ -7573,6 +8138,13 @@ procedure ASSIGN-COLLIDING-WALL:[TIME-TO-COLLISION WALL COLLIDING-PAIR]{-TPL}:
       _fput "fput" Object,LogoList => LogoList
         _procedurevariable:COLLIDING-PAIR "colliding-pair" => Object
         _observervariable:COLLIDING-PARTICLES "colliding-particles" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  obj
+          // parameter final  list
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -7622,9 +8194,6 @@ procedure ASSIGN-COLLIDING-WALL:[TIME-TO-COLLISION WALL COLLIDING-PAIR]{-TPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L10
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedureassigncollidingwall_setobservervariable_1 org/nlogo/nvm/Context org/nlogo/core/LogoList org/nlogo/core/LogoList] [org/nlogo/api/AgentException]
@@ -7639,8 +8208,13 @@ procedure ASSIGN-COLLIDING-WALL:[TIME-TO-COLLISION WALL COLLIDING-PAIR]{-TPL}:
           ATHROW
          L10
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [2]_asm_procedureassigncollidingwall_return_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -7660,12 +8234,14 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
             _notequal "!=" Object,Object => boolean
               _item "item"
                 _asm_proceduresortcollisions_constdouble_2 "1" => Double
+                      // parameter final  context
                      L0
                       ALOAD 0
                       GETFIELD org/nlogo/prim/_asm_proceduresortcollisions_constdouble_2.kept1_value : Ljava/lang/Double;
                      L1
                       ARETURN
                 _asm_proceduresortcollisions_letvariable_3 "collision" => Object
+                      // parameter final  context
                      L0
                       ALOAD 1
                       ALOAD 0
@@ -7677,12 +8253,14 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
             _notequal "!=" Object,Object => boolean
               _item "item"
                 _asm_proceduresortcollisions_constdouble_4 "2" => Double
+                      // parameter final  context
                      L0
                       ALOAD 0
                       GETFIELD org/nlogo/prim/_asm_proceduresortcollisions_constdouble_4.kept1_value : Ljava/lang/Double;
                      L1
                       ARETURN
                 _asm_proceduresortcollisions_letvariable_5 "collision" => Object
+                      // parameter final  context
                      L0
                       ALOAD 1
                       ALOAD 0
@@ -7691,6 +8269,14 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                      L1
                       ARETURN
               _observervariable:COLLIDING-PARTICLE-2 "colliding-particle-2" => Object
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  arg1
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  arg1
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_proceduresortcollisions_or_1.keptinstr3 : Lorg/nlogo/prim/etc/_item;
@@ -7709,12 +8295,12 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 ALOAD 2
                 ALOAD 3
                 INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-                IFEQ L3
-                ICONST_0
+                IFNE L3
+                ICONST_1
                 GOTO L4
                L3
                FRAME APPEND [java/lang/Object java/lang/Object]
-                ICONST_1
+                ICONST_0
                L4
                FRAME SAME1 I
                 IFNE L5
@@ -7735,12 +8321,12 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 ALOAD 2
                 ALOAD 3
                 INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-                IFEQ L8
-                ICONST_0
+                IFNE L8
+                ICONST_1
                 GOTO L9
                L8
                FRAME SAME
-                ICONST_1
+                ICONST_0
                L9
                FRAME SAME1 I
                 GOTO L10
@@ -7759,6 +8345,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                FRAME SAME1 java/lang/Boolean
                 ARETURN
         _asm_proceduresortcollisions_observervariable_6 "colliding-particles" => Object
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_proceduresortcollisions_observervariable_6.world : Lorg/nlogo/agent/World;
@@ -7767,6 +8354,8 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
               INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresortcollisions_setobservervariable_0.keptinstr2 : Lorg/nlogo/prim/etc/_filter;
@@ -7782,9 +8371,6 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L4
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresortcollisions_setobservervariable_0 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -7799,9 +8385,16 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           ATHROW
          L4
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L5
           RETURN
 [1]_asm_proceduresortcollisions_setobservervariable_7 "set" Object => void
       _nobody "nobody" => Nobody$
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
@@ -7815,9 +8408,6 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresortcollisions_setobservervariable_7 org/nlogo/nvm/Context org/nlogo/core/Nobody$] [org/nlogo/api/AgentException]
@@ -7832,9 +8422,16 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_proceduresortcollisions_setobservervariable_8 "set" Object => void
       _nobody "nobody" => Nobody$
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
@@ -7848,9 +8445,6 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresortcollisions_setobservervariable_8 org/nlogo/nvm/Context org/nlogo/core/Nobody$] [org/nlogo/api/AgentException]
@@ -7865,9 +8459,16 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_proceduresortcollisions_setobservervariable_9 "set" Object => void
       _observervariable:ORIGINAL-TICK-LENGTH "original-tick-length" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -7885,9 +8486,6 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresortcollisions_setobservervariable_9 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -7902,11 +8500,22 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduresortcollisions_if_10 "if" boolean => void
       _equal "=" Object,Object => boolean
         _observervariable:COLLIDING-PARTICLES "colliding-particles" => Object
         _constlist:[] "[]" => LogoList
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresortcollisions_if_10.world : Lorg/nlogo/agent/World;
@@ -7979,6 +8588,9 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
 [6]_asm_proceduresortcollisions_let_12 "let" Object => void
       _first "first" Object => Object
         _observervariable:COLLIDING-PARTICLES "colliding-particles" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresortcollisions_let_12.world : Lorg/nlogo/agent/World;
@@ -8065,6 +8677,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           RETURN
 [7]_foreach "foreach"
       _asm_proceduresortcollisions_observervariable_13 "colliding-particles" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresortcollisions_observervariable_13.world : Lorg/nlogo/agent/World;
@@ -8077,12 +8690,14 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
 [8]_asm_proceduresortcollisions_setprocedurevariable_14 "let" Object => void
       _item "item"
         _asm_proceduresortcollisions_constdouble_15 "0" => Double
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_proceduresortcollisions_constdouble_15.kept1_value : Ljava/lang/Double;
              L1
               ARETURN
         _asm_proceduresortcollisions_letvariable_16 "winner" => Object
+              // parameter final  context
              L0
               ALOAD 1
               ALOAD 0
@@ -8090,6 +8705,8 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
               INVOKEVIRTUAL org/nlogo/nvm/Context.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresortcollisions_setprocedurevariable_14.keptinstr2 : Lorg/nlogo/prim/etc/_item;
           ALOAD 1
@@ -8111,6 +8728,13 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
       _greaterthan ">" Object,double => boolean
         _procedurevariable:DT "dt" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -8123,14 +8747,10 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -8138,15 +8758,14 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduresortcollisions_if_17 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -8175,20 +8794,22 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduresortcollisions_if_17 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L7
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L7
+          IFEQ L8
           BIPUSH 10
-          GOTO L8
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduresortcollisions_if_17 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 16
+          GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_proceduresortcollisions_if_17 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_proceduresortcollisions_if_17 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 16
          L9
+         FRAME FULL [org/nlogo/prim/_asm_proceduresortcollisions_if_17 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [10]_asm_proceduresortcollisions_ifelse_18 "ifelse" boolean => void
       _lessorequal "<=" double,double => boolean
@@ -8196,6 +8817,13 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           _procedurevariable:DT "dt" => Object
           _ticks "ticks" => double
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -8284,6 +8912,12 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
       _minus "-" double,double => double
         _procedurevariable:DT "dt" => Object
         _ticks "ticks" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -8354,9 +8988,6 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 12
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L11
          L4
          FRAME FULL [org/nlogo/prim/_asm_proceduresortcollisions_setobservervariable_19 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -8371,16 +9002,22 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           ATHROW
          L11
          FRAME SAME
+          ALOAD 1
+          BIPUSH 12
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [12]_asm_proceduresortcollisions_setobservervariable_20 "set" Object => void
       _item "item"
         _asm_proceduresortcollisions_constdouble_21 "1" => Double
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_proceduresortcollisions_constdouble_21.kept1_value : Ljava/lang/Double;
              L1
               ARETURN
         _asm_proceduresortcollisions_letvariable_22 "winner" => Object
+              // parameter final  context
              L0
               ALOAD 1
               ALOAD 0
@@ -8388,6 +9025,8 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
               INVOKEVIRTUAL org/nlogo/nvm/Context.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresortcollisions_setobservervariable_20.keptinstr2 : Lorg/nlogo/prim/etc/_item;
@@ -8403,9 +9042,6 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 13
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L4
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresortcollisions_setobservervariable_20 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -8420,16 +9056,22 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           ATHROW
          L4
          FRAME SAME
+          ALOAD 1
+          BIPUSH 13
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L5
           RETURN
 [13]_asm_proceduresortcollisions_setobservervariable_23 "set" Object => void
       _item "item"
         _asm_proceduresortcollisions_constdouble_24 "2" => Double
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_proceduresortcollisions_constdouble_24.kept1_value : Ljava/lang/Double;
              L1
               ARETURN
         _asm_proceduresortcollisions_letvariable_25 "winner" => Object
+              // parameter final  context
              L0
               ALOAD 1
               ALOAD 0
@@ -8437,6 +9079,8 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
               INVOKEVIRTUAL org/nlogo/nvm/Context.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresortcollisions_setobservervariable_23.keptinstr2 : Lorg/nlogo/prim/etc/_item;
@@ -8452,9 +9096,6 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 14
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L4
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresortcollisions_setobservervariable_23 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -8469,8 +9110,13 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           ATHROW
          L4
          FRAME SAME
+          ALOAD 1
+          BIPUSH 14
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L5
           RETURN
 [14]_asm_proceduresortcollisions_goto_26 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 16
@@ -8479,6 +9125,9 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           RETURN
 [15]_asm_proceduresortcollisions_setobservervariable_27 "set" Object => void
       _constdouble:1.0 "1" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -8493,9 +9142,6 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 16
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresortcollisions_setobservervariable_27 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -8510,8 +9156,13 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 16
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [16]_asm_proceduresortcollisions_return_28 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -8528,6 +9179,13 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 _letvariable(Let(COLLISION)) "collision" => Object
               _first "first" Object => Object
                 _letvariable(Let(WINNER)) "winner" => Object
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  o1
+                // parameter final  o2
+                // parameter final  context
+                // parameter final  arg0
                L0
                 ALOAD 1
                 ALOAD 0
@@ -8692,40 +9350,36 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                L14
                FRAME SAME
                 ICONST_0
-               L15
-               FRAME SAME1 I
-                GOTO L16
+                GOTO L15
                L13
                FRAME SAME
                 ALOAD 2
                 INSTANCEOF java/lang/String
-                IFEQ L17
+                IFEQ L16
                 ALOAD 3
                 INSTANCEOF java/lang/String
-                IFEQ L17
+                IFEQ L16
                 ALOAD 2
                 CHECKCAST java/lang/String
                 ALOAD 3
                 CHECKCAST java/lang/String
                 INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
                 ICONST_0
-                IF_ICMPGE L18
+                IF_ICMPGE L17
                 ICONST_1
-                GOTO L19
-               L18
+                GOTO L15
+               L17
                FRAME SAME
                 ICONST_0
-               L19
-               FRAME SAME1 I
-                GOTO L16
-               L17
+                GOTO L15
+               L16
                FRAME SAME
                 ALOAD 2
                 INSTANCEOF org/nlogo/agent/Agent
-                IFEQ L20
+                IFEQ L18
                 ALOAD 3
                 INSTANCEOF org/nlogo/agent/Agent
-                IFEQ L20
+                IFEQ L18
                 ALOAD 2
                 CHECKCAST org/nlogo/agent/Agent
                 ASTORE 4
@@ -8736,21 +9390,19 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
                 ALOAD 5
                 INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-                IF_ICMPNE L20
+                IF_ICMPNE L18
                 ALOAD 4
                 ALOAD 5
                 INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
                 ICONST_0
-                IF_ICMPGE L21
+                IF_ICMPGE L19
                 ICONST_1
-                GOTO L22
-               L21
+                GOTO L15
+               L19
                FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
                 ICONST_0
-               L22
-               FRAME SAME1 I
-                GOTO L16
-               L20
+                GOTO L15
+               L18
                FRAME CHOP 2
                 NEW org/nlogo/nvm/RuntimePrimitiveException
                 DUP
@@ -8778,24 +9430,25 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
-               L16
+               L15
                FRAME SAME1 I
                 ISTORE 2
                 ALOAD 1
                 ILOAD 2
-                IFEQ L23
+                IFEQ L20
                 ICONST_1
-                GOTO L24
-               L23
+                GOTO L21
+               L20
                FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
                 ICONST_2
-               L24
+               L21
                FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
                 PUTFIELD org/nlogo/nvm/Context.ip : I
-               L25
+               L22
                 RETURN
    [1]_setletvariable:WINNER "set"
             _asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_letvariable_1 "collision" => Object
+                  // parameter final  context
                  L0
                   ALOAD 1
                   ALOAD 0
@@ -8804,6 +9457,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                  L1
                   ARETURN
    [2]_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_done_2 => void
+                // parameter final  context
                L0
                 ALOAD 1
                 ICONST_1
@@ -8816,6 +9470,13 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
       _equal "=" Object,Object => boolean
         _observervariable:COLLIDING-PARTICLE-1 "colliding-particle-1" => Object
         _nobody "nobody" => Nobody$
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewinners_if_0.world : Lorg/nlogo/agent/World;
@@ -8892,6 +9553,18 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
         _equal "=" Object,String => boolean
           _observervariable:COLLIDING-PARTICLE-2 "colliding-particle-2" => Object
           _conststring:"plane-xneg" ""plane-xneg"" => String
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewinners_if_2.world : Lorg/nlogo/agent/World;
@@ -8904,17 +9577,15 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ASTORE 3
           ASTORE 2
           ALOAD 3
-          ALOAD 2
-          ASTORE 4
           DUP
           IFNONNULL L3
           POP
-          ALOAD 4
+          ALOAD 2
           IFNULL L4
           GOTO L5
          L3
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_if_2 org/nlogo/nvm/Context java/lang/Object java/lang/String java/lang/Object] [java/lang/String]
-          ALOAD 4
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_if_2 org/nlogo/nvm/Context java/lang/Object java/lang/String] [java/lang/String]
+          ALOAD 2
           INVOKEVIRTUAL java/lang/Object.equals (Ljava/lang/Object;)Z
           IFEQ L5
          L4
@@ -8939,17 +9610,15 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ASTORE 3
           ASTORE 2
           ALOAD 3
-          ALOAD 2
-          ASTORE 4
           DUP
           IFNONNULL L11
           POP
-          ALOAD 4
+          ALOAD 2
           IFNULL L12
           GOTO L13
          L11
          FRAME SAME1 java/lang/String
-          ALOAD 4
+          ALOAD 2
           INVOKEVIRTUAL java/lang/Object.equals (Ljava/lang/Object;)Z
           IFEQ L13
          L12
@@ -8974,15 +9643,18 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ICONST_3
           GOTO L17
          L16
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_if_2 org/nlogo/nvm/Context I java/lang/String java/lang/Object] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_if_2 org/nlogo/nvm/Context I java/lang/String] [org/nlogo/nvm/Context]
           BIPUSH 7
          L17
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_if_2 org/nlogo/nvm/Context I java/lang/String java/lang/Object] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_if_2 org/nlogo/nvm/Context I java/lang/String] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L18
           RETURN
 [3]_asm_procedurecollidewinners_ask_3 "ask" Object => void
       _observervariable:COLLIDING-PARTICLE-1 "colliding-particle-1" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewinners_ask_3.world : Lorg/nlogo/agent/World;
@@ -8992,18 +9664,16 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewinners_ask_3.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -9019,8 +9689,8 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_ask_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewinners_ask_3.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -9037,18 +9707,18 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -9065,7 +9735,7 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -9075,23 +9745,12 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_ask_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_4
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -9105,12 +9764,25 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          ICONST_4
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_ask_3 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [4]_asm_procedurecollidewinners_setturtlevariable_4 "set" Object => void
       _unaryminus "-" double => double
         _turtlevariabledouble:HEADING "heading" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -9136,9 +9808,6 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L6
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_setturtlevariable_4 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -9153,8 +9822,13 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ATHROW
          L6
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L7
           RETURN
 [5]_asm_procedurecollidewinners_done_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -9207,6 +9881,18 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
         _equal "=" Object,String => boolean
           _observervariable:COLLIDING-PARTICLE-2 "colliding-particle-2" => Object
           _conststring:"plane-yneg" ""plane-yneg"" => String
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewinners_if_7.world : Lorg/nlogo/agent/World;
@@ -9219,17 +9905,15 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ASTORE 3
           ASTORE 2
           ALOAD 3
-          ALOAD 2
-          ASTORE 4
           DUP
           IFNONNULL L3
           POP
-          ALOAD 4
+          ALOAD 2
           IFNULL L4
           GOTO L5
          L3
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_if_7 org/nlogo/nvm/Context java/lang/Object java/lang/String java/lang/Object] [java/lang/String]
-          ALOAD 4
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_if_7 org/nlogo/nvm/Context java/lang/Object java/lang/String] [java/lang/String]
+          ALOAD 2
           INVOKEVIRTUAL java/lang/Object.equals (Ljava/lang/Object;)Z
           IFEQ L5
          L4
@@ -9254,17 +9938,15 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ASTORE 3
           ASTORE 2
           ALOAD 3
-          ALOAD 2
-          ASTORE 4
           DUP
           IFNONNULL L11
           POP
-          ALOAD 4
+          ALOAD 2
           IFNULL L12
           GOTO L13
          L11
          FRAME SAME1 java/lang/String
-          ALOAD 4
+          ALOAD 2
           INVOKEVIRTUAL java/lang/Object.equals (Ljava/lang/Object;)Z
           IFEQ L13
          L12
@@ -9289,15 +9971,18 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           BIPUSH 8
           GOTO L17
          L16
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_if_7 org/nlogo/nvm/Context I java/lang/String java/lang/Object] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_if_7 org/nlogo/nvm/Context I java/lang/String] [org/nlogo/nvm/Context]
           BIPUSH 12
          L17
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_if_7 org/nlogo/nvm/Context I java/lang/String java/lang/Object] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_if_7 org/nlogo/nvm/Context I java/lang/String] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L18
           RETURN
 [8]_asm_procedurecollidewinners_ask_8 "ask" Object => void
       _observervariable:COLLIDING-PARTICLE-1 "colliding-particle-1" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewinners_ask_8.world : Lorg/nlogo/agent/World;
@@ -9307,18 +9992,16 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewinners_ask_8.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -9334,8 +10017,8 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_ask_8 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewinners_ask_8.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -9352,18 +10035,18 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -9380,7 +10063,7 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -9390,23 +10073,12 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_ask_8 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 9
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 11
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -9420,13 +10092,28 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 9
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 11
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_ask_8 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [9]_asm_procedurecollidewinners_setturtlevariable_9 "set" Object => void
       _minus "-" double,double => double
         _constdouble:180.0 "180" => double
         _turtlevariabledouble:HEADING "heading" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           LDC 180.0
@@ -9456,9 +10143,6 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_setturtlevariable_9 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -9473,8 +10157,13 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [10]_asm_procedurecollidewinners_done_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -9521,6 +10210,9 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           RETURN
 [12]_asm_procedurecollidewinners_ask_12 "ask" Object => void
       _observervariable:COLLIDING-PARTICLE-1 "colliding-particle-1" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewinners_ask_12.world : Lorg/nlogo/agent/World;
@@ -9530,18 +10222,16 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewinners_ask_12.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -9557,8 +10247,8 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_ask_12 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewinners_ask_12.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -9575,18 +10265,18 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -9603,7 +10293,7 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -9613,23 +10303,12 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_ask_12 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 13
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 15
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -9643,11 +10322,20 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 13
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 15
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewinners_ask_12 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [13]_asm_procedurecollidewinners_call_13 "collide-with"
       _observervariable:COLLIDING-PARTICLE-2 "colliding-particle-2" => Object
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -9677,6 +10365,7 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
          L3
           RETURN
 [14]_asm_procedurecollidewinners_done_14 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -9684,6 +10373,7 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
          L1
           RETURN
 [15]_asm_procedurecollidewinners_return_15 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -9697,6 +10387,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
 [0]_asm_procedurecollidewith_setprocedurevariable_0 "let" Object => void
       _breedvariableof:MASS "of"
         _asm_procedurecollidewith_procedurevariable_1 "other-particle" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9705,6 +10396,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
               AALOAD
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_0.keptinstr2 : Lorg/nlogo/prim/_breedvariableof;
           ALOAD 1
@@ -9725,6 +10418,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
 [1]_asm_procedurecollidewith_setprocedurevariable_2 "let" Object => void
       _breedvariableof:SPEED "of"
         _asm_procedurecollidewith_procedurevariable_3 "other-particle" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9733,6 +10427,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
               AALOAD
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_2.keptinstr2 : Lorg/nlogo/prim/_breedvariableof;
           ALOAD 1
@@ -9753,30 +10449,32 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
 [2]_asm_procedurecollidewith_setprocedurevariable_4 "let" Object => void
       _turtlevariableof:HEADING "of" Object => Object
         _procedurevariable:OTHER-PARTICLE "other-particle" => Object
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-         L4
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agentOrSet
+          // parameter final  context
+          // parameter final  arg0
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+         L3
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_0
           AALOAD
-         L5
+         L4
           ASTORE 2
-         L2
+         L0
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L5
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L6
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L7
+          IFNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -9789,45 +10487,45 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-          ALOAD 5
+         L6
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+          ALOAD 4
           ICONST_2
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L8
-         L6
-         FRAME CHOP 1
-          ALOAD 4
+          ASTORE 3
+          GOTO L7
+         L5
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L0
-          ALOAD 4
+          IFEQ L8
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_4 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L10
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           ICONST_2
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
@@ -9835,16 +10533,12 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           GOTO L9
          L10
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
           ALOAD 6
-         L3
-          GOTO L11
-         L0
-         FRAME CHOP 2
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L7
+         L8
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_4 org/nlogo/nvm/Context java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -9858,19 +10552,24 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L7
+         FRAME APPEND [java/lang/Object]
+          ALOAD 3
          L1
+          GOTO L11
+         L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_4 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_4 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9886,6 +10585,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
 [3]_asm_procedurecollidewith_setprocedurevariable_5 "let" Object => void
       _towards "towards"
         _asm_procedurecollidewith_procedurevariable_6 "other-particle" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9894,6 +10594,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
               AALOAD
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_5.keptinstr2 : Lorg/nlogo/prim/etc/_towards;
           ALOAD 1
@@ -9918,6 +10620,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           _minus "-" double,double => double
             _procedurevariable:THETA "theta" => Object
             _turtlevariabledouble:HEADING "heading" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -10034,6 +10749,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           _minus "-" double,double => double
             _procedurevariable:THETA "theta" => Object
             _turtlevariabledouble:HEADING "heading" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -10150,6 +10878,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           _minus "-" double,double => double
             _procedurevariable:THETA "theta" => Object
             _procedurevariable:HEADING2 "heading2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -10273,6 +11014,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           _minus "-" double,double => double
             _procedurevariable:THETA "theta" => Object
             _procedurevariable:HEADING2 "heading2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -10401,6 +11155,26 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
         _plus "+" double,double => double
           _breedvariable:MASS "mass" => Object
           _procedurevariable:MASS2 "mass2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -10660,6 +11434,17 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           _constdouble:2.0 "2" => double
           _procedurevariable:VCM "vcm" => Object
         _procedurevariable:V1T "v1t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -10752,6 +11537,17 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           _constdouble:2.0 "2" => double
           _procedurevariable:VCM "vcm" => Object
         _procedurevariable:V2T "v2t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -10847,6 +11643,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           _mult "*" double,double => double
             _procedurevariable:V1L "v1l" => Object
             _procedurevariable:V1L "v1l" => Object
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  d1
+            // parameter final  d2
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
             TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
             TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -11014,6 +11823,18 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
         _notequal "!=" Object,double => boolean
           _procedurevariable:V1T "v1t" => Object
           _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -11026,11 +11847,9 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -11041,19 +11860,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_15 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_15 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L6
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L7
           IFNE L8
          L9
@@ -11068,11 +11887,9 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L12
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -11083,19 +11900,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ICONST_1
           GOTO L14
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_15 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] []
+         FRAME APPEND [java/lang/Double]
           ICONST_0
          L14
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L15
          L12
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_15 org/nlogo/nvm/Context java/lang/Object D java/lang/Object T I] []
+         FRAME CHOP 1
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L15
          FRAME SAME
-          ILOAD 7
+          ILOAD 5
          L16
           GOTO L17
          L8
@@ -11110,10 +11927,10 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           BIPUSH 13
           GOTO L19
          L18
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_15 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_15 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 14
          L19
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_15 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_15 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L20
           RETURN
@@ -11123,6 +11940,17 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
         _atan "atan" double,double => double
           _procedurevariable:V1L "v1l" => Object
           _procedurevariable:V1T "v1t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -11266,6 +12094,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           GOTO L19
          L20
          FRAME SAME1 D
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
@@ -11273,6 +12102,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           SIPUSH 360
           I2D
           DADD
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_16.validDouble (DLorg/nlogo/nvm/Context;)D
           SIPUSH 360
           I2D
           DREM
@@ -11297,9 +12128,6 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L7
-          ALOAD 1
-          BIPUSH 14
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L23
          L8
          FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_16 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -11314,9 +12142,16 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ATHROW
          L23
          FRAME SAME
+          ALOAD 1
+          BIPUSH 14
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L24
           RETURN
 [14]_asm_procedurecollidewith_ask_17 "ask" Object => void
       _procedurevariable:OTHER-PARTICLE "other-particle" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -11326,18 +12161,16 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_ask_17.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -11353,8 +12186,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_17 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_ask_17.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -11371,18 +12204,18 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -11399,7 +12232,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -11409,23 +12242,12 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_17 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 15
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 17
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -11439,8 +12261,16 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 15
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 17
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_17 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [15]_setbreedvariable:SPEED "set"
       _asm_procedurecollidewith_sqrt_18 "sqrt" double => double
@@ -11451,6 +12281,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           _mult "*" double,double => double
             _procedurevariable:V2L "v2l" => Object
             _procedurevariable:V2L "v2l" => Object
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  d1
+            // parameter final  d2
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
             TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
             TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -11611,6 +12454,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
 [16]_asm_procedurecollidewith_done_19 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -11625,6 +12469,18 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
         _notequal "!=" Object,double => boolean
           _procedurevariable:V2T "v2t" => Object
           _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -11637,11 +12493,9 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -11652,19 +12506,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_20 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_20 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L6
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L7
           IFNE L8
          L9
@@ -11679,11 +12533,9 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L12
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -11694,19 +12546,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ICONST_1
           GOTO L14
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_20 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] []
+         FRAME APPEND [java/lang/Double]
           ICONST_0
          L14
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L15
          L12
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_20 org/nlogo/nvm/Context java/lang/Object D java/lang/Object T I] []
+         FRAME CHOP 1
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L15
          FRAME SAME
-          ILOAD 7
+          ILOAD 5
          L16
           GOTO L17
          L8
@@ -11721,15 +12573,18 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           BIPUSH 18
           GOTO L19
          L18
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_20 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_20 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 21
          L19
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_20 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_20 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L20
           RETURN
 [18]_asm_procedurecollidewith_ask_21 "ask" Object => void
       _procedurevariable:OTHER-PARTICLE "other-particle" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -11739,18 +12594,16 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_ask_21.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -11766,8 +12619,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_21 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_ask_21.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -11784,18 +12637,18 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -11812,7 +12665,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -11822,23 +12675,12 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_21 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 19
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 21
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -11852,8 +12694,16 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 19
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 21
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_21 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [19]_asm_procedurecollidewith_setturtlevariable_22 "set" Object => void
       _minus "-" double,double => double
@@ -11861,6 +12711,17 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
         _atan "atan" double,double => double
           _procedurevariable:V2L "v2l" => Object
           _procedurevariable:V2T "v2t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -12004,6 +12865,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           GOTO L19
          L20
          FRAME SAME1 D
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
@@ -12011,6 +12873,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           SIPUSH 360
           I2D
           DADD
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_22.validDouble (DLorg/nlogo/nvm/Context;)D
           SIPUSH 360
           I2D
           DREM
@@ -12035,9 +12899,6 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L7
-          ALOAD 1
-          BIPUSH 20
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L23
          L8
          FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_22 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -12052,8 +12913,13 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ATHROW
          L23
          FRAME SAME
+          ALOAD 1
+          BIPUSH 20
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L24
           RETURN
 [20]_asm_procedurecollidewith_done_23 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -12080,6 +12946,9 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           RETURN
 [22]_asm_procedurecollidewith_ask_25 "ask" Object => void
       _procedurevariable:OTHER-PARTICLE "other-particle" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -12089,18 +12958,16 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_ask_25.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -12116,8 +12983,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_25 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_ask_25.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -12134,18 +13001,18 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -12162,7 +13029,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -12172,23 +13039,12 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_25 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 23
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 25
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -12202,8 +13058,16 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 23
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 25
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_25 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [23]_asm_procedurecollidewith_call_26 "recolor"
          L0
@@ -12224,6 +13088,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L1
           RETURN
 [24]_asm_procedurecollidewith_done_27 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -12231,6 +13096,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L1
           RETURN
 [25]_asm_procedurecollidewith_return_28 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -12245,6 +13111,13 @@ procedure RECOLOR:[]{-T--}:
       _equal "=" Object,String => boolean
         _observervariable:COLOR-SCHEME "color-scheme" => Object
         _conststring:"red-green-blue" ""red-green-blue"" => String
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerecolor_if_0.world : Lorg/nlogo/agent/World;
@@ -12257,17 +13130,15 @@ procedure RECOLOR:[]{-T--}:
           ASTORE 3
           ASTORE 2
           ALOAD 3
-          ALOAD 2
-          ASTORE 4
           DUP
           IFNONNULL L3
           POP
-          ALOAD 4
+          ALOAD 2
           IFNULL L4
           GOTO L5
          L3
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/String java/lang/Object] [java/lang/String]
-          ALOAD 4
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/String] [java/lang/String]
+          ALOAD 2
           INVOKEVIRTUAL java/lang/Object.equals (Ljava/lang/Object;)Z
           IFEQ L5
          L4
@@ -12286,10 +13157,10 @@ procedure RECOLOR:[]{-T--}:
           ICONST_1
           GOTO L8
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_0 org/nlogo/nvm/Context I java/lang/String java/lang/Object] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_0 org/nlogo/nvm/Context I java/lang/String] [org/nlogo/nvm/Context]
           ICONST_2
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_0 org/nlogo/nvm/Context I java/lang/String java/lang/Object] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_0 org/nlogo/nvm/Context I java/lang/String] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L9
           RETURN
@@ -12315,6 +13186,13 @@ procedure RECOLOR:[]{-T--}:
       _equal "=" Object,String => boolean
         _observervariable:COLOR-SCHEME "color-scheme" => Object
         _conststring:"blue shades" ""blue shades"" => String
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerecolor_if_2.world : Lorg/nlogo/agent/World;
@@ -12327,17 +13205,15 @@ procedure RECOLOR:[]{-T--}:
           ASTORE 3
           ASTORE 2
           ALOAD 3
-          ALOAD 2
-          ASTORE 4
           DUP
           IFNONNULL L3
           POP
-          ALOAD 4
+          ALOAD 2
           IFNULL L4
           GOTO L5
          L3
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_2 org/nlogo/nvm/Context java/lang/Object java/lang/String java/lang/Object] [java/lang/String]
-          ALOAD 4
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_2 org/nlogo/nvm/Context java/lang/Object java/lang/String] [java/lang/String]
+          ALOAD 2
           INVOKEVIRTUAL java/lang/Object.equals (Ljava/lang/Object;)Z
           IFEQ L5
          L4
@@ -12356,10 +13232,10 @@ procedure RECOLOR:[]{-T--}:
           ICONST_3
           GOTO L8
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_2 org/nlogo/nvm/Context I java/lang/String java/lang/Object] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_2 org/nlogo/nvm/Context I java/lang/String] [org/nlogo/nvm/Context]
           ICONST_4
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_2 org/nlogo/nvm/Context I java/lang/String java/lang/Object] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_2 org/nlogo/nvm/Context I java/lang/String] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L9
           RETURN
@@ -12385,6 +13261,13 @@ procedure RECOLOR:[]{-T--}:
       _equal "=" Object,String => boolean
         _observervariable:COLOR-SCHEME "color-scheme" => Object
         _conststring:"one color" ""one color"" => String
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerecolor_if_4.world : Lorg/nlogo/agent/World;
@@ -12397,17 +13280,15 @@ procedure RECOLOR:[]{-T--}:
           ASTORE 3
           ASTORE 2
           ALOAD 3
-          ALOAD 2
-          ASTORE 4
           DUP
           IFNONNULL L3
           POP
-          ALOAD 4
+          ALOAD 2
           IFNULL L4
           GOTO L5
          L3
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_4 org/nlogo/nvm/Context java/lang/Object java/lang/String java/lang/Object] [java/lang/String]
-          ALOAD 4
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_4 org/nlogo/nvm/Context java/lang/Object java/lang/String] [java/lang/String]
+          ALOAD 2
           INVOKEVIRTUAL java/lang/Object.equals (Ljava/lang/Object;)Z
           IFEQ L5
          L4
@@ -12426,10 +13307,10 @@ procedure RECOLOR:[]{-T--}:
           ICONST_5
           GOTO L8
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_4 org/nlogo/nvm/Context I java/lang/String java/lang/Object] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_4 org/nlogo/nvm/Context I java/lang/String] [org/nlogo/nvm/Context]
           BIPUSH 6
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_4 org/nlogo/nvm/Context I java/lang/String java/lang/Object] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_if_4 org/nlogo/nvm/Context I java/lang/String] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L9
           RETURN
@@ -12452,6 +13333,7 @@ procedure RECOLOR:[]{-T--}:
          L1
           RETURN
 [6]_asm_procedurerecolor_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -12464,6 +13346,9 @@ procedure RECOLOR:[]{-T--}:
 procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
 [0]_asm_procedurerecolorbanded_setprocedurevariable_0 "let" Object => void
       _constdouble:1.0 "1" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerecolorbanded_setprocedurevariable_0.kept2_value : Ljava/lang/Double;
@@ -12486,6 +13371,17 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
         _mult "*" double,double => double
           _constdouble:0.5 "0.5" => double
           _procedurevariable:AVG-SPEED "avg-speed" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -12545,14 +13441,10 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L10
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
@@ -12560,15 +13452,14 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
           ICONST_1
           GOTO L12
          L11
-         FRAME APPEND [D java/lang/Object java/lang/Double]
+         FRAME APPEND [D]
           ICONST_0
          L12
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L13
          L10
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -12597,23 +13488,28 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorbanded_ifelse_1 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L14
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L14
+          IFEQ L15
           ICONST_2
-          GOTO L15
-         L14
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorbanded_ifelse_1 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          ICONST_4
+          GOTO L16
          L15
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorbanded_ifelse_1 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorbanded_ifelse_1 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          ICONST_4
          L16
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorbanded_ifelse_1 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L17
           RETURN
 [2]_asm_procedurerecolorbanded_setturtleorlinkvariable_2 "set" Object => void
       _constdouble:105.0 "blue" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -12627,9 +13523,6 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolorbanded_setturtleorlinkvariable_2 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -12644,8 +13537,13 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_procedurerecolorbanded_goto_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 8
@@ -12658,6 +13556,17 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
         _mult "*" double,double => double
           _constdouble:1.5 "1.5" => double
           _procedurevariable:AVG-SPEED "avg-speed" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -12717,14 +13626,10 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L10
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -12732,15 +13637,14 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
           ICONST_1
           GOTO L12
          L11
-         FRAME APPEND [D java/lang/Object java/lang/Double]
+         FRAME APPEND [D]
           ICONST_0
          L12
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L13
          L10
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -12769,23 +13673,28 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorbanded_ifelse_4 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L14
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L14
+          IFEQ L15
           ICONST_5
-          GOTO L15
-         L14
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorbanded_ifelse_4 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 7
+          GOTO L16
          L15
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorbanded_ifelse_4 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorbanded_ifelse_4 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 7
          L16
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorbanded_ifelse_4 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L17
           RETURN
 [5]_asm_procedurerecolorbanded_setturtleorlinkvariable_5 "set" Object => void
       _constdouble:15.0 "red" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -12799,9 +13708,6 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolorbanded_setturtleorlinkvariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -12816,8 +13722,13 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [6]_asm_procedurerecolorbanded_goto_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 8
@@ -12826,6 +13737,9 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
           RETURN
 [7]_asm_procedurerecolorbanded_setturtleorlinkvariable_7 "set" Object => void
       _constdouble:55.0 "green" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -12839,9 +13753,6 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolorbanded_setturtleorlinkvariable_7 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -12856,8 +13767,13 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [8]_asm_procedurerecolorbanded_return_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -12870,6 +13786,9 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
 procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
 [0]_asm_procedurerecolorshaded_setprocedurevariable_0 "let" Object => void
       _constdouble:1.0 "1" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerecolorshaded_setprocedurevariable_0.kept2_value : Ljava/lang/Double;
@@ -12892,6 +13811,17 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
         _mult "*" double,double => double
           _constdouble:3.0 "3" => double
           _procedurevariable:AVG-SPEED "avg-speed" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -12951,14 +13881,10 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L10
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
@@ -12966,15 +13892,14 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
           ICONST_1
           GOTO L12
          L11
-         FRAME APPEND [D java/lang/Object java/lang/Double]
+         FRAME APPEND [D]
           ICONST_0
          L12
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L13
          L10
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -13003,20 +13928,22 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorshaded_ifelse_1 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L14
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L14
+          IFEQ L15
           ICONST_2
-          GOTO L15
-         L14
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorshaded_ifelse_1 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          ICONST_4
+          GOTO L16
          L15
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorshaded_ifelse_1 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorshaded_ifelse_1 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          ICONST_4
          L16
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorshaded_ifelse_1 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L17
           RETURN
 [2]_asm_procedurerecolorshaded_setturtleorlinkvariable_2 "set" Object => void
       _plus "+" double,double => double
@@ -13028,6 +13955,22 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
           _mult "*" double,double => double
             _constdouble:3.0 "3" => double
             _procedurevariable:AVG-SPEED "avg-speed" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -13156,9 +14099,6 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L8
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L22
          L9
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolorshaded_setturtleorlinkvariable_2 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -13173,8 +14113,13 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
           ATHROW
          L22
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L23
           RETURN
 [3]_asm_procedurerecolorshaded_goto_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_5
@@ -13183,6 +14128,9 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
           RETURN
 [4]_asm_procedurerecolorshaded_setturtleorlinkvariable_4 "set" Object => void
       _constdouble:99.999 "+" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -13196,9 +14144,6 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolorshaded_setturtleorlinkvariable_4 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -13213,8 +14158,13 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [5]_asm_procedurerecolorshaded_return_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -13227,6 +14177,9 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
 procedure RECOLOR-NONE:[]{-T-L}:
 [0]_asm_procedurerecolornone_setturtleorlinkvariable_0 "set" Object => void
       _constdouble:54.0 "-" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -13240,9 +14193,6 @@ procedure RECOLOR-NONE:[]{-T-L}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolornone_setturtleorlinkvariable_0 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -13257,8 +14207,13 @@ procedure RECOLOR-NONE:[]{-T-L}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [1]_asm_procedurerecolornone_return_1 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -13291,6 +14246,28 @@ procedure MAKE-BOX:[]{OTPL}:
               _abs "abs" double => double
                 _patchvariabledouble:PXCOR "pxcor" => double
               _observervariable:BOX-EDGE "box-edge" => Object
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d0
+              // parameter final  arg1
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d0
+              // parameter final  arg1
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -13300,10 +14277,8 @@ procedure MAKE-BOX:[]{OTPL}:
               IFEQ L1
               ALOAD 3
               CHECKCAST org/nlogo/agent/Turtle
-              ASTORE 4
-              ALOAD 4
               INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-              ASTORE 5
+              ASTORE 2
               GOTO L2
              L1
              FRAME APPEND [T org/nlogo/agent/Agent]
@@ -13312,26 +14287,21 @@ procedure MAKE-BOX:[]{OTPL}:
               IFEQ L3
               ALOAD 3
               CHECKCAST org/nlogo/agent/Patch
-              ASTORE 6
-              ALOAD 6
-              ASTORE 5
-             L2
-             FRAME APPEND [T org/nlogo/agent/Patch]
-              ALOAD 5
               ASTORE 2
-              ALOAD 2
-              ICONST_0
-              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-              GOTO L4
+              GOTO L2
              L3
-             FRAME CHOP 2
+             FRAME SAME
               NEW scala/MatchError
               DUP
               ALOAD 3
               INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
               ATHROW
+             L2
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+              ALOAD 2
+              ICONST_0
+              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
              L4
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] [D]
               DSTORE 2
               DLOAD 2
               ICONST_0
@@ -13342,7 +14312,7 @@ procedure MAKE-BOX:[]{OTPL}:
               DNEG
               GOTO L6
              L5
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D T org/nlogo/agent/Patch] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D] []
               DLOAD 2
              L6
              FRAME SAME1 D
@@ -13355,11 +14325,9 @@ procedure MAKE-BOX:[]{OTPL}:
               ASTORE 4
               DSTORE 2
               ALOAD 4
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L8
-              ALOAD 5
+              ALOAD 4
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 2
@@ -13370,19 +14338,19 @@ procedure MAKE-BOX:[]{OTPL}:
               ICONST_1
               GOTO L10
              L9
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+             FRAME APPEND [java/lang/Object T java/lang/Double]
               ICONST_0
              L10
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L11
              L8
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L11
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L12
               IFEQ L13
              L14
@@ -13394,38 +14362,31 @@ procedure MAKE-BOX:[]{OTPL}:
               IFEQ L15
               ALOAD 3
               CHECKCAST org/nlogo/agent/Turtle
-              ASTORE 4
-              ALOAD 4
               INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-              ASTORE 5
+              ASTORE 2
               GOTO L16
              L15
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object I] []
               ALOAD 3
               INSTANCEOF org/nlogo/agent/Patch
               IFEQ L17
               ALOAD 3
               CHECKCAST org/nlogo/agent/Patch
-              ASTORE 6
-              ALOAD 6
-              ASTORE 5
-             L16
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] []
-              ALOAD 5
               ASTORE 2
-              ALOAD 2
-              ICONST_1
-              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-              GOTO L18
+              GOTO L16
              L17
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+             FRAME SAME
               NEW scala/MatchError
               DUP
               ALOAD 3
               INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
               ATHROW
+             L16
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object I] []
+              ALOAD 2
+              ICONST_1
+              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
              L18
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] [D]
               DSTORE 2
               DLOAD 2
               ICONST_0
@@ -13436,7 +14397,7 @@ procedure MAKE-BOX:[]{OTPL}:
               DNEG
               GOTO L20
              L19
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object org/nlogo/agent/Patch T I] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object I] []
               DLOAD 2
              L20
              FRAME SAME1 D
@@ -13493,7 +14454,7 @@ procedure MAKE-BOX:[]{OTPL}:
              FRAME SAME1 I
               GOTO L26
              L13
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object java/lang/Object T I] []
+             FRAME SAME
               ICONST_0
              L26
              FRAME SAME1 I
@@ -13507,38 +14468,31 @@ procedure MAKE-BOX:[]{OTPL}:
               IFEQ L29
               ALOAD 3
               CHECKCAST org/nlogo/agent/Turtle
-              ASTORE 4
-              ALOAD 4
               INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-              ASTORE 5
+              ASTORE 2
               GOTO L30
              L29
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object I] []
               ALOAD 3
               INSTANCEOF org/nlogo/agent/Patch
               IFEQ L31
               ALOAD 3
               CHECKCAST org/nlogo/agent/Patch
-              ASTORE 6
-              ALOAD 6
-              ASTORE 5
-             L30
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] []
-              ALOAD 5
               ASTORE 2
-              ALOAD 2
-              ICONST_1
-              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-              GOTO L32
+              GOTO L30
              L31
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+             FRAME SAME
               NEW scala/MatchError
               DUP
               ALOAD 3
               INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
               ATHROW
+             L30
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object I] []
+              ALOAD 2
+              ICONST_1
+              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
              L32
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] [D]
               DSTORE 2
               DLOAD 2
               ICONST_0
@@ -13549,7 +14503,7 @@ procedure MAKE-BOX:[]{OTPL}:
               DNEG
               GOTO L34
              L33
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object org/nlogo/agent/Patch T I] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object I] []
               DLOAD 2
              L34
              FRAME SAME1 D
@@ -13562,11 +14516,9 @@ procedure MAKE-BOX:[]{OTPL}:
               ASTORE 4
               DSTORE 2
               ALOAD 4
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L36
-              ALOAD 5
+              ALOAD 4
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 2
@@ -13577,19 +14529,19 @@ procedure MAKE-BOX:[]{OTPL}:
               ICONST_1
               GOTO L38
              L37
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] []
+             FRAME APPEND [java/lang/Double]
               ICONST_0
              L38
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L39
              L36
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object java/lang/Object T I] []
+             FRAME CHOP 1
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L39
              FRAME SAME
-              ILOAD 7
+              ILOAD 5
              L40
               IFEQ L41
              L42
@@ -13601,38 +14553,31 @@ procedure MAKE-BOX:[]{OTPL}:
               IFEQ L43
               ALOAD 3
               CHECKCAST org/nlogo/agent/Turtle
-              ASTORE 4
-              ALOAD 4
               INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-              ASTORE 5
+              ASTORE 2
               GOTO L44
              L43
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object I] []
               ALOAD 3
               INSTANCEOF org/nlogo/agent/Patch
               IFEQ L45
               ALOAD 3
               CHECKCAST org/nlogo/agent/Patch
-              ASTORE 6
-              ALOAD 6
-              ASTORE 5
-             L44
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] []
-              ALOAD 5
               ASTORE 2
-              ALOAD 2
-              ICONST_0
-              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-              GOTO L46
+              GOTO L44
              L45
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+             FRAME SAME
               NEW scala/MatchError
               DUP
               ALOAD 3
               INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
               ATHROW
+             L44
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object I] []
+              ALOAD 2
+              ICONST_0
+              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
              L46
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] [D]
               DSTORE 2
               DLOAD 2
               ICONST_0
@@ -13643,7 +14588,7 @@ procedure MAKE-BOX:[]{OTPL}:
               DNEG
               GOTO L48
              L47
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object org/nlogo/agent/Patch T I] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object I] []
               DLOAD 2
              L48
              FRAME SAME1 D
@@ -13700,7 +14645,7 @@ procedure MAKE-BOX:[]{OTPL}:
              FRAME SAME1 I
               GOTO L54
              L41
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object java/lang/Object T I] []
+             FRAME SAME
               ICONST_0
              L54
              FRAME SAME1 I
@@ -13719,6 +14664,12 @@ procedure MAKE-BOX:[]{OTPL}:
              L57
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduremakebox_ask_0.world : Lorg/nlogo/agent/World;
@@ -13764,25 +14715,15 @@ procedure MAKE-BOX:[]{OTPL}:
           IFEQ L4
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L5
+          IFEQ L2
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L6
-         FRAME SAME1 java/lang/Object
-          ASTORE 10
-          ALOAD 10
           POP
           GOTO L2
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -13825,17 +14766,17 @@ procedure MAKE-BOX:[]{OTPL}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L7
+         L5
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
-          IFNE L8
+          IFNE L6
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduremakebox_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-          IF_ACMPNE L9
+          IF_ACMPNE L7
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -13846,13 +14787,13 @@ procedure MAKE-BOX:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
+         L7
          FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_ask_0 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduremakebox_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
-          IF_ACMPNE L8
+          IF_ACMPNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -13863,7 +14804,7 @@ procedure MAKE-BOX:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L8
+         L6
          FRAME SAME
           ALOAD 1
           ALOAD 2
@@ -13872,10 +14813,13 @@ procedure MAKE-BOX:[]{OTPL}:
           ALOAD 1
           ICONST_3
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L10
+         L8
           RETURN
 [1]_asm_proceduremakebox_setpatchvariable_2 "set" Object => void
       _constdouble:45.0 "yellow" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -13889,9 +14833,6 @@ procedure MAKE-BOX:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_setpatchvariable_2 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -13906,8 +14847,13 @@ procedure MAKE-BOX:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_proceduremakebox_done_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -13915,6 +14861,7 @@ procedure MAKE-BOX:[]{OTPL}:
          L1
           RETURN
 [3]_asm_proceduremakebox_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -13927,6 +14874,7 @@ procedure MAKE-BOX:[]{OTPL}:
 procedure MAKE-PARTICLES:[]{O---}:
 [0]_createorderedturtles:PARTICLES,+7 "create-ordered-particles"
       _asm_proceduremakeparticles_observervariable_0 "number" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduremakeparticles_observervariable_0.world : Lorg/nlogo/agent/World;
@@ -13937,6 +14885,7 @@ procedure MAKE-PARTICLES:[]{O---}:
             ARETURN
 [1]_setbreedvariable:SPEED "set"
       _asm_proceduremakeparticles_constdouble_1 "1" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduremakeparticles_constdouble_1.kept1_value : Ljava/lang/Double;
@@ -13949,6 +14898,19 @@ procedure MAKE-PARTICLES:[]{O---}:
           _minus "-" double,double => double
             _observervariable:LARGEST-PARTICLE-SIZE "largest-particle-size" => Object
             _observervariable:SMALLEST-PARTICLE-SIZE "smallest-particle-size" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -14065,9 +15027,6 @@ procedure MAKE-PARTICLES:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L7
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L19
          L8
          FRAME FULL [org/nlogo/prim/_asm_proceduremakeparticles_setturtlevariable_2 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -14082,11 +15041,20 @@ procedure MAKE-PARTICLES:[]{O---}:
           ATHROW
          L19
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L20
           RETURN
 [3]_setbreedvariable:MASS "set"
       _asm_proceduremakeparticles_mult_3 "*" double,double => double
         _turtlevariabledouble:SIZE "size" => double
         _turtlevariabledouble:SIZE "size" => double
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -14133,6 +15101,11 @@ procedure MAKE-PARTICLES:[]{O---}:
 [5]_asm_proceduremakeparticles_setturtlevariable_5 "set" Object => void
       _randomfloat "random-float" double => double
         _constdouble:360.0 "360" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           LDC 360.0
@@ -14158,9 +15131,6 @@ procedure MAKE-PARTICLES:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L6
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakeparticles_setturtlevariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -14175,8 +15145,13 @@ procedure MAKE-PARTICLES:[]{O---}:
           ATHROW
          L6
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L7
           RETURN
 [6]_asm_proceduremakeparticles_done_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -14185,6 +15160,7 @@ procedure MAKE-PARTICLES:[]{O---}:
           RETURN
 [7]_asm_proceduremakeparticles_call_7 "arrange"
       _breed:PARTICLES "particles" => AgentSet
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -14213,6 +15189,7 @@ procedure MAKE-PARTICLES:[]{O---}:
          L3
           RETURN
 [8]_asm_proceduremakeparticles_return_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -14227,6 +15204,13 @@ procedure ARRANGE:[PARTICLE-SET]{OTPL}:
       _not "not" boolean => boolean
         _any "any?" AgentSet => boolean
           _procedurevariable:PARTICLE-SET "particle-set" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -14257,22 +15241,22 @@ procedure ARRANGE:[PARTICLE-SET]{OTPL}:
           ASTORE 2
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.isEmpty ()Z
-          IFEQ L5
-          ICONST_0
+          IFNE L5
+          ICONST_1
           GOTO L6
          L5
          FRAME FULL [org/nlogo/prim/_asm_procedurearrange_if_0 org/nlogo/nvm/Context org/nlogo/agent/AgentSet] []
-          ICONST_1
+          ICONST_0
          L6
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L7
-          ICONST_0
+          IFNE L7
+          ICONST_1
           GOTO L8
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurearrange_if_0 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L8
          FRAME SAME1 I
           ISTORE 2
@@ -14329,6 +15313,9 @@ procedure ARRANGE:[PARTICLE-SET]{OTPL}:
           RETURN
 [2]_asm_procedurearrange_ask_2 "ask" Object => void
       _procedurevariable:PARTICLE-SET "particle-set" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -14338,18 +15325,16 @@ procedure ARRANGE:[PARTICLE-SET]{OTPL}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurearrange_ask_2.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -14365,8 +15350,8 @@ procedure ARRANGE:[PARTICLE-SET]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurearrange_ask_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurearrange_ask_2.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -14383,18 +15368,18 @@ procedure ARRANGE:[PARTICLE-SET]{OTPL}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -14411,7 +15396,7 @@ procedure ARRANGE:[PARTICLE-SET]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -14421,23 +15406,12 @@ procedure ARRANGE:[PARTICLE-SET]{OTPL}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurearrange_ask_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_3
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -14451,8 +15425,16 @@ procedure ARRANGE:[PARTICLE-SET]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          ICONST_3
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurearrange_ask_2 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [3]_asm_procedurearrange_call_3 "random-position"
          L0
@@ -14473,6 +15455,7 @@ procedure ARRANGE:[PARTICLE-SET]{OTPL}:
          L1
           RETURN
 [4]_asm_procedurearrange_done_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -14507,6 +15490,10 @@ procedure ARRANGE:[PARTICLE-SET]{OTPL}:
              L1
              FRAME SAME1 java/lang/Object
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           NEW org/nlogo/nvm/Activation
@@ -14586,21 +15573,11 @@ procedure ARRANGE:[PARTICLE-SET]{OTPL}:
           IFEQ L8
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L9
+          IFEQ L6
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L10
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurearrange_call_5 org/nlogo/nvm/Context org/nlogo/agent/AgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object java/lang/Boolean] [org/nlogo/nvm/Activation [Ljava/lang/Object; I]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurearrange_call_5 org/nlogo/nvm/Context org/nlogo/agent/AgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object java/lang/Boolean] [org/nlogo/nvm/Activation [Ljava/lang/Object; I java/lang/Object]
-          ASTORE 10
-          ALOAD 10
           POP
           GOTO L6
          L8
@@ -14647,7 +15624,7 @@ procedure ARRANGE:[PARTICLE-SET]{OTPL}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L11
+         L9
           AASTORE
           ALOAD 1
           SWAP
@@ -14655,9 +15632,10 @@ procedure ARRANGE:[PARTICLE-SET]{OTPL}:
           ALOAD 1
           ICONST_0
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L12
+         L10
           RETURN
 [6]_asm_procedurearrange_return_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -14672,6 +15650,7 @@ reporter procedure OVERLAPPING?:[]{-T--}:
       _anyotherwith "any?" AgentSet,Reporter => boolean
         _inradiusboundingbox "in-radius"
           _asm_procedureoverlapping_breed_1 "particles" => AgentSet
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedureoverlapping_breed_1.world : Lorg/nlogo/agent/World;
@@ -14684,6 +15663,12 @@ reporter procedure OVERLAPPING?:[]{-T--}:
               _turtlevariabledouble:SIZE "size" => double
               _observervariable:LARGEST-PARTICLE-SIZE "largest-particle-size" => Object
             _constdouble:2.0 "2" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  d1
+                // parameter final  d2
+                // parameter final  context
                 TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
                L2
                 ALOAD 1
@@ -14762,6 +15747,16 @@ reporter procedure OVERLAPPING?:[]{-T--}:
               _turtlevariableof:SIZE "of" Agent => Object
                 _myself "myself" => Agent
             _constdouble:2.0 "2" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  agent
+              // parameter final  context
+              // parameter final  d1
+              // parameter final  d2
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  arg1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
               TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
              L5
@@ -14981,6 +15976,9 @@ reporter procedure OVERLAPPING?:[]{-T--}:
              L26
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureoverlapping_report_0.keptinstr3 : Lorg/nlogo/prim/_inradiusboundingbox;
@@ -15045,19 +16043,12 @@ reporter procedure OVERLAPPING?:[]{-T--}:
           IFEQ L6
           ALOAD 7
           CHECKCAST java/lang/Boolean
-          ASTORE 8
-          ALOAD 8
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L7
+          IFEQ L4
           ICONST_1
-          GOTO L8
-         L7
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 9
-          GOTO L4
+          GOTO L7
          L6
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -15091,15 +16082,15 @@ reporter procedure OVERLAPPING?:[]{-T--}:
          L5
          FRAME CHOP 2
           ICONST_0
-         L8
+         L7
          FRAME SAME1 I
-          IFEQ L9
+          IFEQ L8
           GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
-          GOTO L10
-         L9
+          GOTO L9
+         L8
          FRAME SAME
           GETSTATIC java/lang/Boolean.FALSE : Ljava/lang/Boolean;
-         L10
+         L9
          FRAME SAME1 java/lang/Boolean
           ASTORE 2
           ALOAD 1
@@ -15117,7 +16108,7 @@ reporter procedure OVERLAPPING?:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/nvm/Activation.nonLambdaActivation ()Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.procedure ()Lorg/nlogo/nvm/Procedure;
           INVOKEVIRTUAL org/nlogo/nvm/Procedure.isReporter ()Z
-          IFNE L11
+          IFNE L10
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -15133,22 +16124,22 @@ reporter procedure OVERLAPPING?:[]{-T--}:
           INVOKEINTERFACE org/nlogo/core/I18NJava.getN (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L11
+         L10
          FRAME FULL [org/nlogo/prim/_asm_procedureoverlapping_report_0 org/nlogo/nvm/Context java/lang/Boolean org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentIterator] []
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.procedure ()Lorg/nlogo/nvm/Procedure;
           INVOKEVIRTUAL org/nlogo/nvm/Procedure.isLambda ()Z
-          IFEQ L12
+          IFEQ L11
           NEW org/nlogo/nvm/NonLocalExit
           DUP
           INVOKESPECIAL org/nlogo/nvm/NonLocalExit.<init> ()V
           ATHROW
-         L12
+         L11
          FRAME SAME
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.atTopActivation ()Z
-          IFNE L13
+          IFNE L12
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -15164,10 +16155,11 @@ reporter procedure OVERLAPPING?:[]{-T--}:
           INVOKEINTERFACE org/nlogo/core/I18NJava.getN (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L13
+         L12
          FRAME SAME
           RETURN
 [1]_asm_procedureoverlapping_returnreport_4 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -15207,6 +16199,42 @@ procedure RANDOM-POSITION:[]{-T--}:
             _div "/" double,double => double
               _turtlevariabledouble:SIZE "size" => double
               _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  list
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  list
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -15544,6 +16572,7 @@ procedure RANDOM-POSITION:[]{-T--}:
          L43
           RETURN
 [1]_asm_procedurerandomposition_return_1 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -15556,6 +16585,9 @@ procedure RANDOM-POSITION:[]{-T--}:
 procedure REVERSE-TIME:[]{OTPL}:
 [0]_asm_procedurereversetime_ask_0 "ask" AgentSet => void
       _breed:PARTICLES "particles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurereversetime_ask_0.world : Lorg/nlogo/agent/World;
@@ -15612,6 +16644,9 @@ procedure REVERSE-TIME:[]{OTPL}:
           RETURN
 [1]_asm_procedurereversetime_right_1 "rt" double => void
       _constdouble:180.0 "180" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  delta
          L0
           LDC 180.0
          L1
@@ -15627,6 +16662,7 @@ procedure REVERSE-TIME:[]{OTPL}:
          L2
           RETURN
 [2]_asm_procedurereversetime_done_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -15670,6 +16706,7 @@ procedure REVERSE-TIME:[]{OTPL}:
          L1
           RETURN
 [5]_asm_procedurereversetime_return_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -15700,6 +16737,9 @@ procedure TEST-TIME-REVERSAL:[N OLD-CLOCK]{O---}:
           RETURN
 [1]_asm_proceduretesttimereversal_ask_1 "ask" AgentSet => void
       _breed:PARTICLES "particles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduretesttimereversal_ask_1.world : Lorg/nlogo/agent/World;
@@ -15756,6 +16796,7 @@ procedure TEST-TIME-REVERSAL:[N OLD-CLOCK]{O---}:
           RETURN
 [2]_stamp "stamp"
 [3]_asm_proceduretesttimereversal_done_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -15763,6 +16804,7 @@ procedure TEST-TIME-REVERSAL:[N OLD-CLOCK]{O---}:
          L1
           RETURN
 [4]_asm_proceduretesttimereversal_goto_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 6
@@ -15791,6 +16833,10 @@ procedure TEST-TIME-REVERSAL:[N OLD-CLOCK]{O---}:
       _lessthan "<" double,Object => boolean
         _ticks "ticks" => double
         _procedurevariable:N "n" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduretesttimereversal_while_5.world : Lorg/nlogo/agent/World;
@@ -15822,11 +16868,9 @@ procedure TEST-TIME-REVERSAL:[N OLD-CLOCK]{O---}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L4
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -15837,15 +16881,14 @@ procedure TEST-TIME-REVERSAL:[N OLD-CLOCK]{O---}:
           ICONST_1
           GOTO L6
          L5
-         FRAME APPEND [java/lang/Object java/lang/Object java/lang/Double]
+         FRAME APPEND [java/lang/Object T java/lang/Double]
           ICONST_0
          L6
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L7
          L4
-         FRAME CHOP 1
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -15874,23 +16917,27 @@ procedure TEST-TIME-REVERSAL:[N OLD-CLOCK]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduretesttimereversal_while_5 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
+         L8
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L8
+          IFEQ L9
           ICONST_5
-          GOTO L9
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_proceduretesttimereversal_while_5 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 7
+          GOTO L10
          L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduretesttimereversal_while_5 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_proceduretesttimereversal_while_5 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context]
+          BIPUSH 7
          L10
+         FRAME FULL [org/nlogo/prim/_asm_proceduretesttimereversal_while_5 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [7]_asm_proceduretesttimereversal_setprocedurevariable_6 "let" Object => void
       _ticks "ticks" => double
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduretesttimereversal_setprocedurevariable_6.world : Lorg/nlogo/agent/World;
@@ -15949,6 +16996,7 @@ procedure TEST-TIME-REVERSAL:[N OLD-CLOCK]{O---}:
          L1
           RETURN
 [9]_asm_proceduretesttimereversal_goto_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 11
@@ -15979,6 +17027,14 @@ procedure TEST-TIME-REVERSAL:[N OLD-CLOCK]{O---}:
         _mult "*" double,double => double
           _constdouble:2.0 "2" => double
           _procedurevariable:OLD-CLOCK "old-clock" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -16065,6 +17121,9 @@ procedure TEST-TIME-REVERSAL:[N OLD-CLOCK]{O---}:
           RETURN
 [12]_asm_proceduretesttimereversal_ask_11 "ask" AgentSet => void
       _breed:PARTICLES "particles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduretesttimereversal_ask_11.world : Lorg/nlogo/agent/World;
@@ -16121,6 +17180,9 @@ procedure TEST-TIME-REVERSAL:[N OLD-CLOCK]{O---}:
           RETURN
 [13]_asm_proceduretesttimereversal_setturtleorlinkvariable_12 "set" Object => void
       _constdouble:9.9 "white" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -16134,9 +17196,6 @@ procedure TEST-TIME-REVERSAL:[N OLD-CLOCK]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 14
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduretesttimereversal_setturtleorlinkvariable_12 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -16151,8 +17210,13 @@ procedure TEST-TIME-REVERSAL:[N OLD-CLOCK]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 14
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [14]_asm_proceduretesttimereversal_done_13 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -16160,6 +17224,7 @@ procedure TEST-TIME-REVERSAL:[N OLD-CLOCK]{O---}:
          L1
           RETURN
 [15]_asm_proceduretesttimereversal_return_14 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V

--- a/netlogo-headless/test/benchdumps/GasLabNew.txt
+++ b/netlogo-headless/test/benchdumps/GasLabNew.txt
@@ -11,6 +11,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:361.0 "361" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 361.0
          L1
@@ -32,16 +35,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -79,6 +82,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:17000.0 "17000" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 17000.0
          L1
@@ -91,7 +97,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -118,6 +125,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -151,6 +159,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -172,9 +183,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -189,8 +197,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -205,6 +218,7 @@ procedure SETUP:[]{O---}:
 [1]_resetticks "reset-ticks"
 [2]_setdefaultshape "set-default-shape"
       _asm_proceduresetup_breed_0 "particles" => AgentSet
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetup_breed_0.world : Lorg/nlogo/agent/World;
@@ -213,12 +227,16 @@ procedure SETUP:[]{O---}:
            L1
             ARETURN
       _asm_proceduresetup_conststring_1 ""circle"" => String
+            // parameter final  context
            L0
             LDC "circle"
            L1
             ARETURN
 [3]_asm_proceduresetup_setobservervariable_2 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -233,9 +251,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_2 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -250,11 +265,22 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduresetup_setobservervariable_3 "set" Object => void
       _minus "-" double,double => double
         _maxpxcor "max-pxcor" => double
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -284,9 +310,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_3 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -301,6 +324,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [5]_asm_proceduresetup_setobservervariable_4 "set" Object => void
       _plus "+" double,double => double
@@ -310,6 +337,21 @@ procedure SETUP:[]{O---}:
             _observervariable:BOX-EDGE "box-edge" => Object
             _constdouble:1.0 "1" => double
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -377,9 +419,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L14
          L4
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_4 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -394,6 +433,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L14
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L15
           RETURN
 [6]_asm_proceduresetup_setobservervariable_5 "set" Object => void
       _plus "+" double,double => double
@@ -403,6 +446,21 @@ procedure SETUP:[]{O---}:
             _observervariable:BOX-EDGE "box-edge" => Object
             _constdouble:1.0 "1" => double
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -470,9 +528,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L14
          L4
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -487,6 +542,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L14
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L15
           RETURN
 [7]_asm_proceduresetup_call_6 "make-box"
          L0
@@ -544,6 +603,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [10]_asm_proceduresetup_setobservervariable_9 "set" Object => void
       _constlist:[] "[]" => LogoList
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -558,9 +620,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 11
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_9 org/nlogo/nvm/Context org/nlogo/core/LogoList] [org/nlogo/api/AgentException]
@@ -575,9 +634,16 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 11
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [11]_asm_proceduresetup_setobservervariable_10 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -592,9 +658,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 12
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_10 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -609,6 +672,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 12
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [12]_asm_proceduresetup_call_11 "update-variables"
          L0
@@ -630,6 +697,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [13]_asm_proceduresetup_setobservervariable_12 "set" Object => void
       _observervariable:AVG-SPEED "avg-speed" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -647,9 +717,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 14
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_12 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -664,9 +731,16 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 14
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [14]_asm_proceduresetup_setobservervariable_13 "set" Object => void
       _observervariable:AVG-ENERGY "avg-energy" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -684,9 +758,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 15
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_13 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -701,6 +772,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 15
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [15]_asm_proceduresetup_call_14 "setup-plotz"
          L0
@@ -757,6 +832,7 @@ procedure SETUP:[]{O---}:
          L1
           RETURN
 [18]_asm_proceduresetup_return_17 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -773,6 +849,11 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
         _asm_procedureupdatevariables_equal_1 "=" Object,double => boolean
           _turtleorlinkvariable:COLOR "color" => Object
           _constdouble:55.0 "green" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -799,11 +880,9 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -814,19 +893,19 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_equal_1 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_equal_1 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -837,6 +916,12 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  block
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -881,25 +966,15 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           IFEQ L7
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L8
+          IFEQ L5
           ILOAD 5
           ICONST_1
           IADD
           ISTORE 5
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          GOTO L9
-         L8
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L9
-         FRAME SAME1 scala/runtime/BoxedUnit
-          ASTORE 10
           GOTO L5
          L7
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -934,7 +1009,7 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
          FRAME CHOP 2
           ILOAD 5
           I2D
-         L10
+         L8
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -949,10 +1024,7 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L11
+          GOTO L9
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_0 org/nlogo/nvm/Context java/lang/Double T org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator] [org/nlogo/api/AgentException]
           ASTORE 3
@@ -964,8 +1036,12 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L11
+         L9
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [1]_asm_procedureupdatevariables_setobservervariable_2 "set" Object => void
       _countwith "count" AgentSet,Reporter => double
@@ -973,6 +1049,11 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
         _asm_procedureupdatevariables_equal_3 "=" Object,double => boolean
           _turtleorlinkvariable:COLOR "color" => Object
           _constdouble:105.0 "blue" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -999,11 +1080,9 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -1014,19 +1093,19 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_equal_3 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_equal_3 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -1037,6 +1116,12 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  block
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1081,25 +1166,15 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           IFEQ L7
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L8
+          IFEQ L5
           ILOAD 5
           ICONST_1
           IADD
           ISTORE 5
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          GOTO L9
-         L8
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L9
-         FRAME SAME1 scala/runtime/BoxedUnit
-          ASTORE 10
           GOTO L5
          L7
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1134,7 +1209,7 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
          FRAME CHOP 2
           ILOAD 5
           I2D
-         L10
+         L8
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -1149,10 +1224,7 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L11
+          GOTO L9
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_2 org/nlogo/nvm/Context java/lang/Double T org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator] [org/nlogo/api/AgentException]
           ASTORE 3
@@ -1164,8 +1236,12 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L11
+         L9
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [2]_asm_procedureupdatevariables_setobservervariable_4 "set" Object => void
       _countwith "count" AgentSet,Reporter => double
@@ -1173,6 +1249,11 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
         _asm_procedureupdatevariables_equal_5 "=" Object,double => boolean
           _turtleorlinkvariable:COLOR "color" => Object
           _constdouble:15.0 "red" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -1199,11 +1280,9 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -1214,19 +1293,19 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_equal_5 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_equal_5 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -1237,6 +1316,12 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  block
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1281,25 +1366,15 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           IFEQ L7
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L8
+          IFEQ L5
           ILOAD 5
           ICONST_1
           IADD
           ISTORE 5
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          GOTO L9
-         L8
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L9
-         FRAME SAME1 scala/runtime/BoxedUnit
-          ASTORE 10
           GOTO L5
          L7
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1334,7 +1409,7 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
          FRAME CHOP 2
           ILOAD 5
           I2D
-         L10
+         L8
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -1349,10 +1424,7 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L11
+          GOTO L9
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_4 org/nlogo/nvm/Context java/lang/Double T org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator] [org/nlogo/api/AgentException]
           ASTORE 3
@@ -1364,13 +1436,18 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L11
+         L9
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [3]_asm_procedureupdatevariables_setobservervariable_6 "set" Object => void
       _mean "mean" LogoList => double
         _breedvariableof:SPEED "of"
           _asm_procedureupdatevariables_breed_7 "particles" => AgentSet
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedureupdatevariables_breed_7.world : Lorg/nlogo/agent/World;
@@ -1378,6 +1455,8 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
                 INVOKEVIRTUAL org/nlogo/agent/World.getBreed (Ljava/lang/String;)Lorg/nlogo/agent/AgentSet;
                L1
                 ARETURN
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
           ALOAD 0
@@ -1474,7 +1553,8 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -1490,9 +1570,6 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_6 org/nlogo/nvm/Context java/lang/Double T T java/util/Iterator] [org/nlogo/api/AgentException]
@@ -1507,11 +1584,16 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [4]_asm_procedureupdatevariables_setobservervariable_8 "set" Object => void
       _mean "mean" LogoList => double
         _breedvariableof:ENERGY "of"
           _asm_procedureupdatevariables_breed_9 "particles" => AgentSet
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedureupdatevariables_breed_9.world : Lorg/nlogo/agent/World;
@@ -1519,6 +1601,8 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
                 INVOKEVIRTUAL org/nlogo/agent/World.getBreed (Ljava/lang/String;)Lorg/nlogo/agent/AgentSet;
                L1
                 ARETURN
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
           ALOAD 0
@@ -1615,7 +1699,8 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -1631,9 +1716,6 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_8 org/nlogo/nvm/Context java/lang/Double T T java/util/Iterator] [org/nlogo/api/AgentException]
@@ -1648,8 +1730,13 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [5]_asm_procedureupdatevariables_return_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1662,6 +1749,9 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
 procedure GO:[OLD-CLOCK]{O---}:
 [0]_asm_procedurego_ask_0 "ask" AgentSet => void
       _breed:PARTICLES "particles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_0.world : Lorg/nlogo/agent/World;
@@ -1735,6 +1825,7 @@ procedure GO:[OLD-CLOCK]{O---}:
          L1
           RETURN
 [2]_asm_procedurego_done_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1743,6 +1834,9 @@ procedure GO:[OLD-CLOCK]{O---}:
           RETURN
 [3]_asm_procedurego_ask_3 "ask" AgentSet => void
       _breed:PARTICLES "particles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_3.world : Lorg/nlogo/agent/World;
@@ -1816,6 +1910,7 @@ procedure GO:[OLD-CLOCK]{O---}:
          L1
           RETURN
 [5]_asm_procedurego_done_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1824,6 +1919,9 @@ procedure GO:[OLD-CLOCK]{O---}:
           RETURN
 [6]_asm_procedurego_ask_6 "ask" AgentSet => void
       _breed:PARTICLES "particles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_6.world : Lorg/nlogo/agent/World;
@@ -1880,6 +1978,9 @@ procedure GO:[OLD-CLOCK]{O---}:
           RETURN
 [7]_asm_procedurego_if_7 "if" boolean => void
       _observervariable:COLLIDE? "collide?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -1941,6 +2042,7 @@ procedure GO:[OLD-CLOCK]{O---}:
          L1
           RETURN
 [9]_asm_procedurego_done_9 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1949,6 +2051,9 @@ procedure GO:[OLD-CLOCK]{O---}:
           RETURN
 [10]_asm_procedurego_if_10 "if" boolean => void
       _observervariable:TRACE? "trace?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -1994,13 +2099,19 @@ procedure GO:[OLD-CLOCK]{O---}:
 [11]_asm_procedurego_ask_11 "ask" Object => void
       _breedsingular:PARTICLES "particle" double => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  idDouble
+          // parameter final  context
+          // parameter final  target
          L0
           DCONST_0
          L1
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_ask_11.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_ask_11.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           LLOAD 4
           L2D
@@ -2011,14 +2122,14 @@ procedure GO:[OLD-CLOCK]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           DLOAD 2
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (D)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (D)Ljava/lang/StringBuilder;
           LDC " is not an integer"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L2
@@ -2042,13 +2153,7 @@ procedure GO:[OLD-CLOCK]{O---}:
           ALOAD 7
           ALOAD 6
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.contains (Lorg/nlogo/api/Agent;)Z
-          IFEQ L5
-          ALOAD 6
-         L4
-         FRAME SAME1 java/lang/Object
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/AgentSet]
+          IFNE L5
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2091,26 +2196,27 @@ procedure GO:[OLD-CLOCK]{O---}:
           INVOKEVIRTUAL scala/StringContext.s (Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L6
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 6
+         L4
          FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_11 org/nlogo/nvm/Context D J org/nlogo/agent/Turtle] [java/lang/Object]
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L7
-          ALOAD 4
+          IFEQ L6
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
-          IFNE L8
-          ALOAD 5
+          IFNE L7
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_11.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-          IF_ACMPNE L9
+          IF_ACMPNE L8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2121,13 +2227,13 @@ procedure GO:[OLD-CLOCK]{O---}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_11 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet org/nlogo/agent/Turtle] []
-          ALOAD 5
+         L8
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_11 org/nlogo/nvm/Context java/lang/Object T org/nlogo/agent/AgentSet T org/nlogo/agent/Turtle] []
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_11.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
-          IF_ACMPNE L8
+          IF_ACMPNE L7
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2138,24 +2244,24 @@ procedure GO:[OLD-CLOCK]{O---}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L8
-         FRAME SAME
-          ALOAD 5
-          ASTORE 6
-          GOTO L10
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_11 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/Turtle] []
+         FRAME SAME
           ALOAD 4
+          ASTORE 3
+          GOTO L9
+         L6
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_11 org/nlogo/nvm/Context java/lang/Object T J org/nlogo/agent/Turtle] []
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L11
-          ALOAD 4
+          IFEQ L10
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L12
+          IFNE L11
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2168,33 +2274,22 @@ procedure GO:[OLD-CLOCK]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L12
-         FRAME APPEND [org/nlogo/agent/Agent]
-          GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
-          INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_11 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
-          ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 12
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 15
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L13
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_11 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/Turtle] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_11 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/Agent org/nlogo/agent/Turtle] []
+          GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
+          ALOAD 5
+          INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
+          ASTORE 3
+          GOTO L9
+         L10
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_11 org/nlogo/nvm/Context java/lang/Object T J org/nlogo/agent/Turtle] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -2208,11 +2303,22 @@ procedure GO:[OLD-CLOCK]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
-         L13
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_11 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
+         L9
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_11 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet T T org/nlogo/agent/Turtle] []
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 12
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 15
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [12]_asm_procedurego_setpatchvariable_12 "set" Object => void
       _constdouble:5.0 "gray" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2226,9 +2332,6 @@ procedure GO:[OLD-CLOCK]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 13
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_12 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -2243,9 +2346,16 @@ procedure GO:[OLD-CLOCK]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 13
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [13]_asm_procedurego_setobservervariable_13 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2260,9 +2370,6 @@ procedure GO:[OLD-CLOCK]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 14
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setobservervariable_13 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -2277,8 +2384,13 @@ procedure GO:[OLD-CLOCK]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 14
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [14]_asm_procedurego_done_14 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2287,6 +2399,8 @@ procedure GO:[OLD-CLOCK]{O---}:
           RETURN
 [15]_asm_procedurego_setprocedurevariable_15 "let" Object => void
       _ticks "ticks" => double
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_setprocedurevariable_15.world : Lorg/nlogo/agent/World;
@@ -2328,6 +2442,7 @@ procedure GO:[OLD-CLOCK]{O---}:
           RETURN
 [16]_tickadvance "tick-advance"
       _asm_procedurego_observervariable_16 "tick-length" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurego_observervariable_16.world : Lorg/nlogo/agent/World;
@@ -2344,6 +2459,19 @@ procedure GO:[OLD-CLOCK]{O---}:
           _minus "-" double,double => double
             _ticks "ticks" => double
             _observervariable:TICK-LENGTH "tick-length" => Object
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -2458,6 +2586,11 @@ procedure GO:[OLD-CLOCK]{O---}:
 [18]_asm_procedurego_ifelse_18 "ifelse" boolean => void
       _any "any?" AgentSet => boolean
         _breed:PARTICLES "particles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ifelse_18.world : Lorg/nlogo/agent/World;
@@ -2467,12 +2600,12 @@ procedure GO:[OLD-CLOCK]{O---}:
           ASTORE 2
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.isEmpty ()Z
-          IFEQ L2
-          ICONST_0
+          IFNE L2
+          ICONST_1
           GOTO L3
          L2
          FRAME APPEND [org/nlogo/agent/AgentSet]
-          ICONST_1
+          ICONST_0
          L3
          FRAME SAME1 I
           ISTORE 2
@@ -2493,6 +2626,7 @@ procedure GO:[OLD-CLOCK]{O---}:
       _mean "mean" LogoList => double
         _breedvariableof:WALL-HITS "of"
           _asm_procedurego_breed_20 "particles" => AgentSet
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurego_breed_20.world : Lorg/nlogo/agent/World;
@@ -2500,6 +2634,8 @@ procedure GO:[OLD-CLOCK]{O---}:
                 INVOKEVIRTUAL org/nlogo/agent/World.getBreed (Ljava/lang/String;)Lorg/nlogo/agent/AgentSet;
                L1
                 ARETURN
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
           ALOAD 0
@@ -2596,7 +2732,8 @@ procedure GO:[OLD-CLOCK]{O---}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_19.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_19.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -2612,9 +2749,6 @@ procedure GO:[OLD-CLOCK]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 20
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setobservervariable_19 org/nlogo/nvm/Context java/lang/Double T T java/util/Iterator] [org/nlogo/api/AgentException]
@@ -2629,8 +2763,13 @@ procedure GO:[OLD-CLOCK]{O---}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          BIPUSH 20
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [20]_asm_procedurego_goto_21 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 22
@@ -2639,6 +2778,9 @@ procedure GO:[OLD-CLOCK]{O---}:
           RETURN
 [21]_asm_procedurego_setobservervariable_22 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2653,9 +2795,6 @@ procedure GO:[OLD-CLOCK]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 22
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setobservervariable_22 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -2670,9 +2809,16 @@ procedure GO:[OLD-CLOCK]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 22
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [22]_asm_procedurego_ask_23 "ask" AgentSet => void
       _breed:PARTICLES "particles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_23.world : Lorg/nlogo/agent/World;
@@ -2729,12 +2875,14 @@ procedure GO:[OLD-CLOCK]{O---}:
           RETURN
 [23]_setbreedvariable:WALL-HITS "set"
       _asm_procedurego_constdouble_24 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurego_constdouble_24.kept1_value : Ljava/lang/Double;
            L1
             ARETURN
 [24]_asm_procedurego_done_25 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2743,6 +2891,9 @@ procedure GO:[OLD-CLOCK]{O---}:
           RETURN
 [25]_asm_procedurego_if_26 "if" boolean => void
       _observervariable:FADE-NEEDED? "fade-needed?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -2877,6 +3028,9 @@ procedure GO:[OLD-CLOCK]{O---}:
           RETURN
 [31]_asm_procedurego_ask_32 "ask" AgentSet => void
       _breed:CLOCKERS "clockers" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_32.world : Lorg/nlogo/agent/World;
@@ -2935,6 +3089,12 @@ procedure GO:[OLD-CLOCK]{O---}:
       _mult "*" double,double => double
         _ticks "ticks" => double
         _constdouble:360.0 "360" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2979,9 +3139,6 @@ procedure GO:[OLD-CLOCK]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 33
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L8
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setturtlevariable_33 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -2996,8 +3153,13 @@ procedure GO:[OLD-CLOCK]{O---}:
           ATHROW
          L8
          FRAME SAME
+          ALOAD 1
+          BIPUSH 33
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L9
           RETURN
 [33]_asm_procedurego_done_34 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -3012,6 +3174,14 @@ procedure GO:[OLD-CLOCK]{O---}:
             _ticks "ticks" => double
             _breedvariable:BIRTHDAY "birthday" => Object
           _constdouble:0.4 "0.4" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d0
+              // parameter final  d1
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  arg1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
               TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
              L5
@@ -3105,6 +3275,12 @@ procedure GO:[OLD-CLOCK]{O---}:
              L14
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_35.world : Lorg/nlogo/agent/World;
@@ -3151,25 +3327,15 @@ procedure GO:[OLD-CLOCK]{O---}:
           IFEQ L4
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L5
+          IFEQ L2
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L6
-         FRAME SAME1 java/lang/Object
-          ASTORE 10
-          ALOAD 10
           POP
           GOTO L2
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3212,17 +3378,17 @@ procedure GO:[OLD-CLOCK]{O---}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L7
+         L5
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
-          IFNE L8
+          IFNE L6
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_35.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-          IF_ACMPNE L9
+          IF_ACMPNE L7
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3233,13 +3399,13 @@ procedure GO:[OLD-CLOCK]{O---}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
+         L7
          FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_35 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_35.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
-          IF_ACMPNE L8
+          IF_ACMPNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3250,7 +3416,7 @@ procedure GO:[OLD-CLOCK]{O---}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L8
+         L6
          FRAME SAME
           ALOAD 1
           ALOAD 2
@@ -3259,10 +3425,13 @@ procedure GO:[OLD-CLOCK]{O---}:
           ALOAD 1
           BIPUSH 38
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L10
+         L8
           RETURN
 [35]_asm_procedurego_setpatchvariable_37 "set" Object => void
       _constdouble:45.0 "yellow" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3276,9 +3445,6 @@ procedure GO:[OLD-CLOCK]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 36
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_37 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -3293,6 +3459,10 @@ procedure GO:[OLD-CLOCK]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 36
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [36]_asm_procedurego_die_38 "die" => void
          L0
@@ -3319,6 +3489,7 @@ procedure GO:[OLD-CLOCK]{O---}:
          L3
           RETURN
 [37]_asm_procedurego_done_39 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -3327,6 +3498,7 @@ procedure GO:[OLD-CLOCK]{O---}:
           RETURN
 [38]_display "display"
 [39]_asm_procedurego_return_40 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -3343,6 +3515,11 @@ procedure CALCULATE-TICK-LENGTH:[]{OTPL}:
         _asm_procedurecalculateticklength_greaterthan_1 ">" Object,double => boolean
           _breedvariable:SPEED "speed" => Object
           _constdouble:0.0 "0" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  arg1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -3369,14 +3546,10 @@ procedure CALCULATE-TICK-LENGTH:[]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
-              ASTORE 6
-              ALOAD 6
               INVOKEVIRTUAL java/lang/Double.doubleValue ()D
               DLOAD 3
               DCMPL
@@ -3384,15 +3557,14 @@ procedure CALCULATE-TICK-LENGTH:[]{OTPL}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_procedurecalculateticklength_greaterthan_1 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME APPEND [java/lang/Object D]
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
-              ILOAD 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME SAME
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
@@ -3421,16 +3593,24 @@ procedure CALCULATE-TICK-LENGTH:[]{OTPL}:
               INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
               ATHROW
              L8
-             FRAME FULL [org/nlogo/prim/_asm_procedurecalculateticklength_greaterthan_1 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
-              IFEQ L9
-              GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
-              GOTO L10
+             FRAME APPEND [I]
+              ILOAD 5
              L9
+              IFEQ L10
+              GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
+              GOTO L11
+             L10
              FRAME SAME
               GETSTATIC java/lang/Boolean.FALSE : Ljava/lang/Boolean;
-             L10
+             L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecalculateticklength_ifelse_0.world : Lorg/nlogo/agent/World;
@@ -3476,16 +3656,11 @@ procedure CALCULATE-TICK-LENGTH:[]{OTPL}:
           GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
           ALOAD 8
           INVOKEVIRTUAL scala/Predef$.Boolean2boolean (Ljava/lang/Boolean;)Z
-          IFEQ L5
+          IFEQ L2
           ICONST_1
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 9
-          GOTO L2
+          GOTO L5
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3515,21 +3690,21 @@ procedure CALCULATE-TICK-LENGTH:[]{OTPL}:
          L3
          FRAME CHOP 2
           ICONST_0
-         L6
+         L5
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L7
+          IFEQ L6
           ICONST_1
-          GOTO L8
-         L7
+          GOTO L7
+         L6
          FRAME FULL [org/nlogo/prim/_asm_procedurecalculateticklength_ifelse_0 org/nlogo/nvm/Context I org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentIterator] [org/nlogo/nvm/Context]
           ICONST_3
-         L8
+         L7
          FRAME FULL [org/nlogo/prim/_asm_procedurecalculateticklength_ifelse_0 org/nlogo/nvm/Context I org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentIterator] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L9
+         L8
           RETURN
 [1]_asm_procedurecalculateticklength_setobservervariable_2 "set" Object => void
       _div "/" double,double => double
@@ -3538,6 +3713,7 @@ procedure CALCULATE-TICK-LENGTH:[]{OTPL}:
           _max "max"
             _breedvariableof:SPEED "of"
               _asm_procedurecalculateticklength_breed_3 "particles" => AgentSet
+                    // parameter final  context
                    L0
                     ALOAD 0
                     GETFIELD org/nlogo/prim/_asm_procedurecalculateticklength_breed_3.world : Lorg/nlogo/agent/World;
@@ -3545,6 +3721,11 @@ procedure CALCULATE-TICK-LENGTH:[]{OTPL}:
                     INVOKEVIRTUAL org/nlogo/agent/World.getBreed (Ljava/lang/String;)Lorg/nlogo/agent/AgentSet;
                    L1
                     ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -3614,9 +3795,6 @@ procedure CALCULATE-TICK-LENGTH:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurecalculateticklength_setobservervariable_2 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -3631,8 +3809,13 @@ procedure CALCULATE-TICK-LENGTH:[]{OTPL}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [2]_asm_procedurecalculateticklength_goto_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_4
@@ -3641,6 +3824,9 @@ procedure CALCULATE-TICK-LENGTH:[]{OTPL}:
           RETURN
 [3]_asm_procedurecalculateticklength_setobservervariable_5 "set" Object => void
       _constdouble:1.0 "1" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3655,9 +3841,6 @@ procedure CALCULATE-TICK-LENGTH:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecalculateticklength_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -3672,8 +3855,13 @@ procedure CALCULATE-TICK-LENGTH:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_procedurecalculateticklength_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -3690,6 +3878,7 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
         _sum "sum" LogoList => double
           _breedvariableof:MOMENTUM-DIFFERENCE "of"
             _asm_procedurecalculatepressure_breed_1 "particles" => AgentSet
+                  // parameter final  context
                  L0
                   ALOAD 0
                   GETFIELD org/nlogo/prim/_asm_procedurecalculatepressure_breed_1.world : Lorg/nlogo/agent/World;
@@ -3697,6 +3886,14 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
                   INVOKEVIRTUAL org/nlogo/agent/World.getBreed (Ljava/lang/String;)Lorg/nlogo/agent/AgentSet;
                  L1
                   ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  l0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -3742,7 +3939,7 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
           ASTORE 6
           ALOAD 6
           INSTANCEOF java/lang/Double
-          IFEQ L11
+          IFEQ L9
           ALOAD 6
           CHECKCAST java/lang/Double
           ASTORE 7
@@ -3751,26 +3948,20 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DADD
           DSTORE 3
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 8
-          GOTO L9
-         L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurecalculatepressure_setobservervariable_0 org/nlogo/nvm/Context org/nlogo/core/LogoList D java/util/Iterator java/lang/Object] [D]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 8
           GOTO L9
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurecalculatepressure_setobservervariable_0 org/nlogo/nvm/Context org/nlogo/core/LogoList D java/util/Iterator] [D]
+         FRAME SAME1 D
           ALOAD 0
           DLOAD 3
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatepressure_setobservervariable_0.validDouble (D)D
-         L12
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatepressure_setobservervariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
+         L11
           DSTORE 4
           DSTORE 2
           DLOAD 2
           DLOAD 4
           DMUL
-         L13
+         L12
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -3785,10 +3976,7 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L14
+          GOTO L13
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurecalculatepressure_setobservervariable_0 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
           ASTORE 3
@@ -3800,12 +3988,17 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L14
+         L13
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L14
           RETURN
 [1]_asm_procedurecalculatepressure_setobservervariable_2 "set" Object => void
       _lput "lput"
         _asm_procedurecalculatepressure_observervariable_3 "pressure" => Object
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurecalculatepressure_observervariable_3.world : Lorg/nlogo/agent/World;
@@ -3815,6 +4008,7 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
              L1
               ARETURN
         _asm_procedurecalculatepressure_observervariable_4 "pressure-history" => Object
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurecalculatepressure_observervariable_4.world : Lorg/nlogo/agent/World;
@@ -3823,6 +4017,8 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
               INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecalculatepressure_setobservervariable_2.keptinstr2 : Lorg/nlogo/prim/etc/_lput;
@@ -3838,9 +4034,6 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L4
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecalculatepressure_setobservervariable_2 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -3855,6 +4048,10 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
           ATHROW
          L4
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L5
           RETURN
 [2]_asm_procedurecalculatepressure_setobservervariable_5 "set" Object => void
       _length "length" LogoList => double
@@ -3863,6 +4060,11 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
             _asm_procedurecalculatepressure_equal_6 "=" Object,double => boolean
               _letvariable(Let(P)) "p" => Object
               _constdouble:0.0 "0" => double
+                  // parameter final  context
+                  // parameter final  context
+                  // parameter final  context
+                  // parameter final  arg0
+                  // parameter final  d1
                  L0
                   ALOAD 1
                   ALOAD 0
@@ -3874,11 +4076,9 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
                   DSTORE 3
                   ASTORE 2
                   ALOAD 2
-                  ASTORE 5
-                  ALOAD 5
                   INSTANCEOF java/lang/Double
                   IFEQ L3
-                  ALOAD 5
+                  ALOAD 2
                   CHECKCAST java/lang/Double
                   ASTORE 6
                   DLOAD 3
@@ -3889,19 +4089,19 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
                   ICONST_1
                   GOTO L5
                  L4
-                 FRAME FULL [org/nlogo/prim/_asm_procedurecalculatepressure_equal_6 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+                 FRAME FULL [org/nlogo/prim/_asm_procedurecalculatepressure_equal_6 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                   ICONST_0
                  L5
                  FRAME SAME1 I
-                  ISTORE 7
+                  ISTORE 5
                   GOTO L6
                  L3
-                 FRAME CHOP 1
+                 FRAME CHOP 2
                   ICONST_0
-                  ISTORE 7
+                  ISTORE 5
                  L6
-                 FRAME APPEND [T I]
-                  ILOAD 7
+                 FRAME APPEND [I]
+                  ILOAD 5
                  L7
                   IFEQ L8
                   GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -3913,6 +4113,7 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
                  FRAME SAME1 java/lang/Boolean
                   ARETURN
           _asm_procedurecalculatepressure_observervariable_7 "pressure-history" => Object
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurecalculatepressure_observervariable_7.world : Lorg/nlogo/agent/World;
@@ -3921,6 +4122,8 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
                 INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
                L1
                 ARETURN
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
           ALOAD 0
@@ -3966,9 +4169,6 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L8
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurecalculatepressure_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -3983,9 +4183,16 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
           ATHROW
          L8
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L9
           RETURN
 [3]_asm_procedurecalculatepressure_ask_8 "ask" AgentSet => void
       _breed:PARTICLES "particles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecalculatepressure_ask_8.world : Lorg/nlogo/agent/World;
@@ -4042,12 +4249,14 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
           RETURN
 [4]_setbreedvariable:MOMENTUM-DIFFERENCE "set"
       _asm_procedurecalculatepressure_constdouble_9 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurecalculatepressure_constdouble_9.kept1_value : Ljava/lang/Double;
            L1
             ARETURN
 [5]_asm_procedurecalculatepressure_done_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -4055,6 +4264,7 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
          L1
           RETURN
 [6]_asm_procedurecalculatepressure_return_11 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -4068,12 +4278,14 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
 [0]_asm_procedurebounce_if_0 "if" boolean => void
       _shadeof "shade-of?"
         _asm_procedurebounce_constdouble_1 "yellow" => Double
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurebounce_constdouble_1.kept1_value : Ljava/lang/Double;
              L1
               ARETURN
         _asm_procedurebounce_patchvariable_2 "pcolor" => Object
+              // parameter final  context
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -4096,6 +4308,8 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
              L3
              FRAME SAME1 java/lang/Object
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurebounce_if_0.keptinstr2 : Lorg/nlogo/prim/etc/_shadeof;
@@ -4177,11 +4391,14 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
 [2]_asm_procedurebounce_setprocedurevariable_4 "let" Object => void
       _patchahead "patch-ahead"
         _asm_procedurebounce_constdouble_5 "1" => Double
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurebounce_constdouble_5.kept1_value : Ljava/lang/Double;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurebounce_setprocedurevariable_4.keptinstr2 : Lorg/nlogo/prim/etc/_patchahead;
           ALOAD 1
@@ -4202,30 +4419,32 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
 [3]_asm_procedurebounce_setprocedurevariable_6 "let" Object => void
       _patchvariableof:PXCOR "of" Object => Object
         _procedurevariable:NEW-PATCH "new-patch" => Object
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-         L4
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+         L3
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_0
           AALOAD
-         L5
+         L4
           ASTORE 2
-         L2
+         L0
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L5
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L6
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L7
+          IFNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4238,45 +4457,45 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setprocedurevariable_6 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-          ALOAD 5
+         L6
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+          ALOAD 4
           ICONST_0
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L8
-         L6
-         FRAME CHOP 1
-          ALOAD 4
+          ASTORE 3
+          GOTO L7
+         L5
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L0
-          ALOAD 4
+          IFEQ L8
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setprocedurevariable_6 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setprocedurevariable_6 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L10
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           ICONST_0
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
@@ -4284,16 +4503,12 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           GOTO L9
          L10
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setprocedurevariable_6 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
           ALOAD 6
-         L3
-          GOTO L11
-         L0
-         FRAME CHOP 2
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L7
+         L8
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setprocedurevariable_6 org/nlogo/nvm/Context java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -4310,22 +4525,27 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           GETSTATIC org/nlogo/core/Syntax$.MODULE$ : Lorg/nlogo/core/Syntax$;
           INVOKEVIRTUAL org/nlogo/core/Syntax$.PatchsetType ()I
           IOR
-          ALOAD 4
+          ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L7
+         FRAME APPEND [java/lang/Object]
+          ALOAD 3
          L1
+          GOTO L11
+         L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setprocedurevariable_6 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setprocedurevariable_6 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setprocedurevariable_6 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -4341,30 +4561,32 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
 [4]_asm_procedurebounce_setprocedurevariable_7 "let" Object => void
       _patchvariableof:PYCOR "of" Object => Object
         _procedurevariable:NEW-PATCH "new-patch" => Object
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-         L4
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+         L3
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_0
           AALOAD
-         L5
+         L4
           ASTORE 2
-         L2
+         L0
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L5
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L6
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L7
+          IFNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4377,45 +4599,45 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-          ALOAD 5
+         L6
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+          ALOAD 4
           ICONST_1
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L8
-         L6
-         FRAME CHOP 1
-          ALOAD 4
+          ASTORE 3
+          GOTO L7
+         L5
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L0
-          ALOAD 4
+          IFEQ L8
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L10
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           ICONST_1
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
@@ -4423,16 +4645,12 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           GOTO L9
          L10
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
           ALOAD 6
-         L3
-          GOTO L11
-         L0
-         FRAME CHOP 2
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L7
+         L8
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -4449,22 +4667,27 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           GETSTATIC org/nlogo/core/Syntax$.MODULE$ : Lorg/nlogo/core/Syntax$;
           INVOKEVIRTUAL org/nlogo/core/Syntax$.PatchsetType ()I
           IOR
-          ALOAD 4
+          ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L7
+         FRAME APPEND [java/lang/Object]
+          ALOAD 3
          L1
+          GOTO L11
+         L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -4481,6 +4704,7 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
       _not "not" boolean => boolean
         _shadeof "shade-of?"
           _asm_procedurebounce_constdouble_9 "yellow" => Double
+                // parameter final  context
                L0
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_procedurebounce_constdouble_9.kept1_value : Ljava/lang/Double;
@@ -4488,30 +4712,30 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
                 ARETURN
           _asm_procedurebounce_patchvariableof_10 "of" Object => Object
             _procedurevariable:NEW-PATCH "new-patch" => Object
-                TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-                TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-               L4
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+               L3
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
                 ICONST_0
                 AALOAD
-               L5
+               L4
                 ASTORE 2
-               L2
+               L0
                 ALOAD 2
+                INSTANCEOF org/nlogo/agent/Agent
+                IFEQ L5
+                ALOAD 2
+                CHECKCAST org/nlogo/agent/Agent
                 ASTORE 4
                 ALOAD 4
-                INSTANCEOF org/nlogo/agent/Agent
-                IFEQ L6
-                ALOAD 4
-                CHECKCAST org/nlogo/agent/Agent
-                ASTORE 5
-                ALOAD 5
                 INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
                 LDC -1
                 LCMP
-                IFNE L7
+                IFNE L6
                 NEW org/nlogo/nvm/RuntimePrimitiveException
                 DUP
                 ALOAD 1
@@ -4524,45 +4748,45 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
                 ANEWARRAY java/lang/Object
                 DUP
                 ICONST_0
-                ALOAD 5
+                ALOAD 4
                 INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
                 AASTORE
                 INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
                 INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
-               L7
-               FRAME FULL [org/nlogo/prim/_asm_procedurebounce_patchvariableof_10 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-                ALOAD 5
+               L6
+               FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+                ALOAD 4
                 ICONST_2
                 INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
-                ASTORE 6
-                GOTO L8
-               L6
-               FRAME CHOP 1
-                ALOAD 4
+                ASTORE 3
+                GOTO L7
+               L5
+               FRAME CHOP 2
+                ALOAD 2
                 INSTANCEOF org/nlogo/agent/AgentSet
-                IFEQ L0
-                ALOAD 4
+                IFEQ L8
+                ALOAD 2
                 CHECKCAST org/nlogo/agent/AgentSet
-                ASTORE 7
+                ASTORE 5
                 NEW org/nlogo/api/LogoListBuilder
                 DUP
                 INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-                ASTORE 8
-                ALOAD 7
+                ASTORE 6
+                ALOAD 5
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
                 GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
                 INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-                ASTORE 9
+                ASTORE 7
                L9
-               FRAME FULL [org/nlogo/prim/_asm_procedurebounce_patchvariableof_10 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-                ALOAD 9
+               FRAME FULL [org/nlogo/prim/_asm_procedurebounce_patchvariableof_10 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+                ALOAD 7
                 INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
                 IFEQ L10
-                ALOAD 8
-                ALOAD 9
+                ALOAD 6
+                ALOAD 7
                 INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
                 ICONST_2
                 INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
@@ -4570,16 +4794,12 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
                 GOTO L9
                L10
                FRAME SAME
-                ALOAD 8
-                INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-                ASTORE 6
-               L8
-               FRAME FULL [org/nlogo/prim/_asm_procedurebounce_patchvariableof_10 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
                 ALOAD 6
-               L3
-                GOTO L11
-               L0
-               FRAME CHOP 2
+                INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+                ASTORE 3
+                GOTO L7
+               L8
+               FRAME FULL [org/nlogo/prim/_asm_procedurebounce_patchvariableof_10 org/nlogo/nvm/Context java/lang/Object] []
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
                 ALOAD 1
@@ -4596,23 +4816,32 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
                 GETSTATIC org/nlogo/core/Syntax$.MODULE$ : Lorg/nlogo/core/Syntax$;
                 INVOKEVIRTUAL org/nlogo/core/Syntax$.PatchsetType ()I
                 IOR
-                ALOAD 4
+                ALOAD 2
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
+               L7
+               FRAME APPEND [java/lang/Object]
+                ALOAD 3
                L1
+                GOTO L11
+               L2
                FRAME FULL [org/nlogo/prim/_asm_procedurebounce_patchvariableof_10 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-                ASTORE 3
+                ASTORE 8
                 NEW org/nlogo/nvm/RuntimePrimitiveException
                 DUP
                 ALOAD 1
                 ALOAD 0
-                ALOAD 3
+                ALOAD 8
                 INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
                L11
-               FRAME FULL [org/nlogo/prim/_asm_procedurebounce_patchvariableof_10 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_procedurebounce_patchvariableof_10 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
                 ARETURN
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurebounce_if_8.keptinstr3 : Lorg/nlogo/prim/etc/_shadeof;
@@ -4641,12 +4870,12 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L4
-          ICONST_0
+          IFNE L4
+          ICONST_1
           GOTO L5
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_8 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L5
          FRAME SAME1 I
           ISTORE 2
@@ -4711,6 +4940,22 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           _abs "abs" double => double
             _procedurevariable:NEW-PY "new-py" => Object
           _observervariable:BOX-EDGE "box-edge" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -4763,11 +5008,9 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L10
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -4778,19 +5021,19 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ICONST_1
           GOTO L12
          L11
-         FRAME APPEND [java/lang/Object java/lang/Object java/lang/Double]
+         FRAME APPEND [java/lang/Object T java/lang/Double]
           ICONST_0
          L12
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L13
          L10
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L13
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L14
           IFEQ L15
          L16
@@ -4807,7 +5050,7 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           GOTO L18
          L3
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_12 org/nlogo/nvm/Context java/lang/Object T java/lang/Object java/lang/Object T I] [java/lang/ClassCastException]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_12 org/nlogo/nvm/Context java/lang/Object T java/lang/Object I] [java/lang/ClassCastException]
           POP
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
@@ -4830,7 +5073,7 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           DNEG
           GOTO L20
          L19
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_12 org/nlogo/nvm/Context D java/lang/Object java/lang/Object T I] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_12 org/nlogo/nvm/Context D java/lang/Object I] []
           DLOAD 2
          L20
          FRAME SAME1 D
@@ -4843,11 +5086,9 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L22
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -4858,19 +5099,19 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ICONST_1
           GOTO L24
          L23
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_12 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] []
+         FRAME APPEND [java/lang/Double]
           ICONST_0
          L24
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L25
          L22
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_12 org/nlogo/nvm/Context D java/lang/Object java/lang/Object T I] []
+         FRAME CHOP 1
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L25
          FRAME SAME
-          ILOAD 7
+          ILOAD 5
          L26
           GOTO L27
          L15
@@ -4885,10 +5126,10 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           BIPUSH 8
           GOTO L29
          L28
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_12 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_12 org/nlogo/nvm/Context I T java/lang/Object I] [org/nlogo/nvm/Context]
           BIPUSH 9
          L29
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_12 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_12 org/nlogo/nvm/Context I T java/lang/Object I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L30
           RETURN
@@ -4935,6 +5176,15 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
         _abs "abs" double => double
           _procedurevariable:NEW-PX "new-px" => Object
         _observervariable:BOX-EDGE "box-edge" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -4986,11 +5236,9 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L8
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -5001,19 +5249,19 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ICONST_1
           GOTO L10
          L9
-         FRAME APPEND [java/lang/Object java/lang/Object java/lang/Double]
+         FRAME APPEND [java/lang/Object T java/lang/Double]
           ICONST_0
          L10
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L11
          L8
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L11
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L12
           ISTORE 2
           ALOAD 1
@@ -5022,16 +5270,21 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           BIPUSH 10
           GOTO L14
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_14 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_14 org/nlogo/nvm/Context I T java/lang/Object I] [org/nlogo/nvm/Context]
           BIPUSH 13
          L14
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_14 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_14 org/nlogo/nvm/Context I T java/lang/Object I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L15
           RETURN
 [10]_asm_procedurebounce_setturtlevariable_15 "set" Object => void
       _unaryminus "-" double => double
         _turtlevariabledouble:HEADING "heading" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -5057,9 +5310,6 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 11
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L6
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setturtlevariable_15 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -5074,11 +5324,20 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ATHROW
          L6
          FRAME SAME
+          ALOAD 1
+          BIPUSH 11
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L7
           RETURN
 [11]_setbreedvariable:WALL-HITS "set"
       _asm_procedurebounce_plus_16 "+" double,double => double
         _breedvariable:WALL-HITS "wall-hits" => Object
         _constdouble:1.0 "1" => double
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  d1
+            // parameter final  d2
             TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
             TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
            L0
@@ -5149,6 +5408,28 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
                 _breedvariable:MASS "mass" => Object
               _breedvariable:SPEED "speed" => Object
           _observervariable:LENGTH-VERTICAL-SURFACE "length-vertical-surface" => Object
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  d
+            // parameter final  context
+            // parameter final  context
+            // parameter final  d1
+            // parameter final  d2
             TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
             TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
             TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -5383,6 +5664,15 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
         _abs "abs" double => double
           _procedurevariable:NEW-PY "new-py" => Object
         _observervariable:BOX-EDGE "box-edge" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -5434,11 +5724,9 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L8
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -5449,19 +5737,19 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ICONST_1
           GOTO L10
          L9
-         FRAME APPEND [java/lang/Object java/lang/Object java/lang/Double]
+         FRAME APPEND [java/lang/Object T java/lang/Double]
           ICONST_0
          L10
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L11
          L8
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L11
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L12
           ISTORE 2
           ALOAD 1
@@ -5470,10 +5758,10 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           BIPUSH 14
           GOTO L14
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_18 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_18 org/nlogo/nvm/Context I T java/lang/Object I] [org/nlogo/nvm/Context]
           BIPUSH 17
          L14
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_18 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_18 org/nlogo/nvm/Context I T java/lang/Object I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L15
           RETURN
@@ -5481,6 +5769,13 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
       _minus "-" double,double => double
         _constdouble:180.0 "180" => double
         _turtlevariabledouble:HEADING "heading" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           LDC 180.0
@@ -5510,9 +5805,6 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 15
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setturtlevariable_19 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -5527,11 +5819,20 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          BIPUSH 15
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [15]_setbreedvariable:WALL-HITS "set"
       _asm_procedurebounce_plus_20 "+" double,double => double
         _breedvariable:WALL-HITS "wall-hits" => Object
         _constdouble:1.0 "1" => double
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  d1
+            // parameter final  d2
             TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
             TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
            L0
@@ -5602,6 +5903,28 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
                 _breedvariable:MASS "mass" => Object
               _breedvariable:SPEED "speed" => Object
           _observervariable:LENGTH-HORIZONTAL-SURFACE "length-horizontal-surface" => Object
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  d
+            // parameter final  context
+            // parameter final  context
+            // parameter final  d1
+            // parameter final  d2
             TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
             TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
             TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -5834,6 +6157,7 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
 [17]_asm_procedurebounce_ask_22 "ask" Object => void
       _patch "patch"
         _asm_procedurebounce_procedurevariable_23 "new-px" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5843,6 +6167,7 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
              L1
               ARETURN
         _asm_procedurebounce_procedurevariable_24 "new-py" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5851,6 +6176,8 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
               AALOAD
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  target
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurebounce_ask_22.keptinstr2 : Lorg/nlogo/prim/etc/_patch;
           ALOAD 1
@@ -5858,18 +6185,16 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
          L0
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L1
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L2
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurebounce_ask_22.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -5885,8 +6210,8 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_ask_22 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurebounce_ask_22.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -5903,18 +6228,18 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ATHROW
          L2
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L4
          L1
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L5
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -5931,7 +6256,7 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -5941,23 +6266,12 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
          L6
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_ask_22 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 18
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 24
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
+          GOTO L4
          L5
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -5971,11 +6285,20 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L4
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 18
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 24
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_ask_22 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [18]_sprout:FLASHES,+23 "sprout-flashes"
       _asm_procedurebounce_constdouble_25 "1" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurebounce_constdouble_25.kept1_value : Ljava/lang/Double;
@@ -6014,6 +6337,9 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
             ARETURN
 [21]_asm_procedurebounce_setpatchvariable_27 "set" Object => void
       _constdouble:42.0 "-" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -6027,9 +6353,6 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 22
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setpatchvariable_27 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -6044,8 +6367,13 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 22
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [22]_asm_procedurebounce_done_28 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -6053,6 +6381,7 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
          L1
           RETURN
 [23]_asm_procedurebounce_done_29 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -6060,6 +6389,7 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
          L1
           RETURN
 [24]_asm_procedurebounce_return_30 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -6072,6 +6402,9 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
 procedure MOVE:[OLD-PATCH]{-T--}:
 [0]_asm_proceduremove_setprocedurevariable_0 "let" Object => void
       _patchhere "patch-here" => Patch
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -6094,17 +6427,24 @@ procedure MOVE:[OLD-PATCH]{-T--}:
       _mult "*" double,double => double
         _breedvariable:SPEED "speed" => Object
         _observervariable:TICK-LENGTH "tick-length" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  distance
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
-          TRYCATCHBLOCK L7 L8 L8 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L7 L8 L9 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           LDC "SPEED"
           INVOKEVIRTUAL org/nlogo/agent/Agent.getBreedVariable (Ljava/lang/String;)Ljava/lang/Object;
          L1
-          GOTO L9
+          GOTO L10
          L2
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -6116,14 +6456,14 @@ procedure MOVE:[OLD-PATCH]{-T--}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
+         L10
          FRAME SAME1 java/lang/Object
           ASTORE 2
          L3
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
-          GOTO L10
+          GOTO L11
          L4
          FRAME FULL [org/nlogo/prim/_asm_proceduremove_jump_1 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
           POP
@@ -6136,20 +6476,20 @@ procedure MOVE:[OLD-PATCH]{-T--}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
-         L10
+         L11
          FRAME SAME1 D
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduremove_jump_1.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.observer ()Lorg/nlogo/agent/Observer;
           BIPUSH 6
           INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
-         L11
+         L12
           ASTORE 2
          L5
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
-          GOTO L12
+          GOTO L13
          L6
          FRAME SAME1 java/lang/ClassCastException
           POP
@@ -6162,14 +6502,14 @@ procedure MOVE:[OLD-PATCH]{-T--}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
-         L12
+         L13
          FRAME FULL [org/nlogo/prim/_asm_proceduremove_jump_1 org/nlogo/nvm/Context java/lang/Object] [D D]
           DSTORE 4
           DSTORE 2
           DLOAD 2
           DLOAD 4
           DMUL
-         L13
+         L14
           DSTORE 2
          L7
           ALOAD 1
@@ -6177,21 +6517,29 @@ procedure MOVE:[OLD-PATCH]{-T--}:
           CHECKCAST org/nlogo/agent/Turtle
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L14
          L8
+          GOTO L15
+         L9
          FRAME FULL [org/nlogo/prim/_asm_proceduremove_jump_1 org/nlogo/nvm/Context D D] [org/nlogo/api/AgentException]
-          ASTORE 4
-         L14
-         FRAME CHOP 1
+          POP
+         L15
+         FRAME SAME
           ALOAD 1
           ICONST_2
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L15
+         L16
           RETURN
 [2]_asm_proceduremove_if_2 "if" boolean => void
       _notequal "!=" Object,Object => boolean
         _patchhere "patch-here" => Patch
         _procedurevariable:OLD-PATCH "old-patch" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -6210,12 +6558,12 @@ procedure MOVE:[OLD-PATCH]{-T--}:
           ALOAD 2
           ALOAD 3
           INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-          IFEQ L3
-          ICONST_0
+          IFNE L3
+          ICONST_1
           GOTO L4
          L3
          FRAME APPEND [org/nlogo/agent/Patch java/lang/Object]
-          ICONST_1
+          ICONST_0
          L4
          FRAME SAME1 I
           ISTORE 2
@@ -6234,11 +6582,13 @@ procedure MOVE:[OLD-PATCH]{-T--}:
           RETURN
 [3]_setbreedvariable:LAST-COLLISION "set"
       _asm_proceduremove_nobody_3 "nobody" => Nobody$
+            // parameter final  context
            L0
             GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
            L1
             ARETURN
 [4]_asm_proceduremove_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -6254,6 +6604,15 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
         _countother "count" AgentSet => double
           _breedhere:PARTICLES "particles-here" => AgentSet
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -6263,10 +6622,8 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           IFEQ L1
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L2
          L1
          FRAME APPEND [T org/nlogo/agent/Agent]
@@ -6275,60 +6632,55 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           IFEQ L3
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L2
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 5
           ASTORE 2
+          GOTO L2
+         L3
+         FRAME SAME
+          NEW scala/MatchError
+          DUP
+          ALOAD 3
+          INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
+          ATHROW
+         L2
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
           NEW org/nlogo/agent/AgentSetBuilder
           DUP
           GETSTATIC org/nlogo/core/AgentKind$Turtle$.MODULE$ : Lorg/nlogo/core/AgentKind$Turtle$;
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Patch.turtleCount ()I
           INVOKESPECIAL org/nlogo/agent/AgentSetBuilder.<init> (Lorg/nlogo/core/AgentKind;I)V
-          ASTORE 7
+          ASTORE 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecheckforcollision_if_0.world : Lorg/nlogo/agent/World;
           LDC "PARTICLES"
           INVOKEVIRTUAL org/nlogo/agent/World.getBreed (Ljava/lang/String;)Lorg/nlogo/agent/AgentSet;
-          ASTORE 8
+          ASTORE 5
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Patch.turtlesHere ()Ljava/lang/Iterable;
           INVOKEINTERFACE java/lang/Iterable.iterator ()Ljava/util/Iterator;
-          ASTORE 9
+          ASTORE 6
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T org/nlogo/agent/AgentSetBuilder org/nlogo/agent/AgentSet java/util/Iterator] []
-          ALOAD 9
+         FRAME APPEND [org/nlogo/agent/AgentSetBuilder org/nlogo/agent/AgentSet java/util/Iterator]
+          ALOAD 6
           INVOKEINTERFACE java/util/Iterator.hasNext ()Z
           IFEQ L5
-          ALOAD 9
+          ALOAD 6
           INVOKEINTERFACE java/util/Iterator.next ()Ljava/lang/Object;
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 10
-          ALOAD 10
-          INVOKEVIRTUAL org/nlogo/agent/Turtle.getBreed ()Lorg/nlogo/agent/AgentSet;
-          ALOAD 8
-          IF_ACMPNE L4
+          ASTORE 7
           ALOAD 7
-          ALOAD 10
+          INVOKEVIRTUAL org/nlogo/agent/Turtle.getBreed ()Lorg/nlogo/agent/AgentSet;
+          ALOAD 5
+          IF_ACMPNE L4
+          ALOAD 4
+          ALOAD 7
           INVOKEVIRTUAL org/nlogo/agent/AgentSetBuilder.add (Lorg/nlogo/agent/Agent;)V
           GOTO L4
          L5
          FRAME SAME
-          ALOAD 7
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/AgentSetBuilder.build ()Lorg/nlogo/agent/AgentSet;
-          GOTO L6
-         L3
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_0 org/nlogo/nvm/Context T org/nlogo/agent/Agent] []
-          NEW scala/MatchError
-          DUP
-          ALOAD 3
-          INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
-          ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T org/nlogo/agent/AgentSetBuilder org/nlogo/agent/AgentSet java/util/Iterator] [org/nlogo/agent/AgentSet]
           ASTORE 2
           ICONST_0
           ISTORE 3
@@ -6336,7 +6688,7 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.iterator ()Lorg/nlogo/agent/AgentIterator;
           ASTORE 4
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_0 org/nlogo/nvm/Context org/nlogo/agent/AgentSet I org/nlogo/agent/AgentIterator org/nlogo/agent/Patch T org/nlogo/agent/AgentSetBuilder org/nlogo/agent/AgentSet java/util/Iterator] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_0 org/nlogo/nvm/Context org/nlogo/agent/AgentSet I org/nlogo/agent/AgentIterator org/nlogo/agent/AgentSet java/util/Iterator] []
           ALOAD 4
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L8
@@ -6366,7 +6718,7 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           ICONST_1
           GOTO L12
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_0 org/nlogo/nvm/Context D D T org/nlogo/agent/AgentSetBuilder org/nlogo/agent/AgentSet java/util/Iterator] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_0 org/nlogo/nvm/Context D D java/util/Iterator] []
           ICONST_0
          L12
          FRAME SAME1 I
@@ -6377,10 +6729,10 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           ICONST_1
           GOTO L14
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_0 org/nlogo/nvm/Context I T D T org/nlogo/agent/AgentSetBuilder org/nlogo/agent/AgentSet java/util/Iterator] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_0 org/nlogo/nvm/Context I T D java/util/Iterator] [org/nlogo/nvm/Context]
           BIPUSH 8
          L14
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_0 org/nlogo/nvm/Context I T D T org/nlogo/agent/AgentSetBuilder org/nlogo/agent/AgentSet java/util/Iterator] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_0 org/nlogo/nvm/Context I T D java/util/Iterator] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L15
           RETURN
@@ -6396,6 +6748,16 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
             _notequal "!=" Object,Object => boolean
               _myself "myself" => Agent
               _breedvariable:LAST-COLLISION "last-collision" => Object
+                // parameter final  context
+                // parameter final  context
+                // parameter final  agent
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  arg1
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  arg1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                 TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
                L6
@@ -6477,11 +6839,9 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
                 ASTORE 4
                 DSTORE 2
                 ALOAD 4
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L13
-                ALOAD 5
+                ALOAD 4
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 2
@@ -6492,15 +6852,14 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
                 ICONST_1
                 GOTO L15
                L14
-               FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_and_2 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_and_2 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
                 ICONST_0
                L15
                FRAME SAME1 I
-                ISTORE 7
-                ILOAD 7
+                ISTORE 5
                 GOTO L16
                L13
-               FRAME CHOP 1
+               FRAME CHOP 2
                 NEW org/nlogo/nvm/RuntimePrimitiveException
                 DUP
                 ALOAD 1
@@ -6529,19 +6888,21 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
                L16
-               FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_and_2 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
-                IFEQ L17
-               L18
+               FRAME APPEND [I java/lang/Double]
+                ILOAD 5
+               L17
+                IFEQ L18
+               L19
                 ALOAD 1
                 INVOKEVIRTUAL org/nlogo/nvm/Context.myself ()Lorg/nlogo/agent/Agent;
                 ASTORE 2
                 ALOAD 2
-                IFNULL L19
+                IFNULL L20
                 ALOAD 2
                 INSTANCEOF org/nlogo/agent/Observer
-                IFEQ L20
-               L19
-               FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_and_2 org/nlogo/nvm/Context org/nlogo/agent/Agent T java/lang/Object java/lang/Object java/lang/Double I] []
+                IFEQ L21
+               L20
+               FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_and_2 org/nlogo/nvm/Context org/nlogo/agent/Agent T java/lang/Object I java/lang/Double] []
                 NEW org/nlogo/nvm/RuntimePrimitiveException
                 DUP
                 ALOAD 1
@@ -6551,7 +6912,7 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
                 INVOKEINTERFACE org/nlogo/core/I18NJava.get (Ljava/lang/String;)Ljava/lang/String;
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
-               L20
+               L21
                FRAME SAME
                 ALOAD 2
                L3
@@ -6560,7 +6921,7 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
                 LDC "LAST-COLLISION"
                 INVOKEVIRTUAL org/nlogo/agent/Agent.getBreedVariable (Ljava/lang/String;)Ljava/lang/Object;
                L4
-                GOTO L21
+                GOTO L22
                L5
                FRAME SAME1 org/nlogo/api/AgentException
                 ASTORE 2
@@ -6572,37 +6933,45 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
                 INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
-               L21
-               FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_and_2 org/nlogo/nvm/Context org/nlogo/agent/Agent T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/agent/Agent java/lang/Object]
+               L22
+               FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_and_2 org/nlogo/nvm/Context org/nlogo/agent/Agent T java/lang/Object I java/lang/Double] [org/nlogo/agent/Agent java/lang/Object]
                 ASTORE 3
                 ASTORE 2
                 GETSTATIC org/nlogo/api/Equality$.MODULE$ : Lorg/nlogo/api/Equality$;
                 ALOAD 2
                 ALOAD 3
                 INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-                IFEQ L22
-                ICONST_0
-                GOTO L23
-               L22
-               FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_and_2 org/nlogo/nvm/Context org/nlogo/agent/Agent java/lang/Object java/lang/Object java/lang/Object java/lang/Double I] []
+                IFNE L23
                 ICONST_1
-               L23
-               FRAME SAME1 I
                 GOTO L24
-               L17
-               FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_and_2 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] []
+               L23
+               FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_and_2 org/nlogo/nvm/Context org/nlogo/agent/Agent java/lang/Object java/lang/Object I java/lang/Double] []
                 ICONST_0
                L24
-               FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_and_2 org/nlogo/nvm/Context T T java/lang/Object java/lang/Object java/lang/Double I] [I]
-                IFEQ L25
-                GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
-                GOTO L26
+               FRAME SAME1 I
+                GOTO L25
+               L18
+               FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_and_2 org/nlogo/nvm/Context D java/lang/Object I java/lang/Double] []
+                ICONST_0
                L25
+               FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_and_2 org/nlogo/nvm/Context T T java/lang/Object I java/lang/Double] [I]
+                IFEQ L26
+                GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
+                GOTO L27
+               L26
                FRAME SAME
                 GETSTATIC java/lang/Boolean.FALSE : Ljava/lang/Boolean;
-               L26
+               L27
                FRAME SAME1 java/lang/Boolean
                 ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
+          // parameter final  context
+          // parameter final  agents
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -6612,10 +6981,8 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           IFEQ L1
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L2
          L1
          FRAME APPEND [T org/nlogo/agent/Agent]
@@ -6624,60 +6991,55 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           IFEQ L3
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L2
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 5
           ASTORE 2
+          GOTO L2
+         L3
+         FRAME SAME
+          NEW scala/MatchError
+          DUP
+          ALOAD 3
+          INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
+          ATHROW
+         L2
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_setprocedurevariable_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
           NEW org/nlogo/agent/AgentSetBuilder
           DUP
           GETSTATIC org/nlogo/core/AgentKind$Turtle$.MODULE$ : Lorg/nlogo/core/AgentKind$Turtle$;
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Patch.turtleCount ()I
           INVOKESPECIAL org/nlogo/agent/AgentSetBuilder.<init> (Lorg/nlogo/core/AgentKind;I)V
-          ASTORE 7
+          ASTORE 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecheckforcollision_setprocedurevariable_1.world : Lorg/nlogo/agent/World;
           LDC "PARTICLES"
           INVOKEVIRTUAL org/nlogo/agent/World.getBreed (Ljava/lang/String;)Lorg/nlogo/agent/AgentSet;
-          ASTORE 8
+          ASTORE 5
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Patch.turtlesHere ()Ljava/lang/Iterable;
           INVOKEINTERFACE java/lang/Iterable.iterator ()Ljava/util/Iterator;
-          ASTORE 9
+          ASTORE 6
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_setprocedurevariable_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T org/nlogo/agent/AgentSetBuilder org/nlogo/agent/AgentSet java/util/Iterator] []
-          ALOAD 9
+         FRAME APPEND [org/nlogo/agent/AgentSetBuilder org/nlogo/agent/AgentSet java/util/Iterator]
+          ALOAD 6
           INVOKEINTERFACE java/util/Iterator.hasNext ()Z
           IFEQ L5
-          ALOAD 9
+          ALOAD 6
           INVOKEINTERFACE java/util/Iterator.next ()Ljava/lang/Object;
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 10
-          ALOAD 10
-          INVOKEVIRTUAL org/nlogo/agent/Turtle.getBreed ()Lorg/nlogo/agent/AgentSet;
-          ALOAD 8
-          IF_ACMPNE L4
+          ASTORE 7
           ALOAD 7
-          ALOAD 10
+          INVOKEVIRTUAL org/nlogo/agent/Turtle.getBreed ()Lorg/nlogo/agent/AgentSet;
+          ALOAD 5
+          IF_ACMPNE L4
+          ALOAD 4
+          ALOAD 7
           INVOKEVIRTUAL org/nlogo/agent/AgentSetBuilder.add (Lorg/nlogo/agent/Agent;)V
           GOTO L4
          L5
          FRAME SAME
-          ALOAD 7
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/AgentSetBuilder.build ()Lorg/nlogo/agent/AgentSet;
-          GOTO L6
-         L3
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_setprocedurevariable_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent] []
-          NEW scala/MatchError
-          DUP
-          ALOAD 3
-          INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
-          ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_setprocedurevariable_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T org/nlogo/agent/AgentSetBuilder org/nlogo/agent/AgentSet java/util/Iterator] [org/nlogo/agent/AgentSet]
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecheckforcollision_setprocedurevariable_1.keptinstr5 : Lorg/nlogo/nvm/Reporter;
           ASTORE 3
@@ -6701,7 +7063,7 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.iterator ()Lorg/nlogo/agent/AgentIterator;
           ASTORE 6
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_setprocedurevariable_1 org/nlogo/nvm/Context org/nlogo/agent/AgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator java/lang/Object java/lang/Object java/lang/Object] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_setprocedurevariable_1 org/nlogo/nvm/Context org/nlogo/agent/AgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
           ALOAD 6
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L8
@@ -6711,7 +7073,7 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           ALOAD 7
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-          IF_ACMPEQ L9
+          IF_ACMPEQ L7
           ALOAD 4
           ALOAD 7
           ALOAD 3
@@ -6719,27 +7081,18 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           ASTORE 8
           ALOAD 8
           INSTANCEOF java/lang/Boolean
-          IFEQ L10
+          IFEQ L9
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L11
+          IFEQ L7
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L12
-         L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_setprocedurevariable_1 org/nlogo/nvm/Context org/nlogo/agent/AgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object java/lang/Boolean] []
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L12
-         FRAME SAME1 java/lang/Object
-          ASTORE 10
-          ALOAD 10
-          GOTO L13
-         L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_setprocedurevariable_1 org/nlogo/nvm/Context org/nlogo/agent/AgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object java/lang/Object] []
+          POP
+          GOTO L7
+         L9
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -6770,15 +7123,8 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
-         FRAME SAME
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L13
-         FRAME SAME1 java/lang/Object
-          POP
-          GOTO L7
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_setprocedurevariable_1 org/nlogo/nvm/Context org/nlogo/agent/AgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator java/lang/Object java/lang/Object java/lang/Object] []
+         FRAME CHOP 2
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.kind ()Lorg/nlogo/core/AgentKind;
@@ -6789,18 +7135,18 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L14
+         L10
           ASTORE 2
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.count ()I
           ISTORE 3
           ILOAD 3
           ICONST_0
-          IF_ICMPNE L15
+          IF_ICMPNE L11
           GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
-          GOTO L16
-         L15
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_setprocedurevariable_1 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet I org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator java/lang/Object java/lang/Object java/lang/Object] []
+          GOTO L12
+         L11
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_setprocedurevariable_1 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet I org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
           ALOAD 2
           ILOAD 3
           ALOAD 1
@@ -6809,7 +7155,7 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           ILOAD 3
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextInt (I)I
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.randomOne (II)Lorg/nlogo/agent/Agent;
-         L16
+         L12
          FRAME SAME1 java/lang/Object
           ASTORE 2
           ALOAD 1
@@ -6821,7 +7167,7 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           ALOAD 1
           ICONST_2
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L17
+         L13
           RETURN
 [2]_asm_procedurecheckforcollision_if_3 "if" boolean => void
       _and "and"
@@ -6835,6 +7181,7 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           _greaterthan ">" Object,double => boolean
             _breedvariableof:SPEED "of"
               _asm_procedurecheckforcollision_procedurevariable_4 "candidate" => Object
+                    // parameter final  context
                    L0
                     ALOAD 1
                     GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -6844,6 +7191,22 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
                    L1
                     ARETURN
             _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -6860,12 +7223,12 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           ALOAD 2
           ALOAD 3
           INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-          IFEQ L6
-          ICONST_0
+          IFNE L6
+          ICONST_1
           GOTO L7
          L6
          FRAME APPEND [java/lang/Object org/nlogo/core/Nobody$]
-          ICONST_1
+          ICONST_0
          L7
          FRAME SAME1 I
           IFEQ L8
@@ -6894,14 +7257,10 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L11
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -6909,15 +7268,14 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           ICONST_1
           GOTO L13
          L12
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_3 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_3 org/nlogo/nvm/Context java/lang/Object D] []
           ICONST_0
          L13
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L14
          L11
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -6946,41 +7304,38 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L14
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_3 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
-          IFNE L15
+         FRAME APPEND [I]
+          ILOAD 5
+         L15
+          IFNE L16
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecheckforcollision_if_3.keptinstr11 : Lorg/nlogo/prim/_breedvariableof;
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/prim/_breedvariableof.report (Lorg/nlogo/nvm/Context;)Ljava/lang/Object;
-         L16
-          DCONST_0
          L17
+          DCONST_0
+         L18
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
-          IFEQ L18
-          ALOAD 5
+          IFEQ L19
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
-          IFLE L19
+          IFLE L20
           ICONST_1
-          GOTO L20
-         L19
+          GOTO L21
+         L20
          FRAME SAME
           ICONST_0
-         L20
+         L21
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
-          GOTO L21
-         L18
+          ISTORE 5
+          GOTO L22
+         L19
          FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -7009,36 +7364,39 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L21
-         FRAME SAME1 I
-          GOTO L22
-         L15
+         L22
+         FRAME SAME
+          ILOAD 5
+         L23
+          GOTO L24
+         L16
          FRAME SAME
           ICONST_1
-         L22
+         L24
          FRAME SAME1 I
-          GOTO L23
+          GOTO L25
          L8
          FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_3 org/nlogo/nvm/Context java/lang/Object org/nlogo/core/Nobody$] []
           ICONST_0
-         L23
+         L25
          FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_3 org/nlogo/nvm/Context java/lang/Object] [I]
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L24
+          IFEQ L26
           ICONST_3
-          GOTO L25
-         L24
+          GOTO L27
+         L26
          FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_3 org/nlogo/nvm/Context I] [org/nlogo/nvm/Context]
           BIPUSH 8
-         L25
+         L27
          FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_3 org/nlogo/nvm/Context I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L26
+         L28
           RETURN
 [3]_asm_procedurecheckforcollision_call_5 "collide-with"
       _procedurevariable:CANDIDATE "candidate" => Object
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -7069,6 +7427,7 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           RETURN
 [4]_setbreedvariable:LAST-COLLISION "set"
       _asm_procedurecheckforcollision_procedurevariable_6 "candidate" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7079,6 +7438,9 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
             ARETURN
 [5]_asm_procedurecheckforcollision_ask_7 "ask" Object => void
       _procedurevariable:CANDIDATE "candidate" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7088,18 +7450,16 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecheckforcollision_ask_7.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -7115,8 +7475,8 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_ask_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecheckforcollision_ask_7.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -7133,18 +7493,18 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -7161,7 +7521,7 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -7171,23 +7531,12 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_ask_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 6
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -7201,8 +7550,16 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 6
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_ask_7 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [6]_setbreedvariable:LAST-COLLISION "set"
       _asm_procedurecheckforcollision_myself_8 "myself" => Agent
@@ -7232,6 +7589,7 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
            L3
             ARETURN
 [7]_asm_procedurecheckforcollision_done_9 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -7239,6 +7597,7 @@ procedure CHECK-FOR-COLLISION:[CANDIDATE]{-T--}:
          L1
           RETURN
 [8]_asm_procedurecheckforcollision_return_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -7252,6 +7611,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
 [0]_asm_procedurecollidewith_setprocedurevariable_0 "let" Object => void
       _breedvariableof:MASS "of"
         _asm_procedurecollidewith_procedurevariable_1 "other-particle" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7260,6 +7620,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
               AALOAD
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_0.keptinstr2 : Lorg/nlogo/prim/_breedvariableof;
           ALOAD 1
@@ -7280,6 +7642,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
 [1]_asm_procedurecollidewith_setprocedurevariable_2 "let" Object => void
       _breedvariableof:SPEED "of"
         _asm_procedurecollidewith_procedurevariable_3 "other-particle" => Object
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7288,6 +7651,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
               AALOAD
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_2.keptinstr2 : Lorg/nlogo/prim/_breedvariableof;
           ALOAD 1
@@ -7308,30 +7673,32 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
 [2]_asm_procedurecollidewith_setprocedurevariable_4 "let" Object => void
       _turtlevariableof:HEADING "of" Object => Object
         _procedurevariable:OTHER-PARTICLE "other-particle" => Object
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-         L4
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agentOrSet
+          // parameter final  context
+          // parameter final  arg0
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+         L3
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_0
           AALOAD
-         L5
+         L4
           ASTORE 2
-         L2
+         L0
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L5
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L6
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L7
+          IFNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -7344,45 +7711,45 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-          ALOAD 5
+         L6
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+          ALOAD 4
           ICONST_2
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L8
-         L6
-         FRAME CHOP 1
-          ALOAD 4
+          ASTORE 3
+          GOTO L7
+         L5
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L0
-          ALOAD 4
+          IFEQ L8
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_4 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L10
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           ICONST_2
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
@@ -7390,16 +7757,12 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           GOTO L9
          L10
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
           ALOAD 6
-         L3
-          GOTO L11
-         L0
-         FRAME CHOP 2
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L7
+         L8
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_4 org/nlogo/nvm/Context java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -7413,19 +7776,24 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L7
+         FRAME APPEND [java/lang/Object]
+          ALOAD 3
          L1
+          GOTO L11
+         L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_4 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_4 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_4 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7441,6 +7809,11 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
 [3]_asm_procedurecollidewith_setprocedurevariable_5 "let" Object => void
       _randomfloat "random-float" double => double
         _constdouble:360.0 "360" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 360.0
          L1
@@ -7476,6 +7849,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           _minus "-" double,double => double
             _procedurevariable:THETA "theta" => Object
             _turtlevariabledouble:HEADING "heading" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -7592,6 +7978,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           _minus "-" double,double => double
             _procedurevariable:THETA "theta" => Object
             _turtlevariabledouble:HEADING "heading" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -7708,6 +8107,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           _minus "-" double,double => double
             _procedurevariable:THETA "theta" => Object
             _procedurevariable:HEADING2 "heading2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -7831,6 +8243,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           _minus "-" double,double => double
             _procedurevariable:THETA "theta" => Object
             _procedurevariable:HEADING2 "heading2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -7959,6 +8384,26 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
         _plus "+" double,double => double
           _breedvariable:MASS "mass" => Object
           _procedurevariable:MASS2 "mass2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -8218,6 +8663,17 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           _constdouble:2.0 "2" => double
           _procedurevariable:VCM "vcm" => Object
         _procedurevariable:V1T "v1t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -8310,6 +8766,17 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           _constdouble:2.0 "2" => double
           _procedurevariable:VCM "vcm" => Object
         _procedurevariable:V2T "v2t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -8405,6 +8872,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           _mult "*" double,double => double
             _procedurevariable:V1L "v1l" => Object
             _procedurevariable:V1L "v1l" => Object
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  d1
+            // parameter final  d2
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
             TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
             TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -8572,6 +9052,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             _breedvariable:MASS "mass" => Object
           _breedvariable:SPEED "speed" => Object
         _breedvariable:SPEED "speed" => Object
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
             TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
             TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
             TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -8730,6 +9223,18 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
         _notequal "!=" Object,double => boolean
           _procedurevariable:V1T "v1t" => Object
           _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -8742,11 +9247,9 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -8757,19 +9260,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_15 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_15 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L6
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L7
           IFNE L8
          L9
@@ -8784,11 +9287,9 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L12
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -8799,19 +9300,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ICONST_1
           GOTO L14
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_15 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] []
+         FRAME APPEND [java/lang/Double]
           ICONST_0
          L14
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L15
          L12
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_15 org/nlogo/nvm/Context java/lang/Object D java/lang/Object T I] []
+         FRAME CHOP 1
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L15
          FRAME SAME
-          ILOAD 7
+          ILOAD 5
          L16
           GOTO L17
          L8
@@ -8826,10 +9327,10 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           BIPUSH 14
           GOTO L19
          L18
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_15 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_15 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 15
          L19
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_15 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_15 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L20
           RETURN
@@ -8839,6 +9340,17 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
         _atan "atan" double,double => double
           _procedurevariable:V1L "v1l" => Object
           _procedurevariable:V1T "v1t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -8982,6 +9494,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           GOTO L19
          L20
          FRAME SAME1 D
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
@@ -8989,6 +9502,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           SIPUSH 360
           I2D
           DADD
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_16.validDouble (DLorg/nlogo/nvm/Context;)D
           SIPUSH 360
           I2D
           DREM
@@ -9013,9 +9528,6 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L7
-          ALOAD 1
-          BIPUSH 15
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L23
          L8
          FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_16 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -9030,9 +9542,16 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ATHROW
          L23
          FRAME SAME
+          ALOAD 1
+          BIPUSH 15
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L24
           RETURN
 [15]_asm_procedurecollidewith_ask_17 "ask" Object => void
       _procedurevariable:OTHER-PARTICLE "other-particle" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9042,18 +9561,16 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_ask_17.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -9069,8 +9586,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_17 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_ask_17.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -9087,18 +9604,18 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -9115,7 +9632,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -9125,23 +9642,12 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_17 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 16
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 18
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -9155,8 +9661,16 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 16
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 18
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_17 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [16]_setbreedvariable:SPEED "set"
       _asm_procedurecollidewith_sqrt_18 "sqrt" double => double
@@ -9167,6 +9681,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           _mult "*" double,double => double
             _procedurevariable:V2L "v2l" => Object
             _procedurevariable:V2L "v2l" => Object
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  d1
+            // parameter final  d2
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
             TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
             TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -9327,6 +9854,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
 [17]_asm_procedurecollidewith_done_19 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -9335,6 +9863,9 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           RETURN
 [18]_asm_procedurecollidewith_ask_20 "ask" Object => void
       _procedurevariable:OTHER-PARTICLE "other-particle" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9344,18 +9875,16 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_ask_20.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -9371,8 +9900,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_20 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_ask_20.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -9389,18 +9918,18 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -9417,7 +9946,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -9427,23 +9956,12 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_20 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 19
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 21
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -9457,8 +9975,16 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 19
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 21
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_20 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [19]_setbreedvariable:ENERGY "set"
       _asm_procedurecollidewith_mult_21 "*" double,double => double
@@ -9468,6 +9994,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             _breedvariable:MASS "mass" => Object
           _breedvariable:SPEED "speed" => Object
         _breedvariable:SPEED "speed" => Object
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
             TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
             TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
             TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -9619,6 +10158,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
 [20]_asm_procedurecollidewith_done_22 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -9633,6 +10173,18 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
         _notequal "!=" Object,double => boolean
           _procedurevariable:V2T "v2t" => Object
           _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9645,11 +10197,9 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -9660,19 +10210,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_23 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_23 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L6
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L7
           IFNE L8
          L9
@@ -9687,11 +10237,9 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L12
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -9702,19 +10250,19 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ICONST_1
           GOTO L14
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_23 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] []
+         FRAME APPEND [java/lang/Double]
           ICONST_0
          L14
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L15
          L12
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_23 org/nlogo/nvm/Context java/lang/Object D java/lang/Object T I] []
+         FRAME CHOP 1
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L15
          FRAME SAME
-          ILOAD 7
+          ILOAD 5
          L16
           GOTO L17
          L8
@@ -9729,15 +10277,18 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           BIPUSH 22
           GOTO L19
          L18
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_23 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_23 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 25
          L19
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_23 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_if_23 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L20
           RETURN
 [22]_asm_procedurecollidewith_ask_24 "ask" Object => void
       _procedurevariable:OTHER-PARTICLE "other-particle" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -9747,18 +10298,16 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_ask_24.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -9774,8 +10323,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_24 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_ask_24.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -9792,18 +10341,18 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -9820,7 +10369,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -9830,23 +10379,12 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_24 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 23
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 25
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -9860,8 +10398,16 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 23
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 25
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_24 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [23]_asm_procedurecollidewith_setturtlevariable_25 "set" Object => void
       _minus "-" double,double => double
@@ -9869,6 +10415,17 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
         _atan "atan" double,double => double
           _procedurevariable:V2L "v2l" => Object
           _procedurevariable:V2T "v2t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -10012,6 +10569,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           GOTO L19
          L20
          FRAME SAME1 D
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
@@ -10019,6 +10577,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           SIPUSH 360
           I2D
           DADD
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_25.validDouble (DLorg/nlogo/nvm/Context;)D
           SIPUSH 360
           I2D
           DREM
@@ -10043,9 +10603,6 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L7
-          ALOAD 1
-          BIPUSH 24
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L23
          L8
          FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_25 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -10060,8 +10617,13 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ATHROW
          L23
          FRAME SAME
+          ALOAD 1
+          BIPUSH 24
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L24
           RETURN
 [24]_asm_procedurecollidewith_done_26 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -10088,6 +10650,9 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           RETURN
 [26]_asm_procedurecollidewith_ask_28 "ask" Object => void
       _procedurevariable:OTHER-PARTICLE "other-particle" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -10097,18 +10662,16 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_ask_28.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -10124,8 +10687,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_28 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecollidewith_ask_28.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -10142,18 +10705,18 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -10170,7 +10733,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -10180,23 +10743,12 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_28 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 27
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 29
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -10210,8 +10762,16 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 27
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 29
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurecollidewith_ask_28 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [27]_asm_procedurecollidewith_call_29 "recolor"
          L0
@@ -10232,6 +10792,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L1
           RETURN
 [28]_asm_procedurecollidewith_done_30 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -10239,6 +10800,7 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
          L1
           RETURN
 [29]_asm_procedurecollidewith_return_31 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -10253,6 +10815,13 @@ procedure RECOLOR:[]{-T--}:
       _lessthan "<" Object,double => boolean
         _breedvariable:SPEED "speed" => Object
         _constdouble:5.0 "*" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -10279,14 +10848,10 @@ procedure RECOLOR:[]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
@@ -10294,15 +10859,14 @@ procedure RECOLOR:[]{-T--}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -10331,23 +10895,28 @@ procedure RECOLOR:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L9
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L9
+          IFEQ L10
           ICONST_1
-          GOTO L10
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          ICONST_3
+          GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          ICONST_3
          L11
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [1]_asm_procedurerecolor_setturtleorlinkvariable_1 "set" Object => void
       _constdouble:105.0 "blue" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -10361,9 +10930,6 @@ procedure RECOLOR:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_setturtleorlinkvariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -10378,8 +10944,13 @@ procedure RECOLOR:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedurerecolor_goto_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 7
@@ -10390,6 +10961,13 @@ procedure RECOLOR:[]{-T--}:
       _greaterthan ">" Object,double => boolean
         _breedvariable:SPEED "speed" => Object
         _constdouble:15.0 "*" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -10416,14 +10994,10 @@ procedure RECOLOR:[]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -10431,15 +11005,14 @@ procedure RECOLOR:[]{-T--}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_3 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -10468,23 +11041,28 @@ procedure RECOLOR:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_3 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L9
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L9
+          IFEQ L10
           ICONST_4
-          GOTO L10
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_3 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 6
+          GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_3 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_3 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 6
          L11
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_3 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [4]_asm_procedurerecolor_setturtleorlinkvariable_4 "set" Object => void
       _constdouble:15.0 "red" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -10498,9 +11076,6 @@ procedure RECOLOR:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_setturtleorlinkvariable_4 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -10515,8 +11090,13 @@ procedure RECOLOR:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [5]_asm_procedurerecolor_goto_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 7
@@ -10525,6 +11105,9 @@ procedure RECOLOR:[]{-T--}:
           RETURN
 [6]_asm_procedurerecolor_setturtleorlinkvariable_6 "set" Object => void
       _constdouble:55.0 "green" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -10538,9 +11121,6 @@ procedure RECOLOR:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_setturtleorlinkvariable_6 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -10555,8 +11135,13 @@ procedure RECOLOR:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurerecolor_return_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -10577,6 +11162,16 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           _notequal "!=" Object,double => boolean
             _patchvariable:PCOLOR "pcolor" => Object
             _constdouble:0.0 "black" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
               TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
              L0
@@ -10604,11 +11199,9 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L8
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -10619,19 +11212,19 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
               ICONST_1
               GOTO L10
              L9
-             FRAME FULL [org/nlogo/prim/_asm_procedurefadepatches_and_1 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_procedurefadepatches_and_1 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L10
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L11
              L8
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_1
-              ISTORE 7
+              ISTORE 5
              L11
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L12
               IFEQ L13
              L3
@@ -10659,11 +11252,9 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L16
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -10674,19 +11265,19 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
               ICONST_1
               GOTO L18
              L17
-             FRAME FULL [org/nlogo/prim/_asm_procedurefadepatches_and_1 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] []
+             FRAME APPEND [java/lang/Double]
               ICONST_0
              L18
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L19
              L16
-             FRAME FULL [org/nlogo/prim/_asm_procedurefadepatches_and_1 org/nlogo/nvm/Context java/lang/Object D java/lang/Object T I] []
+             FRAME CHOP 1
               ICONST_1
-              ISTORE 7
+              ISTORE 5
              L19
              FRAME SAME
-              ILOAD 7
+              ILOAD 5
              L20
               GOTO L21
              L13
@@ -10703,6 +11294,12 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
              L23
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurefadepatches_setprocedurevariable_0.world : Lorg/nlogo/agent/World;
@@ -10748,25 +11345,15 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           IFEQ L4
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L5
+          IFEQ L2
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L6
-         FRAME SAME1 java/lang/Object
-          ASTORE 10
-          ALOAD 10
           POP
           GOTO L2
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -10809,7 +11396,7 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L7
+         L5
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -10820,11 +11407,16 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           ALOAD 1
           ICONST_1
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L8
+         L6
           RETURN
 [1]_asm_procedurefadepatches_ifelse_2 "ifelse" boolean => void
       _any "any?" AgentSet => boolean
         _procedurevariable:TRACE-PATCHES "trace-patches" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -10855,12 +11447,12 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           ASTORE 2
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.isEmpty ()Z
-          IFEQ L5
-          ICONST_0
+          IFNE L5
+          ICONST_1
           GOTO L6
          L5
          FRAME FULL [org/nlogo/prim/_asm_procedurefadepatches_ifelse_2 org/nlogo/nvm/Context org/nlogo/agent/AgentSet] []
-          ICONST_1
+          ICONST_0
          L6
          FRAME SAME1 I
           ISTORE 2
@@ -10879,6 +11471,9 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           RETURN
 [2]_asm_procedurefadepatches_ask_3 "ask" Object => void
       _procedurevariable:TRACE-PATCHES "trace-patches" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -10888,18 +11483,16 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurefadepatches_ask_3.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -10915,8 +11508,8 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurefadepatches_ask_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurefadepatches_ask_3.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -10933,18 +11526,18 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -10961,7 +11554,7 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -10971,23 +11564,12 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurefadepatches_ask_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_3
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -11001,13 +11583,28 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          ICONST_3
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurefadepatches_ask_3 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [3]_asm_procedurefadepatches_setpatchvariable_4 "set" Object => void
       _minus "-" double,double => double
         _patchvariable:PCOLOR "pcolor" => Object
         _constdouble:0.4 "0.4" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -11072,9 +11669,6 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurefadepatches_setpatchvariable_4 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -11089,6 +11683,10 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [4]_asm_procedurefadepatches_if_5 "if" boolean => void
       _or "or"
@@ -11098,6 +11696,18 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           _round "round" double => double
             _patchvariable:PCOLOR "pcolor" => Object
           _constdouble:0.0 "black" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -11130,12 +11740,12 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L10
-          ICONST_0
+          IFNE L10
+          ICONST_1
           GOTO L11
          L10
          FRAME FULL [org/nlogo/prim/_asm_procedurefadepatches_if_5 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L11
          FRAME SAME1 I
           IFNE L12
@@ -11222,6 +11832,9 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           RETURN
 [5]_asm_procedurefadepatches_setpatchvariable_6 "set" Object => void
       _constdouble:0.0 "black" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -11235,9 +11848,6 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurefadepatches_setpatchvariable_6 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -11252,8 +11862,13 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [6]_asm_procedurefadepatches_done_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -11261,6 +11876,7 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
          L1
           RETURN
 [7]_asm_procedurefadepatches_goto_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 9
@@ -11269,6 +11885,9 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           RETURN
 [8]_asm_procedurefadepatches_setobservervariable_9 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -11283,9 +11902,6 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurefadepatches_setobservervariable_9 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -11300,8 +11916,13 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [9]_asm_procedurefadepatches_return_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -11334,6 +11955,28 @@ procedure MAKE-BOX:[]{OTPL}:
               _abs "abs" double => double
                 _patchvariabledouble:PXCOR "pxcor" => double
               _observervariable:BOX-EDGE "box-edge" => Object
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d0
+              // parameter final  arg1
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d0
+              // parameter final  arg1
+              // parameter final  context
+              // parameter final  context
+              // parameter final  d
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -11343,10 +11986,8 @@ procedure MAKE-BOX:[]{OTPL}:
               IFEQ L1
               ALOAD 3
               CHECKCAST org/nlogo/agent/Turtle
-              ASTORE 4
-              ALOAD 4
               INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-              ASTORE 5
+              ASTORE 2
               GOTO L2
              L1
              FRAME APPEND [T org/nlogo/agent/Agent]
@@ -11355,26 +11996,21 @@ procedure MAKE-BOX:[]{OTPL}:
               IFEQ L3
               ALOAD 3
               CHECKCAST org/nlogo/agent/Patch
-              ASTORE 6
-              ALOAD 6
-              ASTORE 5
-             L2
-             FRAME APPEND [T org/nlogo/agent/Patch]
-              ALOAD 5
               ASTORE 2
-              ALOAD 2
-              ICONST_0
-              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-              GOTO L4
+              GOTO L2
              L3
-             FRAME CHOP 2
+             FRAME SAME
               NEW scala/MatchError
               DUP
               ALOAD 3
               INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
               ATHROW
+             L2
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+              ALOAD 2
+              ICONST_0
+              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
              L4
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] [D]
               DSTORE 2
               DLOAD 2
               ICONST_0
@@ -11385,7 +12021,7 @@ procedure MAKE-BOX:[]{OTPL}:
               DNEG
               GOTO L6
              L5
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D T org/nlogo/agent/Patch] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D] []
               DLOAD 2
              L6
              FRAME SAME1 D
@@ -11398,11 +12034,9 @@ procedure MAKE-BOX:[]{OTPL}:
               ASTORE 4
               DSTORE 2
               ALOAD 4
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L8
-              ALOAD 5
+              ALOAD 4
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 2
@@ -11413,19 +12047,19 @@ procedure MAKE-BOX:[]{OTPL}:
               ICONST_1
               GOTO L10
              L9
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+             FRAME APPEND [java/lang/Object T java/lang/Double]
               ICONST_0
              L10
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L11
              L8
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L11
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L12
               IFEQ L13
              L14
@@ -11437,38 +12071,31 @@ procedure MAKE-BOX:[]{OTPL}:
               IFEQ L15
               ALOAD 3
               CHECKCAST org/nlogo/agent/Turtle
-              ASTORE 4
-              ALOAD 4
               INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-              ASTORE 5
+              ASTORE 2
               GOTO L16
              L15
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object I] []
               ALOAD 3
               INSTANCEOF org/nlogo/agent/Patch
               IFEQ L17
               ALOAD 3
               CHECKCAST org/nlogo/agent/Patch
-              ASTORE 6
-              ALOAD 6
-              ASTORE 5
-             L16
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] []
-              ALOAD 5
               ASTORE 2
-              ALOAD 2
-              ICONST_1
-              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-              GOTO L18
+              GOTO L16
              L17
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+             FRAME SAME
               NEW scala/MatchError
               DUP
               ALOAD 3
               INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
               ATHROW
+             L16
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object I] []
+              ALOAD 2
+              ICONST_1
+              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
              L18
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] [D]
               DSTORE 2
               DLOAD 2
               ICONST_0
@@ -11479,7 +12106,7 @@ procedure MAKE-BOX:[]{OTPL}:
               DNEG
               GOTO L20
              L19
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object org/nlogo/agent/Patch T I] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object I] []
               DLOAD 2
              L20
              FRAME SAME1 D
@@ -11536,7 +12163,7 @@ procedure MAKE-BOX:[]{OTPL}:
              FRAME SAME1 I
               GOTO L26
              L13
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object java/lang/Object T I] []
+             FRAME SAME
               ICONST_0
              L26
              FRAME SAME1 I
@@ -11550,38 +12177,31 @@ procedure MAKE-BOX:[]{OTPL}:
               IFEQ L29
               ALOAD 3
               CHECKCAST org/nlogo/agent/Turtle
-              ASTORE 4
-              ALOAD 4
               INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-              ASTORE 5
+              ASTORE 2
               GOTO L30
              L29
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object I] []
               ALOAD 3
               INSTANCEOF org/nlogo/agent/Patch
               IFEQ L31
               ALOAD 3
               CHECKCAST org/nlogo/agent/Patch
-              ASTORE 6
-              ALOAD 6
-              ASTORE 5
-             L30
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] []
-              ALOAD 5
               ASTORE 2
-              ALOAD 2
-              ICONST_1
-              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-              GOTO L32
+              GOTO L30
              L31
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+             FRAME SAME
               NEW scala/MatchError
               DUP
               ALOAD 3
               INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
               ATHROW
+             L30
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object I] []
+              ALOAD 2
+              ICONST_1
+              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
              L32
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] [D]
               DSTORE 2
               DLOAD 2
               ICONST_0
@@ -11592,7 +12212,7 @@ procedure MAKE-BOX:[]{OTPL}:
               DNEG
               GOTO L34
              L33
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object org/nlogo/agent/Patch T I] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object I] []
               DLOAD 2
              L34
              FRAME SAME1 D
@@ -11605,11 +12225,9 @@ procedure MAKE-BOX:[]{OTPL}:
               ASTORE 4
               DSTORE 2
               ALOAD 4
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L36
-              ALOAD 5
+              ALOAD 4
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 2
@@ -11620,19 +12238,19 @@ procedure MAKE-BOX:[]{OTPL}:
               ICONST_1
               GOTO L38
              L37
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] []
+             FRAME APPEND [java/lang/Double]
               ICONST_0
              L38
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L39
              L36
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object java/lang/Object T I] []
+             FRAME CHOP 1
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L39
              FRAME SAME
-              ILOAD 7
+              ILOAD 5
              L40
               IFEQ L41
              L42
@@ -11644,38 +12262,31 @@ procedure MAKE-BOX:[]{OTPL}:
               IFEQ L43
               ALOAD 3
               CHECKCAST org/nlogo/agent/Turtle
-              ASTORE 4
-              ALOAD 4
               INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-              ASTORE 5
+              ASTORE 2
               GOTO L44
              L43
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object I] []
               ALOAD 3
               INSTANCEOF org/nlogo/agent/Patch
               IFEQ L45
               ALOAD 3
               CHECKCAST org/nlogo/agent/Patch
-              ASTORE 6
-              ALOAD 6
-              ASTORE 5
-             L44
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] []
-              ALOAD 5
               ASTORE 2
-              ALOAD 2
-              ICONST_0
-              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-              GOTO L46
+              GOTO L44
              L45
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+             FRAME SAME
               NEW scala/MatchError
               DUP
               ALOAD 3
               INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
               ATHROW
+             L44
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object I] []
+              ALOAD 2
+              ICONST_0
+              INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
              L46
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] [D]
               DSTORE 2
               DLOAD 2
               ICONST_0
@@ -11686,7 +12297,7 @@ procedure MAKE-BOX:[]{OTPL}:
               DNEG
               GOTO L48
              L47
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object org/nlogo/agent/Patch T I] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object I] []
               DLOAD 2
              L48
              FRAME SAME1 D
@@ -11743,7 +12354,7 @@ procedure MAKE-BOX:[]{OTPL}:
              FRAME SAME1 I
               GOTO L54
              L41
-             FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_or_1 org/nlogo/nvm/Context D java/lang/Object java/lang/Object T I] []
+             FRAME SAME
               ICONST_0
              L54
              FRAME SAME1 I
@@ -11762,6 +12373,12 @@ procedure MAKE-BOX:[]{OTPL}:
              L57
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduremakebox_ask_0.world : Lorg/nlogo/agent/World;
@@ -11807,25 +12424,15 @@ procedure MAKE-BOX:[]{OTPL}:
           IFEQ L4
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L5
+          IFEQ L2
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L6
-         FRAME SAME1 java/lang/Object
-          ASTORE 10
-          ALOAD 10
           POP
           GOTO L2
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -11868,17 +12475,17 @@ procedure MAKE-BOX:[]{OTPL}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L7
+         L5
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
-          IFNE L8
+          IFNE L6
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduremakebox_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-          IF_ACMPNE L9
+          IF_ACMPNE L7
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -11889,13 +12496,13 @@ procedure MAKE-BOX:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
+         L7
          FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_ask_0 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduremakebox_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
-          IF_ACMPNE L8
+          IF_ACMPNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -11906,7 +12513,7 @@ procedure MAKE-BOX:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L8
+         L6
          FRAME SAME
           ALOAD 1
           ALOAD 2
@@ -11915,10 +12522,13 @@ procedure MAKE-BOX:[]{OTPL}:
           ALOAD 1
           ICONST_3
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L10
+         L8
           RETURN
 [1]_asm_proceduremakebox_setpatchvariable_2 "set" Object => void
       _constdouble:45.0 "yellow" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -11932,9 +12542,6 @@ procedure MAKE-BOX:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_setpatchvariable_2 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -11949,8 +12556,13 @@ procedure MAKE-BOX:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_proceduremakebox_done_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -11958,6 +12570,7 @@ procedure MAKE-BOX:[]{OTPL}:
          L1
           RETURN
 [3]_asm_proceduremakebox_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -11970,6 +12583,7 @@ procedure MAKE-BOX:[]{OTPL}:
 procedure MAKE-PARTICLES:[]{O---}:
 [0]_createorderedturtles:PARTICLES,+5 "create-ordered-particles"
       _asm_proceduremakeparticles_observervariable_0 "number-of-particles" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduremakeparticles_observervariable_0.world : Lorg/nlogo/agent/World;
@@ -12033,6 +12647,7 @@ procedure MAKE-PARTICLES:[]{O---}:
          L1
           RETURN
 [4]_asm_proceduremakeparticles_done_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -12058,6 +12673,7 @@ procedure MAKE-PARTICLES:[]{O---}:
          L1
           RETURN
 [6]_asm_proceduremakeparticles_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -12070,6 +12686,7 @@ procedure MAKE-PARTICLES:[]{O---}:
 procedure SETUP-PARTICLE:[]{-T--}:
 [0]_setbreedvariable:SPEED "set"
       _asm_proceduresetupparticle_observervariable_0 "init-particle-speed" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupparticle_observervariable_0.world : Lorg/nlogo/agent/World;
@@ -12080,6 +12697,7 @@ procedure SETUP-PARTICLE:[]{-T--}:
             ARETURN
 [1]_setbreedvariable:MASS "set"
       _asm_proceduresetupparticle_observervariable_1 "particle-mass" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupparticle_observervariable_1.world : Lorg/nlogo/agent/World;
@@ -12096,6 +12714,19 @@ procedure SETUP-PARTICLE:[]{-T--}:
             _breedvariable:MASS "mass" => Object
           _breedvariable:SPEED "speed" => Object
         _breedvariable:SPEED "speed" => Object
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
             TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
             TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
             TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -12248,12 +12879,14 @@ procedure SETUP-PARTICLE:[]{-T--}:
             ARETURN
 [3]_setbreedvariable:LAST-COLLISION "set"
       _asm_proceduresetupparticle_nobody_3 "nobody" => Nobody$
+            // parameter final  context
            L0
             GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
            L1
             ARETURN
 [4]_setbreedvariable:WALL-HITS "set"
       _asm_proceduresetupparticle_constdouble_4 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupparticle_constdouble_4.kept1_value : Ljava/lang/Double;
@@ -12261,12 +12894,14 @@ procedure SETUP-PARTICLE:[]{-T--}:
             ARETURN
 [5]_setbreedvariable:MOMENTUM-DIFFERENCE "set"
       _asm_proceduresetupparticle_constdouble_5 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupparticle_constdouble_5.kept1_value : Ljava/lang/Double;
            L1
             ARETURN
 [6]_asm_proceduresetupparticle_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -12298,6 +12933,44 @@ procedure RANDOM-POSITION:[]{-T--}:
               _constdouble:2.0 "2" => double
               _observervariable:BOX-EDGE "box-edge" => Object
             _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -12535,6 +13208,11 @@ procedure RANDOM-POSITION:[]{-T--}:
 [1]_asm_procedurerandomposition_setturtlevariable_1 "set" Object => void
       _randomfloat "random-float" double => double
         _constdouble:360.0 "360" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           LDC 360.0
@@ -12560,9 +13238,6 @@ procedure RANDOM-POSITION:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L6
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerandomposition_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -12577,8 +13252,13 @@ procedure RANDOM-POSITION:[]{-T--}:
           ATHROW
          L6
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L7
           RETURN
 [2]_asm_procedurerandomposition_return_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -12591,12 +13271,14 @@ procedure RANDOM-POSITION:[]{-T--}:
 procedure SETUP-PLOTZ:[]{OTPL}:
 [0]_setcurrentplot "set-current-plot"
       _asm_proceduresetupplotz_conststring_0 ""Speed Counts"" => String
+            // parameter final  context
            L0
             LDC "Speed Counts"
            L1
             ARETURN
 [1]_setplotyrange "set-plot-y-range"
       _asm_proceduresetupplotz_constdouble_1 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupplotz_constdouble_1.kept1_value : Ljava/lang/Double;
@@ -12606,6 +13288,10 @@ procedure SETUP-PLOTZ:[]{OTPL}:
         _div "/" double,double => double
           _observervariable:NUMBER-OF-PARTICLES "number-of-particles" => Object
           _constdouble:6.0 "6" => double
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  d0
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
            L2
             ALOAD 0
@@ -12668,6 +13354,7 @@ procedure SETUP-PLOTZ:[]{OTPL}:
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
 [2]_asm_proceduresetupplotz_return_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -12680,12 +13367,14 @@ procedure SETUP-PLOTZ:[]{OTPL}:
 procedure SETUP-HISTOGRAMS:[]{OTPL}:
 [0]_setcurrentplot "set-current-plot"
       _asm_proceduresetuphistograms_conststring_0 ""Speed Histogram"" => String
+            // parameter final  context
            L0
             LDC "Speed Histogram"
            L1
             ARETURN
 [1]_setplotxrange "set-plot-x-range"
       _asm_proceduresetuphistograms_constdouble_1 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_1.kept1_value : Ljava/lang/Double;
@@ -12694,6 +13383,11 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
       _asm_proceduresetuphistograms_mult_2 "*" double,double => double
         _observervariable:INIT-PARTICLE-SPEED "init-particle-speed" => Object
         _constdouble:2.0 "2" => double
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
            L2
             ALOAD 0
@@ -12738,6 +13432,7 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [2]_setplotyrange "set-plot-y-range"
       _asm_proceduresetuphistograms_constdouble_3 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_3.kept1_value : Ljava/lang/Double;
@@ -12747,6 +13442,10 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
         _div "/" double,double => double
           _observervariable:NUMBER-OF-PARTICLES "number-of-particles" => Object
           _constdouble:6.0 "6" => double
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  d0
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
            L2
             ALOAD 0
@@ -12810,12 +13509,14 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [3]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduresetuphistograms_conststring_5 ""medium"" => String
+            // parameter final  context
            L0
             LDC "medium"
            L1
             ARETURN
 [4]_sethistogramnumbars "set-histogram-num-bars"
       _asm_proceduresetuphistograms_constdouble_6 "40" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_6.kept1_value : Ljava/lang/Double;
@@ -12823,12 +13524,14 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [5]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduresetuphistograms_conststring_7 ""slow"" => String
+            // parameter final  context
            L0
             LDC "slow"
            L1
             ARETURN
 [6]_sethistogramnumbars "set-histogram-num-bars"
       _asm_proceduresetuphistograms_constdouble_8 "40" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_8.kept1_value : Ljava/lang/Double;
@@ -12836,12 +13539,14 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [7]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduresetuphistograms_conststring_9 ""fast"" => String
+            // parameter final  context
            L0
             LDC "fast"
            L1
             ARETURN
 [8]_sethistogramnumbars "set-histogram-num-bars"
       _asm_proceduresetuphistograms_constdouble_10 "40" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_10.kept1_value : Ljava/lang/Double;
@@ -12849,12 +13554,14 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [9]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduresetuphistograms_conststring_11 ""init-avg-speed"" => String
+            // parameter final  context
            L0
             LDC "init-avg-speed"
            L1
             ARETURN
 [10]_asm_proceduresetuphistograms_call_12 "draw-vert-line"
       _observervariable:INIT-AVG-SPEED "init-avg-speed" => Object
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -12885,12 +13592,14 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
           RETURN
 [11]_setcurrentplot "set-current-plot"
       _asm_proceduresetuphistograms_conststring_13 ""Energy Histogram"" => String
+            // parameter final  context
            L0
             LDC "Energy Histogram"
            L1
             ARETURN
 [12]_setplotxrange "set-plot-x-range"
       _asm_proceduresetuphistograms_constdouble_14 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_14.kept1_value : Ljava/lang/Double;
@@ -12907,6 +13616,27 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             _observervariable:INIT-PARTICLE-SPEED "init-particle-speed" => Object
             _constdouble:2.0 "2" => double
         _observervariable:PARTICLE-MASS "particle-mass" => Object
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
             TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
             TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -13033,6 +13763,7 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [13]_setplotyrange "set-plot-y-range"
       _asm_proceduresetuphistograms_constdouble_16 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_16.kept1_value : Ljava/lang/Double;
@@ -13042,6 +13773,10 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
         _div "/" double,double => double
           _observervariable:NUMBER-OF-PARTICLES "number-of-particles" => Object
           _constdouble:6.0 "6" => double
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  d0
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
            L2
             ALOAD 0
@@ -13105,12 +13840,14 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [14]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduresetuphistograms_conststring_18 ""medium"" => String
+            // parameter final  context
            L0
             LDC "medium"
            L1
             ARETURN
 [15]_sethistogramnumbars "set-histogram-num-bars"
       _asm_proceduresetuphistograms_constdouble_19 "40" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_19.kept1_value : Ljava/lang/Double;
@@ -13118,12 +13855,14 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [16]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduresetuphistograms_conststring_20 ""slow"" => String
+            // parameter final  context
            L0
             LDC "slow"
            L1
             ARETURN
 [17]_sethistogramnumbars "set-histogram-num-bars"
       _asm_proceduresetuphistograms_constdouble_21 "40" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_21.kept1_value : Ljava/lang/Double;
@@ -13131,12 +13870,14 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [18]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduresetuphistograms_conststring_22 ""fast"" => String
+            // parameter final  context
            L0
             LDC "fast"
            L1
             ARETURN
 [19]_sethistogramnumbars "set-histogram-num-bars"
       _asm_proceduresetuphistograms_constdouble_23 "40" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_23.kept1_value : Ljava/lang/Double;
@@ -13144,12 +13885,14 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [20]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduresetuphistograms_conststring_24 ""init-avg-energy"" => String
+            // parameter final  context
            L0
             LDC "init-avg-energy"
            L1
             ARETURN
 [21]_asm_proceduresetuphistograms_call_25 "draw-vert-line"
       _observervariable:INIT-AVG-ENERGY "init-avg-energy" => Object
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -13179,6 +13922,7 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
          L3
           RETURN
 [22]_asm_proceduresetuphistograms_return_26 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -13191,6 +13935,7 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
 procedure DO-PLOTTING:[]{OTPL}:
 [0]_setcurrentplot "set-current-plot"
       _asm_proceduredoplotting_conststring_0 ""Pressure vs. Time"" => String
+            // parameter final  context
            L0
             LDC "Pressure vs. Time"
            L1
@@ -13200,6 +13945,13 @@ procedure DO-PLOTTING:[]{OTPL}:
         _length "length" Object => double
           _observervariable:PRESSURE-HISTORY "pressure-history" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduredoplotting_if_1.world : Lorg/nlogo/agent/World;
@@ -13304,6 +14056,8 @@ procedure DO-PLOTTING:[]{OTPL}:
         _callreport:LAST-N "last-n"
           _constdouble:3.0 "3" => Double
           _observervariable:PRESSURE-HISTORY "pressure-history" => Object
+            // parameter final  context
+            // parameter final  context
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
            L2
             NEW org/nlogo/nvm/Activation
@@ -13436,7 +14190,8 @@ procedure DO-PLOTTING:[]{OTPL}:
             INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
             I2D
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplotting_mean_3.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplotting_mean_3.validDouble (DLorg/nlogo/nvm/Context;)D
            L13
             DSTORE 2
             NEW java/lang/Double
@@ -13446,18 +14201,21 @@ procedure DO-PLOTTING:[]{OTPL}:
             ARETURN
 [3]_setcurrentplot "set-current-plot"
       _asm_proceduredoplotting_conststring_4 ""Speed Counts"" => String
+            // parameter final  context
            L0
             LDC "Speed Counts"
            L1
             ARETURN
 [4]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredoplotting_conststring_5 ""fast"" => String
+            // parameter final  context
            L0
             LDC "fast"
            L1
             ARETURN
 [5]_plot "plot"
       _asm_proceduredoplotting_observervariable_6 "fast" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredoplotting_observervariable_6.world : Lorg/nlogo/agent/World;
@@ -13468,12 +14226,14 @@ procedure DO-PLOTTING:[]{OTPL}:
             ARETURN
 [6]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredoplotting_conststring_7 ""medium"" => String
+            // parameter final  context
            L0
             LDC "medium"
            L1
             ARETURN
 [7]_plot "plot"
       _asm_proceduredoplotting_observervariable_8 "medium" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredoplotting_observervariable_8.world : Lorg/nlogo/agent/World;
@@ -13484,12 +14244,14 @@ procedure DO-PLOTTING:[]{OTPL}:
             ARETURN
 [8]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredoplotting_conststring_9 ""slow"" => String
+            // parameter final  context
            L0
             LDC "slow"
            L1
             ARETURN
 [9]_plot "plot"
       _asm_proceduredoplotting_observervariable_10 "slow" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredoplotting_observervariable_10.world : Lorg/nlogo/agent/World;
@@ -13502,6 +14264,12 @@ procedure DO-PLOTTING:[]{OTPL}:
       _greaterthan ">" double,double => boolean
         _ticks "ticks" => double
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduredoplotting_if_11.world : Lorg/nlogo/agent/World;
@@ -13555,6 +14323,7 @@ procedure DO-PLOTTING:[]{OTPL}:
           RETURN
 [11]_setcurrentplot "set-current-plot"
       _asm_proceduredoplotting_conststring_12 ""Wall Hits per Particle"" => String
+            // parameter final  context
            L0
             LDC "Wall Hits per Particle"
            L1
@@ -13590,6 +14359,7 @@ procedure DO-PLOTTING:[]{OTPL}:
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
       _asm_proceduredoplotting_observervariable_14 "wall-hits-per-particle" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredoplotting_observervariable_14.world : Lorg/nlogo/agent/World;
@@ -13617,6 +14387,7 @@ procedure DO-PLOTTING:[]{OTPL}:
          L1
           RETURN
 [14]_asm_proceduredoplotting_return_16 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -13629,12 +14400,14 @@ procedure DO-PLOTTING:[]{OTPL}:
 procedure PLOT-HISTOGRAMS:[]{OTPL}:
 [0]_setcurrentplot "set-current-plot"
       _asm_procedureplothistograms_conststring_0 ""Energy histogram"" => String
+            // parameter final  context
            L0
             LDC "Energy histogram"
            L1
             ARETURN
 [1]_setcurrentplotpen "set-current-plot-pen"
       _asm_procedureplothistograms_conststring_1 ""fast"" => String
+            // parameter final  context
            L0
             LDC "fast"
            L1
@@ -13646,6 +14419,11 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
           _asm_procedureplothistograms_equal_3 "=" Object,double => boolean
             _turtleorlinkvariable:COLOR "color" => Object
             _constdouble:15.0 "red" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  d1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -13672,11 +14450,9 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                 DSTORE 3
                 ASTORE 2
                 ALOAD 2
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L5
-                ALOAD 5
+                ALOAD 2
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 3
@@ -13687,19 +14463,19 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                 ICONST_1
                 GOTO L7
                L6
-               FRAME FULL [org/nlogo/prim/_asm_procedureplothistograms_equal_3 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_procedureplothistograms_equal_3 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                 ICONST_0
                L7
                FRAME SAME1 I
-                ISTORE 7
+                ISTORE 5
                 GOTO L8
                L5
-               FRAME CHOP 1
+               FRAME CHOP 2
                 ICONST_0
-                ISTORE 7
+                ISTORE 5
                L8
-               FRAME APPEND [T I]
-                ILOAD 7
+               FRAME APPEND [I]
+                ILOAD 5
                L9
                 IFEQ L10
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -13710,6 +14486,10 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                L11
                FRAME SAME1 java/lang/Boolean
                 ARETURN
+              // parameter final  context
+              // parameter final  context
+              // parameter final  sourceSet
+              // parameter final  reporterBlock
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedureplothistograms_with_2.world : Lorg/nlogo/agent/World;
@@ -13756,25 +14536,15 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
               IFEQ L4
               ALOAD 8
               CHECKCAST java/lang/Boolean
-              ASTORE 9
-              ALOAD 9
               INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-              IFEQ L5
+              IFEQ L2
               ALOAD 5
               ALOAD 7
               INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-              GOTO L6
-             L5
-             FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-              GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-             L6
-             FRAME SAME1 java/lang/Object
-              ASTORE 10
-              ALOAD 10
               POP
               GOTO L2
              L4
-             FRAME CHOP 1
+             FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
@@ -13817,10 +14587,11 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
               INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
               CHECKCAST [Lorg/nlogo/agent/Agent;
               INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-             L7
+             L5
               ARETURN
 [3]_setcurrentplotpen "set-current-plot-pen"
       _asm_procedureplothistograms_conststring_4 ""medium"" => String
+            // parameter final  context
            L0
             LDC "medium"
            L1
@@ -13832,6 +14603,11 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
           _asm_procedureplothistograms_equal_6 "=" Object,double => boolean
             _turtleorlinkvariable:COLOR "color" => Object
             _constdouble:55.0 "green" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  d1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -13858,11 +14634,9 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                 DSTORE 3
                 ASTORE 2
                 ALOAD 2
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L5
-                ALOAD 5
+                ALOAD 2
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 3
@@ -13873,19 +14647,19 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                 ICONST_1
                 GOTO L7
                L6
-               FRAME FULL [org/nlogo/prim/_asm_procedureplothistograms_equal_6 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_procedureplothistograms_equal_6 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                 ICONST_0
                L7
                FRAME SAME1 I
-                ISTORE 7
+                ISTORE 5
                 GOTO L8
                L5
-               FRAME CHOP 1
+               FRAME CHOP 2
                 ICONST_0
-                ISTORE 7
+                ISTORE 5
                L8
-               FRAME APPEND [T I]
-                ILOAD 7
+               FRAME APPEND [I]
+                ILOAD 5
                L9
                 IFEQ L10
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -13896,6 +14670,10 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                L11
                FRAME SAME1 java/lang/Boolean
                 ARETURN
+              // parameter final  context
+              // parameter final  context
+              // parameter final  sourceSet
+              // parameter final  reporterBlock
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedureplothistograms_with_5.world : Lorg/nlogo/agent/World;
@@ -13942,25 +14720,15 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
               IFEQ L4
               ALOAD 8
               CHECKCAST java/lang/Boolean
-              ASTORE 9
-              ALOAD 9
               INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-              IFEQ L5
+              IFEQ L2
               ALOAD 5
               ALOAD 7
               INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-              GOTO L6
-             L5
-             FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-              GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-             L6
-             FRAME SAME1 java/lang/Object
-              ASTORE 10
-              ALOAD 10
               POP
               GOTO L2
              L4
-             FRAME CHOP 1
+             FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
@@ -14003,10 +14771,11 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
               INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
               CHECKCAST [Lorg/nlogo/agent/Agent;
               INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-             L7
+             L5
               ARETURN
 [5]_setcurrentplotpen "set-current-plot-pen"
       _asm_procedureplothistograms_conststring_7 ""slow"" => String
+            // parameter final  context
            L0
             LDC "slow"
            L1
@@ -14018,6 +14787,11 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
           _asm_procedureplothistograms_equal_9 "=" Object,double => boolean
             _turtleorlinkvariable:COLOR "color" => Object
             _constdouble:105.0 "blue" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  d1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -14044,11 +14818,9 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                 DSTORE 3
                 ASTORE 2
                 ALOAD 2
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L5
-                ALOAD 5
+                ALOAD 2
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 3
@@ -14059,19 +14831,19 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                 ICONST_1
                 GOTO L7
                L6
-               FRAME FULL [org/nlogo/prim/_asm_procedureplothistograms_equal_9 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_procedureplothistograms_equal_9 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                 ICONST_0
                L7
                FRAME SAME1 I
-                ISTORE 7
+                ISTORE 5
                 GOTO L8
                L5
-               FRAME CHOP 1
+               FRAME CHOP 2
                 ICONST_0
-                ISTORE 7
+                ISTORE 5
                L8
-               FRAME APPEND [T I]
-                ILOAD 7
+               FRAME APPEND [I]
+                ILOAD 5
                L9
                 IFEQ L10
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -14082,6 +14854,10 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                L11
                FRAME SAME1 java/lang/Boolean
                 ARETURN
+              // parameter final  context
+              // parameter final  context
+              // parameter final  sourceSet
+              // parameter final  reporterBlock
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedureplothistograms_with_8.world : Lorg/nlogo/agent/World;
@@ -14128,25 +14904,15 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
               IFEQ L4
               ALOAD 8
               CHECKCAST java/lang/Boolean
-              ASTORE 9
-              ALOAD 9
               INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-              IFEQ L5
+              IFEQ L2
               ALOAD 5
               ALOAD 7
               INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-              GOTO L6
-             L5
-             FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-              GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-             L6
-             FRAME SAME1 java/lang/Object
-              ASTORE 10
-              ALOAD 10
               POP
               GOTO L2
              L4
-             FRAME CHOP 1
+             FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
@@ -14189,10 +14955,11 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
               INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
               CHECKCAST [Lorg/nlogo/agent/Agent;
               INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-             L7
+             L5
               ARETURN
 [7]_setcurrentplotpen "set-current-plot-pen"
       _asm_procedureplothistograms_conststring_10 ""avg-energy"" => String
+            // parameter final  context
            L0
             LDC "avg-energy"
            L1
@@ -14200,6 +14967,7 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
 [8]_plotpenreset "plot-pen-reset"
 [9]_asm_procedureplothistograms_call_11 "draw-vert-line"
       _observervariable:AVG-ENERGY "avg-energy" => Object
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -14230,12 +14998,14 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
           RETURN
 [10]_setcurrentplot "set-current-plot"
       _asm_procedureplothistograms_conststring_12 ""Speed histogram"" => String
+            // parameter final  context
            L0
             LDC "Speed histogram"
            L1
             ARETURN
 [11]_setcurrentplotpen "set-current-plot-pen"
       _asm_procedureplothistograms_conststring_13 ""fast"" => String
+            // parameter final  context
            L0
             LDC "fast"
            L1
@@ -14247,6 +15017,11 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
           _asm_procedureplothistograms_equal_15 "=" Object,double => boolean
             _turtleorlinkvariable:COLOR "color" => Object
             _constdouble:15.0 "red" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  d1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -14273,11 +15048,9 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                 DSTORE 3
                 ASTORE 2
                 ALOAD 2
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L5
-                ALOAD 5
+                ALOAD 2
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 3
@@ -14288,19 +15061,19 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                 ICONST_1
                 GOTO L7
                L6
-               FRAME FULL [org/nlogo/prim/_asm_procedureplothistograms_equal_15 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_procedureplothistograms_equal_15 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                 ICONST_0
                L7
                FRAME SAME1 I
-                ISTORE 7
+                ISTORE 5
                 GOTO L8
                L5
-               FRAME CHOP 1
+               FRAME CHOP 2
                 ICONST_0
-                ISTORE 7
+                ISTORE 5
                L8
-               FRAME APPEND [T I]
-                ILOAD 7
+               FRAME APPEND [I]
+                ILOAD 5
                L9
                 IFEQ L10
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -14311,6 +15084,10 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                L11
                FRAME SAME1 java/lang/Boolean
                 ARETURN
+              // parameter final  context
+              // parameter final  context
+              // parameter final  sourceSet
+              // parameter final  reporterBlock
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedureplothistograms_with_14.world : Lorg/nlogo/agent/World;
@@ -14357,25 +15134,15 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
               IFEQ L4
               ALOAD 8
               CHECKCAST java/lang/Boolean
-              ASTORE 9
-              ALOAD 9
               INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-              IFEQ L5
+              IFEQ L2
               ALOAD 5
               ALOAD 7
               INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-              GOTO L6
-             L5
-             FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-              GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-             L6
-             FRAME SAME1 java/lang/Object
-              ASTORE 10
-              ALOAD 10
               POP
               GOTO L2
              L4
-             FRAME CHOP 1
+             FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
@@ -14418,10 +15185,11 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
               INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
               CHECKCAST [Lorg/nlogo/agent/Agent;
               INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-             L7
+             L5
               ARETURN
 [13]_setcurrentplotpen "set-current-plot-pen"
       _asm_procedureplothistograms_conststring_16 ""medium"" => String
+            // parameter final  context
            L0
             LDC "medium"
            L1
@@ -14433,6 +15201,11 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
           _asm_procedureplothistograms_equal_18 "=" Object,double => boolean
             _turtleorlinkvariable:COLOR "color" => Object
             _constdouble:55.0 "green" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  d1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -14459,11 +15232,9 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                 DSTORE 3
                 ASTORE 2
                 ALOAD 2
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L5
-                ALOAD 5
+                ALOAD 2
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 3
@@ -14474,19 +15245,19 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                 ICONST_1
                 GOTO L7
                L6
-               FRAME FULL [org/nlogo/prim/_asm_procedureplothistograms_equal_18 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_procedureplothistograms_equal_18 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                 ICONST_0
                L7
                FRAME SAME1 I
-                ISTORE 7
+                ISTORE 5
                 GOTO L8
                L5
-               FRAME CHOP 1
+               FRAME CHOP 2
                 ICONST_0
-                ISTORE 7
+                ISTORE 5
                L8
-               FRAME APPEND [T I]
-                ILOAD 7
+               FRAME APPEND [I]
+                ILOAD 5
                L9
                 IFEQ L10
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -14497,6 +15268,10 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                L11
                FRAME SAME1 java/lang/Boolean
                 ARETURN
+              // parameter final  context
+              // parameter final  context
+              // parameter final  sourceSet
+              // parameter final  reporterBlock
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedureplothistograms_with_17.world : Lorg/nlogo/agent/World;
@@ -14543,25 +15318,15 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
               IFEQ L4
               ALOAD 8
               CHECKCAST java/lang/Boolean
-              ASTORE 9
-              ALOAD 9
               INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-              IFEQ L5
+              IFEQ L2
               ALOAD 5
               ALOAD 7
               INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-              GOTO L6
-             L5
-             FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-              GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-             L6
-             FRAME SAME1 java/lang/Object
-              ASTORE 10
-              ALOAD 10
               POP
               GOTO L2
              L4
-             FRAME CHOP 1
+             FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
@@ -14604,10 +15369,11 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
               INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
               CHECKCAST [Lorg/nlogo/agent/Agent;
               INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-             L7
+             L5
               ARETURN
 [15]_setcurrentplotpen "set-current-plot-pen"
       _asm_procedureplothistograms_conststring_19 ""slow"" => String
+            // parameter final  context
            L0
             LDC "slow"
            L1
@@ -14619,6 +15385,11 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
           _asm_procedureplothistograms_equal_21 "=" Object,double => boolean
             _turtleorlinkvariable:COLOR "color" => Object
             _constdouble:105.0 "blue" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  d1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -14645,11 +15416,9 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                 DSTORE 3
                 ASTORE 2
                 ALOAD 2
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L5
-                ALOAD 5
+                ALOAD 2
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 3
@@ -14660,19 +15429,19 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                 ICONST_1
                 GOTO L7
                L6
-               FRAME FULL [org/nlogo/prim/_asm_procedureplothistograms_equal_21 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_procedureplothistograms_equal_21 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                 ICONST_0
                L7
                FRAME SAME1 I
-                ISTORE 7
+                ISTORE 5
                 GOTO L8
                L5
-               FRAME CHOP 1
+               FRAME CHOP 2
                 ICONST_0
-                ISTORE 7
+                ISTORE 5
                L8
-               FRAME APPEND [T I]
-                ILOAD 7
+               FRAME APPEND [I]
+                ILOAD 5
                L9
                 IFEQ L10
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -14683,6 +15452,10 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
                L11
                FRAME SAME1 java/lang/Boolean
                 ARETURN
+              // parameter final  context
+              // parameter final  context
+              // parameter final  sourceSet
+              // parameter final  reporterBlock
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedureplothistograms_with_20.world : Lorg/nlogo/agent/World;
@@ -14729,25 +15502,15 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
               IFEQ L4
               ALOAD 8
               CHECKCAST java/lang/Boolean
-              ASTORE 9
-              ALOAD 9
               INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-              IFEQ L5
+              IFEQ L2
               ALOAD 5
               ALOAD 7
               INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-              GOTO L6
-             L5
-             FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-              GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-             L6
-             FRAME SAME1 java/lang/Object
-              ASTORE 10
-              ALOAD 10
               POP
               GOTO L2
              L4
-             FRAME CHOP 1
+             FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
@@ -14790,10 +15553,11 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
               INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
               CHECKCAST [Lorg/nlogo/agent/Agent;
               INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-             L7
+             L5
               ARETURN
 [17]_setcurrentplotpen "set-current-plot-pen"
       _asm_procedureplothistograms_conststring_22 ""avg-speed"" => String
+            // parameter final  context
            L0
             LDC "avg-speed"
            L1
@@ -14801,6 +15565,7 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
 [18]_plotpenreset "plot-pen-reset"
 [19]_asm_procedureplothistograms_call_23 "draw-vert-line"
       _observervariable:AVG-SPEED "avg-speed" => Object
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -14830,6 +15595,7 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
          L3
           RETURN
 [20]_asm_procedureplothistograms_return_24 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -14842,6 +15608,7 @@ procedure PLOT-HISTOGRAMS:[]{OTPL}:
 procedure DRAW-VERT-LINE:[XVAL]{OTPL}:
 [0]_plotxy "plotxy"
       _asm_proceduredrawvertline_procedurevariable_0 "xval" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -14854,6 +15621,7 @@ procedure DRAW-VERT-LINE:[XVAL]{OTPL}:
 [1]_plotpendown "plot-pen-down"
 [2]_plotxy "plotxy"
       _asm_proceduredrawvertline_procedurevariable_1 "xval" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -14865,6 +15633,7 @@ procedure DRAW-VERT-LINE:[XVAL]{OTPL}:
       _plotymax "plot-y-max"
 [3]_plotpenup "plot-pen-up"
 [4]_asm_proceduredrawvertline_return_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -14880,6 +15649,10 @@ reporter procedure LAST-N:[N THE-LIST]{OTPL}:
         _procedurevariable:N "n" => Object
         _length "length" Object => double
           _procedurevariable:THE-LIST "the-list" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -14988,6 +15761,7 @@ reporter procedure LAST-N:[N THE-LIST]{OTPL}:
           RETURN
 [1]_asm_procedurelastn_report_1 "report" Object => void
       _procedurevariable:THE-LIST "the-list" => Object
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -15062,6 +15836,7 @@ reporter procedure LAST-N:[N THE-LIST]{OTPL}:
          FRAME SAME
           RETURN
 [2]_asm_procedurelastn_goto_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_4
@@ -15073,6 +15848,8 @@ reporter procedure LAST-N:[N THE-LIST]{OTPL}:
         _procedurevariable:N "n" => Object
         _butfirst "butfirst" Object => Object
           _procedurevariable:THE-LIST "the-list" => Object
+          // parameter final  context
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -15264,6 +16041,7 @@ reporter procedure LAST-N:[N THE-LIST]{OTPL}:
          FRAME SAME
           RETURN
 [4]_asm_procedurelastn_returnreport_4 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -15282,6 +16060,7 @@ reporter procedure LAST-N:[N THE-LIST]{OTPL}:
 procedure MAKE-CLOCKER:[]{O---}:
 [0]_setdefaultshape "set-default-shape"
       _asm_proceduremakeclocker_breed_0 "clockers" => AgentSet
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduremakeclocker_breed_0.world : Lorg/nlogo/agent/World;
@@ -15290,12 +16069,14 @@ procedure MAKE-CLOCKER:[]{O---}:
            L1
             ARETURN
       _asm_proceduremakeclocker_conststring_1 ""clocker"" => String
+            // parameter final  context
            L0
             LDC "clocker"
            L1
             ARETURN
 [1]_createorderedturtles:CLOCKERS,+7 "create-ordered-clockers"
       _asm_proceduremakeclocker_constdouble_2 "1" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduremakeclocker_constdouble_2.kept1_value : Ljava/lang/Double;
@@ -15308,6 +16089,16 @@ procedure MAKE-CLOCKER:[]{O---}:
       _minus "-" double,double => double
         _observervariable:BOX-EDGE "box-edge" => Object
         _constdouble:5.0 "5" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L6 org/nlogo/api/AgentException
@@ -15430,6 +16221,9 @@ procedure MAKE-CLOCKER:[]{O---}:
           RETURN
 [3]_asm_proceduremakeclocker_setturtleorlinkvariable_4 "set" Object => void
       _constdouble:117.0 "+" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -15443,9 +16237,6 @@ procedure MAKE-CLOCKER:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakeclocker_setturtleorlinkvariable_4 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -15460,9 +16251,16 @@ procedure MAKE-CLOCKER:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduremakeclocker_setturtlevariable_5 "set" Object => void
       _constdouble:10.0 "10" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -15476,9 +16274,6 @@ procedure MAKE-CLOCKER:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakeclocker_setturtlevariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -15493,9 +16288,16 @@ procedure MAKE-CLOCKER:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [5]_asm_proceduremakeclocker_setturtlevariable_6 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -15509,9 +16311,6 @@ procedure MAKE-CLOCKER:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakeclocker_setturtlevariable_6 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -15526,8 +16325,13 @@ procedure MAKE-CLOCKER:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [6]_asm_proceduremakeclocker_done_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -15535,6 +16339,7 @@ procedure MAKE-CLOCKER:[]{O---}:
          L1
           RETURN
 [7]_asm_proceduremakeclocker_return_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V

--- a/netlogo-headless/test/benchdumps/GasLabOld.txt
+++ b/netlogo-headless/test/benchdumps/GasLabOld.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:361.0 "361" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 361.0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -77,6 +80,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:20000.0 "20000" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 20000.0
          L1
@@ -89,7 +95,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -116,6 +123,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -149,6 +157,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -170,9 +181,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -187,8 +195,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -208,6 +221,16 @@ procedure SETUP:[]{O---}:
             _maxpxcor "max-pxcor" => double
             _observervariable:BOX-SIZE-PERCENT "box-size-percent" => Object
           _constdouble:100.0 "100" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -291,9 +314,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L14
          L4
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_0 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -308,6 +328,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L14
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L15
           RETURN
 [3]_asm_proceduresetup_call_1 "make-box"
          L0
@@ -329,6 +353,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [4]_asm_proceduresetup_setobservervariable_2 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -343,9 +370,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_2 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -360,9 +384,14 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [5]_crofast: "cro"
       _asm_proceduresetup_observervariable_3 "number" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetup_observervariable_3.world : Lorg/nlogo/agent/World;
@@ -373,6 +402,9 @@ procedure SETUP:[]{O---}:
             ARETURN
 [6]_asm_proceduresetup_ask_4 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_4.world : Lorg/nlogo/agent/World;
@@ -428,6 +460,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [7]_asm_proceduresetup_setturtlevariable_5 "set" Object => void
       _observervariable:INITSPEED "initspeed" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -444,9 +479,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtlevariable_5 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -461,9 +493,16 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [8]_asm_proceduresetup_setturtlevariable_6 "set" Object => void
       _observervariable:INITMASS "initmass" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -480,9 +519,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtlevariable_6 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -497,11 +533,22 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [9]_asm_proceduresetup_if_7 "if" boolean => void
       _notequal "!=" double,double => boolean
         _turtlevariabledouble:WHO "who" => double
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -558,6 +605,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [11]_asm_proceduresetup_right_9 "rt" double => void
       _randomconst:360 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  delta
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -580,6 +630,9 @@ procedure SETUP:[]{O---}:
 [12]_asm_proceduresetup_call_10 "recolor-turtle"
       _turtle "turtle" double => Object
         _turtlevariabledouble:WHO "who" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  idDouble
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -602,7 +655,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_call_10.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_call_10.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           LLOAD 4
           L2D
@@ -613,14 +667,14 @@ procedure SETUP:[]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           DLOAD 2
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (D)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (D)Ljava/lang/StringBuilder;
           LDC " is not an integer"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -649,6 +703,7 @@ procedure SETUP:[]{O---}:
          L6
           RETURN
 [13]_asm_proceduresetup_done_11 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -675,6 +730,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [15]_asm_proceduresetup_setobservervariable_13 "set" Object => void
       _observervariable:AVG-SPEED "avg-speed" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -692,9 +750,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 16
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_13 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -709,9 +764,16 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 16
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [16]_asm_proceduresetup_setobservervariable_14 "set" Object => void
       _observervariable:AVG-ENERGY "avg-energy" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -729,9 +791,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 17
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_14 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -746,6 +805,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 17
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [17]_asm_proceduresetup_call_15 "setup-plotz"
          L0
@@ -820,6 +883,7 @@ procedure SETUP:[]{O---}:
          L1
           RETURN
 [21]_asm_proceduresetup_return_19 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -832,6 +896,9 @@ procedure SETUP:[]{O---}:
 procedure UPDATE-VARIABLES:[]{OTPL}:
 [0]_asm_procedureupdatevariables_ask_0 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureupdatevariables_ask_0.world : Lorg/nlogo/agent/World;
@@ -887,6 +954,9 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           RETURN
 [1]_asm_procedureupdatevariables_setturtlevariable_1 "set" Object => void
       _turtlevariable:NEW-SPEED "new-speed" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -917,9 +987,6 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L4
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L5
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -934,6 +1001,10 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [2]_asm_procedureupdatevariables_setturtlevariable_2 "set" Object => void
       _mult "*" double,double => double
@@ -943,6 +1014,21 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
             _turtlevariable:SPEED "speed" => Object
           _turtlevariable:SPEED "speed" => Object
         _turtlevariable:MASS "mass" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -1101,9 +1187,6 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L16
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L26
          L17
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setturtlevariable_2 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1118,8 +1201,13 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ATHROW
          L26
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L27
           RETURN
 [3]_asm_procedureupdatevariables_done_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1132,6 +1220,11 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
         _asm_procedureupdatevariables_equal_5 "=" Object,double => boolean
           _turtleorlinkvariable:COLOR "color" => Object
           _constdouble:55.0 "green" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -1158,11 +1251,9 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -1173,19 +1264,19 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_equal_5 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_equal_5 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -1196,6 +1287,12 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  block
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1239,25 +1336,15 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           IFEQ L7
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L8
+          IFEQ L5
           ILOAD 5
           ICONST_1
           IADD
           ISTORE 5
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          GOTO L9
-         L8
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L9
-         FRAME SAME1 scala/runtime/BoxedUnit
-          ASTORE 10
           GOTO L5
          L7
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1292,7 +1379,7 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
          FRAME CHOP 2
           ILOAD 5
           I2D
-         L10
+         L8
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -1307,10 +1394,7 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L11
+          GOTO L9
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_4 org/nlogo/nvm/Context java/lang/Double T org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator] [org/nlogo/api/AgentException]
           ASTORE 3
@@ -1322,8 +1406,12 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L11
+         L9
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [5]_asm_procedureupdatevariables_setobservervariable_6 "set" Object => void
       _countwith "count" AgentSet,Reporter => double
@@ -1331,6 +1419,11 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
         _asm_procedureupdatevariables_equal_7 "=" Object,double => boolean
           _turtleorlinkvariable:COLOR "color" => Object
           _constdouble:105.0 "blue" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -1357,11 +1450,9 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -1372,19 +1463,19 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_equal_7 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_equal_7 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -1395,6 +1486,12 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  block
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1438,25 +1535,15 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           IFEQ L7
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L8
+          IFEQ L5
           ILOAD 5
           ICONST_1
           IADD
           ISTORE 5
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          GOTO L9
-         L8
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L9
-         FRAME SAME1 scala/runtime/BoxedUnit
-          ASTORE 10
           GOTO L5
          L7
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1491,7 +1578,7 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
          FRAME CHOP 2
           ILOAD 5
           I2D
-         L10
+         L8
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -1506,10 +1593,7 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L11
+          GOTO L9
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_6 org/nlogo/nvm/Context java/lang/Double T org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator] [org/nlogo/api/AgentException]
           ASTORE 3
@@ -1521,8 +1605,12 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L11
+         L9
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [6]_asm_procedureupdatevariables_setobservervariable_8 "set" Object => void
       _countwith "count" AgentSet,Reporter => double
@@ -1530,6 +1618,11 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
         _asm_procedureupdatevariables_equal_9 "=" Object,double => boolean
           _turtleorlinkvariable:COLOR "color" => Object
           _constdouble:15.0 "red" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -1556,11 +1649,9 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -1571,19 +1662,19 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_equal_9 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_equal_9 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -1594,6 +1685,12 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  block
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1637,25 +1734,15 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           IFEQ L7
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L8
+          IFEQ L5
           ILOAD 5
           ICONST_1
           IADD
           ISTORE 5
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          GOTO L9
-         L8
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L9
-         FRAME SAME1 scala/runtime/BoxedUnit
-          ASTORE 10
           GOTO L5
          L7
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1690,7 +1777,7 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
          FRAME CHOP 2
           ILOAD 5
           I2D
-         L10
+         L8
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -1705,10 +1792,7 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L11
+          GOTO L9
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_8 org/nlogo/nvm/Context java/lang/Double T org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator] [org/nlogo/api/AgentException]
           ASTORE 3
@@ -1720,13 +1804,22 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L11
+         L9
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [7]_asm_procedureupdatevariables_setobservervariable_10 "set" Object => void
       _mean "mean" LogoList => double
         _turtlevariableof:SPEED "of" AgentSet => LogoList
           _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L6
@@ -1739,20 +1832,20 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 4
+          ASTORE 3
           ALOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 5
+          ASTORE 4
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_10 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 5
+         FRAME APPEND [org/nlogo/agent/TreeAgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator]
+          ALOAD 4
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L9
+          ALOAD 3
           ALOAD 4
-          ALOAD 5
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           BIPUSH 13
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
@@ -1760,23 +1853,23 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           GOTO L8
          L9
          FRAME SAME
-          ALOAD 4
+          ALOAD 3
           INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
          L1
           GOTO L10
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_10 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 5
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_10 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/core/LogoList]
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_10 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/core/LogoList]
           ASTORE 2
           DCONST_0
           DSTORE 3
@@ -1793,13 +1886,13 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_10 org/nlogo/nvm/Context org/nlogo/core/LogoList D org/nlogo/agent/AgentIterator] []
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_10 org/nlogo/nvm/Context org/nlogo/core/LogoList D] []
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/core/LogoList.toJava ()Ljava/util/AbstractSequentialList;
           INVOKEVIRTUAL java/util/AbstractSequentialList.iterator ()Ljava/util/Iterator;
           ASTORE 5
          L12
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_10 org/nlogo/nvm/Context org/nlogo/core/LogoList D java/util/Iterator] []
+         FRAME APPEND [java/util/Iterator]
           ALOAD 5
           INVOKEINTERFACE java/util/Iterator.hasNext ()Z
           IFEQ L13
@@ -1847,7 +1940,8 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -1863,9 +1957,6 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L4
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L16
          L5
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_10 org/nlogo/nvm/Context java/lang/Double T T java/util/Iterator] [org/nlogo/api/AgentException]
@@ -1880,11 +1971,20 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ATHROW
          L16
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L17
           RETURN
 [8]_asm_procedureupdatevariables_setobservervariable_11 "set" Object => void
       _mean "mean" LogoList => double
         _turtlevariableof:ENERGY "of" AgentSet => LogoList
           _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L6
@@ -1897,20 +1997,20 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 4
+          ASTORE 3
           ALOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 5
+          ASTORE 4
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_11 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 5
+         FRAME APPEND [org/nlogo/agent/TreeAgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator]
+          ALOAD 4
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L9
+          ALOAD 3
           ALOAD 4
-          ALOAD 5
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           BIPUSH 15
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
@@ -1918,23 +2018,23 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           GOTO L8
          L9
          FRAME SAME
-          ALOAD 4
+          ALOAD 3
           INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
          L1
           GOTO L10
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_11 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 5
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_11 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/core/LogoList]
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_11 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/core/LogoList]
           ASTORE 2
           DCONST_0
           DSTORE 3
@@ -1951,13 +2051,13 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_11 org/nlogo/nvm/Context org/nlogo/core/LogoList D org/nlogo/agent/AgentIterator] []
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_11 org/nlogo/nvm/Context org/nlogo/core/LogoList D] []
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/core/LogoList.toJava ()Ljava/util/AbstractSequentialList;
           INVOKEVIRTUAL java/util/AbstractSequentialList.iterator ()Ljava/util/Iterator;
           ASTORE 5
          L12
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_11 org/nlogo/nvm/Context org/nlogo/core/LogoList D java/util/Iterator] []
+         FRAME APPEND [java/util/Iterator]
           ALOAD 5
           INVOKEINTERFACE java/util/Iterator.hasNext ()Z
           IFEQ L13
@@ -2005,7 +2105,8 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -2021,9 +2122,6 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L4
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L16
          L5
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_11 org/nlogo/nvm/Context java/lang/Double T T java/util/Iterator] [org/nlogo/api/AgentException]
@@ -2038,6 +2136,10 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ATHROW
          L16
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L17
           RETURN
 [9]_asm_procedureupdatevariables_setobservervariable_12 "set" Object => void
       _round "round" double => double
@@ -2045,28 +2147,28 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           _max "max"
             _asm_procedureupdatevariables_turtlevariableof_13 "of" Object => Object
               _turtles "turtles" => AgentSet
-                  TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-                  TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-                 L4
+                  // parameter final  context
+                  // parameter final  context
+                  // parameter final  agentOrSet
+                  TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+                 L3
                   ALOAD 0
                   GETFIELD org/nlogo/prim/_asm_procedureupdatevariables_turtlevariableof_13.world : Lorg/nlogo/agent/World;
                   INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-                 L5
+                 L4
                   ASTORE 2
-                 L2
+                 L0
                   ALOAD 2
+                  INSTANCEOF org/nlogo/agent/Agent
+                  IFEQ L5
+                  ALOAD 2
+                  CHECKCAST org/nlogo/agent/Agent
                   ASTORE 4
                   ALOAD 4
-                  INSTANCEOF org/nlogo/agent/Agent
-                  IFEQ L6
-                  ALOAD 4
-                  CHECKCAST org/nlogo/agent/Agent
-                  ASTORE 5
-                  ALOAD 5
                   INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
                   LDC -1
                   LCMP
-                  IFNE L7
+                  IFNE L6
                   NEW org/nlogo/nvm/RuntimePrimitiveException
                   DUP
                   ALOAD 1
@@ -2079,45 +2181,45 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
                   ANEWARRAY java/lang/Object
                   DUP
                   ICONST_0
-                  ALOAD 5
+                  ALOAD 4
                   INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
                   AASTORE
                   INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
                   INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
                   INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                   ATHROW
-                 L7
-                 FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_turtlevariableof_13 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T org/nlogo/agent/TreeAgentSet org/nlogo/agent/Agent] []
-                  ALOAD 5
+                 L6
+                 FRAME APPEND [org/nlogo/agent/TreeAgentSet T org/nlogo/agent/Agent]
+                  ALOAD 4
                   BIPUSH 13
                   INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-                  ASTORE 6
-                  GOTO L8
-                 L6
-                 FRAME CHOP 1
-                  ALOAD 4
+                  ASTORE 3
+                  GOTO L7
+                 L5
+                 FRAME CHOP 2
+                  ALOAD 2
                   INSTANCEOF org/nlogo/agent/AgentSet
-                  IFEQ L0
-                  ALOAD 4
+                  IFEQ L8
+                  ALOAD 2
                   CHECKCAST org/nlogo/agent/AgentSet
-                  ASTORE 7
+                  ASTORE 5
                   NEW org/nlogo/api/LogoListBuilder
                   DUP
                   INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-                  ASTORE 8
-                  ALOAD 7
+                  ASTORE 6
+                  ALOAD 5
                   ALOAD 1
                   GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
                   GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
                   INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-                  ASTORE 9
+                  ASTORE 7
                  L9
-                 FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_turtlevariableof_13 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T org/nlogo/agent/TreeAgentSet T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-                  ALOAD 9
+                 FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_turtlevariableof_13 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+                  ALOAD 7
                   INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
                   IFEQ L10
-                  ALOAD 8
-                  ALOAD 9
+                  ALOAD 6
+                  ALOAD 7
                   INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
                   BIPUSH 13
                   INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
@@ -2125,16 +2227,12 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
                   GOTO L9
                  L10
                  FRAME SAME
-                  ALOAD 8
-                  INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-                  ASTORE 6
-                 L8
-                 FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_turtlevariableof_13 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T org/nlogo/agent/TreeAgentSet T java/lang/Object] []
                   ALOAD 6
-                 L3
-                  GOTO L11
-                 L0
-                 FRAME CHOP 2
+                  INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+                  ASTORE 3
+                  GOTO L7
+                 L8
+                 FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_turtlevariableof_13 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet] []
                   NEW org/nlogo/nvm/ArgumentTypeException
                   DUP
                   ALOAD 1
@@ -2148,21 +2246,34 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
                   ALOAD 2
                   INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                   ATHROW
+                 L7
+                 FRAME APPEND [java/lang/Object]
+                  ALOAD 3
                  L1
+                  GOTO L11
+                 L2
                  FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_turtlevariableof_13 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet] [org/nlogo/api/AgentException]
-                  ASTORE 3
+                  ASTORE 8
                   NEW org/nlogo/nvm/RuntimePrimitiveException
                   DUP
                   ALOAD 1
                   ALOAD 0
-                  ALOAD 3
+                  ALOAD 8
                   INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
                   INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                   ATHROW
                  L11
-                 FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_turtlevariableof_13 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T org/nlogo/agent/TreeAgentSet T java/lang/Object] [java/lang/Object]
+                 FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_turtlevariableof_13 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet java/lang/Object] [java/lang/Object]
                   ARETURN
           _constdouble:1.2 "1.2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
           ALOAD 0
@@ -2218,9 +2329,6 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L10
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_12 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -2235,8 +2343,13 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           ATHROW
          L10
          FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [10]_asm_procedureupdatevariables_return_14 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2249,6 +2362,9 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
 procedure GO:[]{O---}:
 [0]_asm_procedurego_ask_0 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_0.world : Lorg/nlogo/agent/World;
@@ -2321,6 +2437,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [2]_asm_procedurego_done_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2329,6 +2446,9 @@ procedure GO:[]{O---}:
           RETURN
 [3]_asm_procedurego_ask_3 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_3.world : Lorg/nlogo/agent/World;
@@ -2401,6 +2521,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [5]_asm_procedurego_done_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2411,6 +2532,13 @@ procedure GO:[]{O---}:
       _plus "+" double,double => double
         _observervariable:VCLOCK "vclock" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -2462,9 +2590,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L10
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setobservervariable_6 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -2479,11 +2604,22 @@ procedure GO:[]{O---}:
           ATHROW
          L10
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [7]_asm_procedurego_if_7 "if" boolean => void
       _equal "=" Object,Object => boolean
         _observervariable:VCLOCK "vclock" => Object
         _observervariable:VSPLIT "vsplit" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_if_7.world : Lorg/nlogo/agent/World;
@@ -2521,6 +2657,9 @@ procedure GO:[]{O---}:
 [8]_tick "tick"
 [9]_asm_procedurego_setobservervariable_8 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2535,9 +2674,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setobservervariable_8 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -2552,6 +2688,10 @@ procedure GO:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [10]_asm_procedurego_call_9 "update-variables"
          L0
@@ -2609,6 +2749,9 @@ procedure GO:[]{O---}:
           RETURN
 [13]_asm_procedurego_ask_12 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_12.world : Lorg/nlogo/agent/World;
@@ -2681,6 +2824,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [15]_asm_procedurego_done_14 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2688,6 +2832,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [16]_asm_procedurego_return_15 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2724,6 +2869,42 @@ procedure BOUNCE:[]{-T--}:
             _lessthan "<" double,double => boolean
               _turtlevariabledouble:HEADING "heading" => double
               _constdouble:270.0 "270" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -2734,10 +2915,8 @@ procedure BOUNCE:[]{-T--}:
           IFEQ L3
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L4
          L3
          FRAME APPEND [T org/nlogo/agent/Agent]
@@ -2746,26 +2925,21 @@ procedure BOUNCE:[]{-T--}:
           IFEQ L5
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L4
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 5
           ASTORE 2
-          ALOAD 2
-          ICONST_1
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-          GOTO L6
+          GOTO L4
          L5
-         FRAME CHOP 2
+         FRAME SAME
           NEW scala/MatchError
           DUP
           ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L4
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 2
+          ICONST_1
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] [D]
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurebounce_if_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.observer ()Lorg/nlogo/agent/Observer;
@@ -2775,11 +2949,9 @@ procedure BOUNCE:[]{-T--}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L8
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -2790,19 +2962,19 @@ procedure BOUNCE:[]{-T--}:
           ICONST_1
           GOTO L10
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L10
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L11
          L8
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L11
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L12
           IFEQ L13
          L14
@@ -2823,7 +2995,7 @@ procedure BOUNCE:[]{-T--}:
           ICONST_1
           GOTO L18
          L17
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context D D T I] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context D D] []
           ICONST_0
          L18
          FRAME SAME1 I
@@ -2858,10 +3030,10 @@ procedure BOUNCE:[]{-T--}:
          FRAME SAME1 I
           GOTO L26
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context D java/lang/Object java/lang/Object T I] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context D java/lang/Object I] []
           ICONST_0
          L26
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context D T T T I] [I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context D] [I]
           IFNE L27
          L28
           ALOAD 1
@@ -2872,38 +3044,31 @@ procedure BOUNCE:[]{-T--}:
           IFEQ L29
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L30
          L29
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context T org/nlogo/agent/Agent T T T I] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context T org/nlogo/agent/Agent] []
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Patch
           IFEQ L31
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L30
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context T org/nlogo/agent/Agent T org/nlogo/agent/Patch T I] []
-          ALOAD 5
           ASTORE 2
-          ALOAD 2
-          ICONST_1
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-          GOTO L32
+          GOTO L30
          L31
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context T org/nlogo/agent/Agent T T T I] []
+         FRAME SAME
           NEW scala/MatchError
           DUP
           ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L30
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 2
+          ICONST_1
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
          L32
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T I] [D]
           DCONST_0
          L33
           ALOAD 0
@@ -2919,7 +3084,7 @@ procedure BOUNCE:[]{-T--}:
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           GOTO L35
          L1
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent T org/nlogo/agent/Patch T I] [java/lang/ClassCastException]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent] [java/lang/ClassCastException]
           POP
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
@@ -2931,7 +3096,7 @@ procedure BOUNCE:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
          L35
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent T org/nlogo/agent/Patch T I] [D D D]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent] [D D D]
           DSTORE 4
           DSTORE 2
           DLOAD 2
@@ -2947,7 +3112,7 @@ procedure BOUNCE:[]{-T--}:
           ICONST_1
           GOTO L38
          L37
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context D D T I] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context D D] []
           ICONST_0
          L38
          FRAME SAME1 I
@@ -3011,7 +3176,7 @@ procedure BOUNCE:[]{-T--}:
          FRAME SAME1 I
           GOTO L53
          L27
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context D T T T I] []
+         FRAME CHOP 1
           ICONST_1
          L53
          FRAME SAME1 I
@@ -3022,10 +3187,10 @@ procedure BOUNCE:[]{-T--}:
           ICONST_1
           GOTO L55
          L54
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context I T T T T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context I] [org/nlogo/nvm/Context]
           ICONST_2
          L55
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context I T T T T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_0 org/nlogo/nvm/Context I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L56
           RETURN
@@ -3033,6 +3198,13 @@ procedure BOUNCE:[]{-T--}:
       _minus "-" double,double => double
         _constdouble:180.0 "180" => double
         _turtlevariabledouble:HEADING "heading" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           LDC 180.0
@@ -3062,9 +3234,6 @@ procedure BOUNCE:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -3079,6 +3248,10 @@ procedure BOUNCE:[]{-T--}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [2]_asm_procedurebounce_if_2 "if" boolean => void
       _or "or"
@@ -3102,6 +3275,37 @@ procedure BOUNCE:[]{-T--}:
           _greaterthan ">" double,double => boolean
             _turtlevariabledouble:HEADING "heading" => double
             _constdouble:180.0 "180" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -3112,10 +3316,8 @@ procedure BOUNCE:[]{-T--}:
           IFEQ L3
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L4
          L3
          FRAME APPEND [T org/nlogo/agent/Agent]
@@ -3124,26 +3326,21 @@ procedure BOUNCE:[]{-T--}:
           IFEQ L5
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L4
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 5
           ASTORE 2
-          ALOAD 2
-          ICONST_0
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-          GOTO L6
+          GOTO L4
          L5
-         FRAME CHOP 2
+         FRAME SAME
           NEW scala/MatchError
           DUP
           ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L4
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 2
+          ICONST_0
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] [D]
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurebounce_if_2.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.observer ()Lorg/nlogo/agent/Observer;
@@ -3153,11 +3350,9 @@ procedure BOUNCE:[]{-T--}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L8
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -3168,19 +3363,19 @@ procedure BOUNCE:[]{-T--}:
           ICONST_1
           GOTO L10
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L10
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L11
          L8
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L11
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L12
           IFEQ L13
          L14
@@ -3201,7 +3396,7 @@ procedure BOUNCE:[]{-T--}:
           ICONST_1
           GOTO L18
          L17
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context D D T I] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context D D] []
           ICONST_0
          L18
          FRAME SAME1 I
@@ -3236,10 +3431,10 @@ procedure BOUNCE:[]{-T--}:
          FRAME SAME1 I
           GOTO L26
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context D java/lang/Object java/lang/Object T I] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context D java/lang/Object I] []
           ICONST_0
          L26
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context D T T T I] [I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context D] [I]
           IFNE L27
          L28
           ALOAD 1
@@ -3250,38 +3445,31 @@ procedure BOUNCE:[]{-T--}:
           IFEQ L29
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L30
          L29
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context T org/nlogo/agent/Agent T T T I] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context T org/nlogo/agent/Agent] []
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Patch
           IFEQ L31
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L30
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context T org/nlogo/agent/Agent T org/nlogo/agent/Patch T I] []
-          ALOAD 5
           ASTORE 2
-          ALOAD 2
-          ICONST_0
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-          GOTO L32
+          GOTO L30
          L31
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context T org/nlogo/agent/Agent T T T I] []
+         FRAME SAME
           NEW scala/MatchError
           DUP
           ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L30
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 2
+          ICONST_0
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
          L32
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T I] [D]
           DCONST_0
          L33
           ALOAD 0
@@ -3297,7 +3485,7 @@ procedure BOUNCE:[]{-T--}:
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           GOTO L35
          L1
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent T org/nlogo/agent/Patch T I] [java/lang/ClassCastException]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent] [java/lang/ClassCastException]
           POP
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
@@ -3309,7 +3497,7 @@ procedure BOUNCE:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
          L35
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent T org/nlogo/agent/Patch T I] [D D D]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/Agent] [D D D]
           DSTORE 4
           DSTORE 2
           DLOAD 2
@@ -3325,7 +3513,7 @@ procedure BOUNCE:[]{-T--}:
           ICONST_1
           GOTO L38
          L37
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context D D T I] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context D D] []
           ICONST_0
          L38
          FRAME SAME1 I
@@ -3360,7 +3548,7 @@ procedure BOUNCE:[]{-T--}:
          FRAME SAME1 I
           GOTO L46
          L27
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context D T T T I] []
+         FRAME CHOP 1
           ICONST_1
          L46
          FRAME SAME1 I
@@ -3371,10 +3559,10 @@ procedure BOUNCE:[]{-T--}:
           ICONST_3
           GOTO L48
          L47
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context I T T T T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context I] [org/nlogo/nvm/Context]
           ICONST_4
          L48
-         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context I T T T T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurebounce_if_2 org/nlogo/nvm/Context I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L49
           RETURN
@@ -3382,6 +3570,13 @@ procedure BOUNCE:[]{-T--}:
       _minus "-" double,double => double
         _constdouble:0.0 "0" => double
         _turtlevariabledouble:HEADING "heading" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           DCONST_0
@@ -3411,9 +3606,6 @@ procedure BOUNCE:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebounce_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -3428,8 +3620,13 @@ procedure BOUNCE:[]{-T--}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [4]_asm_procedurebounce_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -3444,17 +3641,21 @@ procedure MOVE:[]{-T--}:
       _div "/" double,double => double
         _turtlevariable:SPEED "speed" => Object
         _observervariable:VSPLIT "vsplit" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  distance
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
-          TRYCATCHBLOCK L7 L8 L8 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L7 L8 L9 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           BIPUSH 13
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
          L1
-          GOTO L9
+          GOTO L10
          L2
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -3466,14 +3667,14 @@ procedure MOVE:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
+         L10
          FRAME SAME1 java/lang/Object
           ASTORE 2
          L3
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
-          GOTO L10
+          GOTO L11
          L4
          FRAME FULL [org/nlogo/prim/_asm_proceduremove_jump_0 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
           POP
@@ -3486,20 +3687,20 @@ procedure MOVE:[]{-T--}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
-         L10
+         L11
          FRAME SAME1 D
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduremove_jump_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.observer ()Lorg/nlogo/agent/Observer;
           BIPUSH 12
           INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
-         L11
+         L12
           ASTORE 2
          L5
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
-          GOTO L12
+          GOTO L13
          L6
          FRAME SAME1 java/lang/ClassCastException
           POP
@@ -3512,14 +3713,14 @@ procedure MOVE:[]{-T--}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
-         L12
+         L13
          FRAME FULL [org/nlogo/prim/_asm_proceduremove_jump_0 org/nlogo/nvm/Context java/lang/Object] [D D]
           DSTORE 4
           DSTORE 2
           DLOAD 4
           DCONST_0
           DCMPL
-          IFNE L13
+          IFNE L14
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3529,12 +3730,12 @@ procedure MOVE:[]{-T--}:
           INVOKEINTERFACE org/nlogo/core/I18NJava.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L13
+         L14
          FRAME FULL [org/nlogo/prim/_asm_proceduremove_jump_0 org/nlogo/nvm/Context D D] []
           DLOAD 2
           DLOAD 4
           DDIV
-         L14
+         L15
           DSTORE 2
          L7
           ALOAD 1
@@ -3542,16 +3743,17 @@ procedure MOVE:[]{-T--}:
           CHECKCAST org/nlogo/agent/Turtle
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L15
          L8
+          GOTO L16
+         L9
          FRAME SAME1 org/nlogo/api/AgentException
-          ASTORE 4
-         L15
-         FRAME CHOP 1
+          POP
+         L16
+         FRAME SAME
           ALOAD 1
           ICONST_1
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L16
+         L17
           RETURN
 [1]_asm_proceduremove_call_1 "check-for-collision"
          L0
@@ -3580,6 +3782,17 @@ procedure MOVE:[]{-T--}:
             _constdouble:0.0 "0" => double
         _not "not" boolean => boolean
           _patchvariable:BOX? "box?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -3682,12 +3895,12 @@ procedure MOVE:[]{-T--}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L20
-          ICONST_0
+          IFNE L20
+          ICONST_1
           GOTO L21
          L20
          FRAME FULL [org/nlogo/prim/_asm_proceduremove_if_2 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L21
          FRAME SAME1 I
           GOTO L22
@@ -3712,6 +3925,9 @@ procedure MOVE:[]{-T--}:
           RETURN
 [3]_asm_proceduremove_setpatchvariable_3 "set" Object => void
       _constdouble:45.0 "yellow" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3725,9 +3941,6 @@ procedure MOVE:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremove_setpatchvariable_3 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -3742,8 +3955,13 @@ procedure MOVE:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduremove_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -3762,6 +3980,17 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
           _countother "count" AgentSet => double
             _turtleshere "turtles-here" => AgentSet
           _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -3806,12 +4035,12 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L7
-          ICONST_0
+          IFNE L7
+          ICONST_1
           GOTO L8
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_0 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L8
          FRAME SAME1 I
           IFEQ L9
@@ -3902,6 +4131,12 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
       _oneof "one-of" AgentSet => Object
         _other "other" AgentSet => AgentSet
           _turtleshere "turtles-here" => AgentSet
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  context
+          // parameter final  agents
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -3987,9 +4222,6 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Object I org/nlogo/agent/AgentIterator] [org/nlogo/api/AgentException]
@@ -4004,6 +4236,10 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [2]_asm_procedurecheckforcollision_if_2 "if" boolean => void
       _and "and"
@@ -4014,12 +4250,25 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
         _notequal "!=" Object,Object => boolean
           _turtlevariable:TURTLE2 "turtle2" => Object
           _turtlevariable:TMP-TURTLE "tmp-turtle" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agentOrSet
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L3 L4 L4 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L5 L6 L4 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L7 L8 L9 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L10 L11 L12 org/nlogo/api/AgentException
-         L13
+          TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L6 L7 L8 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L9 L10 L11 org/nlogo/api/AgentException
+         L12
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
@@ -4031,7 +4280,7 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
           BIPUSH 19
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
          L1
-          GOTO L14
+          GOTO L13
          L2
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -4043,23 +4292,21 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L14
+         L13
          FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context] [D java/lang/Object]
           ASTORE 2
-         L5
+         L3
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L14
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L15
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L16
+          IFNE L15
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4072,45 +4319,45 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L16
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] [D]
-          ALOAD 5
+         L15
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context java/lang/Object T org/nlogo/agent/Agent] [D]
+          ALOAD 4
           ICONST_0
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L17
-         L15
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object] [D]
-          ALOAD 4
+          ASTORE 3
+          GOTO L16
+         L14
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context java/lang/Object] [D]
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L3
-          ALOAD 4
+          IFEQ L17
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L18
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [D]
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [D]
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L19
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           ICONST_0
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
@@ -4118,16 +4365,12 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
           GOTO L18
          L19
          FRAME SAME1 D
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L17
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [D]
           ALOAD 6
-         L6
-          GOTO L20
-         L3
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object] [D]
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L16
+         L17
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context java/lang/Object] [D]
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -4141,27 +4384,30 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L16
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [D]
+          ALOAD 3
          L4
+          GOTO L20
+         L5
          FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L20
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [D java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [D java/lang/Object]
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L21
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -4172,15 +4418,14 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
           ICONST_1
           GOTO L23
          L22
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L23
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L24
          L21
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Object] []
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4209,16 +4454,18 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L24
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
-          IFEQ L25
-         L7
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
+         L25
+          IFEQ L26
+         L6
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           BIPUSH 25
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
+         L7
+          GOTO L9
          L8
-          GOTO L10
-         L9
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -4229,15 +4476,15 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L10
+         L9
          FRAME SAME1 java/lang/Object
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           BIPUSH 19
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
+         L10
+          GOTO L27
          L11
-          GOTO L26
-         L12
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -4248,41 +4495,41 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L26
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [java/lang/Object java/lang/Object]
+         L27
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context D java/lang/Object I java/lang/Double] [java/lang/Object java/lang/Object]
           ASTORE 3
           ASTORE 2
           GETSTATIC org/nlogo/api/Equality$.MODULE$ : Lorg/nlogo/api/Equality$;
           ALOAD 2
           ALOAD 3
           INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-          IFEQ L27
-          ICONST_0
-          GOTO L28
-         L27
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context java/lang/Object java/lang/Object java/lang/Object java/lang/Object java/lang/Double I] []
+          IFNE L28
           ICONST_1
-         L28
-         FRAME SAME1 I
           GOTO L29
-         L25
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] []
+         L28
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context java/lang/Object java/lang/Object java/lang/Object I java/lang/Double] []
           ICONST_0
          L29
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context T T java/lang/Object java/lang/Object java/lang/Double I] [I]
+         FRAME SAME1 I
+          GOTO L30
+         L26
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context D java/lang/Object I java/lang/Double] []
+          ICONST_0
+         L30
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context T T java/lang/Object I java/lang/Double] [I]
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L30
+          IFEQ L31
           ICONST_3
-          GOTO L31
-         L30
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          ICONST_5
+          GOTO L32
          L31
-         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context]
+          ICONST_5
          L32
+         FRAME FULL [org/nlogo/prim/_asm_procedurecheckforcollision_if_2 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L33
           RETURN
 [3]_asm_procedurecheckforcollision_call_3 "collide"
          L0
@@ -4305,6 +4552,9 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
 [4]_asm_procedurecheckforcollision_call_4 "recolor-turtle"
       _turtle "turtle" double => Object
         _turtlevariabledouble:WHO "who" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  idDouble
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -4327,7 +4577,8 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforcollision_call_4.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforcollision_call_4.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           LLOAD 4
           L2D
@@ -4338,14 +4589,14 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           DLOAD 2
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (D)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (D)Ljava/lang/StringBuilder;
           LDC " is not an integer"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -4374,6 +4625,7 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
          L6
           RETURN
 [5]_asm_procedurecheckforcollision_return_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -4439,6 +4691,7 @@ procedure COLLIDE:[]{-T--}:
          L1
           RETURN
 [3]_asm_procedurecollide_return_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -4451,6 +4704,9 @@ procedure COLLIDE:[]{-T--}:
 procedure GET-TURTLE2-INFO:[]{-T--}:
 [0]_asm_proceduregetturtle2info_setturtlevariable_0 "set" Object => void
       _turtlevariable:TMP-TURTLE "tmp-turtle" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -4481,9 +4737,6 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L4
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L5
          FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_0 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -4498,21 +4751,29 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [1]_asm_proceduregetturtle2info_setturtlevariable_1 "set" Object => void
       _turtlevariableof:MASS "of" Object => Object
         _turtlevariable:TURTLE2 "turtle2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agentOrSet
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L3 L4 L4 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L5 L6 L4 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L7 L8 L9 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L6 L7 L8 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           BIPUSH 25
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
          L1
-          GOTO L10
+          GOTO L9
          L2
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -4524,23 +4785,21 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L10
+         L9
          FRAME SAME1 java/lang/Object
           ASTORE 2
-         L5
+         L3
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L10
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L11
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L12
+          IFNE L11
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4553,45 +4812,45 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L12
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-          ALOAD 5
+         L11
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+          ALOAD 4
           BIPUSH 14
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L13
-         L11
-         FRAME CHOP 1
-          ALOAD 4
+          ASTORE 3
+          GOTO L12
+         L10
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L3
-          ALOAD 4
+          IFEQ L13
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L14
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L15
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           BIPUSH 14
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
@@ -4599,16 +4858,12 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
           GOTO L14
          L15
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L13
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
           ALOAD 6
-         L6
-          GOTO L16
-         L3
-         FRAME CHOP 2
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L12
+         L13
+         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -4622,32 +4877,34 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L12
+         FRAME APPEND [java/lang/Object]
+          ALOAD 3
          L4
+          GOTO L16
+         L5
          FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L16
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
           ASTORE 2
-         L7
+         L6
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           BIPUSH 21
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
-         L8
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L7
           GOTO L17
-         L9
+         L8
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 3
           NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -4660,21 +4917,29 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
           ATHROW
          L17
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [2]_asm_proceduregetturtle2info_setturtlevariable_2 "set" Object => void
       _turtlevariableof:NEW-SPEED "of" Object => Object
         _turtlevariable:TURTLE2 "turtle2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agentOrSet
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L3 L4 L4 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L5 L6 L4 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L7 L8 L9 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L6 L7 L8 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           BIPUSH 25
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
          L1
-          GOTO L10
+          GOTO L9
          L2
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -4686,23 +4951,21 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L10
+         L9
          FRAME SAME1 java/lang/Object
           ASTORE 2
-         L5
+         L3
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L10
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L11
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L12
+          IFNE L11
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4715,45 +4978,45 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L12
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-          ALOAD 5
+         L11
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+          ALOAD 4
           BIPUSH 16
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L13
-         L11
-         FRAME CHOP 1
-          ALOAD 4
+          ASTORE 3
+          GOTO L12
+         L10
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L3
-          ALOAD 4
+          IFEQ L13
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L14
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_2 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L15
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           BIPUSH 16
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
@@ -4761,16 +5024,12 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
           GOTO L14
          L15
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L13
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
           ALOAD 6
-         L6
-          GOTO L16
-         L3
-         FRAME CHOP 2
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L12
+         L13
+         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_2 org/nlogo/nvm/Context java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -4784,32 +5043,34 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L12
+         FRAME APPEND [java/lang/Object]
+          ALOAD 3
          L4
+          GOTO L16
+         L5
          FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_2 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L16
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_2 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
           ASTORE 2
-         L7
+         L6
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           BIPUSH 22
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
-         L8
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L7
           GOTO L17
-         L9
+         L8
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 3
           NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -4822,21 +5083,29 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
           ATHROW
          L17
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [3]_asm_proceduregetturtle2info_setturtlevariable_3 "set" Object => void
       _turtlevariableof:HEADING "of" Object => Object
         _turtlevariable:TURTLE2 "turtle2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agentOrSet
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L3 L4 L4 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L5 L6 L4 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L7 L8 L9 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L6 L7 L8 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           BIPUSH 25
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
          L1
-          GOTO L10
+          GOTO L9
          L2
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -4848,23 +5117,21 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L10
+         L9
          FRAME SAME1 java/lang/Object
           ASTORE 2
-         L5
+         L3
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L10
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L11
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L12
+          IFNE L11
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4877,45 +5144,45 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L12
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-          ALOAD 5
+         L11
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+          ALOAD 4
           ICONST_2
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L13
-         L11
-         FRAME CHOP 1
-          ALOAD 4
+          ASTORE 3
+          GOTO L12
+         L10
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L3
-          ALOAD 4
+          IFEQ L13
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L14
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L15
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           ICONST_2
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
@@ -4923,16 +5190,12 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
           GOTO L14
          L15
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L13
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
           ALOAD 6
-         L6
-          GOTO L16
-         L3
-         FRAME CHOP 2
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L12
+         L13
+         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -4946,32 +5209,34 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L12
+         FRAME APPEND [java/lang/Object]
+          ALOAD 3
          L4
+          GOTO L16
+         L5
          FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L16
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_proceduregetturtle2info_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
           ASTORE 2
-         L7
+         L6
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           BIPUSH 20
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
-         L8
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L7
           GOTO L17
-         L9
+         L8
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 3
           NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -4984,8 +5249,13 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
           ATHROW
          L17
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [4]_asm_proceduregetturtle2info_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -4998,6 +5268,9 @@ procedure GET-TURTLE2-INFO:[]{-T--}:
 procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
 [0]_asm_procedurecalculatevelocitycomponents_setturtlevariable_0 "set" Object => void
       _randomconst:360 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -5020,9 +5293,6 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_0 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -5037,6 +5307,10 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [1]_asm_procedurecalculatevelocitycomponents_setturtlevariable_1 "set" Object => void
       _mult "*" double,double => double
@@ -5045,6 +5319,19 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           _minus "-" double,double => double
             _turtlevariable:THETA "theta" => Object
             _turtlevariabledouble:HEADING "heading" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -5165,9 +5452,6 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L11
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L20
          L12
          FRAME FULL [org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -5182,6 +5466,10 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           ATHROW
          L20
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L21
           RETURN
 [2]_asm_procedurecalculatevelocitycomponents_setturtlevariable_2 "set" Object => void
       _mult "*" double,double => double
@@ -5190,6 +5478,19 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           _minus "-" double,double => double
             _turtlevariable:THETA "theta" => Object
             _turtlevariabledouble:HEADING "heading" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -5310,9 +5611,6 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L11
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L20
          L12
          FRAME FULL [org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_2 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -5327,6 +5625,10 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           ATHROW
          L20
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L21
           RETURN
 [3]_asm_procedurecalculatevelocitycomponents_setturtlevariable_3 "set" Object => void
       _mult "*" double,double => double
@@ -5335,6 +5637,19 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           _minus "-" double,double => double
             _turtlevariable:THETA "theta" => Object
             _turtlevariable:HEADING2 "heading2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -5490,9 +5805,6 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L16
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L25
          L17
          FRAME FULL [org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -5507,6 +5819,10 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           ATHROW
          L25
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L26
           RETURN
 [4]_asm_procedurecalculatevelocitycomponents_setturtlevariable_4 "set" Object => void
       _mult "*" double,double => double
@@ -5515,6 +5831,19 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           _minus "-" double,double => double
             _turtlevariable:THETA "theta" => Object
             _turtlevariable:HEADING2 "heading2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -5670,9 +5999,6 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L16
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L25
          L17
          FRAME FULL [org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_4 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -5687,6 +6013,10 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           ATHROW
          L25
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L26
           RETURN
 [5]_asm_procedurecalculatevelocitycomponents_setprocedurevariable_5 "let" Object => void
       _div "/" double,double => double
@@ -5700,6 +6030,26 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
         _plus "+" double,double => double
           _turtlevariable:MASS "mass" => Object
           _turtlevariable:MASS2 "mass2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -6015,6 +6365,17 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           _procedurevariable:VCM "vcm" => Object
           _procedurevariable:VCM "vcm" => Object
         _turtlevariable:V1T "v1t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L6 org/nlogo/api/AgentException
@@ -6137,9 +6498,6 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L10
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L20
          L11
          FRAME FULL [org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_6 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -6154,6 +6512,10 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           ATHROW
          L20
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L21
           RETURN
 [7]_asm_procedurecalculatevelocitycomponents_setturtlevariable_7 "set" Object => void
       _minus "-" double,double => double
@@ -6161,6 +6523,17 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           _procedurevariable:VCM "vcm" => Object
           _procedurevariable:VCM "vcm" => Object
         _turtlevariable:V2T "v2t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L6 org/nlogo/api/AgentException
@@ -6283,9 +6656,6 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L10
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L20
          L11
          FRAME FULL [org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_7 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -6300,8 +6670,13 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           ATHROW
          L20
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L21
           RETURN
 [8]_asm_procedurecalculatevelocitycomponents_return_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -6321,6 +6696,21 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           _mult "*" double,double => double
             _turtlevariable:V1L "v1l" => Object
             _turtlevariable:V1L "v1l" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -6544,9 +6934,6 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L21
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L33
          L22
          FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_0 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -6561,6 +6948,10 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ATHROW
          L33
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L34
           RETURN
 [1]_asm_proceduresetnewspeedandheadings_ifelse_1 "ifelse" boolean => void
       _and "and"
@@ -6570,6 +6961,12 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
         _greaterorequal ">=" Object,double => boolean
           _turtlevariable:V1T "v1t" => Object
           _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -6733,6 +7130,17 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
         _atan "atan" double,double => double
           _turtlevariable:V1L "v1l" => Object
           _turtlevariable:V1T "v1t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -6918,6 +7326,7 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           GOTO L25
          L26
          FRAME SAME1 D
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
@@ -6925,6 +7334,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           SIPUSH 360
           I2D
           DADD
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
           SIPUSH 360
           I2D
           DREM
@@ -6949,9 +7360,6 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L16
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L29
          L17
          FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_2 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -6966,8 +7374,13 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ATHROW
          L29
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L30
           RETURN
 [3]_asm_proceduresetnewspeedandheadings_goto_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 12
@@ -6982,6 +7395,18 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
         _lessthan "<" Object,double => boolean
           _turtlevariable:V1T "v1t" => Object
           _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -7009,14 +7434,10 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L8
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
@@ -7024,15 +7445,14 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ICONST_1
           GOTO L10
          L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_4 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L10
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L11
          L8
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -7061,15 +7481,17 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_4 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
-          IFEQ L12
+         FRAME APPEND [I]
+          ILOAD 5
+         L12
+          IFEQ L13
          L3
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           BIPUSH 17
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
          L4
-          GOTO L13
+          GOTO L14
          L5
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -7081,36 +7503,31 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L13
+         L14
          FRAME SAME1 java/lang/Object
           DCONST_0
-         L14
+         L15
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
-          IFEQ L15
-          ALOAD 5
+          IFEQ L16
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
-          IFGE L16
+          IFGE L17
           ICONST_1
-          GOTO L17
-         L16
+          GOTO L18
+         L17
          FRAME SAME
           ICONST_0
-         L17
+         L18
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
-          GOTO L18
-         L15
+          ISTORE 5
+          GOTO L19
+         L16
          FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -7139,27 +7556,29 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L18
-         FRAME SAME1 I
-          GOTO L19
-         L12
+         L19
+         FRAME SAME
+          ILOAD 5
+         L20
+          GOTO L21
+         L13
          FRAME SAME
           ICONST_0
-         L19
+         L21
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L20
+          IFEQ L22
           ICONST_5
-          GOTO L21
-         L20
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_4 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 7
-         L21
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_4 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+          GOTO L23
          L22
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_4 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 7
+         L23
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_4 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L24
           RETURN
 [5]_asm_proceduresetnewspeedandheadings_setturtlevariable_5 "set" Object => void
       _minus "-" double,double => double
@@ -7169,6 +7588,21 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
         _atan "atan" double,double => double
           _turtlevariable:V1L "v1l" => Object
           _turtlevariable:V1T "v1t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -7362,6 +7796,7 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           GOTO L27
          L28
          FRAME SAME1 D
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
@@ -7369,6 +7804,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           SIPUSH 360
           I2D
           DADD
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
           SIPUSH 360
           I2D
           DREM
@@ -7393,9 +7830,6 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L16
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L31
          L17
          FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_5 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -7410,8 +7844,13 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ATHROW
          L31
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L32
           RETURN
 [6]_asm_proceduresetnewspeedandheadings_goto_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 12
@@ -7426,6 +7865,15 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
         _lessthan "<" Object,double => boolean
           _turtlevariable:V1T "v1t" => Object
           _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -7521,14 +7969,10 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L15
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
@@ -7536,15 +7980,14 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ICONST_1
           GOTO L17
          L16
-         FRAME APPEND [java/lang/Object java/lang/Double]
+         FRAME SAME
           ICONST_0
          L17
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L18
          L15
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -7573,26 +8016,28 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L18
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_7 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
-          GOTO L19
-         L12
-         FRAME CHOP 3
-          ICONST_0
+         FRAME APPEND [I]
+          ILOAD 5
          L19
+          GOTO L20
+         L12
+         FRAME CHOP 1
+          ICONST_0
+         L20
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L20
+          IFEQ L21
           BIPUSH 8
-          GOTO L21
-         L20
+          GOTO L22
+         L21
          FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_7 org/nlogo/nvm/Context I D] [org/nlogo/nvm/Context]
           BIPUSH 10
-         L21
+         L22
          FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_7 org/nlogo/nvm/Context I D] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L22
+         L23
           RETURN
 [8]_asm_proceduresetnewspeedandheadings_setturtlevariable_8 "set" Object => void
       _minus "-" double,double => double
@@ -7602,6 +8047,21 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
         _atan "atan" double,double => double
           _turtlevariable:V1L "v1l" => Object
           _turtlevariable:V1T "v1t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -7795,6 +8255,7 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           GOTO L27
          L28
          FRAME SAME1 D
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
@@ -7802,6 +8263,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           SIPUSH 360
           I2D
           DADD
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
           SIPUSH 360
           I2D
           DREM
@@ -7826,9 +8289,6 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L16
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L31
          L17
          FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_8 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -7843,8 +8303,13 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ATHROW
          L31
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L32
           RETURN
 [9]_asm_proceduresetnewspeedandheadings_goto_9 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 12
@@ -7859,6 +8324,15 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
         _greaterorequal ">=" Object,double => boolean
           _turtlevariable:V1T "v1t" => Object
           _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -7886,14 +8360,10 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L8
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
@@ -7901,15 +8371,14 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ICONST_1
           GOTO L10
          L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_if_10 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L10
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L11
          L8
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -7938,15 +8407,17 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_if_10 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
-          IFEQ L12
+         FRAME APPEND [I]
+          ILOAD 5
+         L12
+          IFEQ L13
          L3
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           BIPUSH 17
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
          L4
-          GOTO L13
+          GOTO L14
          L5
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -7958,30 +8429,30 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L13
+         L14
          FRAME SAME1 java/lang/Object
           DCONST_0
-         L14
+         L15
           DSTORE 3
           ASTORE 2
           ALOAD 2
           INSTANCEOF java/lang/Double
-          IFEQ L15
+          IFEQ L16
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
-          IFLT L16
+          IFLT L17
           ICONST_1
-          GOTO L17
-         L16
+          GOTO L18
+         L17
          FRAME SAME
           ICONST_0
-         L17
+         L18
          FRAME SAME1 I
-          GOTO L18
-         L15
+          GOTO L19
+         L16
          FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -8005,27 +8476,27 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKEINTERFACE org/nlogo/core/I18NJava.getN (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L18
+         L19
          FRAME SAME1 I
-          GOTO L19
-         L12
+          GOTO L20
+         L13
          FRAME SAME
           ICONST_0
-         L19
+         L20
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L20
+          IFEQ L21
           BIPUSH 11
-          GOTO L21
-         L20
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_if_10 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 12
+          GOTO L22
          L21
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_if_10 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_if_10 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 12
          L22
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_if_10 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L23
           RETURN
 [11]_asm_proceduresetnewspeedandheadings_setturtlevariable_11 "set" Object => void
       _minus "-" double,double => double
@@ -8033,6 +8504,17 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
         _atan "atan" double,double => double
           _turtlevariable:V1L "v1l" => Object
           _turtlevariable:V1T "v1t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -8218,6 +8700,7 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           GOTO L25
          L26
          FRAME SAME1 D
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
@@ -8225,6 +8708,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           SIPUSH 360
           I2D
           DADD
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
           SIPUSH 360
           I2D
           DREM
@@ -8249,9 +8734,6 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L16
-          ALOAD 1
-          BIPUSH 12
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L29
          L17
          FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_11 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -8266,6 +8748,10 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ATHROW
          L29
          FRAME SAME
+          ALOAD 1
+          BIPUSH 12
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L30
           RETURN
 [12]_asm_proceduresetnewspeedandheadings_setprocedurevariable_12 "let" Object => void
       _sqrt "sqrt" double => double
@@ -8276,6 +8762,21 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           _mult "*" double,double => double
             _turtlevariable:V2L "v2l" => Object
             _turtlevariable:V2L "v2l" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -8504,6 +9005,9 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           RETURN
 [13]_asm_proceduresetnewspeedandheadings_ask_13 "ask" Object => void
       _turtlevariable:TURTLE2 "turtle2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -8527,18 +9031,16 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          FRAME SAME1 java/lang/Object
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L4
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L5
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ask_13.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -8554,8 +9056,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ask_13 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ask_13.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -8572,18 +9074,18 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ATHROW
          L5
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L7
          L4
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L8
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -8600,7 +9102,7 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -8610,23 +9112,12 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L9
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ask_13 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 14
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 16
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L10
+          GOTO L7
          L8
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -8640,11 +9131,22 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L7
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 14
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 16
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L10
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ask_13 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [14]_asm_proceduresetnewspeedandheadings_setturtlevariable_14 "set" Object => void
       _procedurevariable:NEW-NEW-SPEED "new-new-speed" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -8661,9 +9163,6 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 15
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_14 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -8678,8 +9177,13 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 15
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [15]_asm_proceduresetnewspeedandheadings_done_15 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -8694,6 +9198,12 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
         _greaterorequal ">=" Object,double => boolean
           _turtlevariable:V2T "v2t" => Object
           _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -8857,6 +9367,17 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
         _atan "atan" double,double => double
           _turtlevariable:V2L "v2l" => Object
           _turtlevariable:V2T "v2t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -9042,6 +9563,7 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           GOTO L25
          L26
          FRAME SAME1 D
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
@@ -9049,6 +9571,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           SIPUSH 360
           I2D
           DADD
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_17.validDouble (DLorg/nlogo/nvm/Context;)D
           SIPUSH 360
           I2D
           DREM
@@ -9073,9 +9597,6 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L16
-          ALOAD 1
-          BIPUSH 18
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L29
          L17
          FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_17 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -9090,8 +9611,13 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ATHROW
          L29
          FRAME SAME
+          ALOAD 1
+          BIPUSH 18
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L30
           RETURN
 [18]_asm_proceduresetnewspeedandheadings_goto_18 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 27
@@ -9106,6 +9632,18 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
         _lessthan "<" Object,double => boolean
           _turtlevariable:V2T "v2t" => Object
           _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -9133,14 +9671,10 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L8
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
@@ -9148,15 +9682,14 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ICONST_1
           GOTO L10
          L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_19 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L10
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L11
          L8
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -9185,15 +9718,17 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_19 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
-          IFEQ L12
+         FRAME APPEND [I]
+          ILOAD 5
+         L12
+          IFEQ L13
          L3
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           BIPUSH 23
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
          L4
-          GOTO L13
+          GOTO L14
          L5
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -9205,36 +9740,31 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L13
+         L14
          FRAME SAME1 java/lang/Object
           DCONST_0
-         L14
+         L15
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
-          IFEQ L15
-          ALOAD 5
+          IFEQ L16
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
-          IFGE L16
+          IFGE L17
           ICONST_1
-          GOTO L17
-         L16
+          GOTO L18
+         L17
          FRAME SAME
           ICONST_0
-         L17
+         L18
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
-          GOTO L18
-         L15
+          ISTORE 5
+          GOTO L19
+         L16
          FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -9263,27 +9793,29 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L18
-         FRAME SAME1 I
-          GOTO L19
-         L12
+         L19
+         FRAME SAME
+          ILOAD 5
+         L20
+          GOTO L21
+         L13
          FRAME SAME
           ICONST_0
-         L19
+         L21
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L20
+          IFEQ L22
           BIPUSH 20
-          GOTO L21
-         L20
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_19 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 22
-         L21
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_19 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+          GOTO L23
          L22
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_19 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 22
+         L23
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_19 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L24
           RETURN
 [20]_asm_proceduresetnewspeedandheadings_setturtlevariable_20 "set" Object => void
       _minus "-" double,double => double
@@ -9293,6 +9825,21 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
         _atan "atan" double,double => double
           _turtlevariable:V2L "v2l" => Object
           _turtlevariable:V2T "v2t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -9486,6 +10033,7 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           GOTO L27
          L28
          FRAME SAME1 D
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
@@ -9493,6 +10041,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           SIPUSH 360
           I2D
           DADD
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_20.validDouble (DLorg/nlogo/nvm/Context;)D
           SIPUSH 360
           I2D
           DREM
@@ -9517,9 +10067,6 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L16
-          ALOAD 1
-          BIPUSH 21
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L31
          L17
          FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_20 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -9534,8 +10081,13 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ATHROW
          L31
          FRAME SAME
+          ALOAD 1
+          BIPUSH 21
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L32
           RETURN
 [21]_asm_proceduresetnewspeedandheadings_goto_21 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 27
@@ -9550,6 +10102,15 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
         _lessthan "<" Object,double => boolean
           _turtlevariable:V2T "v2t" => Object
           _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -9645,14 +10206,10 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L15
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
@@ -9660,15 +10217,14 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ICONST_1
           GOTO L17
          L16
-         FRAME APPEND [java/lang/Object java/lang/Double]
+         FRAME SAME
           ICONST_0
          L17
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L18
          L15
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -9697,26 +10253,28 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L18
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_22 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
-          GOTO L19
-         L12
-         FRAME CHOP 3
-          ICONST_0
+         FRAME APPEND [I]
+          ILOAD 5
          L19
+          GOTO L20
+         L12
+         FRAME CHOP 1
+          ICONST_0
+         L20
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L20
+          IFEQ L21
           BIPUSH 23
-          GOTO L21
-         L20
+          GOTO L22
+         L21
          FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_22 org/nlogo/nvm/Context I D] [org/nlogo/nvm/Context]
           BIPUSH 25
-         L21
+         L22
          FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ifelse_22 org/nlogo/nvm/Context I D] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L22
+         L23
           RETURN
 [23]_asm_proceduresetnewspeedandheadings_setturtlevariable_23 "set" Object => void
       _minus "-" double,double => double
@@ -9726,6 +10284,21 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
         _atan "atan" double,double => double
           _turtlevariable:V2L "v2l" => Object
           _turtlevariable:V2T "v2t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -9919,6 +10492,7 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           GOTO L27
          L28
          FRAME SAME1 D
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
@@ -9926,6 +10500,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           SIPUSH 360
           I2D
           DADD
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_23.validDouble (DLorg/nlogo/nvm/Context;)D
           SIPUSH 360
           I2D
           DREM
@@ -9950,9 +10526,6 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L16
-          ALOAD 1
-          BIPUSH 24
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L31
          L17
          FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_23 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -9967,8 +10540,13 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ATHROW
          L31
          FRAME SAME
+          ALOAD 1
+          BIPUSH 24
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L32
           RETURN
 [24]_asm_proceduresetnewspeedandheadings_goto_24 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 27
@@ -9983,6 +10561,15 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
         _greaterorequal ">=" Object,double => boolean
           _turtlevariable:V2T "v2t" => Object
           _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -10010,14 +10597,10 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L8
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
@@ -10025,15 +10608,14 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ICONST_1
           GOTO L10
          L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_if_25 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L10
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L11
          L8
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -10062,15 +10644,17 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_if_25 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
-          IFEQ L12
+         FRAME APPEND [I]
+          ILOAD 5
+         L12
+          IFEQ L13
          L3
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           BIPUSH 23
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
          L4
-          GOTO L13
+          GOTO L14
          L5
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -10082,30 +10666,30 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L13
+         L14
          FRAME SAME1 java/lang/Object
           DCONST_0
-         L14
+         L15
           DSTORE 3
           ASTORE 2
           ALOAD 2
           INSTANCEOF java/lang/Double
-          IFEQ L15
+          IFEQ L16
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
-          IFLT L16
+          IFLT L17
           ICONST_1
-          GOTO L17
-         L16
+          GOTO L18
+         L17
          FRAME SAME
           ICONST_0
-         L17
+         L18
          FRAME SAME1 I
-          GOTO L18
-         L15
+          GOTO L19
+         L16
          FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -10129,27 +10713,27 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKEINTERFACE org/nlogo/core/I18NJava.getN (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L18
+         L19
          FRAME SAME1 I
-          GOTO L19
-         L12
+          GOTO L20
+         L13
          FRAME SAME
           ICONST_0
-         L19
+         L20
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L20
+          IFEQ L21
           BIPUSH 26
-          GOTO L21
-         L20
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_if_25 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 27
+          GOTO L22
          L21
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_if_25 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_if_25 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 27
          L22
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_if_25 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L23
           RETURN
 [26]_asm_proceduresetnewspeedandheadings_setturtlevariable_26 "set" Object => void
       _minus "-" double,double => double
@@ -10157,6 +10741,17 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
         _atan "atan" double,double => double
           _turtlevariable:V2L "v2l" => Object
           _turtlevariable:V2T "v2t" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -10342,6 +10937,7 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           GOTO L25
          L26
          FRAME SAME1 D
+          ALOAD 0
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.atan2 (DD)D
@@ -10349,6 +10945,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           SIPUSH 360
           I2D
           DADD
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_26.validDouble (DLorg/nlogo/nvm/Context;)D
           SIPUSH 360
           I2D
           DREM
@@ -10373,9 +10971,6 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L16
-          ALOAD 1
-          BIPUSH 27
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L29
          L17
          FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_26 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -10390,9 +10985,16 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ATHROW
          L29
          FRAME SAME
+          ALOAD 1
+          BIPUSH 27
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L30
           RETURN
 [27]_asm_proceduresetnewspeedandheadings_setprocedurevariable_27 "let" Object => void
       _turtlevariable:HEADING2 "heading2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -10428,6 +11030,9 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           RETURN
 [28]_asm_proceduresetnewspeedandheadings_ask_28 "ask" Object => void
       _turtlevariable:TURTLE2 "turtle2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -10451,18 +11056,16 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          FRAME SAME1 java/lang/Object
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L4
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L5
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ask_28.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -10478,8 +11081,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ask_28 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ask_28.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -10496,18 +11099,18 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ATHROW
          L5
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L7
          L4
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L8
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -10524,7 +11127,7 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -10534,23 +11137,12 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L9
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ask_28 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 29
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 31
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L10
+          GOTO L7
          L8
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -10564,11 +11156,22 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L7
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 29
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 31
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L10
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_ask_28 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [29]_asm_proceduresetnewspeedandheadings_setturtlevariable_29 "set" Object => void
       _procedurevariable:NEW-HEADING "new-heading" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -10585,9 +11188,6 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 30
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_29 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -10602,8 +11202,13 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 30
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [30]_asm_proceduresetnewspeedandheadings_done_30 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -10612,6 +11217,7 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           RETURN
 [31]_asm_proceduresetnewspeedandheadings_call_31 "recolor-turtle"
       _turtlevariable:TURTLE2 "turtle2" => Object
+          // parameter final  context
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           NEW org/nlogo/nvm/Activation
@@ -10655,6 +11261,7 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
          L5
           RETURN
 [32]_asm_proceduresetnewspeedandheadings_return_32 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -10672,31 +11279,41 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
         _mult "*" double,double => double
           _constdouble:0.5 "0.5" => double
           _observervariable:INITSPEED "initspeed" => Object
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
-         L6
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agentOrSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
+         L5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_0
           AALOAD
-         L7
+         L6
           ASTORE 2
-         L2
+         L0
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L7
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L8
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L9
+          IFNE L8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -10709,45 +11326,45 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-          ALOAD 5
+         L8
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+          ALOAD 4
           BIPUSH 16
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L10
-         L8
-         FRAME CHOP 1
-          ALOAD 4
+          ASTORE 3
+          GOTO L9
+         L7
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L0
-          ALOAD 4
+          IFEQ L10
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L12
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           BIPUSH 16
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
@@ -10755,16 +11372,12 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           GOTO L11
          L12
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
           ALOAD 6
-         L3
-          GOTO L13
-         L0
-         FRAME CHOP 2
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L9
+         L10
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -10778,19 +11391,24 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L9
+         FRAME APPEND [java/lang/Object]
+          ALOAD 3
          L1
+          GOTO L13
+         L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
           LDC 0.5
          L14
           ALOAD 0
@@ -10800,12 +11418,12 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
          L15
           ASTORE 2
-         L4
+         L3
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           GOTO L16
-         L5
+         L4
          FRAME SAME1 java/lang/ClassCastException
           POP
           NEW org/nlogo/nvm/ArgumentTypeException
@@ -10818,7 +11436,7 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
          L16
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object D D]
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object D D]
           DSTORE 4
           DSTORE 2
           DLOAD 2
@@ -10828,14 +11446,10 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L18
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
@@ -10843,15 +11457,14 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ICONST_1
           GOTO L20
          L19
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context java/lang/Object D] []
           ICONST_0
          L20
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L21
          L18
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Object] []
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -10880,23 +11493,28 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L21
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L22
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L22
+          IFEQ L23
           ICONST_1
-          GOTO L23
-         L22
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          ICONST_5
+          GOTO L24
          L23
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          ICONST_5
          L24
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L25
           RETURN
 [1]_asm_procedurerecolorturtle_ask_1 "ask" Object => void
       _procedurevariable:THE-TURTLE "the-turtle" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -10906,18 +11524,16 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerecolorturtle_ask_1.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -10933,8 +11549,8 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ask_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerecolorturtle_ask_1.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -10951,18 +11567,18 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -10979,7 +11595,7 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -10989,23 +11605,12 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ask_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_2
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -11019,11 +11624,22 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          ICONST_2
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ask_1 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [2]_asm_procedurerecolorturtle_setturtleorlinkvariable_2 "set" Object => void
       _constdouble:105.0 "blue" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -11037,9 +11653,6 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_setturtleorlinkvariable_2 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -11054,8 +11667,13 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_procedurerecolorturtle_done_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -11063,6 +11681,7 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
          L1
           RETURN
 [4]_asm_procedurerecolorturtle_goto_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 13
@@ -11076,31 +11695,41 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
         _mult "*" double,double => double
           _constdouble:1.5 "1.5" => double
           _observervariable:INITSPEED "initspeed" => Object
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
-         L6
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agentOrSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
+         L5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_0
           AALOAD
-         L7
+         L6
           ASTORE 2
-         L2
+         L0
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L7
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L8
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L9
+          IFNE L8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -11113,45 +11742,45 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-          ALOAD 5
+         L8
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+          ALOAD 4
           BIPUSH 16
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L10
-         L8
-         FRAME CHOP 1
-          ALOAD 4
+          ASTORE 3
+          GOTO L9
+         L7
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L0
-          ALOAD 4
+          IFEQ L10
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L12
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           BIPUSH 16
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
@@ -11159,16 +11788,12 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           GOTO L11
          L12
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
           ALOAD 6
-         L3
-          GOTO L13
-         L0
-         FRAME CHOP 2
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L9
+         L10
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -11182,19 +11807,24 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L9
+         FRAME APPEND [java/lang/Object]
+          ALOAD 3
          L1
+          GOTO L13
+         L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
           LDC 1.5
          L14
           ALOAD 0
@@ -11204,12 +11834,12 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
          L15
           ASTORE 2
-         L4
+         L3
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           GOTO L16
-         L5
+         L4
          FRAME SAME1 java/lang/ClassCastException
           POP
           NEW org/nlogo/nvm/ArgumentTypeException
@@ -11222,7 +11852,7 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
          L16
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object D D]
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object D D]
           DSTORE 4
           DSTORE 2
           DLOAD 2
@@ -11232,14 +11862,10 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L18
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -11247,15 +11873,14 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ICONST_1
           GOTO L20
          L19
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context java/lang/Object D] []
           ICONST_0
          L20
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L21
          L18
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Object] []
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -11284,23 +11909,28 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L21
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L22
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L22
+          IFEQ L23
           BIPUSH 6
-          GOTO L23
-         L22
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 10
+          GOTO L24
          L23
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          BIPUSH 10
          L24
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L25
           RETURN
 [6]_asm_procedurerecolorturtle_ask_6 "ask" Object => void
       _procedurevariable:THE-TURTLE "the-turtle" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -11310,18 +11940,16 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerecolorturtle_ask_6.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -11337,8 +11965,8 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ask_6 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerecolorturtle_ask_6.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -11355,18 +11983,18 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -11383,7 +12011,7 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -11393,23 +12021,12 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ask_6 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 7
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -11423,11 +12040,22 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 7
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ask_6 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [7]_asm_procedurerecolorturtle_setturtleorlinkvariable_7 "set" Object => void
       _constdouble:15.0 "red" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -11441,9 +12069,6 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_setturtleorlinkvariable_7 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -11458,8 +12083,13 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [8]_asm_procedurerecolorturtle_done_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -11467,6 +12097,7 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
          L1
           RETURN
 [9]_asm_procedurerecolorturtle_goto_9 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 13
@@ -11475,6 +12106,9 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           RETURN
 [10]_asm_procedurerecolorturtle_ask_10 "ask" Object => void
       _procedurevariable:THE-TURTLE "the-turtle" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -11484,18 +12118,16 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerecolorturtle_ask_10.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -11511,8 +12143,8 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ask_10 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerecolorturtle_ask_10.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -11529,18 +12161,18 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -11557,7 +12189,7 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -11567,23 +12199,12 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ask_10 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 11
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 13
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -11597,11 +12218,22 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 11
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 13
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_ask_10 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [11]_asm_procedurerecolorturtle_setturtleorlinkvariable_11 "set" Object => void
       _constdouble:55.0 "green" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -11615,9 +12247,6 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 12
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtle_setturtleorlinkvariable_11 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -11632,8 +12261,13 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 12
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [12]_asm_procedurerecolorturtle_done_12 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -11641,6 +12275,7 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
          L1
           RETURN
 [13]_asm_procedurerecolorturtle_return_13 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -11658,6 +12293,16 @@ procedure FADE:[]{-TP-}:
         _notequal "!=" Object,double => boolean
           _patchvariable:PCOLOR "pcolor" => Object
           _constdouble:0.0 "black" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -11703,12 +12348,12 @@ procedure FADE:[]{-TP-}:
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L10
-          ICONST_0
+          IFNE L10
+          ICONST_1
           GOTO L11
          L10
          FRAME FULL [org/nlogo/prim/_asm_procedurefade_if_0 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L11
          FRAME SAME1 I
           IFEQ L12
@@ -11737,11 +12382,9 @@ procedure FADE:[]{-TP-}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L15
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -11752,19 +12395,19 @@ procedure FADE:[]{-TP-}:
           ICONST_1
           GOTO L17
          L16
-         FRAME FULL [org/nlogo/prim/_asm_procedurefade_if_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurefade_if_0 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L17
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L18
          L15
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L18
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L19
           GOTO L20
          L12
@@ -11790,6 +12433,13 @@ procedure FADE:[]{-TP-}:
       _minus "-" double,double => double
         _patchvariable:PCOLOR "pcolor" => Object
         _constdouble:0.4 "0.4" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -11854,9 +12504,6 @@ procedure FADE:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurefade_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -11871,12 +12518,25 @@ procedure FADE:[]{-TP-}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [2]_asm_procedurefade_if_2 "if" boolean => void
       _equal "=" double,double => boolean
         _round "round" double => double
           _patchvariable:PCOLOR "pcolor" => Object
         _constdouble:40.0 "40" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -11956,6 +12616,9 @@ procedure FADE:[]{-TP-}:
           RETURN
 [3]_asm_procedurefade_setpatchvariable_3 "set" Object => void
       _constdouble:0.0 "black" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -11969,9 +12632,6 @@ procedure FADE:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurefade_setpatchvariable_3 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -11986,8 +12646,13 @@ procedure FADE:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_procedurefade_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -12000,6 +12665,9 @@ procedure FADE:[]{-TP-}:
 procedure MAKE-BOX:[]{OTPL}:
 [0]_asm_proceduremakebox_ask_0 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduremakebox_ask_0.world : Lorg/nlogo/agent/World;
@@ -12055,6 +12723,9 @@ procedure MAKE-BOX:[]{OTPL}:
           RETURN
 [1]_asm_proceduremakebox_setpatchvariable_1 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -12068,9 +12739,6 @@ procedure MAKE-BOX:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -12085,6 +12753,10 @@ procedure MAKE-BOX:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_proceduremakebox_if_2 "if" boolean => void
       _or "or"
@@ -12106,6 +12778,30 @@ procedure MAKE-BOX:[]{OTPL}:
             _abs "abs" double => double
               _patchvariabledouble:PXCOR "pxcor" => double
             _observervariable:BOX-EDGE "box-edge" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -12115,10 +12811,8 @@ procedure MAKE-BOX:[]{OTPL}:
           IFEQ L1
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L2
          L1
          FRAME APPEND [T org/nlogo/agent/Agent]
@@ -12127,26 +12821,21 @@ procedure MAKE-BOX:[]{OTPL}:
           IFEQ L3
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L2
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 5
           ASTORE 2
-          ALOAD 2
-          ICONST_0
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-          GOTO L4
+          GOTO L2
          L3
-         FRAME CHOP 2
+         FRAME SAME
           NEW scala/MatchError
           DUP
           ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L2
+         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 2
+          ICONST_0
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
          L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch] [D]
           DSTORE 2
           DLOAD 2
           ICONST_0
@@ -12157,7 +12846,7 @@ procedure MAKE-BOX:[]{OTPL}:
           DNEG
           GOTO L6
          L5
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context D T org/nlogo/agent/Patch] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context D] []
           DLOAD 2
          L6
          FRAME SAME1 D
@@ -12170,11 +12859,9 @@ procedure MAKE-BOX:[]{OTPL}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L8
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -12185,19 +12872,19 @@ procedure MAKE-BOX:[]{OTPL}:
           ICONST_1
           GOTO L10
          L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object T java/lang/Double]
           ICONST_0
          L10
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L11
          L8
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L11
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L12
           IFEQ L13
          L14
@@ -12209,38 +12896,31 @@ procedure MAKE-BOX:[]{OTPL}:
           IFEQ L15
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L16
          L15
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object I] []
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Patch
           IFEQ L17
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L16
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] []
-          ALOAD 5
           ASTORE 2
-          ALOAD 2
-          ICONST_1
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-          GOTO L18
+          GOTO L16
          L17
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+         FRAME SAME
           NEW scala/MatchError
           DUP
           ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L16
+         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object I] []
+          ALOAD 2
+          ICONST_1
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
          L18
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] [D]
           DSTORE 2
           DLOAD 2
           ICONST_0
@@ -12251,7 +12931,7 @@ procedure MAKE-BOX:[]{OTPL}:
           DNEG
           GOTO L20
          L19
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context D java/lang/Object org/nlogo/agent/Patch T I] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context D java/lang/Object I] []
           DLOAD 2
          L20
          FRAME SAME1 D
@@ -12308,7 +12988,7 @@ procedure MAKE-BOX:[]{OTPL}:
          FRAME SAME1 I
           GOTO L26
          L13
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context D java/lang/Object java/lang/Object T I] []
+         FRAME SAME
           ICONST_0
          L26
          FRAME SAME1 I
@@ -12322,38 +13002,31 @@ procedure MAKE-BOX:[]{OTPL}:
           IFEQ L29
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L30
          L29
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object I] []
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Patch
           IFEQ L31
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L30
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] []
-          ALOAD 5
           ASTORE 2
-          ALOAD 2
-          ICONST_1
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-          GOTO L32
+          GOTO L30
          L31
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+         FRAME SAME
           NEW scala/MatchError
           DUP
           ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L30
+         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object I] []
+          ALOAD 2
+          ICONST_1
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
          L32
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] [D]
           DSTORE 2
           DLOAD 2
           ICONST_0
@@ -12364,7 +13037,7 @@ procedure MAKE-BOX:[]{OTPL}:
           DNEG
           GOTO L34
          L33
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context D java/lang/Object org/nlogo/agent/Patch T I] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context D java/lang/Object I] []
           DLOAD 2
          L34
          FRAME SAME1 D
@@ -12377,11 +13050,9 @@ procedure MAKE-BOX:[]{OTPL}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L36
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -12392,19 +13063,19 @@ procedure MAKE-BOX:[]{OTPL}:
           ICONST_1
           GOTO L38
          L37
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] []
+         FRAME APPEND [java/lang/Double]
           ICONST_0
          L38
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L39
          L36
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context D java/lang/Object java/lang/Object T I] []
+         FRAME CHOP 1
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L39
          FRAME SAME
-          ILOAD 7
+          ILOAD 5
          L40
           IFEQ L41
          L42
@@ -12416,38 +13087,31 @@ procedure MAKE-BOX:[]{OTPL}:
           IFEQ L43
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L44
          L43
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object I] []
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Patch
           IFEQ L45
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L44
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] []
-          ALOAD 5
           ASTORE 2
-          ALOAD 2
-          ICONST_0
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
-          GOTO L46
+          GOTO L44
          L45
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context T org/nlogo/agent/Agent java/lang/Object java/lang/Object T I] []
+         FRAME SAME
           NEW scala/MatchError
           DUP
           ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L44
+         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object I] []
+          ALOAD 2
+          ICONST_0
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariableDouble (I)D
          L46
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent java/lang/Object org/nlogo/agent/Patch T I] [D]
           DSTORE 2
           DLOAD 2
           ICONST_0
@@ -12458,7 +13122,7 @@ procedure MAKE-BOX:[]{OTPL}:
           DNEG
           GOTO L48
          L47
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context D java/lang/Object org/nlogo/agent/Patch T I] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context D java/lang/Object I] []
           DLOAD 2
          L48
          FRAME SAME1 D
@@ -12515,7 +13179,7 @@ procedure MAKE-BOX:[]{OTPL}:
          FRAME SAME1 I
           GOTO L54
          L41
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context D java/lang/Object java/lang/Object T I] []
+         FRAME SAME
           ICONST_0
          L54
          FRAME SAME1 I
@@ -12532,15 +13196,18 @@ procedure MAKE-BOX:[]{OTPL}:
           ICONST_3
           GOTO L57
          L56
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context I T java/lang/Object I] [org/nlogo/nvm/Context]
           ICONST_5
          L57
-         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_if_2 org/nlogo/nvm/Context I T java/lang/Object I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L58
           RETURN
 [3]_asm_proceduremakebox_setpatchvariable_3 "set" Object => void
       _constdouble:15.0 "red" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -12554,9 +13221,6 @@ procedure MAKE-BOX:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_setpatchvariable_3 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -12571,9 +13235,16 @@ procedure MAKE-BOX:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduremakebox_setpatchvariable_4 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -12587,9 +13258,6 @@ procedure MAKE-BOX:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakebox_setpatchvariable_4 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -12604,8 +13272,13 @@ procedure MAKE-BOX:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [5]_asm_proceduremakebox_done_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -12613,6 +13286,7 @@ procedure MAKE-BOX:[]{OTPL}:
          L1
           RETURN
 [6]_asm_proceduremakebox_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -12644,6 +13318,44 @@ procedure RANDOM-POSITION:[]{-T--}:
               _constdouble:2.0 "2" => double
               _observervariable:BOX-EDGE "box-edge" => Object
             _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  maxDouble
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  maxDouble
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -12729,7 +13441,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -12870,7 +13583,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -12981,6 +13695,7 @@ procedure RANDOM-POSITION:[]{-T--}:
          L47
           RETURN
 [1]_asm_procedurerandomposition_return_1 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -12993,18 +13708,21 @@ procedure RANDOM-POSITION:[]{-T--}:
 procedure SETUP-PLOTZ:[]{OTPL}:
 [0]_setcurrentplot "set-current-plot"
       _asm_proceduresetupplotz_conststring_0 ""Speed Counts"" => String
+            // parameter final  context
            L0
             LDC "Speed Counts"
            L1
             ARETURN
 [1]_setplotyrange "set-plot-y-range"
       _asm_proceduresetupplotz_constdouble_1 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupplotz_constdouble_1.kept1_value : Ljava/lang/Double;
            L1
             ARETURN
       _asm_proceduresetupplotz_observervariable_2 "number" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupplotz_observervariable_2.world : Lorg/nlogo/agent/World;
@@ -13014,6 +13732,7 @@ procedure SETUP-PLOTZ:[]{OTPL}:
            L1
             ARETURN
 [2]_asm_proceduresetupplotz_return_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -13026,18 +13745,21 @@ procedure SETUP-PLOTZ:[]{OTPL}:
 procedure DO-PLOTTING:[]{OTPL}:
 [0]_setcurrentplot "set-current-plot"
       _asm_proceduredoplotting_conststring_0 ""Speed Counts"" => String
+            // parameter final  context
            L0
             LDC "Speed Counts"
            L1
             ARETURN
 [1]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredoplotting_conststring_1 ""fast"" => String
+            // parameter final  context
            L0
             LDC "fast"
            L1
             ARETURN
 [2]_plot "plot"
       _asm_proceduredoplotting_observervariable_2 "fast" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredoplotting_observervariable_2.world : Lorg/nlogo/agent/World;
@@ -13048,12 +13770,14 @@ procedure DO-PLOTTING:[]{OTPL}:
             ARETURN
 [3]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredoplotting_conststring_3 ""average"" => String
+            // parameter final  context
            L0
             LDC "average"
            L1
             ARETURN
 [4]_plot "plot"
       _asm_proceduredoplotting_observervariable_4 "average" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredoplotting_observervariable_4.world : Lorg/nlogo/agent/World;
@@ -13064,12 +13788,14 @@ procedure DO-PLOTTING:[]{OTPL}:
             ARETURN
 [5]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredoplotting_conststring_5 ""slow"" => String
+            // parameter final  context
            L0
             LDC "slow"
            L1
             ARETURN
 [6]_plot "plot"
       _asm_proceduredoplotting_observervariable_6 "slow" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredoplotting_observervariable_6.world : Lorg/nlogo/agent/World;
@@ -13079,6 +13805,7 @@ procedure DO-PLOTTING:[]{OTPL}:
            L1
             ARETURN
 [7]_asm_proceduredoplotting_return_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -13091,12 +13818,14 @@ procedure DO-PLOTTING:[]{OTPL}:
 procedure SETUP-HISTOGRAMS:[]{OTPL}:
 [0]_setcurrentplot "set-current-plot"
       _asm_proceduresetuphistograms_conststring_0 ""Speed Histogram"" => String
+            // parameter final  context
            L0
             LDC "Speed Histogram"
            L1
             ARETURN
 [1]_setplotxrange "set-plot-x-range"
       _asm_proceduresetuphistograms_constdouble_1 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_1.kept1_value : Ljava/lang/Double;
@@ -13105,6 +13834,11 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
       _asm_proceduresetuphistograms_mult_2 "*" double,double => double
         _observervariable:INITSPEED "initspeed" => Object
         _constdouble:2.0 "2" => double
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
            L2
             ALOAD 0
@@ -13149,6 +13883,7 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [2]_setplotyrange "set-plot-y-range"
       _asm_proceduresetuphistograms_constdouble_3 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_3.kept1_value : Ljava/lang/Double;
@@ -13158,6 +13893,10 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
         _div "/" double,double => double
           _observervariable:NUMBER "number" => Object
           _constdouble:6.0 "6" => double
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  d0
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
            L2
             ALOAD 0
@@ -13223,12 +13962,14 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [3]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduresetuphistograms_conststring_5 ""average"" => String
+            // parameter final  context
            L0
             LDC "average"
            L1
             ARETURN
 [4]_sethistogramnumbars "set-histogram-num-bars"
       _asm_proceduresetuphistograms_constdouble_6 "32" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_6.kept1_value : Ljava/lang/Double;
@@ -13236,12 +13977,14 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [5]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduresetuphistograms_conststring_7 ""slow"" => String
+            // parameter final  context
            L0
             LDC "slow"
            L1
             ARETURN
 [6]_sethistogramnumbars "set-histogram-num-bars"
       _asm_proceduresetuphistograms_constdouble_8 "32" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_8.kept1_value : Ljava/lang/Double;
@@ -13249,12 +13992,14 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [7]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduresetuphistograms_conststring_9 ""fast"" => String
+            // parameter final  context
            L0
             LDC "fast"
            L1
             ARETURN
 [8]_sethistogramnumbars "set-histogram-num-bars"
       _asm_proceduresetuphistograms_constdouble_10 "32" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_10.kept1_value : Ljava/lang/Double;
@@ -13262,12 +14007,14 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [9]_setcurrentplot "set-current-plot"
       _asm_proceduresetuphistograms_conststring_11 ""Energy Histogram"" => String
+            // parameter final  context
            L0
             LDC "Energy Histogram"
            L1
             ARETURN
 [10]_setplotxrange "set-plot-x-range"
       _asm_proceduresetuphistograms_constdouble_12 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_12.kept1_value : Ljava/lang/Double;
@@ -13284,6 +14031,27 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             _observervariable:INITSPEED "initspeed" => Object
             _constdouble:2.0 "2" => double
         _observervariable:INITMASS "initmass" => Object
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
             TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
             TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -13410,6 +14178,7 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [11]_setplotyrange "set-plot-y-range"
       _asm_proceduresetuphistograms_constdouble_14 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_14.kept1_value : Ljava/lang/Double;
@@ -13419,6 +14188,10 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
         _div "/" double,double => double
           _observervariable:NUMBER "number" => Object
           _constdouble:6.0 "6" => double
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  d0
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
            L2
             ALOAD 0
@@ -13484,12 +14257,14 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [12]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduresetuphistograms_conststring_16 ""average"" => String
+            // parameter final  context
            L0
             LDC "average"
            L1
             ARETURN
 [13]_sethistogramnumbars "set-histogram-num-bars"
       _asm_proceduresetuphistograms_constdouble_17 "32" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_17.kept1_value : Ljava/lang/Double;
@@ -13497,12 +14272,14 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [14]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduresetuphistograms_conststring_18 ""slow"" => String
+            // parameter final  context
            L0
             LDC "slow"
            L1
             ARETURN
 [15]_sethistogramnumbars "set-histogram-num-bars"
       _asm_proceduresetuphistograms_constdouble_19 "32" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_19.kept1_value : Ljava/lang/Double;
@@ -13510,18 +14287,21 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             ARETURN
 [16]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduresetuphistograms_conststring_20 ""fast"" => String
+            // parameter final  context
            L0
             LDC "fast"
            L1
             ARETURN
 [17]_sethistogramnumbars "set-histogram-num-bars"
       _asm_proceduresetuphistograms_constdouble_21 "32" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuphistograms_constdouble_21.kept1_value : Ljava/lang/Double;
            L1
             ARETURN
 [18]_asm_proceduresetuphistograms_return_22 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -13534,12 +14314,14 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
 procedure DO-HISTOGRAMS:[]{OTPL}:
 [0]_setcurrentplot "set-current-plot"
       _asm_proceduredohistograms_conststring_0 ""Speed Histogram"" => String
+            // parameter final  context
            L0
             LDC "Speed Histogram"
            L1
             ARETURN
 [1]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredohistograms_conststring_1 ""average"" => String
+            // parameter final  context
            L0
             LDC "average"
            L1
@@ -13551,6 +14333,11 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
           _asm_proceduredohistograms_equal_3 "=" Object,double => boolean
             _turtleorlinkvariable:COLOR "color" => Object
             _constdouble:55.0 "green" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  d1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -13577,11 +14364,9 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                 DSTORE 3
                 ASTORE 2
                 ALOAD 2
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L5
-                ALOAD 5
+                ALOAD 2
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 3
@@ -13592,19 +14377,19 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                 ICONST_1
                 GOTO L7
                L6
-               FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_equal_3 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_equal_3 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                 ICONST_0
                L7
                FRAME SAME1 I
-                ISTORE 7
+                ISTORE 5
                 GOTO L8
                L5
-               FRAME CHOP 1
+               FRAME CHOP 2
                 ICONST_0
-                ISTORE 7
+                ISTORE 5
                L8
-               FRAME APPEND [T I]
-                ILOAD 7
+               FRAME APPEND [I]
+                ILOAD 5
                L9
                 IFEQ L10
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -13615,13 +14400,18 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                L11
                FRAME SAME1 java/lang/Boolean
                 ARETURN
-            TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-            TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-           L4
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  reporterBlock
+            // parameter final  context
+            // parameter final  agentOrSet
+            TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+           L3
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_2.world : Lorg/nlogo/agent/World;
             INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-           L5
+           L4
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_2.keptinstr4 : Lorg/nlogo/nvm/Reporter;
             ASTORE 3
@@ -13644,11 +14434,11 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ALOAD 2
             INVOKEVIRTUAL org/nlogo/agent/AgentSet.iterator ()Lorg/nlogo/agent/AgentIterator;
             ASTORE 6
-           L6
+           L5
            FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_2 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
             ALOAD 6
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-            IFEQ L7
+            IFEQ L6
             ALOAD 6
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
             ASTORE 7
@@ -13659,28 +14449,18 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ASTORE 8
             ALOAD 8
             INSTANCEOF java/lang/Boolean
-            IFEQ L8
+            IFEQ L7
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L9
+            IFEQ L5
             ALOAD 5
             ALOAD 7
             INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-            GOTO L10
-           L9
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L10
-           FRAME SAME1 java/lang/Object
-            ASTORE 10
-            ALOAD 10
             POP
-            GOTO L6
-           L8
-           FRAME CHOP 1
+            GOTO L5
+           L7
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -13711,7 +14491,7 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L7
+           L6
            FRAME CHOP 2
             GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
             ALOAD 2
@@ -13723,22 +14503,20 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
             CHECKCAST [Lorg/nlogo/agent/Agent;
             INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-           L11
+           L8
             ASTORE 2
-           L2
+           L0
             ALOAD 2
+            INSTANCEOF org/nlogo/agent/Agent
+            IFEQ L9
+            ALOAD 2
+            CHECKCAST org/nlogo/agent/Agent
             ASTORE 4
             ALOAD 4
-            INSTANCEOF org/nlogo/agent/Agent
-            IFEQ L12
-            ALOAD 4
-            CHECKCAST org/nlogo/agent/Agent
-            ASTORE 5
-            ALOAD 5
             INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
             LDC -1
             LCMP
-            IFNE L13
+            IFNE L10
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -13751,62 +14529,58 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ANEWARRAY java/lang/Object
             DUP
             ICONST_0
-            ALOAD 5
+            ALOAD 4
             INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
             AASTORE
             INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
             INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L13
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_2 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet org/nlogo/agent/Agent org/nlogo/agent/AgentIterator] []
-            ALOAD 5
+           L10
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_2 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/Agent scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            ALOAD 4
             BIPUSH 13
             INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-            ASTORE 6
-            GOTO L14
-           L12
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_2 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
-            ALOAD 4
+            ASTORE 3
+            GOTO L11
+           L9
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_2 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            ALOAD 2
             INSTANCEOF org/nlogo/agent/AgentSet
-            IFEQ L0
-            ALOAD 4
+            IFEQ L12
+            ALOAD 2
             CHECKCAST org/nlogo/agent/AgentSet
-            ASTORE 7
+            ASTORE 5
             NEW org/nlogo/api/LogoListBuilder
             DUP
             INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-            ASTORE 8
-            ALOAD 7
+            ASTORE 6
+            ALOAD 5
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
             GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
             INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-            ASTORE 9
-           L15
-           FRAME APPEND [org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator]
-            ALOAD 9
+            ASTORE 7
+           L13
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_2 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+            ALOAD 7
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-            IFEQ L16
-            ALOAD 8
-            ALOAD 9
+            IFEQ L14
+            ALOAD 6
+            ALOAD 7
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
             BIPUSH 13
             INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
             INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
-            GOTO L15
-           L16
-           FRAME SAME
-            ALOAD 8
-            INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-            ASTORE 6
+            GOTO L13
            L14
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_2 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object] []
+           FRAME SAME
             ALOAD 6
-           L3
-            GOTO L17
-           L0
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_2 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+            ASTORE 3
+            GOTO L11
+           L12
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_2 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
             NEW org/nlogo/nvm/ArgumentTypeException
             DUP
             ALOAD 1
@@ -13820,22 +14594,28 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ALOAD 2
             INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
             ATHROW
+           L11
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_2 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object java/lang/Object java/lang/Object] []
+            ALOAD 3
            L1
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_2 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter java/lang/Object java/lang/Object java/lang/Object] [org/nlogo/api/AgentException]
-            ASTORE 3
+            GOTO L15
+           L2
+           FRAME SAME1 org/nlogo/api/AgentException
+            ASTORE 8
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
             ALOAD 0
-            ALOAD 3
+            ALOAD 8
             INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L17
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_2 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object] [java/lang/Object]
+           L15
+           FRAME SAME1 java/lang/Object
             ARETURN
 [3]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredohistograms_conststring_4 ""slow"" => String
+            // parameter final  context
            L0
             LDC "slow"
            L1
@@ -13847,6 +14627,11 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
           _asm_proceduredohistograms_equal_6 "=" Object,double => boolean
             _turtleorlinkvariable:COLOR "color" => Object
             _constdouble:105.0 "blue" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  d1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -13873,11 +14658,9 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                 DSTORE 3
                 ASTORE 2
                 ALOAD 2
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L5
-                ALOAD 5
+                ALOAD 2
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 3
@@ -13888,19 +14671,19 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                 ICONST_1
                 GOTO L7
                L6
-               FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_equal_6 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_equal_6 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                 ICONST_0
                L7
                FRAME SAME1 I
-                ISTORE 7
+                ISTORE 5
                 GOTO L8
                L5
-               FRAME CHOP 1
+               FRAME CHOP 2
                 ICONST_0
-                ISTORE 7
+                ISTORE 5
                L8
-               FRAME APPEND [T I]
-                ILOAD 7
+               FRAME APPEND [I]
+                ILOAD 5
                L9
                 IFEQ L10
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -13911,13 +14694,18 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                L11
                FRAME SAME1 java/lang/Boolean
                 ARETURN
-            TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-            TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-           L4
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  reporterBlock
+            // parameter final  context
+            // parameter final  agentOrSet
+            TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+           L3
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_5.world : Lorg/nlogo/agent/World;
             INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-           L5
+           L4
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_5.keptinstr4 : Lorg/nlogo/nvm/Reporter;
             ASTORE 3
@@ -13940,11 +14728,11 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ALOAD 2
             INVOKEVIRTUAL org/nlogo/agent/AgentSet.iterator ()Lorg/nlogo/agent/AgentIterator;
             ASTORE 6
-           L6
+           L5
            FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_5 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
             ALOAD 6
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-            IFEQ L7
+            IFEQ L6
             ALOAD 6
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
             ASTORE 7
@@ -13955,28 +14743,18 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ASTORE 8
             ALOAD 8
             INSTANCEOF java/lang/Boolean
-            IFEQ L8
+            IFEQ L7
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L9
+            IFEQ L5
             ALOAD 5
             ALOAD 7
             INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-            GOTO L10
-           L9
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L10
-           FRAME SAME1 java/lang/Object
-            ASTORE 10
-            ALOAD 10
             POP
-            GOTO L6
-           L8
-           FRAME CHOP 1
+            GOTO L5
+           L7
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -14007,7 +14785,7 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L7
+           L6
            FRAME CHOP 2
             GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
             ALOAD 2
@@ -14019,22 +14797,20 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
             CHECKCAST [Lorg/nlogo/agent/Agent;
             INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-           L11
+           L8
             ASTORE 2
-           L2
+           L0
             ALOAD 2
+            INSTANCEOF org/nlogo/agent/Agent
+            IFEQ L9
+            ALOAD 2
+            CHECKCAST org/nlogo/agent/Agent
             ASTORE 4
             ALOAD 4
-            INSTANCEOF org/nlogo/agent/Agent
-            IFEQ L12
-            ALOAD 4
-            CHECKCAST org/nlogo/agent/Agent
-            ASTORE 5
-            ALOAD 5
             INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
             LDC -1
             LCMP
-            IFNE L13
+            IFNE L10
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -14047,62 +14823,58 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ANEWARRAY java/lang/Object
             DUP
             ICONST_0
-            ALOAD 5
+            ALOAD 4
             INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
             AASTORE
             INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
             INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L13
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_5 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet org/nlogo/agent/Agent org/nlogo/agent/AgentIterator] []
-            ALOAD 5
+           L10
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_5 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/Agent scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            ALOAD 4
             BIPUSH 13
             INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-            ASTORE 6
-            GOTO L14
-           L12
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_5 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
-            ALOAD 4
+            ASTORE 3
+            GOTO L11
+           L9
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_5 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            ALOAD 2
             INSTANCEOF org/nlogo/agent/AgentSet
-            IFEQ L0
-            ALOAD 4
+            IFEQ L12
+            ALOAD 2
             CHECKCAST org/nlogo/agent/AgentSet
-            ASTORE 7
+            ASTORE 5
             NEW org/nlogo/api/LogoListBuilder
             DUP
             INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-            ASTORE 8
-            ALOAD 7
+            ASTORE 6
+            ALOAD 5
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
             GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
             INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-            ASTORE 9
-           L15
-           FRAME APPEND [org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator]
-            ALOAD 9
+            ASTORE 7
+           L13
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_5 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+            ALOAD 7
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-            IFEQ L16
-            ALOAD 8
-            ALOAD 9
+            IFEQ L14
+            ALOAD 6
+            ALOAD 7
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
             BIPUSH 13
             INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
             INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
-            GOTO L15
-           L16
-           FRAME SAME
-            ALOAD 8
-            INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-            ASTORE 6
+            GOTO L13
            L14
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_5 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object] []
+           FRAME SAME
             ALOAD 6
-           L3
-            GOTO L17
-           L0
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_5 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+            ASTORE 3
+            GOTO L11
+           L12
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_5 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
             NEW org/nlogo/nvm/ArgumentTypeException
             DUP
             ALOAD 1
@@ -14116,22 +14888,28 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ALOAD 2
             INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
             ATHROW
+           L11
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_5 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object java/lang/Object java/lang/Object] []
+            ALOAD 3
            L1
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_5 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter java/lang/Object java/lang/Object java/lang/Object] [org/nlogo/api/AgentException]
-            ASTORE 3
+            GOTO L15
+           L2
+           FRAME SAME1 org/nlogo/api/AgentException
+            ASTORE 8
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
             ALOAD 0
-            ALOAD 3
+            ALOAD 8
             INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L17
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_5 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object] [java/lang/Object]
+           L15
+           FRAME SAME1 java/lang/Object
             ARETURN
 [5]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredohistograms_conststring_7 ""fast"" => String
+            // parameter final  context
            L0
             LDC "fast"
            L1
@@ -14143,6 +14921,11 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
           _asm_proceduredohistograms_equal_9 "=" Object,double => boolean
             _turtleorlinkvariable:COLOR "color" => Object
             _constdouble:15.0 "red" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  d1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -14169,11 +14952,9 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                 DSTORE 3
                 ASTORE 2
                 ALOAD 2
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L5
-                ALOAD 5
+                ALOAD 2
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 3
@@ -14184,19 +14965,19 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                 ICONST_1
                 GOTO L7
                L6
-               FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_equal_9 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_equal_9 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                 ICONST_0
                L7
                FRAME SAME1 I
-                ISTORE 7
+                ISTORE 5
                 GOTO L8
                L5
-               FRAME CHOP 1
+               FRAME CHOP 2
                 ICONST_0
-                ISTORE 7
+                ISTORE 5
                L8
-               FRAME APPEND [T I]
-                ILOAD 7
+               FRAME APPEND [I]
+                ILOAD 5
                L9
                 IFEQ L10
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -14207,13 +14988,18 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                L11
                FRAME SAME1 java/lang/Boolean
                 ARETURN
-            TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-            TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-           L4
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  reporterBlock
+            // parameter final  context
+            // parameter final  agentOrSet
+            TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+           L3
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_8.world : Lorg/nlogo/agent/World;
             INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-           L5
+           L4
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_8.keptinstr4 : Lorg/nlogo/nvm/Reporter;
             ASTORE 3
@@ -14236,11 +15022,11 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ALOAD 2
             INVOKEVIRTUAL org/nlogo/agent/AgentSet.iterator ()Lorg/nlogo/agent/AgentIterator;
             ASTORE 6
-           L6
+           L5
            FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_8 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
             ALOAD 6
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-            IFEQ L7
+            IFEQ L6
             ALOAD 6
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
             ASTORE 7
@@ -14251,28 +15037,18 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ASTORE 8
             ALOAD 8
             INSTANCEOF java/lang/Boolean
-            IFEQ L8
+            IFEQ L7
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L9
+            IFEQ L5
             ALOAD 5
             ALOAD 7
             INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-            GOTO L10
-           L9
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L10
-           FRAME SAME1 java/lang/Object
-            ASTORE 10
-            ALOAD 10
             POP
-            GOTO L6
-           L8
-           FRAME CHOP 1
+            GOTO L5
+           L7
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -14303,7 +15079,7 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L7
+           L6
            FRAME CHOP 2
             GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
             ALOAD 2
@@ -14315,22 +15091,20 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
             CHECKCAST [Lorg/nlogo/agent/Agent;
             INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-           L11
+           L8
             ASTORE 2
-           L2
+           L0
             ALOAD 2
+            INSTANCEOF org/nlogo/agent/Agent
+            IFEQ L9
+            ALOAD 2
+            CHECKCAST org/nlogo/agent/Agent
             ASTORE 4
             ALOAD 4
-            INSTANCEOF org/nlogo/agent/Agent
-            IFEQ L12
-            ALOAD 4
-            CHECKCAST org/nlogo/agent/Agent
-            ASTORE 5
-            ALOAD 5
             INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
             LDC -1
             LCMP
-            IFNE L13
+            IFNE L10
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -14343,62 +15117,58 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ANEWARRAY java/lang/Object
             DUP
             ICONST_0
-            ALOAD 5
+            ALOAD 4
             INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
             AASTORE
             INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
             INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L13
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_8 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet org/nlogo/agent/Agent org/nlogo/agent/AgentIterator] []
-            ALOAD 5
+           L10
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_8 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/Agent scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            ALOAD 4
             BIPUSH 13
             INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-            ASTORE 6
-            GOTO L14
-           L12
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_8 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
-            ALOAD 4
+            ASTORE 3
+            GOTO L11
+           L9
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_8 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            ALOAD 2
             INSTANCEOF org/nlogo/agent/AgentSet
-            IFEQ L0
-            ALOAD 4
+            IFEQ L12
+            ALOAD 2
             CHECKCAST org/nlogo/agent/AgentSet
-            ASTORE 7
+            ASTORE 5
             NEW org/nlogo/api/LogoListBuilder
             DUP
             INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-            ASTORE 8
-            ALOAD 7
+            ASTORE 6
+            ALOAD 5
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
             GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
             INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-            ASTORE 9
-           L15
-           FRAME APPEND [org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator]
-            ALOAD 9
+            ASTORE 7
+           L13
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_8 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+            ALOAD 7
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-            IFEQ L16
-            ALOAD 8
-            ALOAD 9
+            IFEQ L14
+            ALOAD 6
+            ALOAD 7
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
             BIPUSH 13
             INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
             INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
-            GOTO L15
-           L16
-           FRAME SAME
-            ALOAD 8
-            INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-            ASTORE 6
+            GOTO L13
            L14
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_8 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object] []
+           FRAME SAME
             ALOAD 6
-           L3
-            GOTO L17
-           L0
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_8 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+            ASTORE 3
+            GOTO L11
+           L12
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_8 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
             NEW org/nlogo/nvm/ArgumentTypeException
             DUP
             ALOAD 1
@@ -14412,22 +15182,28 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ALOAD 2
             INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
             ATHROW
+           L11
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_8 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object java/lang/Object java/lang/Object] []
+            ALOAD 3
            L1
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_8 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter java/lang/Object java/lang/Object java/lang/Object] [org/nlogo/api/AgentException]
-            ASTORE 3
+            GOTO L15
+           L2
+           FRAME SAME1 org/nlogo/api/AgentException
+            ASTORE 8
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
             ALOAD 0
-            ALOAD 3
+            ALOAD 8
             INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L17
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_8 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object] [java/lang/Object]
+           L15
+           FRAME SAME1 java/lang/Object
             ARETURN
 [7]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredohistograms_conststring_10 ""Vert-Line"" => String
+            // parameter final  context
            L0
             LDC "Vert-Line"
            L1
@@ -14436,6 +15212,8 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
 [9]_asm_proceduredohistograms_call_11 "draw-vert-line"
       _observervariable:AVG-SPEED "avg-speed" => Object
       _constdouble:5.0 "gray" => Double
+          // parameter final  context
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -14475,6 +15253,8 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
 [10]_asm_proceduredohistograms_call_12 "draw-vert-line"
       _observervariable:AVG-SPEED-INIT "avg-speed-init" => Object
       _constdouble:0.0 "black" => Double
+          // parameter final  context
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -14513,12 +15293,14 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
           RETURN
 [11]_setcurrentplot "set-current-plot"
       _asm_proceduredohistograms_conststring_13 ""Energy Histogram"" => String
+            // parameter final  context
            L0
             LDC "Energy Histogram"
            L1
             ARETURN
 [12]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredohistograms_conststring_14 ""average"" => String
+            // parameter final  context
            L0
             LDC "average"
            L1
@@ -14530,6 +15312,11 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
           _asm_proceduredohistograms_equal_16 "=" Object,double => boolean
             _turtleorlinkvariable:COLOR "color" => Object
             _constdouble:55.0 "green" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  d1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -14556,11 +15343,9 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                 DSTORE 3
                 ASTORE 2
                 ALOAD 2
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L5
-                ALOAD 5
+                ALOAD 2
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 3
@@ -14571,19 +15356,19 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                 ICONST_1
                 GOTO L7
                L6
-               FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_equal_16 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_equal_16 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                 ICONST_0
                L7
                FRAME SAME1 I
-                ISTORE 7
+                ISTORE 5
                 GOTO L8
                L5
-               FRAME CHOP 1
+               FRAME CHOP 2
                 ICONST_0
-                ISTORE 7
+                ISTORE 5
                L8
-               FRAME APPEND [T I]
-                ILOAD 7
+               FRAME APPEND [I]
+                ILOAD 5
                L9
                 IFEQ L10
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -14594,13 +15379,18 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                L11
                FRAME SAME1 java/lang/Boolean
                 ARETURN
-            TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-            TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-           L4
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  reporterBlock
+            // parameter final  context
+            // parameter final  agentOrSet
+            TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+           L3
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_15.world : Lorg/nlogo/agent/World;
             INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-           L5
+           L4
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_15.keptinstr4 : Lorg/nlogo/nvm/Reporter;
             ASTORE 3
@@ -14623,11 +15413,11 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ALOAD 2
             INVOKEVIRTUAL org/nlogo/agent/AgentSet.iterator ()Lorg/nlogo/agent/AgentIterator;
             ASTORE 6
-           L6
+           L5
            FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_15 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
             ALOAD 6
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-            IFEQ L7
+            IFEQ L6
             ALOAD 6
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
             ASTORE 7
@@ -14638,28 +15428,18 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ASTORE 8
             ALOAD 8
             INSTANCEOF java/lang/Boolean
-            IFEQ L8
+            IFEQ L7
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L9
+            IFEQ L5
             ALOAD 5
             ALOAD 7
             INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-            GOTO L10
-           L9
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L10
-           FRAME SAME1 java/lang/Object
-            ASTORE 10
-            ALOAD 10
             POP
-            GOTO L6
-           L8
-           FRAME CHOP 1
+            GOTO L5
+           L7
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -14690,7 +15470,7 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L7
+           L6
            FRAME CHOP 2
             GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
             ALOAD 2
@@ -14702,22 +15482,20 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
             CHECKCAST [Lorg/nlogo/agent/Agent;
             INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-           L11
+           L8
             ASTORE 2
-           L2
+           L0
             ALOAD 2
+            INSTANCEOF org/nlogo/agent/Agent
+            IFEQ L9
+            ALOAD 2
+            CHECKCAST org/nlogo/agent/Agent
             ASTORE 4
             ALOAD 4
-            INSTANCEOF org/nlogo/agent/Agent
-            IFEQ L12
-            ALOAD 4
-            CHECKCAST org/nlogo/agent/Agent
-            ASTORE 5
-            ALOAD 5
             INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
             LDC -1
             LCMP
-            IFNE L13
+            IFNE L10
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -14730,62 +15508,58 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ANEWARRAY java/lang/Object
             DUP
             ICONST_0
-            ALOAD 5
+            ALOAD 4
             INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
             AASTORE
             INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
             INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L13
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_15 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet org/nlogo/agent/Agent org/nlogo/agent/AgentIterator] []
-            ALOAD 5
+           L10
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_15 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/Agent scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            ALOAD 4
             BIPUSH 15
             INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-            ASTORE 6
-            GOTO L14
-           L12
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_15 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
-            ALOAD 4
+            ASTORE 3
+            GOTO L11
+           L9
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_15 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            ALOAD 2
             INSTANCEOF org/nlogo/agent/AgentSet
-            IFEQ L0
-            ALOAD 4
+            IFEQ L12
+            ALOAD 2
             CHECKCAST org/nlogo/agent/AgentSet
-            ASTORE 7
+            ASTORE 5
             NEW org/nlogo/api/LogoListBuilder
             DUP
             INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-            ASTORE 8
-            ALOAD 7
+            ASTORE 6
+            ALOAD 5
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
             GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
             INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-            ASTORE 9
-           L15
-           FRAME APPEND [org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator]
-            ALOAD 9
+            ASTORE 7
+           L13
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_15 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+            ALOAD 7
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-            IFEQ L16
-            ALOAD 8
-            ALOAD 9
+            IFEQ L14
+            ALOAD 6
+            ALOAD 7
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
             BIPUSH 15
             INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
             INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
-            GOTO L15
-           L16
-           FRAME SAME
-            ALOAD 8
-            INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-            ASTORE 6
+            GOTO L13
            L14
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_15 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object] []
+           FRAME SAME
             ALOAD 6
-           L3
-            GOTO L17
-           L0
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_15 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+            ASTORE 3
+            GOTO L11
+           L12
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_15 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
             NEW org/nlogo/nvm/ArgumentTypeException
             DUP
             ALOAD 1
@@ -14799,22 +15573,28 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ALOAD 2
             INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
             ATHROW
+           L11
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_15 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object java/lang/Object java/lang/Object] []
+            ALOAD 3
            L1
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_15 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter java/lang/Object java/lang/Object java/lang/Object] [org/nlogo/api/AgentException]
-            ASTORE 3
+            GOTO L15
+           L2
+           FRAME SAME1 org/nlogo/api/AgentException
+            ASTORE 8
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
             ALOAD 0
-            ALOAD 3
+            ALOAD 8
             INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L17
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_15 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object] [java/lang/Object]
+           L15
+           FRAME SAME1 java/lang/Object
             ARETURN
 [14]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredohistograms_conststring_17 ""slow"" => String
+            // parameter final  context
            L0
             LDC "slow"
            L1
@@ -14826,6 +15606,11 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
           _asm_proceduredohistograms_equal_19 "=" Object,double => boolean
             _turtleorlinkvariable:COLOR "color" => Object
             _constdouble:105.0 "blue" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  d1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -14852,11 +15637,9 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                 DSTORE 3
                 ASTORE 2
                 ALOAD 2
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L5
-                ALOAD 5
+                ALOAD 2
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 3
@@ -14867,19 +15650,19 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                 ICONST_1
                 GOTO L7
                L6
-               FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_equal_19 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_equal_19 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                 ICONST_0
                L7
                FRAME SAME1 I
-                ISTORE 7
+                ISTORE 5
                 GOTO L8
                L5
-               FRAME CHOP 1
+               FRAME CHOP 2
                 ICONST_0
-                ISTORE 7
+                ISTORE 5
                L8
-               FRAME APPEND [T I]
-                ILOAD 7
+               FRAME APPEND [I]
+                ILOAD 5
                L9
                 IFEQ L10
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -14890,13 +15673,18 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                L11
                FRAME SAME1 java/lang/Boolean
                 ARETURN
-            TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-            TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-           L4
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  reporterBlock
+            // parameter final  context
+            // parameter final  agentOrSet
+            TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+           L3
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_18.world : Lorg/nlogo/agent/World;
             INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-           L5
+           L4
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_18.keptinstr4 : Lorg/nlogo/nvm/Reporter;
             ASTORE 3
@@ -14919,11 +15707,11 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ALOAD 2
             INVOKEVIRTUAL org/nlogo/agent/AgentSet.iterator ()Lorg/nlogo/agent/AgentIterator;
             ASTORE 6
-           L6
+           L5
            FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_18 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
             ALOAD 6
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-            IFEQ L7
+            IFEQ L6
             ALOAD 6
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
             ASTORE 7
@@ -14934,28 +15722,18 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ASTORE 8
             ALOAD 8
             INSTANCEOF java/lang/Boolean
-            IFEQ L8
+            IFEQ L7
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L9
+            IFEQ L5
             ALOAD 5
             ALOAD 7
             INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-            GOTO L10
-           L9
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L10
-           FRAME SAME1 java/lang/Object
-            ASTORE 10
-            ALOAD 10
             POP
-            GOTO L6
-           L8
-           FRAME CHOP 1
+            GOTO L5
+           L7
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -14986,7 +15764,7 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L7
+           L6
            FRAME CHOP 2
             GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
             ALOAD 2
@@ -14998,22 +15776,20 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
             CHECKCAST [Lorg/nlogo/agent/Agent;
             INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-           L11
+           L8
             ASTORE 2
-           L2
+           L0
             ALOAD 2
+            INSTANCEOF org/nlogo/agent/Agent
+            IFEQ L9
+            ALOAD 2
+            CHECKCAST org/nlogo/agent/Agent
             ASTORE 4
             ALOAD 4
-            INSTANCEOF org/nlogo/agent/Agent
-            IFEQ L12
-            ALOAD 4
-            CHECKCAST org/nlogo/agent/Agent
-            ASTORE 5
-            ALOAD 5
             INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
             LDC -1
             LCMP
-            IFNE L13
+            IFNE L10
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -15026,62 +15802,58 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ANEWARRAY java/lang/Object
             DUP
             ICONST_0
-            ALOAD 5
+            ALOAD 4
             INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
             AASTORE
             INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
             INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L13
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_18 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet org/nlogo/agent/Agent org/nlogo/agent/AgentIterator] []
-            ALOAD 5
+           L10
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_18 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/Agent scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            ALOAD 4
             BIPUSH 15
             INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-            ASTORE 6
-            GOTO L14
-           L12
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_18 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
-            ALOAD 4
+            ASTORE 3
+            GOTO L11
+           L9
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_18 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            ALOAD 2
             INSTANCEOF org/nlogo/agent/AgentSet
-            IFEQ L0
-            ALOAD 4
+            IFEQ L12
+            ALOAD 2
             CHECKCAST org/nlogo/agent/AgentSet
-            ASTORE 7
+            ASTORE 5
             NEW org/nlogo/api/LogoListBuilder
             DUP
             INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-            ASTORE 8
-            ALOAD 7
+            ASTORE 6
+            ALOAD 5
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
             GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
             INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-            ASTORE 9
-           L15
-           FRAME APPEND [org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator]
-            ALOAD 9
+            ASTORE 7
+           L13
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_18 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+            ALOAD 7
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-            IFEQ L16
-            ALOAD 8
-            ALOAD 9
+            IFEQ L14
+            ALOAD 6
+            ALOAD 7
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
             BIPUSH 15
             INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
             INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
-            GOTO L15
-           L16
-           FRAME SAME
-            ALOAD 8
-            INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-            ASTORE 6
+            GOTO L13
            L14
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_18 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object] []
+           FRAME SAME
             ALOAD 6
-           L3
-            GOTO L17
-           L0
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_18 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+            ASTORE 3
+            GOTO L11
+           L12
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_18 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
             NEW org/nlogo/nvm/ArgumentTypeException
             DUP
             ALOAD 1
@@ -15095,22 +15867,28 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ALOAD 2
             INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
             ATHROW
+           L11
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_18 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object java/lang/Object java/lang/Object] []
+            ALOAD 3
            L1
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_18 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter java/lang/Object java/lang/Object java/lang/Object] [org/nlogo/api/AgentException]
-            ASTORE 3
+            GOTO L15
+           L2
+           FRAME SAME1 org/nlogo/api/AgentException
+            ASTORE 8
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
             ALOAD 0
-            ALOAD 3
+            ALOAD 8
             INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L17
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_18 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object] [java/lang/Object]
+           L15
+           FRAME SAME1 java/lang/Object
             ARETURN
 [16]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredohistograms_conststring_20 ""fast"" => String
+            // parameter final  context
            L0
             LDC "fast"
            L1
@@ -15122,6 +15900,11 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
           _asm_proceduredohistograms_equal_22 "=" Object,double => boolean
             _turtleorlinkvariable:COLOR "color" => Object
             _constdouble:15.0 "red" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  d1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -15148,11 +15931,9 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                 DSTORE 3
                 ASTORE 2
                 ALOAD 2
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L5
-                ALOAD 5
+                ALOAD 2
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 3
@@ -15163,19 +15944,19 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                 ICONST_1
                 GOTO L7
                L6
-               FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_equal_22 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_equal_22 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                 ICONST_0
                L7
                FRAME SAME1 I
-                ISTORE 7
+                ISTORE 5
                 GOTO L8
                L5
-               FRAME CHOP 1
+               FRAME CHOP 2
                 ICONST_0
-                ISTORE 7
+                ISTORE 5
                L8
-               FRAME APPEND [T I]
-                ILOAD 7
+               FRAME APPEND [I]
+                ILOAD 5
                L9
                 IFEQ L10
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -15186,13 +15967,18 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
                L11
                FRAME SAME1 java/lang/Boolean
                 ARETURN
-            TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-            TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-           L4
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  reporterBlock
+            // parameter final  context
+            // parameter final  agentOrSet
+            TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+           L3
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_21.world : Lorg/nlogo/agent/World;
             INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-           L5
+           L4
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_21.keptinstr4 : Lorg/nlogo/nvm/Reporter;
             ASTORE 3
@@ -15215,11 +16001,11 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ALOAD 2
             INVOKEVIRTUAL org/nlogo/agent/AgentSet.iterator ()Lorg/nlogo/agent/AgentIterator;
             ASTORE 6
-           L6
+           L5
            FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_21 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
             ALOAD 6
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-            IFEQ L7
+            IFEQ L6
             ALOAD 6
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
             ASTORE 7
@@ -15230,28 +16016,18 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ASTORE 8
             ALOAD 8
             INSTANCEOF java/lang/Boolean
-            IFEQ L8
+            IFEQ L7
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L9
+            IFEQ L5
             ALOAD 5
             ALOAD 7
             INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-            GOTO L10
-           L9
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L10
-           FRAME SAME1 java/lang/Object
-            ASTORE 10
-            ALOAD 10
             POP
-            GOTO L6
-           L8
-           FRAME CHOP 1
+            GOTO L5
+           L7
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -15282,7 +16058,7 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L7
+           L6
            FRAME CHOP 2
             GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
             ALOAD 2
@@ -15294,22 +16070,20 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
             CHECKCAST [Lorg/nlogo/agent/Agent;
             INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-           L11
+           L8
             ASTORE 2
-           L2
+           L0
             ALOAD 2
+            INSTANCEOF org/nlogo/agent/Agent
+            IFEQ L9
+            ALOAD 2
+            CHECKCAST org/nlogo/agent/Agent
             ASTORE 4
             ALOAD 4
-            INSTANCEOF org/nlogo/agent/Agent
-            IFEQ L12
-            ALOAD 4
-            CHECKCAST org/nlogo/agent/Agent
-            ASTORE 5
-            ALOAD 5
             INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
             LDC -1
             LCMP
-            IFNE L13
+            IFNE L10
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -15322,62 +16096,58 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ANEWARRAY java/lang/Object
             DUP
             ICONST_0
-            ALOAD 5
+            ALOAD 4
             INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
             AASTORE
             INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
             INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L13
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_21 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet org/nlogo/agent/Agent org/nlogo/agent/AgentIterator] []
-            ALOAD 5
+           L10
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_21 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/Agent scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            ALOAD 4
             BIPUSH 15
             INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-            ASTORE 6
-            GOTO L14
-           L12
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_21 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
-            ALOAD 4
+            ASTORE 3
+            GOTO L11
+           L9
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_21 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            ALOAD 2
             INSTANCEOF org/nlogo/agent/AgentSet
-            IFEQ L0
-            ALOAD 4
+            IFEQ L12
+            ALOAD 2
             CHECKCAST org/nlogo/agent/AgentSet
-            ASTORE 7
+            ASTORE 5
             NEW org/nlogo/api/LogoListBuilder
             DUP
             INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-            ASTORE 8
-            ALOAD 7
+            ASTORE 6
+            ALOAD 5
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
             GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
             INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-            ASTORE 9
-           L15
-           FRAME APPEND [org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator]
-            ALOAD 9
+            ASTORE 7
+           L13
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_21 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+            ALOAD 7
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-            IFEQ L16
-            ALOAD 8
-            ALOAD 9
+            IFEQ L14
+            ALOAD 6
+            ALOAD 7
             INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
             BIPUSH 15
             INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
             INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
-            GOTO L15
-           L16
-           FRAME SAME
-            ALOAD 8
-            INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-            ASTORE 6
+            GOTO L13
            L14
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_21 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object] []
+           FRAME SAME
             ALOAD 6
-           L3
-            GOTO L17
-           L0
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_21 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
+            INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+            ASTORE 3
+            GOTO L11
+           L12
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_21 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
             NEW org/nlogo/nvm/ArgumentTypeException
             DUP
             ALOAD 1
@@ -15391,22 +16161,28 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
             ALOAD 2
             INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
             ATHROW
+           L11
+           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_21 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object java/lang/Object java/lang/Object] []
+            ALOAD 3
            L1
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_21 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter java/lang/Object java/lang/Object java/lang/Object] [org/nlogo/api/AgentException]
-            ASTORE 3
+            GOTO L15
+           L2
+           FRAME SAME1 org/nlogo/api/AgentException
+            ASTORE 8
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
             ALOAD 0
-            ALOAD 3
+            ALOAD 8
             INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L17
-           FRAME FULL [org/nlogo/prim/_asm_proceduredohistograms_turtlevariableof_21 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/agent/IndexedAgentSet java/lang/Object java/lang/Object] [java/lang/Object]
+           L15
+           FRAME SAME1 java/lang/Object
             ARETURN
 [18]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredohistograms_conststring_23 ""Vert-Line"" => String
+            // parameter final  context
            L0
             LDC "Vert-Line"
            L1
@@ -15415,6 +16191,8 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
 [20]_asm_proceduredohistograms_call_24 "draw-vert-line"
       _observervariable:AVG-ENERGY "avg-energy" => Object
       _constdouble:5.0 "gray" => Double
+          // parameter final  context
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -15454,6 +16232,8 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
 [21]_asm_proceduredohistograms_call_25 "draw-vert-line"
       _observervariable:AVG-ENERGY-INIT "avg-energy-init" => Object
       _constdouble:0.0 "black" => Double
+          // parameter final  context
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -15491,6 +16271,7 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
          L5
           RETURN
 [22]_asm_proceduredohistograms_return_26 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -15503,6 +16284,7 @@ procedure DO-HISTOGRAMS:[]{OTPL}:
 procedure DRAW-VERT-LINE:[XVAL LINECOLOR]{OTPL}:
 [0]_setplotpencolor "set-plot-pen-color"
       _asm_proceduredrawvertline_procedurevariable_0 "linecolor" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -15513,6 +16295,7 @@ procedure DRAW-VERT-LINE:[XVAL LINECOLOR]{OTPL}:
             ARETURN
 [1]_plotxy "plotxy"
       _asm_proceduredrawvertline_procedurevariable_1 "xval" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -15525,6 +16308,7 @@ procedure DRAW-VERT-LINE:[XVAL LINECOLOR]{OTPL}:
 [2]_plotpendown "plot-pen-down"
 [3]_plotxy "plotxy"
       _asm_proceduredrawvertline_procedurevariable_2 "xval" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -15536,6 +16320,7 @@ procedure DRAW-VERT-LINE:[XVAL LINECOLOR]{OTPL}:
       _plotymax "plot-y-max"
 [4]_plotpenup "plot-pen-up"
 [5]_asm_proceduredrawvertline_return_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V

--- a/netlogo-headless/test/benchdumps/GridWalk.txt
+++ b/netlogo-headless/test/benchdumps/GridWalk.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:362.0 "362" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 362.0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -77,6 +80,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [2]_resettimer "reset-timer"
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:20000.0 "20000" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 20000.0
          L1
@@ -89,7 +95,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -116,6 +123,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -149,6 +157,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -170,9 +181,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -187,8 +195,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -203,6 +216,7 @@ procedure SETUP:[]{O---}:
 [1]_resetticks "reset-ticks"
 [2]_createorderedturtles:,+6 "cro"
       _asm_proceduresetup_constdouble_0 "1000" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetup_constdouble_0.kept1_value : Ljava/lang/Double;
@@ -211,6 +225,9 @@ procedure SETUP:[]{O---}:
 [3]_moveto "move-to"
       _asm_proceduresetup_oneof_1 "one-of" AgentSet => Object
         _patches "patches" => AgentSet
+            // parameter final  context
+            // parameter final  context
+            // parameter final  agents
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetup_oneof_1.world : Lorg/nlogo/agent/World;
@@ -241,45 +258,45 @@ procedure SETUP:[]{O---}:
 [4]_asm_proceduresetup_face_2 "face" Agent => void
       _oneof "one-of" AgentSet => Object
         _neighbors4 "neighbors4" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
+          // parameter final  context
+          // parameter final  target
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-          ASTORE 2
-          ALOAD 2
-          INSTANCEOF org/nlogo/agent/Turtle
-          IFEQ L3
-          ALOAD 2
-          CHECKCAST org/nlogo/agent/Turtle
           ASTORE 3
           ALOAD 3
+          INSTANCEOF org/nlogo/agent/Turtle
+          IFEQ L3
+          ALOAD 3
+          CHECKCAST org/nlogo/agent/Turtle
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 4
+          ASTORE 2
           GOTO L4
          L3
-         FRAME APPEND [org/nlogo/agent/Agent]
-          ALOAD 2
+         FRAME APPEND [T org/nlogo/agent/Agent]
+          ALOAD 3
           INSTANCEOF org/nlogo/agent/Patch
           IFEQ L5
-          ALOAD 2
+          ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 5
-          ALOAD 5
-          ASTORE 4
-         L4
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 4
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors4 ()Lorg/nlogo/agent/AgentSet;
-          GOTO L6
+          ASTORE 2
+          GOTO L4
          L5
-         FRAME CHOP 2
+         FRAME SAME
           NEW scala/MatchError
           DUP
-          ALOAD 2
+          ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L4
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_face_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 2
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors4 ()Lorg/nlogo/agent/AgentSet;
          L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_face_2 org/nlogo/nvm/Context org/nlogo/agent/Agent T org/nlogo/agent/Patch] [org/nlogo/agent/AgentSet]
           ASTORE 2
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.count ()I
@@ -290,7 +307,7 @@ procedure SETUP:[]{O---}:
           GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
           GOTO L8
          L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_face_2 org/nlogo/nvm/Context org/nlogo/agent/AgentSet I org/nlogo/agent/Patch] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_face_2 org/nlogo/nvm/Context org/nlogo/agent/AgentSet I] []
           ALOAD 2
           ILOAD 3
           ALOAD 1
@@ -307,7 +324,7 @@ procedure SETUP:[]{O---}:
           CHECKCAST org/nlogo/agent/Agent
           GOTO L9
          L1
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_face_2 org/nlogo/nvm/Context java/lang/Object I org/nlogo/agent/Patch] [java/lang/ClassCastException]
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_face_2 org/nlogo/nvm/Context java/lang/Object I] [java/lang/ClassCastException]
           POP
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
@@ -335,7 +352,7 @@ procedure SETUP:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L10
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_face_2 org/nlogo/nvm/Context org/nlogo/agent/Agent I org/nlogo/agent/Patch] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_face_2 org/nlogo/nvm/Context org/nlogo/agent/Agent I] []
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
@@ -374,6 +391,7 @@ procedure SETUP:[]{O---}:
          L12
           RETURN
 [5]_asm_proceduresetup_done_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -381,6 +399,7 @@ procedure SETUP:[]{O---}:
          L1
           RETURN
 [6]_asm_proceduresetup_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -393,6 +412,9 @@ procedure SETUP:[]{O---}:
 procedure GO:[]{O---}:
 [0]_asm_procedurego_ask_0 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_0.world : Lorg/nlogo/agent/World;
@@ -449,45 +471,45 @@ procedure GO:[]{O---}:
 [1]_asm_procedurego_face_1 "face" Agent => void
       _oneof "one-of" AgentSet => Object
         _neighbors4 "neighbors4" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
+          // parameter final  context
+          // parameter final  target
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-          ASTORE 2
-          ALOAD 2
-          INSTANCEOF org/nlogo/agent/Turtle
-          IFEQ L3
-          ALOAD 2
-          CHECKCAST org/nlogo/agent/Turtle
           ASTORE 3
           ALOAD 3
+          INSTANCEOF org/nlogo/agent/Turtle
+          IFEQ L3
+          ALOAD 3
+          CHECKCAST org/nlogo/agent/Turtle
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 4
+          ASTORE 2
           GOTO L4
          L3
-         FRAME APPEND [org/nlogo/agent/Agent]
-          ALOAD 2
+         FRAME APPEND [T org/nlogo/agent/Agent]
+          ALOAD 3
           INSTANCEOF org/nlogo/agent/Patch
           IFEQ L5
-          ALOAD 2
+          ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 5
-          ALOAD 5
-          ASTORE 4
-         L4
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 4
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors4 ()Lorg/nlogo/agent/AgentSet;
-          GOTO L6
+          ASTORE 2
+          GOTO L4
          L5
-         FRAME CHOP 2
+         FRAME SAME
           NEW scala/MatchError
           DUP
-          ALOAD 2
+          ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L4
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_face_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 2
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors4 ()Lorg/nlogo/agent/AgentSet;
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_face_1 org/nlogo/nvm/Context org/nlogo/agent/Agent T org/nlogo/agent/Patch] [org/nlogo/agent/AgentSet]
           ASTORE 2
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.count ()I
@@ -498,7 +520,7 @@ procedure GO:[]{O---}:
           GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
           GOTO L8
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_face_1 org/nlogo/nvm/Context org/nlogo/agent/AgentSet I org/nlogo/agent/Patch] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_face_1 org/nlogo/nvm/Context org/nlogo/agent/AgentSet I] []
           ALOAD 2
           ILOAD 3
           ALOAD 1
@@ -515,7 +537,7 @@ procedure GO:[]{O---}:
           CHECKCAST org/nlogo/agent/Agent
           GOTO L9
          L1
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_face_1 org/nlogo/nvm/Context java/lang/Object I org/nlogo/agent/Patch] [java/lang/ClassCastException]
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_face_1 org/nlogo/nvm/Context java/lang/Object I] [java/lang/ClassCastException]
           POP
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
@@ -543,7 +565,7 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_face_1 org/nlogo/nvm/Context org/nlogo/agent/Agent I org/nlogo/agent/Patch] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_face_1 org/nlogo/nvm/Context org/nlogo/agent/Agent I] []
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
@@ -582,25 +604,28 @@ procedure GO:[]{O---}:
          L12
           RETURN
 [2]_asm_procedurego_fd1_2 "fd" => void
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
+          // parameter final  context
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
           DCONST_1
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L2
          L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          ASTORE 2
+          GOTO L3
          L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L3
          FRAME SAME
           ALOAD 1
           ICONST_3
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L3
+         L4
           RETURN
 [3]_asm_procedurego_done_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -609,6 +634,7 @@ procedure GO:[]{O---}:
           RETURN
 [4]_tick "tick"
 [5]_asm_procedurego_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V

--- a/netlogo-headless/test/benchdumps/Heatbugs.txt
+++ b/netlogo-headless/test/benchdumps/Heatbugs.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:362.0 "362" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 362.0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -77,6 +80,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [2]_resettimer "reset-timer"
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:1000.0 "1000" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 1000.0
          L1
@@ -89,7 +95,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -116,6 +123,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -149,6 +157,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -170,9 +181,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -187,8 +195,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -204,6 +217,7 @@ procedure SETUP:[]{O---}:
 [2]_asm_proceduresetup_ask_0 "ask" Object => void
       _nof "n-of"
         _asm_proceduresetup_observervariable_1 "bug-count" => Object
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_proceduresetup_observervariable_1.world : Lorg/nlogo/agent/World;
@@ -213,12 +227,15 @@ procedure SETUP:[]{O---}:
              L1
               ARETURN
         _asm_proceduresetup_patches_2 "patches" => AgentSet
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_proceduresetup_patches_2.world : Lorg/nlogo/agent/World;
               INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  target
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_0.keptinstr2 : Lorg/nlogo/prim/etc/_nof;
           ALOAD 1
@@ -226,18 +243,16 @@ procedure SETUP:[]{O---}:
          L0
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L1
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L2
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -253,8 +268,8 @@ procedure SETUP:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_ask_0 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -271,18 +286,18 @@ procedure SETUP:[]{O---}:
           ATHROW
          L2
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L4
          L1
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L5
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -299,7 +314,7 @@ procedure SETUP:[]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -309,23 +324,12 @@ procedure SETUP:[]{O---}:
          L6
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_ask_0 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_3
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 11
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
+          GOTO L4
          L5
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -339,11 +343,20 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L4
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          ICONST_3
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 11
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_ask_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [3]_sprout:,+10 "sprout"
       _asm_proceduresetup_constdouble_3 "1" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetup_constdouble_3.kept1_value : Ljava/lang/Double;
@@ -351,6 +364,9 @@ procedure SETUP:[]{O---}:
             ARETURN
 [4]_asm_proceduresetup_setturtleorlinkvariable_4 "set" Object => void
       _constdouble:65.0 "lime" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -364,9 +380,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtleorlinkvariable_4 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -381,9 +394,16 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [5]_asm_proceduresetup_setturtlevariable_5 "set" Object => void
       _constdouble:1.75 "1.75" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -397,9 +417,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtlevariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -414,6 +431,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [6]_asm_proceduresetup_setturtlevariable_6 "set" Object => void
       _plus "+" double,double => double
@@ -423,6 +444,21 @@ procedure SETUP:[]{O---}:
             _minus "-" double,double => double
               _observervariable:MAX-IDEAL-TEMP "max-ideal-temp" => Object
               _observervariable:MIN-IDEAL-TEMP "min-ideal-temp" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  maxDouble
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -529,7 +565,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_6.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_6.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -604,9 +641,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L7
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L26
          L8
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtlevariable_6 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -621,6 +655,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L26
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L27
           RETURN
 [7]_asm_proceduresetup_setturtlevariable_7 "set" Object => void
       _plus "+" double,double => double
@@ -630,6 +668,21 @@ procedure SETUP:[]{O---}:
             _minus "-" double,double => double
               _observervariable:MAX-OUTPUT-HEAT "max-output-heat" => Object
               _observervariable:MIN-OUTPUT-HEAT "min-output-heat" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  maxDouble
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -736,7 +789,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_7.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_7.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -811,9 +865,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L7
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L26
          L8
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtlevariable_7 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -828,12 +879,25 @@ procedure SETUP:[]{O---}:
           ATHROW
          L26
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L27
           RETURN
 [8]_asm_proceduresetup_setturtlevariable_8 "set" Object => void
       _abs "abs" double => double
         _minus "-" double,double => double
           _turtlevariable:IDEAL-TEMP "ideal-temp" => Object
           _patchvariable:TEMP "temp" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -951,9 +1015,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L11
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L19
          L12
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtlevariable_8 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -968,8 +1029,13 @@ procedure SETUP:[]{O---}:
           ATHROW
          L19
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L20
           RETURN
 [9]_asm_proceduresetup_done_9 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -977,6 +1043,7 @@ procedure SETUP:[]{O---}:
          L1
           RETURN
 [10]_asm_proceduresetup_done_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -984,6 +1051,7 @@ procedure SETUP:[]{O---}:
          L1
           RETURN
 [11]_asm_proceduresetup_return_11 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -998,6 +1066,13 @@ procedure GO:[]{O---}:
       _not "not" boolean => boolean
         _any "any?" AgentSet => boolean
           _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_if_0.world : Lorg/nlogo/agent/World;
@@ -1006,22 +1081,22 @@ procedure GO:[]{O---}:
           ASTORE 2
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.isEmpty ()Z
-          IFEQ L2
-          ICONST_0
+          IFNE L2
+          ICONST_1
           GOTO L3
          L2
          FRAME APPEND [org/nlogo/agent/TreeAgentSet]
-          ICONST_1
+          ICONST_0
          L3
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L4
-          ICONST_0
+          IFNE L4
+          ICONST_1
           GOTO L5
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurego_if_0 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L5
          FRAME SAME1 I
           ISTORE 2
@@ -1078,6 +1153,7 @@ procedure GO:[]{O---}:
           RETURN
 [2]_diffuse:TEMP "diffuse"
       _asm_procedurego_observervariable_2 "diffusion-rate" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurego_observervariable_2.world : Lorg/nlogo/agent/World;
@@ -1088,6 +1164,9 @@ procedure GO:[]{O---}:
             ARETURN
 [3]_asm_procedurego_ask_3 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_3.world : Lorg/nlogo/agent/World;
@@ -1160,6 +1239,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [5]_asm_procedurego_done_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1186,6 +1266,7 @@ procedure GO:[]{O---}:
           RETURN
 [7]_tick "tick"
 [8]_asm_procedurego_return_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1198,6 +1279,9 @@ procedure GO:[]{O---}:
 procedure RECOLOR-PATCHES:[]{OTPL}:
 [0]_asm_procedurerecolorpatches_ask_0 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerecolorpatches_ask_0.world : Lorg/nlogo/agent/World;
@@ -1257,6 +1341,17 @@ procedure RECOLOR-PATCHES:[]{OTPL}:
         _minus "-" double,double => double
           _constdouble:1.0 "1" => double
           _observervariable:EVAPORATION-RATE "evaporation-rate" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -1354,9 +1449,6 @@ procedure RECOLOR-PATCHES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L8
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L17
          L9
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolorpatches_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1371,6 +1463,10 @@ procedure RECOLOR-PATCHES:[]{OTPL}:
           ATHROW
          L17
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [2]_asm_procedurerecolorpatches_setpatchvariable_2 "set" Object => void
       _scalecolor "scale-color" double,double,double,double => double
@@ -1378,6 +1474,12 @@ procedure RECOLOR-PATCHES:[]{OTPL}:
         _patchvariable:TEMP "temp" => Object
         _constdouble:0.0 "0" => double
         _constdouble:500.0 "500" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -1532,7 +1634,8 @@ procedure RECOLOR-PATCHES:[]{OTPL}:
           DLOAD 2
           DLOAD 10
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorpatches_setpatchvariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorpatches_setpatchvariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L21
           DSTORE 2
           NEW java/lang/Double
@@ -1547,9 +1650,6 @@ procedure RECOLOR-PATCHES:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L22
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolorpatches_setpatchvariable_2 org/nlogo/nvm/Context java/lang/Double T D D D D] [org/nlogo/api/AgentException]
@@ -1564,8 +1664,13 @@ procedure RECOLOR-PATCHES:[]{OTPL}:
           ATHROW
          L22
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L23
           RETURN
 [3]_asm_procedurerecolorpatches_done_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1573,6 +1678,7 @@ procedure RECOLOR-PATCHES:[]{OTPL}:
          L1
           RETURN
 [4]_asm_procedurerecolorpatches_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1588,6 +1694,15 @@ procedure STEP:[TARGET]{-T--}:
         _minus "-" double,double => double
           _turtlevariable:IDEAL-TEMP "ideal-temp" => Object
           _patchvariable:TEMP "temp" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -1705,9 +1820,6 @@ procedure STEP:[TARGET]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L11
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L19
          L12
          FRAME FULL [org/nlogo/prim/_asm_procedurestep_setturtlevariable_0 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1722,11 +1834,22 @@ procedure STEP:[TARGET]{-T--}:
           ATHROW
          L19
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L20
           RETURN
 [1]_asm_procedurestep_ifelse_1 "ifelse" boolean => void
       _equal "=" Object,double => boolean
         _turtlevariable:UNHAPPINESS "unhappiness" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1753,11 +1876,9 @@ procedure STEP:[TARGET]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -1768,19 +1889,19 @@ procedure STEP:[TARGET]{-T--}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurestep_ifelse_1 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurestep_ifelse_1 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -1789,10 +1910,10 @@ procedure STEP:[TARGET]{-T--}:
           ICONST_2
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurestep_ifelse_1 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurestep_ifelse_1 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           ICONST_4
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurestep_ifelse_1 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurestep_ifelse_1 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
@@ -1800,6 +1921,13 @@ procedure STEP:[TARGET]{-T--}:
       _plus "+" double,double => double
         _patchvariable:TEMP "temp" => Object
         _turtlevariable:OUTPUT-HEAT "output-heat" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -1903,9 +2031,6 @@ procedure STEP:[TARGET]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L11
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L17
          L12
          FRAME FULL [org/nlogo/prim/_asm_procedurestep_setpatchvariable_2 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1920,8 +2045,13 @@ procedure STEP:[TARGET]{-T--}:
           ATHROW
          L17
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [3]_asm_procedurestep_goto_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 8
@@ -1930,6 +2060,8 @@ procedure STEP:[TARGET]{-T--}:
           RETURN
 [4]_asm_procedurestep_setprocedurevariable_4 "let" Object => void
       _callreport:FIND-TARGET "find-target"
+          // parameter final  context
+          // parameter final  arg0
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -1973,6 +2105,18 @@ procedure STEP:[TARGET]{-T--}:
         _greaterthan ">" Object,double => boolean
           _observervariable:RANDOM-MOVE-CHANCE "random-move-chance" => Object
           _randomconst:100 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -1991,12 +2135,12 @@ procedure STEP:[TARGET]{-T--}:
           ALOAD 2
           ALOAD 3
           INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-          IFEQ L3
-          ICONST_0
+          IFNE L3
+          ICONST_1
           GOTO L4
          L3
          FRAME APPEND [org/nlogo/agent/Patch java/lang/Object]
-          ICONST_1
+          ICONST_0
          L4
          FRAME SAME1 I
           IFNE L5
@@ -2017,14 +2161,10 @@ procedure STEP:[TARGET]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L9
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -2032,15 +2172,14 @@ procedure STEP:[TARGET]{-T--}:
           ICONST_1
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurestep_if_5 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurestep_if_5 org/nlogo/nvm/Context java/lang/Object D] []
           ICONST_0
          L11
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L12
          L9
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2069,29 +2208,32 @@ procedure STEP:[TARGET]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L12
-         FRAME FULL [org/nlogo/prim/_asm_procedurestep_if_5 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
-          GOTO L13
+         FRAME APPEND [I]
+          ILOAD 5
+         L13
+          GOTO L14
          L5
          FRAME FULL [org/nlogo/prim/_asm_procedurestep_if_5 org/nlogo/nvm/Context org/nlogo/agent/Patch java/lang/Object] []
           ICONST_1
-         L13
+         L14
          FRAME FULL [org/nlogo/prim/_asm_procedurestep_if_5 org/nlogo/nvm/Context java/lang/Object] [I]
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L14
+          IFEQ L15
           BIPUSH 6
-          GOTO L15
-         L14
+          GOTO L16
+         L15
          FRAME FULL [org/nlogo/prim/_asm_procedurestep_if_5 org/nlogo/nvm/Context I] [org/nlogo/nvm/Context]
           BIPUSH 7
-         L15
+         L16
          FRAME FULL [org/nlogo/prim/_asm_procedurestep_if_5 org/nlogo/nvm/Context I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L16
+         L17
           RETURN
 [6]_asm_procedurestep_call_6 "bug-move"
       _procedurevariable:TARGET "target" => Object
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -2124,6 +2266,13 @@ procedure STEP:[TARGET]{-T--}:
       _plus "+" double,double => double
         _patchvariable:TEMP "temp" => Object
         _turtlevariable:OUTPUT-HEAT "output-heat" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -2227,9 +2376,6 @@ procedure STEP:[TARGET]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L11
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L17
          L12
          FRAME FULL [org/nlogo/prim/_asm_procedurestep_setpatchvariable_7 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -2244,8 +2390,13 @@ procedure STEP:[TARGET]{-T--}:
           ATHROW
          L17
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [8]_asm_procedurestep_return_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2260,6 +2411,13 @@ reporter procedure FIND-TARGET:[]{-T--}:
       _lessthan "<" Object,Object => boolean
         _patchvariable:TEMP "temp" => Object
         _turtlevariable:IDEAL-TEMP "ideal-temp" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  o1
+          // parameter final  o2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -2322,40 +2480,36 @@ reporter procedure FIND-TARGET:[]{-T--}:
          L8
          FRAME APPEND [java/lang/Object java/lang/Object]
           ICONST_0
-         L9
-         FRAME SAME1 I
-          GOTO L10
+          GOTO L9
          L7
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L11
+          IFEQ L10
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L11
+          IFEQ L10
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
           ICONST_0
-          IF_ICMPGE L12
+          IF_ICMPGE L11
           ICONST_1
-          GOTO L13
-         L12
+          GOTO L9
+         L11
          FRAME SAME
           ICONST_0
-         L13
-         FRAME SAME1 I
-          GOTO L10
-         L11
+          GOTO L9
+         L10
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L14
+          IFEQ L12
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L14
+          IFEQ L12
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -2366,21 +2520,19 @@ reporter procedure FIND-TARGET:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L14
+          IF_ICMPNE L12
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
           ICONST_0
-          IF_ICMPGE L15
+          IF_ICMPGE L13
           ICONST_1
-          GOTO L16
-         L15
+          GOTO L9
+         L13
          FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
           ICONST_0
-         L16
-         FRAME SAME1 I
-          GOTO L10
-         L14
+          GOTO L9
+         L12
          FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -2408,65 +2560,62 @@ reporter procedure FIND-TARGET:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L10
+         L9
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L17
+          IFEQ L14
           ICONST_1
-          GOTO L18
-         L17
+          GOTO L15
+         L14
          FRAME FULL [org/nlogo/prim/_asm_procedurefindtarget_ifelse_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
           ICONST_3
-         L18
+         L15
          FRAME FULL [org/nlogo/prim/_asm_procedurefindtarget_ifelse_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L19
+         L16
           RETURN
 [1]_asm_procedurefindtarget_report_1 "report" Object => void
       _maxoneof "max-one-of"
         _asm_procedurefindtarget_neighbors_2 "neighbors" => AgentSet
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-              ASTORE 2
-              ALOAD 2
-              INSTANCEOF org/nlogo/agent/Turtle
-              IFEQ L1
-              ALOAD 2
-              CHECKCAST org/nlogo/agent/Turtle
               ASTORE 3
               ALOAD 3
+              INSTANCEOF org/nlogo/agent/Turtle
+              IFEQ L1
+              ALOAD 3
+              CHECKCAST org/nlogo/agent/Turtle
               INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-              ASTORE 4
+              ASTORE 2
               GOTO L2
              L1
-             FRAME APPEND [org/nlogo/agent/Agent]
-              ALOAD 2
+             FRAME APPEND [T org/nlogo/agent/Agent]
+              ALOAD 3
               INSTANCEOF org/nlogo/agent/Patch
               IFEQ L3
-              ALOAD 2
+              ALOAD 3
               CHECKCAST org/nlogo/agent/Patch
-              ASTORE 5
-              ALOAD 5
-              ASTORE 4
-             L2
-             FRAME APPEND [T org/nlogo/agent/Patch]
-              ALOAD 4
-              INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/AgentSet;
-              GOTO L4
+              ASTORE 2
+              GOTO L2
              L3
-             FRAME CHOP 2
+             FRAME SAME
               NEW scala/MatchError
               DUP
-              ALOAD 2
+              ALOAD 3
               INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
               ATHROW
+             L2
+             FRAME FULL [org/nlogo/prim/_asm_procedurefindtarget_neighbors_2 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+              ALOAD 2
+              INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/AgentSet;
              L4
-             FRAME FULL [org/nlogo/prim/_asm_procedurefindtarget_neighbors_2 org/nlogo/nvm/Context org/nlogo/agent/Agent T org/nlogo/agent/Patch] [org/nlogo/agent/AgentSet]
               ARETURN
         _asm_procedurefindtarget_patchvariable_3 "temp" => Object
+              // parameter final  context
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -2561,6 +2710,7 @@ reporter procedure FIND-TARGET:[]{-T--}:
          FRAME SAME
           RETURN
 [2]_asm_procedurefindtarget_goto_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_4
@@ -2570,46 +2720,43 @@ reporter procedure FIND-TARGET:[]{-T--}:
 [3]_asm_procedurefindtarget_report_5 "report" Object => void
       _minoneof "min-one-of"
         _asm_procedurefindtarget_neighbors_6 "neighbors" => AgentSet
+              // parameter final  context
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-              ASTORE 2
-              ALOAD 2
-              INSTANCEOF org/nlogo/agent/Turtle
-              IFEQ L1
-              ALOAD 2
-              CHECKCAST org/nlogo/agent/Turtle
               ASTORE 3
               ALOAD 3
+              INSTANCEOF org/nlogo/agent/Turtle
+              IFEQ L1
+              ALOAD 3
+              CHECKCAST org/nlogo/agent/Turtle
               INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-              ASTORE 4
+              ASTORE 2
               GOTO L2
              L1
-             FRAME APPEND [org/nlogo/agent/Agent]
-              ALOAD 2
+             FRAME APPEND [T org/nlogo/agent/Agent]
+              ALOAD 3
               INSTANCEOF org/nlogo/agent/Patch
               IFEQ L3
-              ALOAD 2
+              ALOAD 3
               CHECKCAST org/nlogo/agent/Patch
-              ASTORE 5
-              ALOAD 5
-              ASTORE 4
-             L2
-             FRAME APPEND [T org/nlogo/agent/Patch]
-              ALOAD 4
-              INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/AgentSet;
-              GOTO L4
+              ASTORE 2
+              GOTO L2
              L3
-             FRAME CHOP 2
+             FRAME SAME
               NEW scala/MatchError
               DUP
-              ALOAD 2
+              ALOAD 3
               INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
               ATHROW
+             L2
+             FRAME FULL [org/nlogo/prim/_asm_procedurefindtarget_neighbors_6 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+              ALOAD 2
+              INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/AgentSet;
              L4
-             FRAME FULL [org/nlogo/prim/_asm_procedurefindtarget_neighbors_6 org/nlogo/nvm/Context org/nlogo/agent/Agent T org/nlogo/agent/Patch] [org/nlogo/agent/AgentSet]
               ARETURN
         _asm_procedurefindtarget_patchvariable_7 "temp" => Object
+              // parameter final  context
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -2704,6 +2851,7 @@ reporter procedure FIND-TARGET:[]{-T--}:
          FRAME SAME
           RETURN
 [4]_asm_procedurefindtarget_returnreport_8 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -2722,6 +2870,9 @@ reporter procedure FIND-TARGET:[]{-T--}:
 procedure BUG-MOVE:[TARGET TRIES]{-T--}:
 [0]_asm_procedurebugmove_setprocedurevariable_0 "let" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurebugmove_setprocedurevariable_0.kept2_value : Ljava/lang/Double;
@@ -2743,6 +2894,7 @@ procedure BUG-MOVE:[TARGET TRIES]{-T--}:
         _any "any?" AgentSet => boolean
           _turtleson "turtles-on"
             _asm_procedurebugmove_procedurevariable_2 "target" => Object
+                  // parameter final  context
                  L0
                   ALOAD 1
                   GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -2751,6 +2903,12 @@ procedure BUG-MOVE:[TARGET TRIES]{-T--}:
                   AALOAD
                  L1
                   ARETURN
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurebugmove_if_1.keptinstr4 : Lorg/nlogo/prim/etc/_turtleson;
@@ -2779,22 +2937,22 @@ procedure BUG-MOVE:[TARGET TRIES]{-T--}:
           ASTORE 2
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.isEmpty ()Z
-          IFEQ L4
-          ICONST_0
+          IFNE L4
+          ICONST_1
           GOTO L5
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurebugmove_if_1 org/nlogo/nvm/Context org/nlogo/agent/AgentSet] []
-          ICONST_1
+          ICONST_0
          L5
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L6
-          ICONST_0
+          IFNE L6
+          ICONST_1
           GOTO L7
          L6
          FRAME FULL [org/nlogo/prim/_asm_procedurebugmove_if_1 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L7
          FRAME SAME1 I
           ISTORE 2
@@ -2813,6 +2971,7 @@ procedure BUG-MOVE:[TARGET TRIES]{-T--}:
           RETURN
 [2]_moveto "move-to"
       _asm_procedurebugmove_procedurevariable_3 "target" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -2860,6 +3019,7 @@ procedure BUG-MOVE:[TARGET TRIES]{-T--}:
          L3
           RETURN
 [4]_asm_procedurebugmove_goto_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 10
@@ -2870,6 +3030,13 @@ procedure BUG-MOVE:[TARGET TRIES]{-T--}:
       _plus "+" double,double => double
         _procedurevariable:TRIES "tries" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -2926,44 +3093,44 @@ procedure BUG-MOVE:[TARGET TRIES]{-T--}:
 [6]_asm_procedurebugmove_setprocedurevariable_7 "set" Object => void
       _oneof "one-of" AgentSet => Object
         _neighbors "neighbors" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-          ASTORE 2
-          ALOAD 2
-          INSTANCEOF org/nlogo/agent/Turtle
-          IFEQ L1
-          ALOAD 2
-          CHECKCAST org/nlogo/agent/Turtle
           ASTORE 3
           ALOAD 3
+          INSTANCEOF org/nlogo/agent/Turtle
+          IFEQ L1
+          ALOAD 3
+          CHECKCAST org/nlogo/agent/Turtle
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 4
+          ASTORE 2
           GOTO L2
          L1
-         FRAME APPEND [org/nlogo/agent/Agent]
-          ALOAD 2
+         FRAME APPEND [T org/nlogo/agent/Agent]
+          ALOAD 3
           INSTANCEOF org/nlogo/agent/Patch
           IFEQ L3
-          ALOAD 2
+          ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 5
-          ALOAD 5
-          ASTORE 4
-         L2
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 4
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/AgentSet;
-          GOTO L4
+          ASTORE 2
+          GOTO L2
          L3
-         FRAME CHOP 2
+         FRAME SAME
           NEW scala/MatchError
           DUP
-          ALOAD 2
+          ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L2
+         FRAME FULL [org/nlogo/prim/_asm_procedurebugmove_setprocedurevariable_7 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 2
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/AgentSet;
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurebugmove_setprocedurevariable_7 org/nlogo/nvm/Context org/nlogo/agent/Agent T org/nlogo/agent/Patch] [org/nlogo/agent/AgentSet]
           ASTORE 2
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.count ()I
@@ -2974,7 +3141,7 @@ procedure BUG-MOVE:[TARGET TRIES]{-T--}:
           GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
           GOTO L6
          L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurebugmove_setprocedurevariable_7 org/nlogo/nvm/Context org/nlogo/agent/AgentSet I org/nlogo/agent/Patch] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurebugmove_setprocedurevariable_7 org/nlogo/nvm/Context org/nlogo/agent/AgentSet I] []
           ALOAD 2
           ILOAD 3
           ALOAD 1
@@ -3002,6 +3169,7 @@ procedure BUG-MOVE:[TARGET TRIES]{-T--}:
         _any "any?" AgentSet => boolean
           _turtleson "turtles-on"
             _asm_procedurebugmove_procedurevariable_9 "target" => Object
+                  // parameter final  context
                  L0
                   ALOAD 1
                   GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -3010,6 +3178,12 @@ procedure BUG-MOVE:[TARGET TRIES]{-T--}:
                   AALOAD
                  L1
                   ARETURN
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurebugmove_if_8.keptinstr4 : Lorg/nlogo/prim/etc/_turtleson;
@@ -3038,22 +3212,22 @@ procedure BUG-MOVE:[TARGET TRIES]{-T--}:
           ASTORE 2
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.isEmpty ()Z
-          IFEQ L4
-          ICONST_0
+          IFNE L4
+          ICONST_1
           GOTO L5
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedurebugmove_if_8 org/nlogo/nvm/Context org/nlogo/agent/AgentSet] []
-          ICONST_1
+          ICONST_0
          L5
          FRAME SAME1 I
           ISTORE 2
           ILOAD 2
-          IFEQ L6
-          ICONST_0
+          IFNE L6
+          ICONST_1
           GOTO L7
          L6
          FRAME FULL [org/nlogo/prim/_asm_procedurebugmove_if_8 org/nlogo/nvm/Context I] []
-          ICONST_1
+          ICONST_0
          L7
          FRAME SAME1 I
           ISTORE 2
@@ -3072,6 +3246,7 @@ procedure BUG-MOVE:[TARGET TRIES]{-T--}:
           RETURN
 [8]_moveto "move-to"
       _asm_procedurebugmove_procedurevariable_10 "target" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -3122,6 +3297,8 @@ procedure BUG-MOVE:[TARGET TRIES]{-T--}:
       _lessorequal "<=" Object,double => boolean
         _procedurevariable:TRIES "tries" => Object
         _constdouble:9.0 "9" => double
+          // parameter final  context
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -3191,6 +3368,7 @@ procedure BUG-MOVE:[TARGET TRIES]{-T--}:
          L9
           RETURN
 [11]_asm_procedurebugmove_return_13 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V

--- a/netlogo-headless/test/benchdumps/ImportWorld.txt
+++ b/netlogo-headless/test/benchdumps/ImportWorld.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[NAME SALT]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:362.0 "362" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 362.0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[NAME SALT]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -58,6 +61,9 @@ procedure BENCHMARK:[NAME SALT]{O---}:
           RETURN
 [1]_asm_procedurebenchmark_ask_1 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurebenchmark_ask_1.world : Lorg/nlogo/agent/World;
@@ -113,6 +119,9 @@ procedure BENCHMARK:[NAME SALT]{O---}:
           RETURN
 [2]_asm_procedurebenchmark_setpatchvariable_2 "set" Object => void
       _randomconst:100 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -135,9 +144,6 @@ procedure BENCHMARK:[NAME SALT]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setpatchvariable_2 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -152,9 +158,16 @@ procedure BENCHMARK:[NAME SALT]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_procedurebenchmark_setpatchvariable_3 "set" Object => void
       _randomconst:100 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -177,9 +190,6 @@ procedure BENCHMARK:[NAME SALT]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setpatchvariable_3 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -194,10 +204,19 @@ procedure BENCHMARK:[NAME SALT]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_procedurebenchmark_setpatchvariable_4 "set" Object => void
       _oneof "one-of" LogoList => Object
         _basecolors "base-colors" => LogoList
+          // parameter final  context
+          // parameter final  context
+          // parameter final  list
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           GETSTATIC org/nlogo/api/Color$.MODULE$ : Lorg/nlogo/api/Color$;
@@ -246,9 +265,6 @@ procedure BENCHMARK:[NAME SALT]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setpatchvariable_4 org/nlogo/nvm/Context java/lang/Object I] [org/nlogo/api/AgentException]
@@ -263,8 +279,13 @@ procedure BENCHMARK:[NAME SALT]{O---}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [5]_asm_procedurebenchmark_done_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -273,6 +294,9 @@ procedure BENCHMARK:[NAME SALT]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setprocedurevariable_6 "let" Object => void
       _conststring:"" """" => String
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC ""
          L1
@@ -320,6 +344,9 @@ procedure BENCHMARK:[NAME SALT]{O---}:
           RETURN
 [8]_asm_procedurebenchmark_randomseed_8 "random-seed" double => void
       _newseed "new-seed" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurebenchmark_randomseed_8.world : Lorg/nlogo/agent/World;
@@ -343,16 +370,16 @@ procedure BENCHMARK:[NAME SALT]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -371,6 +398,9 @@ procedure BENCHMARK:[NAME SALT]{O---}:
           RETURN
 [9]_asm_procedurebenchmark_setprocedurevariable_9 "let" Object => void
       _randomconst:10000000 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -401,6 +431,11 @@ procedure BENCHMARK:[NAME SALT]{O---}:
         _conststring:"firebig-" ""firebig-"" => String
         _procedurevariable:SALT "salt" => Object
         _conststring:".csv" "".csv"" => String
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           NEW java/lang/StringBuilder
           DUP
@@ -439,6 +474,7 @@ procedure BENCHMARK:[NAME SALT]{O---}:
          L8
           RETURN
 [11]_asm_procedurebenchmark_done_11 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -447,6 +483,7 @@ procedure BENCHMARK:[NAME SALT]{O---}:
           RETURN
 [12]_exportworld "export-world"
       _asm_procedurebenchmark_procedurevariable_12 "name" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -458,6 +495,7 @@ procedure BENCHMARK:[NAME SALT]{O---}:
 [13]_resettimer "reset-timer"
 [14]_importworld "import-world"
       _asm_procedurebenchmark_procedurevariable_13 "name" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -468,6 +506,9 @@ procedure BENCHMARK:[NAME SALT]{O---}:
             ARETURN
 [15]_asm_procedurebenchmark_setobservervariable_14 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -489,9 +530,6 @@ procedure BENCHMARK:[NAME SALT]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 16
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_14 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -506,8 +544,13 @@ procedure BENCHMARK:[NAME SALT]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 16
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [16]_asm_procedurebenchmark_return_15 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V

--- a/netlogo-headless/test/benchdumps/Ising.txt
+++ b/netlogo-headless/test/benchdumps/Ising.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:2929.0 "2929" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 2929.0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -59,6 +62,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [1]_resettimer "reset-timer"
 [2]_asm_procedurebenchmark_call_1 "setup"
       _constdouble:0.0 "0" => Double
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -86,6 +90,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:2000000.0 "2000000" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 2000000.0
          L1
@@ -98,7 +105,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -125,6 +133,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -158,6 +167,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -179,9 +191,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -196,8 +205,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -212,6 +226,9 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
 [1]_resetticks "reset-ticks"
 [2]_asm_proceduresetup_ask_0 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_0.world : Lorg/nlogo/agent/World;
@@ -269,6 +286,13 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
       _equal "=" Object,double => boolean
         _procedurevariable:INITIAL-MAGNETIZATION "initial-magnetization" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -281,11 +305,9 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -296,19 +318,19 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_ifelse_1 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_ifelse_1 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L6
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L7
           ISTORE 2
           ALOAD 1
@@ -317,16 +339,21 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
           ICONST_4
           GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_ifelse_1 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_ifelse_1 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 6
          L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_ifelse_1 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_ifelse_1 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L10
           RETURN
 [4]_asm_proceduresetup_setpatchvariable_2 "set" Object => void
       _oneof "one-of" LogoList => Object
         _constlist:[-1 1] "[-1 1]" => LogoList
+          // parameter final  context
+          // parameter final  context
+          // parameter final  list
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -375,9 +402,6 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_2 org/nlogo/nvm/Context java/lang/Object I] [org/nlogo/api/AgentException]
@@ -392,8 +416,13 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [5]_asm_proceduresetup_goto_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 7
@@ -402,6 +431,9 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
           RETURN
 [6]_asm_proceduresetup_setpatchvariable_4 "set" Object => void
       _procedurevariable:INITIAL-MAGNETIZATION "initial-magnetization" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -418,9 +450,6 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -435,6 +464,10 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_proceduresetup_call_5 "recolor"
          L0
@@ -455,6 +488,7 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
          L1
           RETURN
 [8]_asm_proceduresetup_done_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -465,6 +499,13 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
       _sum "sum" LogoList => double
         _patchvariableof:SPIN "of" AgentSet => LogoList
           _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  context
+          // parameter final  l0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L6
@@ -477,20 +518,20 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 4
+          ASTORE 3
           ALOAD 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 5
+          ASTORE 4
          L8
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_7 org/nlogo/nvm/Context org/nlogo/agent/AgentSet T org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 5
+         FRAME APPEND [org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator]
+          ALOAD 4
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L9
+          ALOAD 3
           ALOAD 4
-          ALOAD 5
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
@@ -498,23 +539,23 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
           GOTO L8
          L9
          FRAME SAME
-          ALOAD 4
+          ALOAD 3
           INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
          L1
           GOTO L10
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_7 org/nlogo/nvm/Context org/nlogo/agent/AgentSet] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 5
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L10
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_7 org/nlogo/nvm/Context org/nlogo/agent/AgentSet T org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/core/LogoList]
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_7 org/nlogo/nvm/Context org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [org/nlogo/core/LogoList]
           ASTORE 2
           DCONST_0
           DSTORE 3
@@ -531,7 +572,7 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
           ASTORE 6
           ALOAD 6
           INSTANCEOF java/lang/Double
-          IFEQ L13
+          IFEQ L11
           ALOAD 6
           CHECKCAST java/lang/Double
           ASTORE 7
@@ -540,20 +581,14 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DADD
           DSTORE 3
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 8
-          GOTO L11
-         L13
-         FRAME APPEND [java/lang/Object]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 8
           GOTO L11
          L12
-         FRAME CHOP 1
+         FRAME SAME
           ALOAD 0
           DLOAD 3
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_7.validDouble (D)D
-         L14
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
+         L13
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -568,10 +603,7 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L4
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L15
+          GOTO L14
          L5
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_7 org/nlogo/nvm/Context java/lang/Double T T java/util/Iterator] [org/nlogo/api/AgentException]
           ASTORE 3
@@ -583,8 +615,12 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L15
+         L14
          FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L15
           RETURN
 [10]_asm_proceduresetup_call_8 "setup-plot"
          L0
@@ -623,6 +659,7 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
          L1
           RETURN
 [12]_asm_proceduresetup_return_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -636,6 +673,11 @@ procedure GO:[]{O---}:
 [0]_asm_procedurego_ask_0 "ask" Object => void
       _oneof "one-of" AgentSet => Object
         _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_0.world : Lorg/nlogo/agent/World;
@@ -664,18 +706,16 @@ procedure GO:[]{O---}:
          FRAME SAME1 java/lang/Object
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L4
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L5
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -691,8 +731,8 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_0 org/nlogo/nvm/Context java/lang/Object I java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_0 org/nlogo/nvm/Context java/lang/Object I org/nlogo/agent/AgentSet] []
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -709,18 +749,18 @@ procedure GO:[]{O---}:
           ATHROW
          L5
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L7
          L4
          FRAME CHOP 1
-          ALOAD 4
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L8
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -737,7 +777,7 @@ procedure GO:[]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -745,23 +785,12 @@ procedure GO:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L9
-         FRAME APPEND [T T org/nlogo/agent/Agent]
+         FRAME APPEND [T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_0 org/nlogo/nvm/Context java/lang/Object I java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_1
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L10
+          GOTO L7
          L8
          FRAME CHOP 2
           NEW org/nlogo/nvm/ArgumentTypeException
@@ -777,8 +806,16 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L7
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet] []
+          ALOAD 1
+          ALOAD 3
+          ICONST_1
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ask_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [1]_asm_procedurego_call_1 "update"
          L0
@@ -799,6 +836,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [2]_asm_procedurego_done_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -825,6 +863,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [5]_asm_procedurego_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -841,6 +880,17 @@ procedure UPDATE:[EDIFF]{-TP-}:
           _constdouble:2.0 "2" => double
           _patchvariable:SPIN "spin" => Object
         _nsum4:SPIN "sum" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L5
@@ -899,10 +949,8 @@ procedure UPDATE:[EDIFF]{-TP-}:
           IFEQ L9
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L10
          L9
          FRAME FULL [org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0 org/nlogo/nvm/Context T org/nlogo/agent/Agent D] [D]
@@ -911,46 +959,48 @@ procedure UPDATE:[EDIFF]{-TP-}:
           IFEQ L11
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L10
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0 org/nlogo/nvm/Context T org/nlogo/agent/Agent T org/nlogo/agent/Patch] [D]
-          ALOAD 5
           ASTORE 2
+          GOTO L10
+         L11
+         FRAME SAME1 D
+          NEW scala/MatchError
+          DUP
+          ALOAD 3
+          INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
+          ATHROW
+         L10
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent D] [D]
           DCONST_0
-          DSTORE 7
+          DSTORE 4
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors4 ()Lorg/nlogo/agent/AgentSet;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.iterator ()Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 6
          L12
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T D org/nlogo/agent/AgentIterator] [D]
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent D org/nlogo/agent/AgentIterator] [D]
+          ALOAD 6
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L13
-          ALOAD 9
+          ALOAD 6
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Patch
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Patch.getPatchVariable (I)Ljava/lang/Object;
-          ASTORE 10
-          ALOAD 10
+          ASTORE 7
+          ALOAD 7
           INSTANCEOF java/lang/Double
           IFEQ L14
-          ALOAD 10
+          ALOAD 7
           CHECKCAST java/lang/Double
-          ASTORE 11
-          DLOAD 7
-          ALOAD 11
+          ASTORE 8
+          DLOAD 4
+          ALOAD 8
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DADD
-          DSTORE 7
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 12
+          DSTORE 4
           GOTO L12
          L14
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T D org/nlogo/agent/AgentIterator java/lang/Object] [D]
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent D org/nlogo/agent/AgentIterator java/lang/Object] [D]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -964,14 +1014,14 @@ procedure UPDATE:[EDIFF]{-TP-}:
           DUP
           ICONST_0
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
-          ALOAD 10
+          ALOAD 7
           INVOKEVIRTUAL org/nlogo/api/Dump$.logoObject (Ljava/lang/Object;)Ljava/lang/String;
           INVOKEVIRTUAL java/lang/String.toString ()Ljava/lang/String;
           AASTORE
           DUP
           ICONST_1
           GETSTATIC org/nlogo/api/TypeNames$.MODULE$ : Lorg/nlogo/api/TypeNames$;
-          ALOAD 10
+          ALOAD 7
           INVOKEVIRTUAL org/nlogo/api/TypeNames$.name (Ljava/lang/Object;)Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -979,20 +1029,12 @@ procedure UPDATE:[EDIFF]{-TP-}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T D org/nlogo/agent/AgentIterator] [D]
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent D org/nlogo/agent/AgentIterator] [D]
           ALOAD 0
-          DLOAD 7
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0.validDouble (D)D
-          GOTO L15
-         L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0 org/nlogo/nvm/Context T org/nlogo/agent/Agent D] [D]
-          NEW scala/MatchError
-          DUP
-          ALOAD 3
-          INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
-          ATHROW
+          DLOAD 4
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T D org/nlogo/agent/AgentIterator] [D D]
           DSTORE 4
           DSTORE 2
           DLOAD 2
@@ -1033,6 +1075,27 @@ procedure UPDATE:[EDIFF]{-TP-}:
                 _unaryminus "-" double => double
                   _procedurevariable:EDIFF "Ediff" => Object
                 _observervariable:TEMPERATURE "temperature" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -1102,14 +1165,10 @@ procedure UPDATE:[EDIFF]{-TP-}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L15
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPL
@@ -1117,15 +1176,14 @@ procedure UPDATE:[EDIFF]{-TP-}:
           ICONST_1
           GOTO L17
          L16
-         FRAME APPEND [java/lang/Object java/lang/Double]
+         FRAME SAME
           ICONST_0
          L17
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L18
          L15
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1154,11 +1212,13 @@ procedure UPDATE:[EDIFF]{-TP-}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L18
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_if_1 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
-          IFEQ L19
-         L20
-          DCONST_1
+         FRAME APPEND [I]
+          ILOAD 5
+         L19
+          IFEQ L20
          L21
+          DCONST_1
+         L22
           DSTORE 2
           DLOAD 2
           ALOAD 1
@@ -1166,21 +1226,21 @@ procedure UPDATE:[EDIFF]{-TP-}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-         L22
+         L23
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_0
           AALOAD
-         L23
+         L24
           ASTORE 2
          L0
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
-          GOTO L24
+          GOTO L25
          L1
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_if_1 org/nlogo/nvm/Context java/lang/Object T T java/lang/Object java/lang/Double I] [java/lang/ClassCastException]
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_if_1 org/nlogo/nvm/Context java/lang/Object T T I] [java/lang/ClassCastException]
           POP
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
@@ -1191,24 +1251,24 @@ procedure UPDATE:[EDIFF]{-TP-}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
-         L24
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_if_1 org/nlogo/nvm/Context java/lang/Object T T java/lang/Object java/lang/Double I] [D D]
+         L25
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_if_1 org/nlogo/nvm/Context java/lang/Object T T I] [D D]
           DSTORE 2
           DLOAD 2
           DNEG
-         L25
+         L26
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureupdate_if_1.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.observer ()Lorg/nlogo/agent/Observer;
           ICONST_0
           INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
-         L26
+         L27
           ASTORE 2
          L2
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
-          GOTO L27
+          GOTO L28
          L3
          FRAME SAME1 java/lang/ClassCastException
           POP
@@ -1221,14 +1281,14 @@ procedure UPDATE:[EDIFF]{-TP-}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
-         L27
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_if_1 org/nlogo/nvm/Context java/lang/Object T T java/lang/Object java/lang/Double I] [D D D]
+         L28
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_if_1 org/nlogo/nvm/Context java/lang/Object T T I] [D D D]
           DSTORE 4
           DSTORE 2
           DLOAD 4
           DCONST_0
           DCMPL
-          IFNE L28
+          IFNE L29
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1238,54 +1298,54 @@ procedure UPDATE:[EDIFF]{-TP-}:
           INVOKEINTERFACE org/nlogo/core/I18NJava.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L28
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_if_1 org/nlogo/nvm/Context D D java/lang/Double I] [D]
+         L29
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_if_1 org/nlogo/nvm/Context D D] [D]
           DLOAD 2
           DLOAD 4
           DDIV
-         L29
+         L30
           DSTORE 2
           DLOAD 2
           INVOKESTATIC java/lang/StrictMath.exp (D)D
-         L30
+         L31
           DSTORE 4
           DSTORE 2
           DLOAD 2
           DLOAD 4
           DCMPG
-          IFGE L31
+          IFGE L32
           ICONST_1
-          GOTO L32
-         L31
+          GOTO L33
+         L32
          FRAME SAME
           ICONST_0
-         L32
-         FRAME SAME1 I
-          GOTO L33
-         L19
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_if_1 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] []
-          ICONST_0
          L33
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_if_1 org/nlogo/nvm/Context T T T T java/lang/Double I] [I]
+         FRAME SAME1 I
           GOTO L34
-         L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_if_1 org/nlogo/nvm/Context java/lang/Object D] []
-          ICONST_1
+         L20
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_if_1 org/nlogo/nvm/Context java/lang/Object D I] []
+          ICONST_0
          L34
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdate_if_1 org/nlogo/nvm/Context] [I]
+          GOTO L35
+         L11
+         FRAME APPEND [java/lang/Object D]
+          ICONST_1
+         L35
          FRAME FULL [org/nlogo/prim/_asm_procedureupdate_if_1 org/nlogo/nvm/Context] [I]
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L35
+          IFEQ L36
           ICONST_2
-          GOTO L36
-         L35
+          GOTO L37
+         L36
          FRAME FULL [org/nlogo/prim/_asm_procedureupdate_if_1 org/nlogo/nvm/Context I] [org/nlogo/nvm/Context]
           ICONST_3
-         L36
+         L37
          FRAME FULL [org/nlogo/prim/_asm_procedureupdate_if_1 org/nlogo/nvm/Context I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L37
+         L38
           RETURN
 [2]_asm_procedureupdate_call_2 "flip"
          L0
@@ -1306,6 +1366,7 @@ procedure UPDATE:[EDIFF]{-TP-}:
          L1
           RETURN
 [3]_asm_procedureupdate_return_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1319,6 +1380,11 @@ procedure FLIP:[]{-TP-}:
 [0]_asm_procedureflip_setpatchvariable_0 "set" Object => void
       _unaryminus "-" double => double
         _patchvariable:SPIN "spin" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -1379,9 +1445,6 @@ procedure FLIP:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L11
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedureflip_setpatchvariable_0 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1396,6 +1459,10 @@ procedure FLIP:[]{-TP-}:
           ATHROW
          L11
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [1]_asm_procedureflip_setobservervariable_1 "set" Object => void
       _plus "+" double,double => double
@@ -1403,6 +1470,17 @@ procedure FLIP:[]{-TP-}:
         _mult "*" double,double => double
           _constdouble:2.0 "2" => double
           _patchvariable:SPIN "spin" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -1501,9 +1579,6 @@ procedure FLIP:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L8
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L17
          L9
          FRAME FULL [org/nlogo/prim/_asm_procedureflip_setobservervariable_1 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1518,6 +1593,10 @@ procedure FLIP:[]{-TP-}:
           ATHROW
          L17
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [2]_asm_procedureflip_call_2 "recolor"
          L0
@@ -1538,6 +1617,7 @@ procedure FLIP:[]{-TP-}:
          L1
           RETURN
 [3]_asm_procedureflip_return_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1552,6 +1632,13 @@ procedure RECOLOR:[]{-TP-}:
       _equal "=" Object,double => boolean
         _patchvariable:SPIN "spin" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1578,11 +1665,9 @@ procedure RECOLOR:[]{-TP-}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -1593,19 +1678,19 @@ procedure RECOLOR:[]{-TP-}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -1614,15 +1699,18 @@ procedure RECOLOR:[]{-TP-}:
           ICONST_1
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           ICONST_3
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
 [1]_asm_procedurerecolor_setpatchvariable_1 "set" Object => void
       _constdouble:15.0 "red" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1636,9 +1724,6 @@ procedure RECOLOR:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1653,8 +1738,13 @@ procedure RECOLOR:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedurerecolor_goto_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_4
@@ -1663,6 +1753,9 @@ procedure RECOLOR:[]{-TP-}:
           RETURN
 [3]_asm_procedurerecolor_setpatchvariable_3 "set" Object => void
       _constdouble:105.0 "blue" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1676,9 +1769,6 @@ procedure RECOLOR:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolor_setpatchvariable_3 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1693,8 +1783,13 @@ procedure RECOLOR:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_procedurerecolor_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1710,6 +1805,10 @@ reporter procedure MAGNETIZATION:[]{OTPL}:
         _observervariable:SUM-OF-SPINS "sum-of-spins" => Object
         _count "count" AgentSet => double
           _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -1840,6 +1939,7 @@ reporter procedure MAGNETIZATION:[]{OTPL}:
          FRAME SAME
           RETURN
 [1]_asm_proceduremagnetization_returnreport_1 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -1858,12 +1958,14 @@ reporter procedure MAGNETIZATION:[]{OTPL}:
 procedure SETUP-PLOT:[]{OTPL}:
 [0]_setcurrentplot "set-current-plot"
       _asm_proceduresetupplot_conststring_0 ""Magnetization"" => String
+            // parameter final  context
            L0
             LDC "Magnetization"
            L1
             ARETURN
 [1]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduresetupplot_conststring_1 ""axis"" => String
+            // parameter final  context
            L0
             LDC "axis"
            L1
@@ -1871,12 +1973,14 @@ procedure SETUP-PLOT:[]{OTPL}:
 [2]_autoplotoff "auto-plot-off"
 [3]_plotxy "plotxy"
       _asm_proceduresetupplot_constdouble_2 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupplot_constdouble_2.kept1_value : Ljava/lang/Double;
            L1
             ARETURN
       _asm_proceduresetupplot_constdouble_3 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupplot_constdouble_3.kept1_value : Ljava/lang/Double;
@@ -1884,12 +1988,14 @@ procedure SETUP-PLOT:[]{OTPL}:
             ARETURN
 [4]_plotxy "plotxy"
       _asm_proceduresetupplot_constdouble_4 "1000000000" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupplot_constdouble_4.kept1_value : Ljava/lang/Double;
            L1
             ARETURN
       _asm_proceduresetupplot_constdouble_5 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupplot_constdouble_5.kept1_value : Ljava/lang/Double;
@@ -1897,6 +2003,7 @@ procedure SETUP-PLOT:[]{OTPL}:
             ARETURN
 [5]_autoploton "auto-plot-on"
 [6]_asm_proceduresetupplot_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1909,12 +2016,14 @@ procedure SETUP-PLOT:[]{OTPL}:
 procedure UPDATE-PLOT:[]{OTPL}:
 [0]_setcurrentplot "set-current-plot"
       _asm_procedureupdateplot_conststring_0 ""Magnetization"" => String
+            // parameter final  context
            L0
             LDC "Magnetization"
            L1
             ARETURN
 [1]_setcurrentplotpen "set-current-plot-pen"
       _asm_procedureupdateplot_conststring_1 ""average spin"" => String
+            // parameter final  context
            L0
             LDC "average spin"
            L1
@@ -1975,6 +2084,7 @@ procedure UPDATE-PLOT:[]{OTPL}:
            FRAME SAME1 java/lang/Object
             ARETURN
 [3]_asm_procedureupdateplot_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V

--- a/netlogo-headless/test/benchdumps/Life.txt
+++ b/netlogo-headless/test/benchdumps/Life.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:22.0 "22" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 22.0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -77,6 +80,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:500.0 "500" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 500.0
          L1
@@ -89,7 +95,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -116,6 +123,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -149,6 +157,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -170,9 +181,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -187,8 +195,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -203,6 +216,9 @@ procedure SETUP-RANDOM:[]{O---}:
 [1]_resetticks "reset-ticks"
 [2]_asm_proceduresetuprandom_ask_0 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetuprandom_ask_0.world : Lorg/nlogo/agent/World;
@@ -261,6 +277,15 @@ procedure SETUP-RANDOM:[]{O---}:
         _randomfloat "random-float" double => double
           _constdouble:1.0 "1.0" => double
         _observervariable:INITIAL-DENSITY "initial-density" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           DCONST_1
          L1
@@ -281,11 +306,9 @@ procedure SETUP-RANDOM:[]{O---}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L4
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -296,15 +319,14 @@ procedure SETUP-RANDOM:[]{O---}:
           ICONST_1
           GOTO L6
          L5
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetuprandom_ifelse_1 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetuprandom_ifelse_1 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L6
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L7
          L4
-         FRAME CHOP 1
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -333,20 +355,22 @@ procedure SETUP-RANDOM:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetuprandom_ifelse_1 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
+         L8
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L8
+          IFEQ L9
           ICONST_4
-          GOTO L9
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetuprandom_ifelse_1 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 6
+          GOTO L10
          L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetuprandom_ifelse_1 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetuprandom_ifelse_1 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context]
+          BIPUSH 6
          L10
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetuprandom_ifelse_1 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [4]_asm_proceduresetuprandom_call_2 "cell-birth"
          L0
@@ -367,6 +391,7 @@ procedure SETUP-RANDOM:[]{O---}:
          L1
           RETURN
 [5]_asm_proceduresetuprandom_goto_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 7
@@ -392,6 +417,7 @@ procedure SETUP-RANDOM:[]{O---}:
          L1
           RETURN
 [7]_asm_proceduresetuprandom_done_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -399,6 +425,7 @@ procedure SETUP-RANDOM:[]{O---}:
          L1
           RETURN
 [8]_asm_proceduresetuprandom_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -411,6 +438,9 @@ procedure SETUP-RANDOM:[]{O---}:
 procedure CELL-BIRTH:[]{-TP-}:
 [0]_asm_procedurecellbirth_setpatchvariable_0 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -424,9 +454,6 @@ procedure CELL-BIRTH:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecellbirth_setpatchvariable_0 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -441,9 +468,16 @@ procedure CELL-BIRTH:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [1]_asm_procedurecellbirth_setpatchvariable_1 "set" Object => void
       _observervariable:FGCOLOR "fgcolor" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -460,9 +494,6 @@ procedure CELL-BIRTH:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecellbirth_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -477,8 +508,13 @@ procedure CELL-BIRTH:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedurecellbirth_return_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -491,6 +527,9 @@ procedure CELL-BIRTH:[]{-TP-}:
 procedure CELL-DEATH:[]{-TP-}:
 [0]_asm_procedurecelldeath_setpatchvariable_0 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -504,9 +543,6 @@ procedure CELL-DEATH:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecelldeath_setpatchvariable_0 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -521,9 +557,16 @@ procedure CELL-DEATH:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [1]_asm_procedurecelldeath_setpatchvariable_1 "set" Object => void
       _observervariable:BGCOLOR "bgcolor" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -540,9 +583,6 @@ procedure CELL-DEATH:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecelldeath_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -557,8 +597,13 @@ procedure CELL-DEATH:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedurecelldeath_return_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -571,6 +616,9 @@ procedure CELL-DEATH:[]{-TP-}:
 procedure GO:[]{O---}:
 [0]_asm_procedurego_ask_0 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_0.world : Lorg/nlogo/agent/World;
@@ -628,6 +676,7 @@ procedure GO:[]{O---}:
       _countwith "count" AgentSet,Reporter => double
         _neighbors "neighbors" => AgentSet
         _asm_procedurego_patchvariable_2 "living?" => Object
+              // parameter final  context
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -650,45 +699,46 @@ procedure GO:[]{O---}:
              L3
              FRAME SAME1 java/lang/Object
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  block
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-          ASTORE 2
-          ALOAD 2
-          INSTANCEOF org/nlogo/agent/Turtle
-          IFEQ L4
-          ALOAD 2
-          CHECKCAST org/nlogo/agent/Turtle
           ASTORE 3
           ALOAD 3
+          INSTANCEOF org/nlogo/agent/Turtle
+          IFEQ L4
+          ALOAD 3
+          CHECKCAST org/nlogo/agent/Turtle
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 4
+          ASTORE 2
           GOTO L5
          L4
-         FRAME APPEND [org/nlogo/agent/Agent]
-          ALOAD 2
+         FRAME APPEND [T org/nlogo/agent/Agent]
+          ALOAD 3
           INSTANCEOF org/nlogo/agent/Patch
           IFEQ L6
-          ALOAD 2
+          ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 5
-          ALOAD 5
-          ASTORE 4
-         L5
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 4
-          INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/AgentSet;
-          GOTO L7
+          ASTORE 2
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME SAME
           NEW scala/MatchError
           DUP
-          ALOAD 2
+          ALOAD 3
           INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
           ATHROW
+         L5
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_1 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+          ALOAD 2
+          INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/AgentSet;
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_1 org/nlogo/nvm/Context org/nlogo/agent/Agent T org/nlogo/agent/Patch] [org/nlogo/agent/AgentSet]
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_setpatchvariable_1.keptinstr4 : Lorg/nlogo/nvm/Reporter;
           ASTORE 3
@@ -726,25 +776,15 @@ procedure GO:[]{O---}:
           IFEQ L10
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L11
+          IFEQ L8
           ILOAD 5
           ICONST_1
           IADD
           ISTORE 5
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          GOTO L12
-         L11
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L12
-         FRAME SAME1 scala/runtime/BoxedUnit
-          ASTORE 10
           GOTO L8
          L10
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -779,7 +819,7 @@ procedure GO:[]{O---}:
          FRAME CHOP 2
           ILOAD 5
           I2D
-         L13
+         L11
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -793,10 +833,7 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L14
+          GOTO L12
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double T org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator] [org/nlogo/api/AgentException]
           ASTORE 3
@@ -808,10 +845,15 @@ procedure GO:[]{O---}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L14
+         L12
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [2]_asm_procedurego_done_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -820,6 +862,9 @@ procedure GO:[]{O---}:
           RETURN
 [3]_asm_procedurego_ask_4 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_4.world : Lorg/nlogo/agent/World;
@@ -877,6 +922,13 @@ procedure GO:[]{O---}:
       _equal "=" Object,double => boolean
         _patchvariable:LIVE-NEIGHBORS "live-neighbors" => Object
         _constdouble:3.0 "3" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -903,11 +955,9 @@ procedure GO:[]{O---}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -918,19 +968,19 @@ procedure GO:[]{O---}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_5 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_5 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -939,10 +989,10 @@ procedure GO:[]{O---}:
           ICONST_5
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_5 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_5 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 7
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_5 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_ifelse_5 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
@@ -965,6 +1015,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [6]_asm_procedurego_goto_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 9
@@ -975,6 +1026,13 @@ procedure GO:[]{O---}:
       _notequal "!=" Object,double => boolean
         _patchvariable:LIVE-NEIGHBORS "live-neighbors" => Object
         _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1001,11 +1059,9 @@ procedure GO:[]{O---}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -1016,19 +1072,19 @@ procedure GO:[]{O---}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_8 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_8 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -1037,10 +1093,10 @@ procedure GO:[]{O---}:
           BIPUSH 8
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_8 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_8 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 9
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_8 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_8 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
@@ -1063,6 +1119,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [9]_asm_procedurego_done_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1071,6 +1128,7 @@ procedure GO:[]{O---}:
           RETURN
 [10]_tick "tick"
 [11]_asm_procedurego_return_11 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V

--- a/netlogo-headless/test/benchdumps/PrefAttach.txt
+++ b/netlogo-headless/test/benchdumps/PrefAttach.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:121862.0 "121862" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 121862.0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -77,6 +80,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:3000.0 "3000" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 3000.0
          L1
@@ -89,7 +95,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -116,6 +123,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -149,6 +157,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -170,9 +181,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -187,8 +195,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -203,6 +216,7 @@ procedure SETUP:[]{O---}:
 [1]_resetticks "reset-ticks"
 [2]_setdefaultshape "set-default-shape"
       _asm_proceduresetup_turtles_0 "turtles" => AgentSet
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetup_turtles_0.world : Lorg/nlogo/agent/World;
@@ -210,12 +224,14 @@ procedure SETUP:[]{O---}:
            L1
             ARETURN
       _asm_proceduresetup_conststring_1 ""circle"" => String
+            // parameter final  context
            L0
             LDC "circle"
            L1
             ARETURN
 [3]_asm_proceduresetup_call_2 "make-node"
       _nobody "nobody" => Nobody$
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -243,6 +259,9 @@ procedure SETUP:[]{O---}:
 [4]_asm_proceduresetup_call_3 "make-node"
       _turtle "turtle" double => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  idDouble
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -261,7 +280,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_call_3.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_call_3.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           LLOAD 4
           L2D
@@ -272,14 +292,14 @@ procedure SETUP:[]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           DLOAD 2
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (D)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (D)Ljava/lang/StringBuilder;
           LDC " is not an integer"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -308,6 +328,7 @@ procedure SETUP:[]{O---}:
          L6
           RETURN
 [5]_asm_proceduresetup_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -320,6 +341,9 @@ procedure SETUP:[]{O---}:
 procedure GO:[]{O---}:
 [0]_asm_procedurego_ask_0 "ask" AgentSet => void
       _links "links" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_0.world : Lorg/nlogo/agent/World;
@@ -375,6 +399,9 @@ procedure GO:[]{O---}:
           RETURN
 [1]_asm_procedurego_setturtleorlinkvariable_1 "set" Object => void
       _constdouble:5.0 "gray" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -388,9 +415,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setturtleorlinkvariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -405,8 +429,13 @@ procedure GO:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedurego_done_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -461,6 +490,7 @@ procedure GO:[]{O---}:
           RETURN
 [4]_tick "tick"
 [5]_asm_procedurego_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -473,6 +503,7 @@ procedure GO:[]{O---}:
 procedure MAKE-NODE:[OLD-NODE]{O---}:
 [0]_createorderedturtles:,+11 "cro"
       _asm_proceduremakenode_constdouble_0 "1" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduremakenode_constdouble_0.kept1_value : Ljava/lang/Double;
@@ -480,6 +511,9 @@ procedure MAKE-NODE:[OLD-NODE]{O---}:
             ARETURN
 [1]_asm_proceduremakenode_setturtleorlinkvariable_1 "set" Object => void
       _constdouble:15.0 "red" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -493,9 +527,6 @@ procedure MAKE-NODE:[OLD-NODE]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakenode_setturtleorlinkvariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -510,11 +541,22 @@ procedure MAKE-NODE:[OLD-NODE]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_proceduremakenode_if_2 "if" boolean => void
       _notequal "!=" Object,Object => boolean
         _procedurevariable:OLD-NODE "old-node" => Object
         _nobody "nobody" => Nobody$
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -530,12 +572,12 @@ procedure MAKE-NODE:[OLD-NODE]{O---}:
           ALOAD 2
           ALOAD 3
           INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-          IFEQ L3
-          ICONST_0
+          IFNE L3
+          ICONST_1
           GOTO L4
          L3
          FRAME APPEND [java/lang/Object org/nlogo/core/Nobody$]
-          ICONST_1
+          ICONST_0
          L4
          FRAME SAME1 I
           ISTORE 2
@@ -554,6 +596,7 @@ procedure MAKE-NODE:[OLD-NODE]{O---}:
           RETURN
 [3]_createlinkwith:,+6 "create-link-with"
       _asm_proceduremakenode_procedurevariable_3 "old-node" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -564,6 +607,9 @@ procedure MAKE-NODE:[OLD-NODE]{O---}:
             ARETURN
 [4]_asm_proceduremakenode_setturtleorlinkvariable_4 "set" Object => void
       _constdouble:55.0 "green" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -577,9 +623,6 @@ procedure MAKE-NODE:[OLD-NODE]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakenode_setturtleorlinkvariable_4 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -594,8 +637,13 @@ procedure MAKE-NODE:[OLD-NODE]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [5]_asm_proceduremakenode_done_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -604,6 +652,7 @@ procedure MAKE-NODE:[OLD-NODE]{O---}:
           RETURN
 [6]_moveto "move-to"
       _asm_proceduremakenode_procedurevariable_6 "old-node" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -614,6 +663,9 @@ procedure MAKE-NODE:[OLD-NODE]{O---}:
             ARETURN
 [7]_asm_proceduremakenode_right_7 "rt" double => void
       _randomconst:360 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  delta
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -635,6 +687,9 @@ procedure MAKE-NODE:[OLD-NODE]{O---}:
           RETURN
 [8]_asm_proceduremakenode_fd_8 "fd" double => void
       _constdouble:8.0 "8" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
          L0
           LDC 8.0
          L1
@@ -653,9 +708,10 @@ procedure MAKE-NODE:[OLD-NODE]{O---}:
          L2
           RETURN
 [9]_asm_proceduremakenode_fdinternal_9 => void
+          // parameter final  context
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L3 L4 L1 org/nlogo/api/AgentException
-         L5
+          TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
+         L6
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
@@ -676,38 +732,48 @@ procedure MAKE-NODE:[OLD-NODE]{O---}:
           GETSTATIC org/nlogo/api/Numbers$.MODULE$ : Lorg/nlogo/api/Numbers$;
           INVOKEVIRTUAL org/nlogo/api/Numbers$.Infinitesimal ()D
           DCMPG
-          IFGT L6
+          IFGT L7
           ALOAD 1
           BIPUSH 10
           PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
-         L6
+          GOTO L8
+         L7
          FRAME FULL [org/nlogo/prim/_asm_proceduremakenode_fdinternal_9 org/nlogo/nvm/Context org/nlogo/agent/Turtle org/nlogo/nvm/MutableDouble D D] []
           DLOAD 6
           DCONST_1
           DCMPG
-          IFGT L4
-         L3
+          IFGT L9
+         L0
           ALOAD 2
           DLOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
+         L1
+          GOTO L10
+         L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L10
+         FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L8
-         L4
+         L9
          FRAME SAME
           DLOAD 4
           ICONST_0
           I2D
           DCMPL
-          IFLE L9
+          IFLE L11
           ICONST_1
-          GOTO L10
-         L9
+          GOTO L12
+         L11
          FRAME SAME
           ICONST_M1
-         L10
+         L12
          FRAME SAME1 I
           ISTORE 8
-         L0
+         L3
           ALOAD 2
           ILOAD 8
           I2D
@@ -719,26 +785,19 @@ procedure MAKE-NODE:[OLD-NODE]{O---}:
           I2D
           DSUB
           INVOKEVIRTUAL org/nlogo/nvm/MutableDouble.value_$eq (D)V
-          GOTO L7
-         L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          POP
-         L8
-         FRAME SAME
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
-         L2
+         L4
+          GOTO L8
+         L5
          FRAME FULL [org/nlogo/prim/_asm_proceduremakenode_fdinternal_9 org/nlogo/nvm/Context org/nlogo/agent/Turtle org/nlogo/nvm/MutableDouble D D I] [org/nlogo/api/AgentException]
           POP
           ALOAD 1
           BIPUSH 10
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L7
+         L8
          FRAME CHOP 1
           RETURN
 [10]_asm_proceduremakenode_done_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -746,6 +805,7 @@ procedure MAKE-NODE:[OLD-NODE]{O---}:
          L1
           RETURN
 [11]_asm_proceduremakenode_return_11 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -762,6 +822,9 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
           _of "of"
             _asm_procedurefindpartner_count_1 "count" AgentSet => double
               _linkneighbors:null "link-neighbors" => AgentSet
+                  // parameter final  context
+                  // parameter final  context
+                  // parameter final  arg0
                  L0
                   ALOAD 0
                   GETFIELD org/nlogo/prim/_asm_procedurefindpartner_count_1.kept2_breedName : Ljava/lang/String;
@@ -805,12 +868,19 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
                   INVOKESPECIAL java/lang/Double.<init> (D)V
                   ARETURN
             _asm_procedurefindpartner_turtles_2 "turtles" => AgentSet
+                  // parameter final  context
                  L0
                   ALOAD 0
                   GETFIELD org/nlogo/prim/_asm_procedurefindpartner_turtles_2.world : Lorg/nlogo/agent/World;
                   INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
                  L1
                   ARETURN
+          // parameter final  context
+          // parameter final  l0
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurefindpartner_setprocedurevariable_0.keptinstr4 : Lorg/nlogo/prim/_of;
@@ -852,7 +922,7 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
           ASTORE 6
           ALOAD 6
           INSTANCEOF java/lang/Double
-          IFEQ L6
+          IFEQ L4
           ALOAD 6
           CHECKCAST java/lang/Double
           ASTORE 7
@@ -861,20 +931,14 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DADD
           DSTORE 3
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 8
-          GOTO L4
-         L6
-         FRAME APPEND [java/lang/Object]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 8
           GOTO L4
          L5
-         FRAME CHOP 1
+         FRAME SAME
           ALOAD 0
           DLOAD 3
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindpartner_setprocedurevariable_0.validDouble (D)D
-         L7
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindpartner_setprocedurevariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
+         L6
           DSTORE 2
           DLOAD 2
           ALOAD 1
@@ -882,7 +946,7 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-         L8
+         L7
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -898,10 +962,13 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
           ALOAD 1
           ICONST_1
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L9
+         L8
           RETURN
 [1]_asm_procedurefindpartner_setprocedurevariable_3 "let" Object => void
       _nobody "nobody" => Nobody$
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
          L1
@@ -919,6 +986,9 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
           RETURN
 [2]_asm_procedurefindpartner_ask_4 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurefindpartner_ask_4.world : Lorg/nlogo/agent/World;
@@ -975,6 +1045,11 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
 [3]_asm_procedurefindpartner_let_5 "let" Object => void
       _count "count" AgentSet => double
         _linkneighbors:null "link-neighbors" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurefindpartner_let_5.kept3_breedName : Ljava/lang/String;
@@ -1031,6 +1106,13 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
       _equal "=" Object,Object => boolean
         _procedurevariable:PARTNER "partner" => Object
         _nobody "nobody" => Nobody$
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -1065,6 +1147,13 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
       _greaterthan ">" Object,Object => boolean
         _letvariable(Let(NC)) "nc" => Object
         _procedurevariable:TOTAL "total" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  o1
+          // parameter final  o2
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           ALOAD 0
@@ -1098,40 +1187,36 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
          L4
          FRAME APPEND [java/lang/Object java/lang/Object]
           ICONST_0
-         L5
-         FRAME SAME1 I
-          GOTO L6
+          GOTO L5
          L3
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
           ICONST_0
-          IF_ICMPLE L8
+          IF_ICMPLE L7
           ICONST_1
-          GOTO L9
-         L8
+          GOTO L5
+         L7
          FRAME SAME
           ICONST_0
-         L9
-         FRAME SAME1 I
-          GOTO L6
-         L7
+          GOTO L5
+         L6
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -1142,21 +1227,19 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L10
+          IF_ICMPNE L8
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
           ICONST_0
-          IF_ICMPLE L11
+          IF_ICMPLE L9
           ICONST_1
-          GOTO L12
-         L11
+          GOTO L5
+         L9
          FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
           ICONST_0
-         L12
-         FRAME SAME1 I
-          GOTO L6
-         L10
+          GOTO L5
+         L8
          FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -1184,24 +1267,27 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L6
+         L5
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L13
+          IFEQ L10
           BIPUSH 6
-          GOTO L14
-         L13
+          GOTO L11
+         L10
          FRAME FULL [org/nlogo/prim/_asm_procedurefindpartner_ifelse_7 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
           BIPUSH 8
-         L14
+         L11
          FRAME FULL [org/nlogo/prim/_asm_procedurefindpartner_ifelse_7 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L15
+         L12
           RETURN
 [6]_asm_procedurefindpartner_setprocedurevariable_8 "set" Object => void
       _self "self" => Agent
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -1219,6 +1305,7 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
          L2
           RETURN
 [7]_asm_procedurefindpartner_goto_9 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 9
@@ -1229,6 +1316,13 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
       _minus "-" double,double => double
         _procedurevariable:TOTAL "total" => Object
         _letvariable(Let(NC)) "nc" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -1307,6 +1401,7 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
          L10
           RETURN
 [9]_asm_procedurefindpartner_done_11 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1315,6 +1410,7 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
           RETURN
 [10]_asm_procedurefindpartner_report_12 "report" Object => void
       _procedurevariable:PARTNER "partner" => Object
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -1389,6 +1485,7 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
          FRAME SAME
           RETURN
 [11]_asm_procedurefindpartner_returnreport_13 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -1407,6 +1504,9 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
 procedure LAYOUT:[_repeatlocal:0]{OTPL}:
 [0]_asm_procedurelayout_repeatlocal_0 "repeat" double => void
       _constdouble:3.0 "3" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 3.0
          L1
@@ -1419,7 +1519,8 @@ procedure LAYOUT:[_repeatlocal:0]{OTPL}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurelayout_repeatlocal_0.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurelayout_repeatlocal_0.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -1429,6 +1530,7 @@ procedure LAYOUT:[_repeatlocal:0]{OTPL}:
           RETURN
 [1]_layoutspring "layout-spring"
       _asm_procedurelayout_turtles_1 "turtles" => AgentSet
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurelayout_turtles_1.world : Lorg/nlogo/agent/World;
@@ -1436,6 +1538,7 @@ procedure LAYOUT:[_repeatlocal:0]{OTPL}:
            L1
             ARETURN
       _asm_procedurelayout_links_2 "links" => AgentSet
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurelayout_links_2.world : Lorg/nlogo/agent/World;
@@ -1443,18 +1546,21 @@ procedure LAYOUT:[_repeatlocal:0]{OTPL}:
            L1
             ARETURN
       _asm_procedurelayout_constdouble_3 "0.5" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurelayout_constdouble_3.kept1_value : Ljava/lang/Double;
            L1
             ARETURN
       _asm_procedurelayout_constdouble_4 "1.0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurelayout_constdouble_4.kept1_value : Ljava/lang/Double;
            L1
             ARETURN
       _asm_procedurelayout_constdouble_5 "0.4" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurelayout_constdouble_5.kept1_value : Ljava/lang/Double;
@@ -1462,6 +1568,7 @@ procedure LAYOUT:[_repeatlocal:0]{OTPL}:
             ARETURN
 [2]_display "display"
 [3]_asm_procedurelayout_repeatlocalinternal_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -1494,6 +1601,7 @@ procedure LAYOUT:[_repeatlocal:0]{OTPL}:
          FRAME SAME
           RETURN
 [4]_asm_procedurelayout_return_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V

--- a/netlogo-headless/test/benchdumps/Team.txt
+++ b/netlogo-headless/test/benchdumps/Team.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:2468.0 "2468" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 2468.0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -77,6 +80,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:7000.0 "7000" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 7000.0
          L1
@@ -89,7 +95,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -116,6 +123,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -149,6 +157,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -170,9 +181,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -187,8 +195,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -201,6 +214,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
 procedure MAKE-NEWCOMER:[]{O---}:
 [0]_createturtles:,+9 "create-turtles"
       _asm_proceduremakenewcomer_constdouble_0 "1" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduremakenewcomer_constdouble_0.kept1_value : Ljava/lang/Double;
@@ -208,6 +222,9 @@ procedure MAKE-NEWCOMER:[]{O---}:
             ARETURN
 [1]_asm_proceduremakenewcomer_setturtleorlinkvariable_1 "set" Object => void
       _constdouble:106.0 "+" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -221,9 +238,6 @@ procedure MAKE-NEWCOMER:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakenewcomer_setturtleorlinkvariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -238,9 +252,16 @@ procedure MAKE-NEWCOMER:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_proceduremakenewcomer_setturtlevariable_2 "set" Object => void
       _constdouble:1.8 "1.8" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -254,9 +275,6 @@ procedure MAKE-NEWCOMER:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakenewcomer_setturtlevariable_2 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -271,9 +289,16 @@ procedure MAKE-NEWCOMER:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_proceduremakenewcomer_setturtlevariable_3 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -287,9 +312,6 @@ procedure MAKE-NEWCOMER:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakenewcomer_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -304,9 +326,16 @@ procedure MAKE-NEWCOMER:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduremakenewcomer_setturtlevariable_4 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -320,9 +349,6 @@ procedure MAKE-NEWCOMER:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakenewcomer_setturtlevariable_4 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -337,9 +363,16 @@ procedure MAKE-NEWCOMER:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [5]_asm_proceduremakenewcomer_setobservervariable_5 "set" Object => void
       _self "self" => Agent
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -354,9 +387,6 @@ procedure MAKE-NEWCOMER:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakenewcomer_setobservervariable_5 org/nlogo/nvm/Context org/nlogo/agent/Agent] [org/nlogo/api/AgentException]
@@ -371,9 +401,16 @@ procedure MAKE-NEWCOMER:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [6]_asm_proceduremakenewcomer_setturtlevariable_6 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -387,9 +424,6 @@ procedure MAKE-NEWCOMER:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakenewcomer_setturtlevariable_6 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -404,9 +438,16 @@ procedure MAKE-NEWCOMER:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_proceduremakenewcomer_setturtlevariable_7 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -420,9 +461,6 @@ procedure MAKE-NEWCOMER:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduremakenewcomer_setturtlevariable_7 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -437,8 +475,13 @@ procedure MAKE-NEWCOMER:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [8]_asm_proceduremakenewcomer_done_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -446,6 +489,7 @@ procedure MAKE-NEWCOMER:[]{O---}:
          L1
           RETURN
 [9]_asm_proceduremakenewcomer_return_9 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -460,6 +504,7 @@ procedure SETUP:[_repeatlocal:0]{O---}:
 [1]_resetticks "reset-ticks"
 [2]_setdefaultshape "set-default-shape"
       _asm_proceduresetup_turtles_0 "turtles" => AgentSet
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetup_turtles_0.world : Lorg/nlogo/agent/World;
@@ -467,12 +512,16 @@ procedure SETUP:[_repeatlocal:0]{O---}:
            L1
             ARETURN
       _asm_proceduresetup_conststring_1 ""circle"" => String
+            // parameter final  context
            L0
             LDC "circle"
            L1
             ARETURN
 [3]_asm_proceduresetup_repeatlocal_2 "repeat" double => void
       _observervariable:TEAM-SIZE "team-size" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -510,7 +559,8 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -537,6 +587,7 @@ procedure SETUP:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_proceduresetup_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -570,6 +621,9 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_proceduresetup_ask_5 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_5.world : Lorg/nlogo/agent/World;
@@ -625,6 +679,9 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           RETURN
 [7]_asm_proceduresetup_setturtlevariable_6 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -638,9 +695,6 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtlevariable_6 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -655,9 +709,16 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [8]_asm_proceduresetup_setturtlevariable_7 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -671,9 +732,6 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtlevariable_7 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -688,8 +746,13 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [9]_asm_proceduresetup_done_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -734,6 +797,9 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           RETURN
 [12]_asm_proceduresetup_ask_11 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_11.world : Lorg/nlogo/agent/World;
@@ -793,6 +859,14 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           _constdouble:360.0 "360" => double
           _observervariable:TEAM-SIZE "team-size" => Object
         _turtlevariabledouble:WHO "who" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -870,9 +944,6 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 14
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L13
          L4
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtlevariable_12 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -887,9 +958,16 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ATHROW
          L13
          FRAME SAME
+          ALOAD 1
+          BIPUSH 14
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L14
           RETURN
 [14]_asm_proceduresetup_fd_13 "fd" double => void
       _constdouble:1.75 "1.75" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
          L0
           LDC 1.75
          L1
@@ -908,9 +986,10 @@ procedure SETUP:[_repeatlocal:0]{O---}:
          L2
           RETURN
 [15]_asm_proceduresetup_fdinternal_14 => void
+          // parameter final  context
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L3 L4 L1 org/nlogo/api/AgentException
-         L5
+          TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
+         L6
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
@@ -931,38 +1010,48 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           GETSTATIC org/nlogo/api/Numbers$.MODULE$ : Lorg/nlogo/api/Numbers$;
           INVOKEVIRTUAL org/nlogo/api/Numbers$.Infinitesimal ()D
           DCMPG
-          IFGT L6
+          IFGT L7
           ALOAD 1
           BIPUSH 16
           PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
-         L6
+          GOTO L8
+         L7
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_fdinternal_14 org/nlogo/nvm/Context org/nlogo/agent/Turtle org/nlogo/nvm/MutableDouble D D] []
           DLOAD 6
           DCONST_1
           DCMPG
-          IFGT L4
-         L3
+          IFGT L9
+         L0
           ALOAD 2
           DLOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
+         L1
+          GOTO L10
+         L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L10
+         FRAME SAME
+          ALOAD 1
+          BIPUSH 16
+          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L8
-         L4
+         L9
          FRAME SAME
           DLOAD 4
           ICONST_0
           I2D
           DCMPL
-          IFLE L9
+          IFLE L11
           ICONST_1
-          GOTO L10
-         L9
+          GOTO L12
+         L11
          FRAME SAME
           ICONST_M1
-         L10
+         L12
          FRAME SAME1 I
           ISTORE 8
-         L0
+         L3
           ALOAD 2
           ILOAD 8
           I2D
@@ -974,27 +1063,22 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           I2D
           DSUB
           INVOKEVIRTUAL org/nlogo/nvm/MutableDouble.value_$eq (D)V
-          GOTO L7
-         L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          POP
-         L8
-         FRAME SAME
-          ALOAD 1
-          BIPUSH 16
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
-         L2
+         L4
+          GOTO L8
+         L5
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_fdinternal_14 org/nlogo/nvm/Context org/nlogo/agent/Turtle org/nlogo/nvm/MutableDouble D D I] [org/nlogo/api/AgentException]
           POP
           ALOAD 1
           BIPUSH 16
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L7
+         L8
          FRAME CHOP 1
           RETURN
 [16]_asm_proceduresetup_setturtlevariable_15 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1008,9 +1092,6 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 17
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtlevariable_15 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -1025,8 +1106,13 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 17
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [17]_asm_proceduresetup_done_16 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1034,6 +1120,7 @@ procedure SETUP:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [18]_asm_proceduresetup_return_17 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1046,6 +1133,9 @@ procedure SETUP:[_repeatlocal:0]{O---}:
 procedure GO:[]{O---}:
 [0]_asm_procedurego_ask_0 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_0.world : Lorg/nlogo/agent/World;
@@ -1101,6 +1191,9 @@ procedure GO:[]{O---}:
           RETURN
 [1]_asm_procedurego_setturtlevariable_1 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1114,9 +1207,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -1131,9 +1221,16 @@ procedure GO:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedurego_setturtleorlinkvariable_2 "set" Object => void
       _constdouble:3.5 "-" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1147,9 +1244,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setturtleorlinkvariable_2 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1164,9 +1258,16 @@ procedure GO:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_procedurego_setturtlevariable_3 "set" Object => void
       _constdouble:0.9 "0.9" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1180,9 +1281,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1197,8 +1295,13 @@ procedure GO:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_procedurego_done_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1207,6 +1310,9 @@ procedure GO:[]{O---}:
           RETURN
 [5]_asm_procedurego_ask_5 "ask" AgentSet => void
       _links "links" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_5.world : Lorg/nlogo/agent/World;
@@ -1262,6 +1368,9 @@ procedure GO:[]{O---}:
           RETURN
 [6]_asm_procedurego_setlinkvariable_6 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1275,9 +1384,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setLinkVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setlinkvariable_6 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -1292,8 +1398,13 @@ procedure GO:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurego_done_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1356,6 +1467,9 @@ procedure GO:[]{O---}:
           RETURN
 [11]_asm_procedurego_ask_11 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_11.world : Lorg/nlogo/agent/World;
@@ -1413,6 +1527,13 @@ procedure GO:[]{O---}:
       _greaterthan ">" Object,Object => boolean
         _turtlevariable:DOWNTIME "downtime" => Object
         _observervariable:MAX-DOWNTIME "max-downtime" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  o1
+          // parameter final  o2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1461,40 +1582,36 @@ procedure GO:[]{O---}:
          L6
          FRAME APPEND [java/lang/Object java/lang/Object]
           ICONST_0
-         L7
-         FRAME SAME1 I
-          GOTO L8
+          GOTO L7
          L5
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L9
+          IFEQ L8
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L9
+          IFEQ L8
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
           ICONST_0
-          IF_ICMPLE L10
+          IF_ICMPLE L9
           ICONST_1
-          GOTO L11
-         L10
+          GOTO L7
+         L9
          FRAME SAME
           ICONST_0
-         L11
-         FRAME SAME1 I
-          GOTO L8
-         L9
+          GOTO L7
+         L8
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L12
+          IFEQ L10
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L12
+          IFEQ L10
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -1505,21 +1622,19 @@ procedure GO:[]{O---}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L12
+          IF_ICMPNE L10
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
           ICONST_0
-          IF_ICMPLE L13
+          IF_ICMPLE L11
           ICONST_1
-          GOTO L14
-         L13
+          GOTO L7
+         L11
          FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
           ICONST_0
-         L14
-         FRAME SAME1 I
-          GOTO L8
-         L12
+          GOTO L7
+         L10
          FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -1547,21 +1662,21 @@ procedure GO:[]{O---}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L8
+         L7
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L15
+          IFEQ L12
           BIPUSH 13
-          GOTO L16
-         L15
+          GOTO L13
+         L12
          FRAME FULL [org/nlogo/prim/_asm_procedurego_if_12 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
           BIPUSH 14
-         L16
+         L13
          FRAME FULL [org/nlogo/prim/_asm_procedurego_if_12 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L17
+         L14
           RETURN
 [13]_asm_procedurego_die_13 "die" => void
          L0
@@ -1589,6 +1704,9 @@ procedure GO:[]{O---}:
           RETURN
 [14]_asm_procedurego_setturtlevariable_14 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1602,9 +1720,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 15
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setturtlevariable_14 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -1619,11 +1734,22 @@ procedure GO:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 15
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [15]_asm_procedurego_setturtlevariable_15 "set" Object => void
       _plus "+" double,double => double
         _turtlevariable:DOWNTIME "downtime" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -1688,9 +1814,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          BIPUSH 16
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setturtlevariable_15 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1705,8 +1828,13 @@ procedure GO:[]{O---}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          BIPUSH 16
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [16]_asm_procedurego_done_16 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1715,6 +1843,9 @@ procedure GO:[]{O---}:
           RETURN
 [17]_asm_procedurego_if_17 "if" boolean => void
       _observervariable:LAYOUT? "layout?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -1777,6 +1908,9 @@ procedure GO:[]{O---}:
           RETURN
 [19]_asm_procedurego_if_19 "if" boolean => void
       _observervariable:PLOT? "plot?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -1839,6 +1973,7 @@ procedure GO:[]{O---}:
           RETURN
 [21]_tick "tick"
 [22]_asm_procedurego_return_21 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1851,6 +1986,9 @@ procedure GO:[]{O---}:
 procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
 [0]_asm_procedurepickteammembers_setprocedurevariable_0 "let" Object => void
       _nobody "nobody" => Nobody$
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
          L1
@@ -1868,6 +2006,9 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           RETURN
 [1]_asm_procedurepickteammembers_repeatlocal_1 "repeat" double => void
       _observervariable:TEAM-SIZE "team-size" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -1905,7 +2046,8 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepickteammembers_repeatlocal_1.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepickteammembers_repeatlocal_1.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -1918,6 +2060,12 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
         _randomfloat "random-float" double => double
           _constdouble:100.0 "100.0" => double
         _observervariable:P "p" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 100.0
          L1
@@ -2014,6 +2162,9 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           RETURN
 [4]_asm_procedurepickteammembers_setprocedurevariable_4 "set" Object => void
       _observervariable:NEWCOMER "newcomer" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurepickteammembers_setprocedurevariable_4.world : Lorg/nlogo/agent/World;
@@ -2034,6 +2185,7 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
          L2
           RETURN
 [5]_asm_procedurepickteammembers_goto_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 10
@@ -2054,6 +2206,9 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
               _linkneighbors:null "link-neighbors" => AgentSet
               _asm_procedurepickteammembers_not_8 "not" boolean => boolean
                 _turtlevariable:IN-TEAM? "in-team?" => Object
+                    // parameter final  context
+                    // parameter final  context
+                    // parameter final  arg0
                     TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                     TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
                    L0
@@ -2098,12 +2253,12 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
                    FRAME SAME1 I
                     ISTORE 2
                     ILOAD 2
-                    IFEQ L7
-                    ICONST_0
+                    IFNE L7
+                    ICONST_1
                     GOTO L8
                    L7
                    FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_not_8 org/nlogo/nvm/Context I] []
-                    ICONST_1
+                    ICONST_0
                    L8
                    FRAME SAME1 I
                     IFEQ L9
@@ -2115,6 +2270,11 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
                    L10
                    FRAME SAME1 java/lang/Boolean
                     ARETURN
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  sourceSet
+                // parameter final  arg1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                 TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
                L0
@@ -2228,16 +2388,11 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
                 GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
                 ALOAD 8
                 INVOKEVIRTUAL scala/Predef$.Boolean2boolean (Ljava/lang/Boolean;)Z
-                IFEQ L15
+                IFEQ L12
                 ICONST_1
-                GOTO L16
-               L15
-               FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-                GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-                ASTORE 9
-                GOTO L12
+                GOTO L15
                L14
-               FRAME CHOP 1
+               FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
                 NEW org/nlogo/nvm/RuntimePrimitiveException
                 DUP
                 ALOAD 1
@@ -2267,23 +2422,36 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
                L13
                FRAME CHOP 2
                 ICONST_0
-               L16
+               L15
                FRAME SAME1 I
-                GOTO L17
+                GOTO L16
                L7
                FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_and_7 org/nlogo/nvm/Context java/lang/Object] []
                 ICONST_0
-               L17
+               L16
                FRAME SAME1 I
-                IFEQ L18
+                IFEQ L17
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
-                GOTO L19
-               L18
+                GOTO L18
+               L17
                FRAME SAME
                 GETSTATIC java/lang/Boolean.FALSE : Ljava/lang/Boolean;
-               L19
+               L18
                FRAME SAME1 java/lang/Boolean
                 ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 100.0
          L1
@@ -2304,11 +2472,9 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L4
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -2319,15 +2485,14 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           ICONST_1
           GOTO L6
          L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L6
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L7
          L4
-         FRAME CHOP 1
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2356,13 +2521,15 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
-          IFEQ L8
-         L9
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
+         L8
+          IFEQ L9
+         L10
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-         L10
+         L11
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6.keptinstr9 : Lorg/nlogo/nvm/Reporter;
           ASTORE 3
@@ -2380,11 +2547,11 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.iterator ()Lorg/nlogo/agent/AgentIterator;
           ASTORE 5
-         L11
+         L12
          FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentIterator java/lang/Object] []
           ALOAD 5
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-          IFEQ L12
+          IFEQ L13
           ALOAD 5
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           ASTORE 6
@@ -2395,23 +2562,18 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           ASTORE 7
           ALOAD 7
           INSTANCEOF java/lang/Boolean
-          IFEQ L13
+          IFEQ L14
           ALOAD 7
           CHECKCAST java/lang/Boolean
           ASTORE 8
           GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
           ALOAD 8
           INVOKEVIRTUAL scala/Predef$.Boolean2boolean (Ljava/lang/Boolean;)Z
-          IFEQ L14
+          IFEQ L12
           ICONST_1
           GOTO L15
          L14
-         FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object java/lang/Boolean] []
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 9
-          GOTO L11
-         L13
-         FRAME CHOP 1
+         FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object] []
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2438,17 +2600,17 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L12
+         L13
          FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context org/nlogo/agent/AgentIterator java/lang/Object] []
           ICONST_0
          L15
          FRAME SAME1 I
           GOTO L16
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] []
+         L9
+         FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6 org/nlogo/nvm/Context D java/lang/Object I java/lang/Double] []
           ICONST_0
          L16
-         FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6 org/nlogo/nvm/Context T T java/lang/Object java/lang/Object java/lang/Object] [I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6 org/nlogo/nvm/Context T T java/lang/Object T java/lang/Object] [I]
           ISTORE 2
           ALOAD 1
           ILOAD 2
@@ -2456,10 +2618,10 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           BIPUSH 7
           GOTO L18
          L17
-         FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Object] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6 org/nlogo/nvm/Context I T java/lang/Object T java/lang/Object] [org/nlogo/nvm/Context]
           BIPUSH 9
          L18
-         FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Object] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6 org/nlogo/nvm/Context I T java/lang/Object T java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L19
           RETURN
@@ -2472,6 +2634,7 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           _anywith "any?" AgentSet,Reporter => boolean
             _linkneighbors:null "link-neighbors" => AgentSet
             _asm_procedurepickteammembers_turtlevariable_11 "in-team?" => Object
+                  // parameter final  context
                   TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                  L0
                   ALOAD 1
@@ -2494,6 +2657,13 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
                  L3
                  FRAME SAME1 java/lang/Object
                   ARETURN
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  context
+              // parameter final  context
+              // parameter final  sourceSet
+              // parameter final  arg1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
               TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
              L0
@@ -2538,12 +2708,12 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
              FRAME SAME1 I
               ISTORE 2
               ILOAD 2
-              IFEQ L7
-              ICONST_0
+              IFNE L7
+              ICONST_1
               GOTO L8
              L7
              FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_and_10 org/nlogo/nvm/Context I] []
-              ICONST_1
+              ICONST_0
              L8
              FRAME SAME1 I
               IFEQ L9
@@ -2617,16 +2787,11 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
               GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
               ALOAD 8
               INVOKEVIRTUAL scala/Predef$.Boolean2boolean (Ljava/lang/Boolean;)Z
-              IFEQ L17
+              IFEQ L14
               ICONST_1
-              GOTO L18
-             L17
-             FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-              GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-              ASTORE 9
-              GOTO L14
+              GOTO L17
              L16
-             FRAME CHOP 1
+             FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
@@ -2656,23 +2821,29 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
              L15
              FRAME CHOP 2
               ICONST_0
-             L18
+             L17
              FRAME SAME1 I
-              GOTO L19
+              GOTO L18
              L9
              FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_and_10 org/nlogo/nvm/Context I] []
               ICONST_0
-             L19
+             L18
              FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_and_10 org/nlogo/nvm/Context] [I]
-              IFEQ L20
+              IFEQ L19
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
-              GOTO L21
-             L20
+              GOTO L20
+             L19
              FRAME SAME
               GETSTATIC java/lang/Boolean.FALSE : Ljava/lang/Boolean;
-             L21
+             L20
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurepickteammembers_setprocedurevariable_9.world : Lorg/nlogo/agent/World;
@@ -2720,16 +2891,11 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
           ALOAD 8
           INVOKEVIRTUAL scala/Predef$.Boolean2boolean (Ljava/lang/Boolean;)Z
-          IFEQ L5
+          IFEQ L2
           ALOAD 6
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 9
-          GOTO L2
+          GOTO L5
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2759,7 +2925,7 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
          L3
          FRAME CHOP 2
           GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
-         L6
+         L5
          FRAME SAME1 java/lang/Object
           ASTORE 2
           ALOAD 1
@@ -2771,9 +2937,10 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           ALOAD 1
           BIPUSH 8
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L7
+         L6
           RETURN
 [8]_asm_procedurepickteammembers_goto_12 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 10
@@ -2785,6 +2952,9 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
         _turtles "turtles" => AgentSet
         _asm_procedurepickteammembers_not_14 "not" boolean => boolean
           _turtlevariable:IN-TEAM? "in-team?" => Object
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
               TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
              L0
@@ -2829,12 +2999,12 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
              FRAME SAME1 I
               ISTORE 2
               ILOAD 2
-              IFEQ L7
-              ICONST_0
+              IFNE L7
+              ICONST_1
               GOTO L8
              L7
              FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_not_14 org/nlogo/nvm/Context I] []
-              ICONST_1
+              ICONST_0
              L8
              FRAME SAME1 I
               IFEQ L9
@@ -2846,6 +3016,12 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
              L10
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurepickteammembers_setprocedurevariable_13.world : Lorg/nlogo/agent/World;
@@ -2893,16 +3069,11 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
           ALOAD 8
           INVOKEVIRTUAL scala/Predef$.Boolean2boolean (Ljava/lang/Boolean;)Z
-          IFEQ L5
+          IFEQ L2
           ALOAD 6
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 9
-          GOTO L2
+          GOTO L5
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2932,7 +3103,7 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
          L3
          FRAME CHOP 2
           GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
-         L6
+         L5
          FRAME SAME1 java/lang/Object
           ASTORE 2
           ALOAD 1
@@ -2944,10 +3115,13 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           ALOAD 1
           BIPUSH 10
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L7
+         L6
           RETURN
 [10]_asm_procedurepickteammembers_ask_15 "ask" Object => void
       _procedurevariable:NEW-TEAM-MEMBER "new-team-member" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -2957,18 +3131,16 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurepickteammembers_ask_15.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -2984,8 +3156,8 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ask_15 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurepickteammembers_ask_15.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -3002,18 +3174,18 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -3030,7 +3202,7 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -3040,23 +3212,12 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ask_15 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 11
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 16
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -3070,11 +3231,22 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 11
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 16
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_ask_15 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [11]_asm_procedurepickteammembers_setturtlevariable_16 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3088,9 +3260,6 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 12
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_setturtlevariable_16 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -3105,9 +3274,16 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 12
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [12]_asm_procedurepickteammembers_setturtlevariable_17 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3121,9 +3297,6 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 13
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_setturtlevariable_17 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -3138,9 +3311,16 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 13
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [13]_asm_procedurepickteammembers_setturtlevariable_18 "set" Object => void
       _constdouble:1.8 "1.8" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3154,9 +3334,6 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 14
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_setturtlevariable_18 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -3171,10 +3348,15 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 14
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [14]_asm_procedurepickteammembers_setturtleorlinkvariable_19 "set" Object => void
       _ifelsevalue "ifelse-value"
         _asm_procedurepickteammembers_turtlevariable_20 "incumbent?" => Object
+              // parameter final  context
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -3198,17 +3380,21 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
              FRAME SAME1 java/lang/Object
               ARETURN
         _asm_procedurepickteammembers_constdouble_21 "+" => Double
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurepickteammembers_constdouble_21.kept1_value : Ljava/lang/Double;
              L1
               ARETURN
         _asm_procedurepickteammembers_constdouble_22 "+" => Double
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurepickteammembers_constdouble_22.kept1_value : Ljava/lang/Double;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurepickteammembers_setturtleorlinkvariable_19.keptinstr2 : Lorg/nlogo/prim/etc/_ifelsevalue;
@@ -3223,9 +3409,6 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 15
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L4
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurepickteammembers_setturtleorlinkvariable_19 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -3240,8 +3423,13 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           ATHROW
          L4
          FRAME SAME
+          ALOAD 1
+          BIPUSH 15
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L5
           RETURN
 [15]_asm_procedurepickteammembers_done_23 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -3249,6 +3437,7 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
          L1
           RETURN
 [16]_asm_procedurepickteammembers_repeatlocalinternal_24 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -3281,6 +3470,7 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
          FRAME SAME
           RETURN
 [17]_asm_procedurepickteammembers_return_25 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -3295,6 +3485,7 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
       _with "with" AgentSet,Reporter => AgentSet
         _turtles "turtles" => AgentSet
         _asm_proceduretiecollaborators_turtlevariable_1 "in-team?" => Object
+              // parameter final  context
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -3317,6 +3508,12 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
              L3
              FRAME SAME1 java/lang/Object
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduretiecollaborators_ask_0.world : Lorg/nlogo/agent/World;
@@ -3362,25 +3559,15 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
           IFEQ L4
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L5
+          IFEQ L2
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L6
-         FRAME SAME1 java/lang/Object
-          ASTORE 10
-          ALOAD 10
           POP
           GOTO L2
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3423,17 +3610,17 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L7
+         L5
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
-          IFNE L8
+          IFNE L6
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduretiecollaborators_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-          IF_ACMPNE L9
+          IF_ACMPNE L7
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3444,13 +3631,13 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
+         L7
          FRAME FULL [org/nlogo/prim/_asm_proceduretiecollaborators_ask_0 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduretiecollaborators_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
-          IF_ACMPNE L8
+          IF_ACMPNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3461,7 +3648,7 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L8
+         L6
          FRAME SAME
           ALOAD 1
           ALOAD 2
@@ -3470,12 +3657,13 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
           ALOAD 1
           BIPUSH 6
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L10
+         L8
           RETURN
 [1]_createlinkswith:,+5 "create-links-with"
       _asm_proceduretiecollaborators_otherwith_2 "other" AgentSet,Reporter => AgentSet
         _turtles "turtles" => AgentSet
         _asm_proceduretiecollaborators_turtlevariable_3 "in-team?" => Object
+              // parameter final  context
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -3498,6 +3686,10 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
              L3
              FRAME SAME1 java/lang/Object
               ARETURN
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  reporterBlock
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduretiecollaborators_otherwith_2.world : Lorg/nlogo/agent/World;
@@ -3536,7 +3728,7 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
             ALOAD 7
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-            IF_ACMPEQ L4
+            IF_ACMPEQ L2
             ALOAD 4
             ALOAD 7
             ALOAD 3
@@ -3544,27 +3736,18 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
             ASTORE 8
             ALOAD 8
             INSTANCEOF java/lang/Boolean
-            IFEQ L5
+            IFEQ L4
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L6
+            IFEQ L2
             ALOAD 5
             ALOAD 7
             INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-            GOTO L7
-           L6
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L7
-           FRAME SAME1 java/lang/Object
-            ASTORE 10
-            ALOAD 10
-            GOTO L8
-           L5
-           FRAME CHOP 1
+            POP
+            GOTO L2
+           L4
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -3595,15 +3778,8 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
             INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L4
-           FRAME CHOP 1
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L8
-           FRAME SAME1 java/lang/Object
-            POP
-            GOTO L2
            L3
-           FRAME CHOP 1
+           FRAME CHOP 2
             GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
             ALOAD 2
             INVOKEVIRTUAL org/nlogo/agent/AgentSet.kind ()Lorg/nlogo/core/AgentKind;
@@ -3614,10 +3790,13 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
             INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
             CHECKCAST [Lorg/nlogo/agent/Agent;
             INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-           L9
+           L5
             ARETURN
 [2]_asm_proceduretiecollaborators_setlinkvariable_4 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3631,9 +3810,6 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setLinkVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduretiecollaborators_setlinkvariable_4 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -3648,9 +3824,16 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_proceduretiecollaborators_setlinkvariable_5 "set" Object => void
       _constdouble:0.3 "0.3" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3664,9 +3847,6 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setLinkVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduretiecollaborators_setlinkvariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -3681,8 +3861,13 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduretiecollaborators_done_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -3690,6 +3875,7 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
          L1
           RETURN
 [5]_asm_proceduretiecollaborators_done_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -3697,6 +3883,7 @@ procedure TIE-COLLABORATORS:[]{OTPL}:
          L1
           RETURN
 [6]_asm_proceduretiecollaborators_return_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -3715,21 +3902,25 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
             _linkvariable:END1 "end1" => Object
           _turtlevariableof:IN-TEAM? "of" Object => Object
             _linkvariable:END2 "end2" => Object
+              // parameter final  context
+              // parameter final  context
+              // parameter final  agentOrSet
+              // parameter final  context
+              // parameter final  context
+              // parameter final  agentOrSet
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
-              TRYCATCHBLOCK L3 L4 L4 org/nlogo/api/AgentException
-              TRYCATCHBLOCK L5 L6 L4 org/nlogo/api/AgentException
-              TRYCATCHBLOCK L7 L8 L8 java/lang/ClassCastException
-              TRYCATCHBLOCK L9 L10 L11 org/nlogo/api/AgentException
-              TRYCATCHBLOCK L12 L13 L13 org/nlogo/api/AgentException
-              TRYCATCHBLOCK L14 L15 L13 org/nlogo/api/AgentException
-              TRYCATCHBLOCK L16 L17 L17 java/lang/ClassCastException
+              TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
+              TRYCATCHBLOCK L6 L7 L7 java/lang/ClassCastException
+              TRYCATCHBLOCK L8 L9 L10 org/nlogo/api/AgentException
+              TRYCATCHBLOCK L11 L12 L13 org/nlogo/api/AgentException
+              TRYCATCHBLOCK L14 L15 L15 java/lang/ClassCastException
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
               ICONST_0
               INVOKEVIRTUAL org/nlogo/agent/Agent.getLinkVariable (I)Ljava/lang/Object;
              L1
-              GOTO L18
+              GOTO L16
              L2
              FRAME SAME1 org/nlogo/api/AgentException
               ASTORE 2
@@ -3741,23 +3932,21 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
               INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
               INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
               ATHROW
-             L18
+             L16
              FRAME SAME1 java/lang/Object
               ASTORE 2
-             L5
+             L3
               ALOAD 2
+              INSTANCEOF org/nlogo/agent/Agent
+              IFEQ L17
+              ALOAD 2
+              CHECKCAST org/nlogo/agent/Agent
               ASTORE 4
               ALOAD 4
-              INSTANCEOF org/nlogo/agent/Agent
-              IFEQ L19
-              ALOAD 4
-              CHECKCAST org/nlogo/agent/Agent
-              ASTORE 5
-              ALOAD 5
               INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
               LDC -1
               LCMP
-              IFNE L20
+              IFNE L18
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
@@ -3770,62 +3959,58 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
               ANEWARRAY java/lang/Object
               DUP
               ICONST_0
-              ALOAD 5
+              ALOAD 4
               INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
               AASTORE
               INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
               INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
               INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
               ATHROW
-             L20
-             FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_and_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-              ALOAD 5
+             L18
+             FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+              ALOAD 4
               BIPUSH 14
               INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-              ASTORE 6
-              GOTO L21
-             L19
-             FRAME CHOP 1
-              ALOAD 4
+              ASTORE 3
+              GOTO L19
+             L17
+             FRAME CHOP 2
+              ALOAD 2
               INSTANCEOF org/nlogo/agent/AgentSet
-              IFEQ L3
-              ALOAD 4
+              IFEQ L20
+              ALOAD 2
               CHECKCAST org/nlogo/agent/AgentSet
-              ASTORE 7
+              ASTORE 5
               NEW org/nlogo/api/LogoListBuilder
               DUP
               INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-              ASTORE 8
-              ALOAD 7
+              ASTORE 6
+              ALOAD 5
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
               GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
               INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-              ASTORE 9
-             L22
-             FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_and_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-              ALOAD 9
+              ASTORE 7
+             L21
+             FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_and_1 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+              ALOAD 7
               INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-              IFEQ L23
-              ALOAD 8
-              ALOAD 9
+              IFEQ L22
+              ALOAD 6
+              ALOAD 7
               INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
               BIPUSH 14
               INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
               INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
-              GOTO L22
-             L23
+              GOTO L21
+             L22
              FRAME SAME
-              ALOAD 8
-              INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-              ASTORE 6
-             L21
-             FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_and_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
               ALOAD 6
-             L6
-              GOTO L24
-             L3
-             FRAME CHOP 2
+              INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+              ASTORE 3
+              GOTO L19
+             L20
+             FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_and_1 org/nlogo/nvm/Context java/lang/Object] []
               NEW org/nlogo/nvm/ArgumentTypeException
               DUP
               ALOAD 1
@@ -3839,26 +4024,31 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
               ALOAD 2
               INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
               ATHROW
+             L19
+             FRAME APPEND [java/lang/Object]
+              ALOAD 3
              L4
+              GOTO L23
+             L5
              FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_and_1 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-              ASTORE 3
+              ASTORE 8
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
               ALOAD 0
-              ALOAD 3
+              ALOAD 8
               INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
               INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
               ATHROW
-             L24
-             FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_and_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+             L23
+             FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_and_1 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
               ASTORE 2
-             L7
+             L6
               ALOAD 2
               CHECKCAST java/lang/Boolean
               INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-              GOTO L25
-             L8
+              GOTO L24
+             L7
              FRAME SAME1 java/lang/ClassCastException
               POP
               NEW org/nlogo/nvm/ArgumentTypeException
@@ -3870,17 +4060,17 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
               ALOAD 2
               INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
               ATHROW
-             L25
+             L24
              FRAME SAME1 I
-              IFEQ L26
-             L9
+              IFEQ L25
+             L8
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
               ICONST_1
               INVOKEVIRTUAL org/nlogo/agent/Agent.getLinkVariable (I)Ljava/lang/Object;
+             L9
+              GOTO L26
              L10
-              GOTO L27
-             L11
              FRAME SAME1 org/nlogo/api/AgentException
               ASTORE 2
               NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -3891,23 +4081,21 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
               INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
               INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
               ATHROW
-             L27
+             L26
              FRAME SAME1 java/lang/Object
               ASTORE 2
-             L14
+             L11
               ALOAD 2
+              INSTANCEOF org/nlogo/agent/Agent
+              IFEQ L27
+              ALOAD 2
+              CHECKCAST org/nlogo/agent/Agent
               ASTORE 4
               ALOAD 4
-              INSTANCEOF org/nlogo/agent/Agent
-              IFEQ L28
-              ALOAD 4
-              CHECKCAST org/nlogo/agent/Agent
-              ASTORE 5
-              ALOAD 5
               INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
               LDC -1
               LCMP
-              IFNE L29
+              IFNE L28
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
@@ -3920,45 +4108,45 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
               ANEWARRAY java/lang/Object
               DUP
               ICONST_0
-              ALOAD 5
+              ALOAD 4
               INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
               AASTORE
               INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
               INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
               INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
               ATHROW
-             L29
-             FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_and_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent java/lang/Object] []
-              ALOAD 5
+             L28
+             FRAME APPEND [org/nlogo/agent/Agent]
+              ALOAD 4
               BIPUSH 14
               INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-              ASTORE 6
-              GOTO L30
-             L28
-             FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_and_1 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
-              ALOAD 4
+              ASTORE 3
+              GOTO L29
+             L27
+             FRAME CHOP 1
+              ALOAD 2
               INSTANCEOF org/nlogo/agent/AgentSet
-              IFEQ L12
-              ALOAD 4
+              IFEQ L30
+              ALOAD 2
               CHECKCAST org/nlogo/agent/AgentSet
-              ASTORE 7
+              ASTORE 5
               NEW org/nlogo/api/LogoListBuilder
               DUP
               INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-              ASTORE 8
-              ALOAD 7
+              ASTORE 6
+              ALOAD 5
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
               GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
               INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-              ASTORE 9
+              ASTORE 7
              L31
-             FRAME APPEND [org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator]
-              ALOAD 9
+             FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_and_1 org/nlogo/nvm/Context java/lang/Object java/lang/Object T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+              ALOAD 7
               INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
               IFEQ L32
-              ALOAD 8
-              ALOAD 9
+              ALOAD 6
+              ALOAD 7
               INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
               BIPUSH 14
               INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
@@ -3966,16 +4154,12 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
               GOTO L31
              L32
              FRAME SAME
-              ALOAD 8
-              INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-              ASTORE 6
-             L30
-             FRAME CHOP 3
               ALOAD 6
-             L15
-              GOTO L33
-             L12
-             FRAME SAME
+              INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+              ASTORE 3
+              GOTO L29
+             L30
+             FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_and_1 org/nlogo/nvm/Context java/lang/Object java/lang/Object] []
               NEW org/nlogo/nvm/ArgumentTypeException
               DUP
               ALOAD 1
@@ -3989,26 +4173,31 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
               ALOAD 2
               INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
               ATHROW
+             L29
+             FRAME SAME
+              ALOAD 3
+             L12
+              GOTO L33
              L13
              FRAME SAME1 org/nlogo/api/AgentException
-              ASTORE 3
+              ASTORE 8
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
               ALOAD 0
-              ALOAD 3
+              ALOAD 8
               INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
               INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
               ATHROW
              L33
              FRAME SAME1 java/lang/Object
               ASTORE 2
-             L16
+             L14
               ALOAD 2
               CHECKCAST java/lang/Boolean
               INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
               GOTO L34
-             L17
+             L15
              FRAME SAME1 java/lang/ClassCastException
               POP
               NEW org/nlogo/nvm/ArgumentTypeException
@@ -4023,7 +4212,7 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
              L34
              FRAME SAME1 I
               GOTO L35
-             L26
+             L25
              FRAME SAME
               ICONST_0
              L35
@@ -4037,6 +4226,12 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
              L37
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecolorcollaborations_ask_0.world : Lorg/nlogo/agent/World;
@@ -4082,25 +4277,15 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           IFEQ L4
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L5
+          IFEQ L2
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L6
-         FRAME SAME1 java/lang/Object
-          ASTORE 10
-          ALOAD 10
           POP
           GOTO L2
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4143,17 +4328,17 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L7
+         L5
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
-          IFNE L8
+          IFNE L6
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecolorcollaborations_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-          IF_ACMPNE L9
+          IF_ACMPNE L7
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4164,13 +4349,13 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
+         L7
          FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ask_0 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecolorcollaborations_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
-          IF_ACMPNE L8
+          IF_ACMPNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4181,7 +4366,7 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L8
+         L6
          FRAME SAME
           ALOAD 1
           ALOAD 2
@@ -4190,10 +4375,13 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ALOAD 1
           BIPUSH 12
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L10
+         L8
           RETURN
 [1]_asm_procedurecolorcollaborations_ifelse_2 "ifelse" boolean => void
       _linkvariable:NEW-COLLABORATION? "new-collaboration?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -4256,21 +4444,27 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           _linkvariable:END1 "end1" => Object
         _turtlevariableof:INCUMBENT? "of" Object => Object
           _linkvariable:END2 "end2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agentOrSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agentOrSet
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L3 L4 L4 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L5 L6 L4 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L7 L8 L8 java/lang/ClassCastException
-          TRYCATCHBLOCK L9 L10 L11 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L12 L13 L13 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L14 L15 L13 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L16 L17 L17 java/lang/ClassCastException
+          TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L6 L7 L7 java/lang/ClassCastException
+          TRYCATCHBLOCK L8 L9 L10 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L11 L12 L13 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L14 L15 L15 java/lang/ClassCastException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           ICONST_0
           INVOKEVIRTUAL org/nlogo/agent/Agent.getLinkVariable (I)Ljava/lang/Object;
          L1
-          GOTO L18
+          GOTO L16
          L2
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -4282,23 +4476,21 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L18
+         L16
          FRAME SAME1 java/lang/Object
           ASTORE 2
-         L5
+         L3
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L17
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L19
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L20
+          IFNE L18
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4311,62 +4503,58 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L20
-         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-          ALOAD 5
+         L18
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+          ALOAD 4
           BIPUSH 13
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L21
-         L19
-         FRAME CHOP 1
-          ALOAD 4
+          ASTORE 3
+          GOTO L19
+         L17
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L3
-          ALOAD 4
+          IFEQ L20
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
-         L22
-         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+          ASTORE 7
+         L21
+         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_3 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-          IFEQ L23
-          ALOAD 8
-          ALOAD 9
+          IFEQ L22
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           BIPUSH 13
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
           INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
-          GOTO L22
-         L23
+          GOTO L21
+         L22
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L21
-         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
           ALOAD 6
-         L6
-          GOTO L24
-         L3
-         FRAME CHOP 2
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L19
+         L20
+         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_3 org/nlogo/nvm/Context java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -4380,26 +4568,31 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L19
+         FRAME APPEND [java/lang/Object]
+          ALOAD 3
          L4
+          GOTO L23
+         L5
          FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_3 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L24
-         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+         L23
+         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
           ASTORE 2
-         L7
+         L6
           ALOAD 2
           CHECKCAST java/lang/Boolean
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          GOTO L25
-         L8
+          GOTO L24
+         L7
          FRAME SAME1 java/lang/ClassCastException
           POP
           NEW org/nlogo/nvm/ArgumentTypeException
@@ -4411,17 +4604,17 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
-         L25
+         L24
          FRAME SAME1 I
-          IFEQ L26
-         L9
+          IFEQ L25
+         L8
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           ICONST_1
           INVOKEVIRTUAL org/nlogo/agent/Agent.getLinkVariable (I)Ljava/lang/Object;
+         L9
+          GOTO L26
          L10
-          GOTO L27
-         L11
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -4432,23 +4625,21 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L27
+         L26
          FRAME SAME1 java/lang/Object
           ASTORE 2
-         L14
+         L11
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L27
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L28
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L29
+          IFNE L28
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4461,45 +4652,45 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L29
-         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent java/lang/Object] []
-          ALOAD 5
+         L28
+         FRAME APPEND [org/nlogo/agent/Agent]
+          ALOAD 4
           BIPUSH 13
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L30
-         L28
-         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
-          ALOAD 4
+          ASTORE 3
+          GOTO L29
+         L27
+         FRAME CHOP 1
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L12
-          ALOAD 4
+          IFEQ L30
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L31
-         FRAME APPEND [org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator]
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L32
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           BIPUSH 13
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
@@ -4507,16 +4698,12 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           GOTO L31
          L32
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L30
-         FRAME CHOP 3
           ALOAD 6
-         L15
-          GOTO L33
-         L12
-         FRAME SAME
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L29
+         L30
+         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -4530,26 +4717,31 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L29
+         FRAME SAME
+          ALOAD 3
+         L12
+          GOTO L33
          L13
          FRAME SAME1 org/nlogo/api/AgentException
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L33
          FRAME SAME1 java/lang/Object
           ASTORE 2
-         L16
+         L14
           ALOAD 2
           CHECKCAST java/lang/Boolean
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
           GOTO L34
-         L17
+         L15
          FRAME SAME1 java/lang/ClassCastException
           POP
           NEW org/nlogo/nvm/ArgumentTypeException
@@ -4564,7 +4756,7 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
          L34
          FRAME SAME1 I
           GOTO L35
-         L26
+         L25
          FRAME SAME
           ICONST_0
          L35
@@ -4576,15 +4768,18 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ICONST_3
           GOTO L37
          L36
-         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_3 org/nlogo/nvm/Context I T java/lang/Object T java/lang/Object] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_3 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
           ICONST_5
          L37
-         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_3 org/nlogo/nvm/Context I T java/lang/Object T java/lang/Object] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_3 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L38
           RETURN
 [3]_asm_procedurecolorcollaborations_setturtleorlinkvariable_4 "set" Object => void
       _constdouble:45.0 "yellow" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -4598,9 +4793,6 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_setturtleorlinkvariable_4 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -4615,8 +4807,13 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_procedurecolorcollaborations_goto_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 9
@@ -4629,21 +4826,27 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           _linkvariable:END1 "end1" => Object
         _turtlevariableof:INCUMBENT? "of" Object => Object
           _linkvariable:END2 "end2" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agentOrSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agentOrSet
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L3 L4 L4 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L5 L6 L4 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L7 L8 L8 java/lang/ClassCastException
-          TRYCATCHBLOCK L9 L10 L11 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L12 L13 L13 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L14 L15 L13 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L16 L17 L17 java/lang/ClassCastException
+          TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L6 L7 L7 java/lang/ClassCastException
+          TRYCATCHBLOCK L8 L9 L10 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L11 L12 L13 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L14 L15 L15 java/lang/ClassCastException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           ICONST_0
           INVOKEVIRTUAL org/nlogo/agent/Agent.getLinkVariable (I)Ljava/lang/Object;
          L1
-          GOTO L18
+          GOTO L16
          L2
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -4655,23 +4858,21 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L18
+         L16
          FRAME SAME1 java/lang/Object
           ASTORE 2
-         L5
+         L3
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L17
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L19
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L20
+          IFNE L18
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4684,62 +4885,58 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L20
-         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_6 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] []
-          ALOAD 5
+         L18
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/Agent]
+          ALOAD 4
           BIPUSH 13
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L21
-         L19
-         FRAME CHOP 1
-          ALOAD 4
+          ASTORE 3
+          GOTO L19
+         L17
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L3
-          ALOAD 4
+          IFEQ L20
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
-         L22
-         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_6 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+          ASTORE 7
+         L21
+         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_6 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
-          IFEQ L23
-          ALOAD 8
-          ALOAD 9
+          IFEQ L22
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           BIPUSH 13
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
           INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.add (Ljava/lang/Object;)V
-          GOTO L22
-         L23
+          GOTO L21
+         L22
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L21
-         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_6 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
           ALOAD 6
-         L6
-          GOTO L24
-         L3
-         FRAME CHOP 2
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L19
+         L20
+         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_6 org/nlogo/nvm/Context java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -4753,26 +4950,31 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L19
+         FRAME APPEND [java/lang/Object]
+          ALOAD 3
          L4
+          GOTO L23
+         L5
          FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_6 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L24
-         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_6 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [java/lang/Object]
+         L23
+         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_6 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
           ASTORE 2
-         L7
+         L6
           ALOAD 2
           CHECKCAST java/lang/Boolean
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          GOTO L25
-         L8
+          GOTO L24
+         L7
          FRAME SAME1 java/lang/ClassCastException
           POP
           NEW org/nlogo/nvm/ArgumentTypeException
@@ -4784,17 +4986,17 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
-         L25
+         L24
          FRAME SAME1 I
-          IFNE L26
-         L9
+          IFNE L25
+         L8
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           ICONST_1
           INVOKEVIRTUAL org/nlogo/agent/Agent.getLinkVariable (I)Ljava/lang/Object;
+         L9
+          GOTO L26
          L10
-          GOTO L27
-         L11
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -4805,23 +5007,21 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L27
+         L26
          FRAME SAME1 java/lang/Object
           ASTORE 2
-         L14
+         L11
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L27
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L28
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L29
+          IFNE L28
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4834,45 +5034,45 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L29
-         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_6 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent java/lang/Object] []
-          ALOAD 5
+         L28
+         FRAME APPEND [org/nlogo/agent/Agent]
+          ALOAD 4
           BIPUSH 13
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L30
-         L28
-         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_6 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] []
-          ALOAD 4
+          ASTORE 3
+          GOTO L29
+         L27
+         FRAME CHOP 1
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L12
-          ALOAD 4
+          IFEQ L30
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L31
-         FRAME APPEND [org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator]
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_6 org/nlogo/nvm/Context java/lang/Object java/lang/Object T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L32
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           BIPUSH 13
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
@@ -4880,16 +5080,12 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           GOTO L31
          L32
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L30
-         FRAME CHOP 3
           ALOAD 6
-         L15
-          GOTO L33
-         L12
-         FRAME SAME
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L29
+         L30
+         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_6 org/nlogo/nvm/Context java/lang/Object java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -4903,26 +5099,31 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L29
+         FRAME SAME
+          ALOAD 3
+         L12
+          GOTO L33
          L13
          FRAME SAME1 org/nlogo/api/AgentException
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L33
          FRAME SAME1 java/lang/Object
           ASTORE 2
-         L16
+         L14
           ALOAD 2
           CHECKCAST java/lang/Boolean
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
           GOTO L34
-         L17
+         L15
          FRAME SAME1 java/lang/ClassCastException
           POP
           NEW org/nlogo/nvm/ArgumentTypeException
@@ -4937,7 +5138,7 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
          L34
          FRAME SAME1 I
           GOTO L35
-         L26
+         L25
          FRAME SAME
           ICONST_1
          L35
@@ -4949,15 +5150,18 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           BIPUSH 6
           GOTO L37
          L36
-         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_6 org/nlogo/nvm/Context I T java/lang/Object T java/lang/Object] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_6 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
           BIPUSH 8
          L37
-         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_6 org/nlogo/nvm/Context I T java/lang/Object T java/lang/Object] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_ifelse_6 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L38
           RETURN
 [6]_asm_procedurecolorcollaborations_setturtleorlinkvariable_7 "set" Object => void
       _constdouble:55.0 "green" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -4971,9 +5175,6 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_setturtleorlinkvariable_7 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -4988,8 +5189,13 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurecolorcollaborations_goto_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 9
@@ -4998,6 +5204,9 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           RETURN
 [8]_asm_procedurecolorcollaborations_setturtleorlinkvariable_9 "set" Object => void
       _constdouble:105.0 "blue" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -5011,9 +5220,6 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_setturtleorlinkvariable_9 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -5028,8 +5234,13 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [9]_asm_procedurecolorcollaborations_goto_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 11
@@ -5038,6 +5249,9 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           RETURN
 [10]_asm_procedurecolorcollaborations_setturtleorlinkvariable_11 "set" Object => void
       _constdouble:15.0 "red" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -5051,9 +5265,6 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 11
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecolorcollaborations_setturtleorlinkvariable_11 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -5068,8 +5279,13 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 11
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [11]_asm_procedurecolorcollaborations_done_12 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -5077,6 +5293,7 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
          L1
           RETURN
 [12]_asm_procedurecolorcollaborations_return_13 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -5089,6 +5306,9 @@ procedure COLOR-COLLABORATIONS:[]{OTPL}:
 procedure LAYOUT:[_repeatlocal:0]{OTPL}:
 [0]_asm_procedurelayout_repeatlocal_0 "repeat" double => void
       _constdouble:12.0 "12" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 12.0
          L1
@@ -5101,7 +5321,8 @@ procedure LAYOUT:[_repeatlocal:0]{OTPL}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurelayout_repeatlocal_0.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurelayout_repeatlocal_0.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -5111,6 +5332,7 @@ procedure LAYOUT:[_repeatlocal:0]{OTPL}:
           RETURN
 [1]_layoutspring "layout-spring"
       _asm_procedurelayout_turtles_1 "turtles" => AgentSet
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurelayout_turtles_1.world : Lorg/nlogo/agent/World;
@@ -5118,6 +5340,7 @@ procedure LAYOUT:[_repeatlocal:0]{OTPL}:
            L1
             ARETURN
       _asm_procedurelayout_links_2 "links" => AgentSet
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurelayout_links_2.world : Lorg/nlogo/agent/World;
@@ -5125,18 +5348,21 @@ procedure LAYOUT:[_repeatlocal:0]{OTPL}:
            L1
             ARETURN
       _asm_procedurelayout_constdouble_3 "0.18" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurelayout_constdouble_3.kept1_value : Ljava/lang/Double;
            L1
             ARETURN
       _asm_procedurelayout_constdouble_4 "0.01" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurelayout_constdouble_4.kept1_value : Ljava/lang/Double;
            L1
             ARETURN
       _asm_procedurelayout_constdouble_5 "1.2" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurelayout_constdouble_5.kept1_value : Ljava/lang/Double;
@@ -5144,6 +5370,7 @@ procedure LAYOUT:[_repeatlocal:0]{OTPL}:
             ARETURN
 [2]_display "display"
 [3]_asm_procedurelayout_repeatlocalinternal_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5176,6 +5403,7 @@ procedure LAYOUT:[_repeatlocal:0]{OTPL}:
          FRAME SAME
           RETURN
 [4]_asm_procedurelayout_return_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -5188,12 +5416,16 @@ procedure LAYOUT:[_repeatlocal:0]{OTPL}:
 procedure DO-PLOT:[TOTAL]{OTPL}:
 [0]_setcurrentplot "set-current-plot"
       _asm_proceduredoplot_conststring_0 ""Link counts"" => String
+            // parameter final  context
            L0
             LDC "Link counts"
            L1
             ARETURN
 [1]_asm_proceduredoplot_setprocedurevariable_1 "let" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_1.kept2_value : Ljava/lang/Double;
@@ -5212,6 +5444,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           RETURN
 [2]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredoplot_conststring_2 ""previous collaborators"" => String
+            // parameter final  context
            L0
             LDC "previous collaborators"
            L1
@@ -5248,6 +5481,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
       _asm_proceduredoplot_procedurevariable_4 "total" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5264,6 +5498,11 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           _asm_proceduredoplot_equal_6 "=" Object,double => boolean
             _turtleorlinkvariable:COLOR "color" => Object
             _constdouble:15.0 "red" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  d1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -5290,11 +5529,9 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
                 DSTORE 3
                 ASTORE 2
                 ALOAD 2
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L5
-                ALOAD 5
+                ALOAD 2
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 3
@@ -5305,19 +5542,19 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
                 ICONST_1
                 GOTO L7
                L6
-               FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_equal_6 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_equal_6 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                 ICONST_0
                L7
                FRAME SAME1 I
-                ISTORE 7
+                ISTORE 5
                 GOTO L8
                L5
-               FRAME CHOP 1
+               FRAME CHOP 2
                 ICONST_0
-                ISTORE 7
+                ISTORE 5
                L8
-               FRAME APPEND [T I]
-                ILOAD 7
+               FRAME APPEND [I]
+                ILOAD 5
                L9
                 IFEQ L10
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -5328,6 +5565,16 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
                L11
                FRAME SAME1 java/lang/Boolean
                 ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  block
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -5397,22 +5644,12 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           IFEQ L8
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L9
+          IFEQ L6
           ILOAD 5
           ICONST_1
           IADD
           ISTORE 5
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          GOTO L10
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_5 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object java/lang/Boolean] [D]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L10
-         FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_5 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object java/lang/Boolean] [D scala/runtime/BoxedUnit]
-          ASTORE 10
           GOTO L6
          L8
          FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_5 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object] [D]
@@ -5450,13 +5687,13 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
          FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_5 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator] [D]
           ILOAD 5
           I2D
-         L11
+         L9
           DSTORE 4
           DSTORE 2
           DLOAD 2
           DLOAD 4
           DADD
-         L12
+         L10
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -5472,7 +5709,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           ALOAD 1
           BIPUSH 6
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L13
+         L11
           RETURN
 [6]_plotpendown "plot-pen-down"
 [7]_plotxy "plotxy"
@@ -5506,6 +5743,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
       _asm_proceduredoplot_procedurevariable_8 "total" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5516,6 +5754,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             ARETURN
 [8]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredoplot_conststring_9 ""incumbent-incumbent"" => String
+            // parameter final  context
            L0
             LDC "incumbent-incumbent"
            L1
@@ -5552,6 +5791,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
       _asm_proceduredoplot_procedurevariable_11 "total" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5568,6 +5808,11 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           _asm_proceduredoplot_equal_13 "=" Object,double => boolean
             _turtleorlinkvariable:COLOR "color" => Object
             _constdouble:45.0 "yellow" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  d1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -5594,11 +5839,9 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
                 DSTORE 3
                 ASTORE 2
                 ALOAD 2
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L5
-                ALOAD 5
+                ALOAD 2
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 3
@@ -5609,19 +5852,19 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
                 ICONST_1
                 GOTO L7
                L6
-               FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_equal_13 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_equal_13 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                 ICONST_0
                L7
                FRAME SAME1 I
-                ISTORE 7
+                ISTORE 5
                 GOTO L8
                L5
-               FRAME CHOP 1
+               FRAME CHOP 2
                 ICONST_0
-                ISTORE 7
+                ISTORE 5
                L8
-               FRAME APPEND [T I]
-                ILOAD 7
+               FRAME APPEND [I]
+                ILOAD 5
                L9
                 IFEQ L10
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -5632,6 +5875,16 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
                L11
                FRAME SAME1 java/lang/Boolean
                 ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  block
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -5701,22 +5954,12 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           IFEQ L8
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L9
+          IFEQ L6
           ILOAD 5
           ICONST_1
           IADD
           ISTORE 5
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          GOTO L10
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_12 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object java/lang/Boolean] [D]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L10
-         FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_12 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object java/lang/Boolean] [D scala/runtime/BoxedUnit]
-          ASTORE 10
           GOTO L6
          L8
          FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_12 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object] [D]
@@ -5754,13 +5997,13 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
          FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_12 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator] [D]
           ILOAD 5
           I2D
-         L11
+         L9
           DSTORE 4
           DSTORE 2
           DLOAD 2
           DLOAD 4
           DADD
-         L12
+         L10
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -5776,7 +6019,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           ALOAD 1
           BIPUSH 12
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L13
+         L11
           RETURN
 [12]_plotpendown "plot-pen-down"
 [13]_plotxy "plotxy"
@@ -5810,6 +6053,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
       _asm_proceduredoplot_procedurevariable_15 "total" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5820,6 +6064,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             ARETURN
 [14]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredoplot_conststring_16 ""newcomer-incumbent"" => String
+            // parameter final  context
            L0
             LDC "newcomer-incumbent"
            L1
@@ -5856,6 +6101,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
       _asm_proceduredoplot_procedurevariable_18 "total" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5872,6 +6118,11 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           _asm_proceduredoplot_equal_20 "=" Object,double => boolean
             _turtleorlinkvariable:COLOR "color" => Object
             _constdouble:55.0 "green" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  d1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -5898,11 +6149,9 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
                 DSTORE 3
                 ASTORE 2
                 ALOAD 2
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L5
-                ALOAD 5
+                ALOAD 2
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 3
@@ -5913,19 +6162,19 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
                 ICONST_1
                 GOTO L7
                L6
-               FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_equal_20 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_equal_20 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                 ICONST_0
                L7
                FRAME SAME1 I
-                ISTORE 7
+                ISTORE 5
                 GOTO L8
                L5
-               FRAME CHOP 1
+               FRAME CHOP 2
                 ICONST_0
-                ISTORE 7
+                ISTORE 5
                L8
-               FRAME APPEND [T I]
-                ILOAD 7
+               FRAME APPEND [I]
+                ILOAD 5
                L9
                 IFEQ L10
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -5936,6 +6185,16 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
                L11
                FRAME SAME1 java/lang/Boolean
                 ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  block
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -6005,22 +6264,12 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           IFEQ L8
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L9
+          IFEQ L6
           ILOAD 5
           ICONST_1
           IADD
           ISTORE 5
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          GOTO L10
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_19 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object java/lang/Boolean] [D]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L10
-         FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_19 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object java/lang/Boolean] [D scala/runtime/BoxedUnit]
-          ASTORE 10
           GOTO L6
          L8
          FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_19 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object] [D]
@@ -6058,13 +6307,13 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
          FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_19 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator] [D]
           ILOAD 5
           I2D
-         L11
+         L9
           DSTORE 4
           DSTORE 2
           DLOAD 2
           DLOAD 4
           DADD
-         L12
+         L10
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -6080,7 +6329,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           ALOAD 1
           BIPUSH 18
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L13
+         L11
           RETURN
 [18]_plotpendown "plot-pen-down"
 [19]_plotxy "plotxy"
@@ -6114,6 +6363,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
       _asm_proceduredoplot_procedurevariable_22 "total" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -6124,6 +6374,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             ARETURN
 [20]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduredoplot_conststring_23 ""newcomer-newcomer"" => String
+            // parameter final  context
            L0
             LDC "newcomer-newcomer"
            L1
@@ -6160,6 +6411,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
       _asm_proceduredoplot_procedurevariable_25 "total" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -6176,6 +6428,11 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           _asm_proceduredoplot_equal_27 "=" Object,double => boolean
             _turtleorlinkvariable:COLOR "color" => Object
             _constdouble:105.0 "blue" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  d1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -6202,11 +6459,9 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
                 DSTORE 3
                 ASTORE 2
                 ALOAD 2
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L5
-                ALOAD 5
+                ALOAD 2
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 3
@@ -6217,19 +6472,19 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
                 ICONST_1
                 GOTO L7
                L6
-               FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_equal_27 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_equal_27 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                 ICONST_0
                L7
                FRAME SAME1 I
-                ISTORE 7
+                ISTORE 5
                 GOTO L8
                L5
-               FRAME CHOP 1
+               FRAME CHOP 2
                 ICONST_0
-                ISTORE 7
+                ISTORE 5
                L8
-               FRAME APPEND [T I]
-                ILOAD 7
+               FRAME APPEND [I]
+                ILOAD 5
                L9
                 IFEQ L10
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -6240,6 +6495,16 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
                L11
                FRAME SAME1 java/lang/Boolean
                 ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  block
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -6309,22 +6574,12 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           IFEQ L8
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L9
+          IFEQ L6
           ILOAD 5
           ICONST_1
           IADD
           ISTORE 5
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          GOTO L10
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_26 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object java/lang/Boolean] [D]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L10
-         FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_26 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object java/lang/Boolean] [D scala/runtime/BoxedUnit]
-          ASTORE 10
           GOTO L6
          L8
          FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_26 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator org/nlogo/agent/Agent java/lang/Object] [D]
@@ -6362,13 +6617,13 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
          FRAME FULL [org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_26 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context I org/nlogo/agent/AgentIterator] [D]
           ILOAD 5
           I2D
-         L11
+         L9
           DSTORE 4
           DSTORE 2
           DLOAD 2
           DLOAD 4
           DADD
-         L12
+         L10
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -6384,7 +6639,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           ALOAD 1
           BIPUSH 24
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L13
+         L11
           RETURN
 [24]_plotpendown "plot-pen-down"
 [25]_plotxy "plotxy"
@@ -6418,6 +6673,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
       _asm_proceduredoplot_procedurevariable_29 "total" => Object
+            // parameter final  context
            L0
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -6446,6 +6702,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           RETURN
 [27]_setcurrentplot "set-current-plot"
       _asm_proceduredoplot_conststring_31 ""% of agents in the giant component"" => String
+            // parameter final  context
            L0
             LDC "% of agents in the giant component"
            L1
@@ -6484,6 +6741,10 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
         _observervariable:GIANT-COMPONENT-SIZE "giant-component-size" => Object
         _count "count" AgentSet => double
           _turtles "turtles" => AgentSet
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
            L2
             ALOAD 0
@@ -6550,6 +6811,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             ARETURN
 [29]_setcurrentplot "set-current-plot"
       _asm_proceduredoplot_conststring_34 ""Average component size"" => String
+            // parameter final  context
            L0
             LDC "Average component size"
            L1
@@ -6586,6 +6848,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             ARETURN
       _asm_proceduredoplot_mean_36 "mean" LogoList => double
         _observervariable:COMPONENTS "components" => Object
+            // parameter final  context
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
            L2
             ALOAD 0
@@ -6683,7 +6946,8 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
             I2D
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_mean_36.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_mean_36.validDouble (DLorg/nlogo/nvm/Context;)D
            L9
             DSTORE 2
             NEW java/lang/Double
@@ -6692,6 +6956,7 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
 [31]_asm_proceduredoplot_return_37 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -6704,6 +6969,9 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
 procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
 [0]_asm_procedurefindallcomponents_setobservervariable_0 "set" Object => void
       _constlist:[] "[]" => LogoList
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -6718,9 +6986,6 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurefindallcomponents_setobservervariable_0 org/nlogo/nvm/Context org/nlogo/core/LogoList] [org/nlogo/api/AgentException]
@@ -6735,9 +7000,16 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [1]_asm_procedurefindallcomponents_setobservervariable_1 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -6752,9 +7024,6 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurefindallcomponents_setobservervariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -6769,9 +7038,16 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedurefindallcomponents_ask_2 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurefindallcomponents_ask_2.world : Lorg/nlogo/agent/World;
@@ -6827,6 +7103,9 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           RETURN
 [3]_asm_procedurefindallcomponents_setturtlevariable_3 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -6840,9 +7119,6 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurefindallcomponents_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -6857,8 +7133,13 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_procedurefindallcomponents_done_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -6870,6 +7151,9 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
         _turtles "turtles" => AgentSet
         _asm_procedurefindallcomponents_not_6 "not" boolean => boolean
           _turtlevariable:EXPLORED? "explored?" => Object
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
               TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
              L0
@@ -6914,12 +7198,12 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
              FRAME SAME1 I
               ISTORE 2
               ILOAD 2
-              IFEQ L7
-              ICONST_0
+              IFNE L7
+              ICONST_1
               GOTO L8
              L7
              FRAME FULL [org/nlogo/prim/_asm_procedurefindallcomponents_not_6 org/nlogo/nvm/Context I] []
-              ICONST_1
+              ICONST_0
              L8
              FRAME SAME1 I
               IFEQ L9
@@ -6931,6 +7215,12 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
              L10
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurefindallcomponents_setprocedurevariable_5.world : Lorg/nlogo/agent/World;
@@ -6978,16 +7268,11 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
           ALOAD 8
           INVOKEVIRTUAL scala/Predef$.Boolean2boolean (Ljava/lang/Boolean;)Z
-          IFEQ L5
+          IFEQ L2
           ALOAD 6
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 9
-          GOTO L2
+          GOTO L5
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -7017,7 +7302,7 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
          L3
          FRAME CHOP 2
           GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
-         L6
+         L5
          FRAME SAME1 java/lang/Object
           ASTORE 2
           ALOAD 1
@@ -7029,12 +7314,19 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           ALOAD 1
           BIPUSH 6
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L7
+         L6
           RETURN
 [6]_asm_procedurefindallcomponents_if_7 "if" boolean => void
       _equal "=" Object,Object => boolean
         _procedurevariable:START "start" => Object
         _nobody "nobody" => Nobody$
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7105,6 +7397,9 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           RETURN
 [8]_asm_procedurefindallcomponents_setobservervariable_9 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -7119,9 +7414,6 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurefindallcomponents_setobservervariable_9 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -7136,9 +7428,16 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [9]_asm_procedurefindallcomponents_ask_10 "ask" Object => void
       _procedurevariable:START "start" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7148,18 +7447,16 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
          L1
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L2
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L3
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurefindallcomponents_ask_10.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -7175,8 +7472,8 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindallcomponents_ask_10 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurefindallcomponents_ask_10.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -7193,18 +7490,18 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           ATHROW
          L3
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L5
          L2
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L6
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -7221,7 +7518,7 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -7231,23 +7528,12 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
          L7
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindallcomponents_ask_10 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          BIPUSH 10
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 12
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L8
+          GOTO L5
          L6
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -7261,8 +7547,16 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L5
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          BIPUSH 10
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 12
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindallcomponents_ask_10 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [10]_asm_procedurefindallcomponents_call_11 "explore"
          L0
@@ -7283,6 +7577,7 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
          L1
           RETURN
 [11]_asm_procedurefindallcomponents_done_12 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -7293,6 +7588,13 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
       _greaterthan ">" Object,Object => boolean
         _observervariable:COMPONENT-SIZE "component-size" => Object
         _observervariable:GIANT-COMPONENT-SIZE "giant-component-size" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  o1
+          // parameter final  o2
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurefindallcomponents_if_13.world : Lorg/nlogo/agent/World;
@@ -7327,40 +7629,36 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
          L4
          FRAME APPEND [java/lang/Object java/lang/Object]
           ICONST_0
-         L5
-         FRAME SAME1 I
-          GOTO L6
+          GOTO L5
          L3
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
           ICONST_0
-          IF_ICMPLE L8
+          IF_ICMPLE L7
           ICONST_1
-          GOTO L9
-         L8
+          GOTO L5
+         L7
          FRAME SAME
           ICONST_0
-         L9
-         FRAME SAME1 I
-          GOTO L6
-         L7
+          GOTO L5
+         L6
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -7371,21 +7669,19 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L10
+          IF_ICMPNE L8
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
           ICONST_0
-          IF_ICMPLE L11
+          IF_ICMPLE L9
           ICONST_1
-          GOTO L12
-         L11
+          GOTO L5
+         L9
          FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
           ICONST_0
-         L12
-         FRAME SAME1 I
-          GOTO L6
-         L10
+          GOTO L5
+         L8
          FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -7413,24 +7709,27 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L6
+         L5
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L13
+          IFEQ L10
           BIPUSH 13
-          GOTO L14
-         L13
+          GOTO L11
+         L10
          FRAME FULL [org/nlogo/prim/_asm_procedurefindallcomponents_if_13 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
           BIPUSH 14
-         L14
+         L11
          FRAME FULL [org/nlogo/prim/_asm_procedurefindallcomponents_if_13 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L15
+         L12
           RETURN
 [13]_asm_procedurefindallcomponents_setobservervariable_14 "set" Object => void
       _observervariable:COMPONENT-SIZE "component-size" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -7448,9 +7747,6 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 14
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurefindallcomponents_setobservervariable_14 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -7465,10 +7761,15 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 14
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [14]_asm_procedurefindallcomponents_setobservervariable_15 "set" Object => void
       _lput "lput"
         _asm_procedurefindallcomponents_observervariable_16 "component-size" => Object
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurefindallcomponents_observervariable_16.world : Lorg/nlogo/agent/World;
@@ -7478,6 +7779,7 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
              L1
               ARETURN
         _asm_procedurefindallcomponents_observervariable_17 "components" => Object
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurefindallcomponents_observervariable_17.world : Lorg/nlogo/agent/World;
@@ -7486,6 +7788,8 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
               INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurefindallcomponents_setobservervariable_15.keptinstr2 : Lorg/nlogo/prim/etc/_lput;
@@ -7501,9 +7805,6 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 15
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L4
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurefindallcomponents_setobservervariable_15 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -7518,8 +7819,13 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
           ATHROW
          L4
          FRAME SAME
+          ALOAD 1
+          BIPUSH 15
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L5
           RETURN
 [15]_asm_procedurefindallcomponents_goto_18 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_5
@@ -7527,6 +7833,7 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
          L1
           RETURN
 [16]_asm_procedurefindallcomponents_return_19 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -7539,6 +7846,9 @@ procedure FIND-ALL-COMPONENTS:[START]{OTPL}:
 procedure EXPLORE:[]{-T--}:
 [0]_asm_procedureexplore_if_0 "if" boolean => void
       _turtlevariable:EXPLORED? "explored?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -7635,6 +7945,9 @@ procedure EXPLORE:[]{-T--}:
           RETURN
 [2]_asm_procedureexplore_setturtlevariable_2 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -7648,9 +7961,6 @@ procedure EXPLORE:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureexplore_setturtlevariable_2 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -7665,11 +7975,22 @@ procedure EXPLORE:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_procedureexplore_setobservervariable_3 "set" Object => void
       _plus "+" double,double => double
         _observervariable:COMPONENT-SIZE "component-size" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -7721,9 +8042,6 @@ procedure EXPLORE:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L10
          L4
          FRAME FULL [org/nlogo/prim/_asm_procedureexplore_setobservervariable_3 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -7738,9 +8056,16 @@ procedure EXPLORE:[]{-T--}:
           ATHROW
          L10
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [4]_asm_procedureexplore_ask_4 "ask" AgentSet => void
       _linkneighbors:null "link-neighbors" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureexplore_ask_4.kept2_breedName : Ljava/lang/String;
@@ -7821,6 +8146,7 @@ procedure EXPLORE:[]{-T--}:
          L6
           RETURN
 [5]_asm_procedureexplore_recursefast_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.atTopActivation ()Z
@@ -7839,6 +8165,7 @@ procedure EXPLORE:[]{-T--}:
          FRAME SAME
           RETURN
 [6]_asm_procedureexplore_done_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -7846,6 +8173,7 @@ procedure EXPLORE:[]{-T--}:
          L1
           RETURN
 [7]_asm_procedureexplore_return_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V

--- a/netlogo-headless/test/benchdumps/Termites.txt
+++ b/netlogo-headless/test/benchdumps/Termites.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:471.0 "471" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 471.0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -77,6 +80,7 @@ procedure BENCHMARK:[]{O---}:
 [2]_resettimer "reset-timer"
 [3]_askconcurrent:+8 "ask-concurrent"
       _asm_procedurebenchmark_turtles_2 "turtles" => AgentSet
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurebenchmark_turtles_2.world : Lorg/nlogo/agent/World;
@@ -85,6 +89,9 @@ procedure BENCHMARK:[]{O---}:
             ARETURN
 [4]_asm_procedurebenchmark_repeat_3 "repeat" double => void
       _constdouble:350.0 "350" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
          L0
           LDC 350.0
          L1
@@ -96,7 +103,8 @@ procedure BENCHMARK:[]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeat_3.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeat_3.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           INVOKEVIRTUAL org/nlogo/nvm/Context.let (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
           ALOAD 1
@@ -123,6 +131,7 @@ procedure BENCHMARK:[]{O---}:
          L1
           RETURN
 [6]_asm_procedurebenchmark_repeatinternal_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           ALOAD 0
@@ -154,6 +163,7 @@ procedure BENCHMARK:[]{O---}:
          FRAME SAME
           RETURN
 [7]_asm_procedurebenchmark_done_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -162,6 +172,9 @@ procedure BENCHMARK:[]{O---}:
           RETURN
 [8]_asm_procedurebenchmark_setobservervariable_7 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -183,9 +196,6 @@ procedure BENCHMARK:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_7 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -200,8 +210,13 @@ procedure BENCHMARK:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [9]_asm_procedurebenchmark_return_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -215,6 +230,9 @@ procedure SETUP:[]{O---}:
 [0]_clearall "ca"
 [1]_asm_proceduresetup_ask_0 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_0.world : Lorg/nlogo/agent/World;
@@ -272,6 +290,13 @@ procedure SETUP:[]{O---}:
       _lessthan "<" double,Object => boolean
         _randomconst:100 "random" => double
         _observervariable:DENSITY "density" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -289,11 +314,9 @@ procedure SETUP:[]{O---}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -304,15 +327,14 @@ procedure SETUP:[]{O---}:
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_1 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_1 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -341,23 +363,28 @@ procedure SETUP:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_1 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
+         L7
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L7
+          IFEQ L8
           ICONST_3
-          GOTO L8
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_1 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          ICONST_4
+          GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_1 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_1 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context]
+          ICONST_4
          L9
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_if_1 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [3]_asm_proceduresetup_setpatchvariable_2 "set" Object => void
       _constdouble:45.0 "yellow" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -371,9 +398,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_2 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -388,8 +412,13 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduresetup_done_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -398,6 +427,7 @@ procedure SETUP:[]{O---}:
           RETURN
 [5]_crofast: "create-ordered-turtles"
       _asm_proceduresetup_observervariable_4 "number" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetup_observervariable_4.world : Lorg/nlogo/agent/World;
@@ -408,6 +438,9 @@ procedure SETUP:[]{O---}:
             ARETURN
 [6]_asm_proceduresetup_ask_5 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_5.world : Lorg/nlogo/agent/World;
@@ -463,6 +496,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [7]_asm_proceduresetup_setturtleorlinkvariable_6 "set" Object => void
       _constdouble:9.9 "white" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -476,9 +512,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtleorlinkvariable_6 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -493,12 +526,22 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [8]_asm_proceduresetup_setxy_7 "setxy" double,double => void
       _random "random" double => double
         _worldwidth "world-width" => double
       _random "random" double => double
         _worldheight "world-height" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  maxDouble
+          // parameter final  context
+          // parameter final  context
+          // parameter final  maxDouble
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -509,7 +552,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_7.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_7.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -573,7 +617,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_7.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_7.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -678,6 +723,7 @@ procedure SETUP:[]{O---}:
          L19
           RETURN
 [9]_asm_proceduresetup_done_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -685,6 +731,7 @@ procedure SETUP:[]{O---}:
          L1
           RETURN
 [10]_asm_proceduresetup_return_9 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -750,6 +797,7 @@ procedure GO:[]{-T--}:
          L1
           RETURN
 [3]_asm_procedurego_return_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -764,6 +812,13 @@ procedure SEARCH-FOR-CHIP:[]{-T--}:
       _equal "=" Object,double => boolean
         _patchvariable:PCOLOR "pcolor" => Object
         _constdouble:45.0 "yellow" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -790,11 +845,9 @@ procedure SEARCH-FOR-CHIP:[]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -805,19 +858,19 @@ procedure SEARCH-FOR-CHIP:[]{-T--}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduresearchforchip_ifelse_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduresearchforchip_ifelse_0 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -826,15 +879,18 @@ procedure SEARCH-FOR-CHIP:[]{-T--}:
           ICONST_1
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_proceduresearchforchip_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_proceduresearchforchip_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           ICONST_5
          L11
-         FRAME FULL [org/nlogo/prim/_asm_proceduresearchforchip_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_proceduresearchforchip_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
 [1]_asm_proceduresearchforchip_setpatchvariable_1 "set" Object => void
       _constdouble:0.0 "black" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -848,9 +904,6 @@ procedure SEARCH-FOR-CHIP:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresearchforchip_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -865,9 +918,16 @@ procedure SEARCH-FOR-CHIP:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_proceduresearchforchip_setturtleorlinkvariable_2 "set" Object => void
       _constdouble:25.0 "orange" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -881,9 +941,6 @@ procedure SEARCH-FOR-CHIP:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresearchforchip_setturtleorlinkvariable_2 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -898,13 +955,20 @@ procedure SEARCH-FOR-CHIP:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_proceduresearchforchip_jump_3 "jump" double => void
       _constdouble:20.0 "20" => double
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-         L2
-          LDC 20.0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  distance
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
+          LDC 20.0
+         L4
           DSTORE 2
          L0
           ALOAD 1
@@ -912,18 +976,20 @@ procedure SEARCH-FOR-CHIP:[]{-T--}:
           CHECKCAST org/nlogo/agent/Turtle
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L4
          L1
+          GOTO L5
+         L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresearchforchip_jump_3 org/nlogo/nvm/Context D] [org/nlogo/api/AgentException]
-          ASTORE 4
-         L4
+          POP
+         L5
          FRAME SAME
           ALOAD 1
           ICONST_4
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L5
+         L6
           RETURN
 [4]_asm_proceduresearchforchip_goto_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 7
@@ -949,6 +1015,7 @@ procedure SEARCH-FOR-CHIP:[]{-T--}:
          L1
           RETURN
 [6]_asm_proceduresearchforchip_recursefast_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.atTopActivation ()Z
@@ -967,6 +1034,7 @@ procedure SEARCH-FOR-CHIP:[]{-T--}:
          FRAME SAME
           RETURN
 [7]_asm_proceduresearchforchip_return_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -981,6 +1049,13 @@ procedure FIND-NEW-PILE:[]{-T--}:
       _notequal "!=" Object,double => boolean
         _patchvariable:PCOLOR "pcolor" => Object
         _constdouble:45.0 "yellow" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1007,11 +1082,9 @@ procedure FIND-NEW-PILE:[]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -1022,19 +1095,19 @@ procedure FIND-NEW-PILE:[]{-T--}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewpile_if_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewpile_if_0 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -1043,10 +1116,10 @@ procedure FIND-NEW-PILE:[]{-T--}:
           ICONST_1
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewpile_if_0 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewpile_if_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           ICONST_3
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewpile_if_0 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurefindnewpile_if_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
@@ -1069,6 +1142,7 @@ procedure FIND-NEW-PILE:[]{-T--}:
          L1
           RETURN
 [2]_asm_procedurefindnewpile_recursefast_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.atTopActivation ()Z
@@ -1087,6 +1161,7 @@ procedure FIND-NEW-PILE:[]{-T--}:
          FRAME SAME
           RETURN
 [3]_asm_procedurefindnewpile_return_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1101,6 +1176,13 @@ procedure FIND-EMPTY-SPOT:[]{-T--}:
       _equal "=" Object,double => boolean
         _patchvariable:PCOLOR "pcolor" => Object
         _constdouble:0.0 "black" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1127,11 +1209,9 @@ procedure FIND-EMPTY-SPOT:[]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -1142,19 +1222,19 @@ procedure FIND-EMPTY-SPOT:[]{-T--}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindemptyspot_ifelse_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurefindemptyspot_ifelse_0 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -1163,15 +1243,18 @@ procedure FIND-EMPTY-SPOT:[]{-T--}:
           ICONST_1
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindemptyspot_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedurefindemptyspot_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           ICONST_5
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedurefindemptyspot_ifelse_0 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedurefindemptyspot_ifelse_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
 [1]_asm_procedurefindemptyspot_setpatchvariable_1 "set" Object => void
       _constdouble:45.0 "yellow" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1185,9 +1268,6 @@ procedure FIND-EMPTY-SPOT:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurefindemptyspot_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1202,9 +1282,16 @@ procedure FIND-EMPTY-SPOT:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedurefindemptyspot_setturtleorlinkvariable_2 "set" Object => void
       _constdouble:9.9 "white" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1218,9 +1305,6 @@ procedure FIND-EMPTY-SPOT:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurefindemptyspot_setturtleorlinkvariable_2 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1235,6 +1319,10 @@ procedure FIND-EMPTY-SPOT:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_procedurefindemptyspot_call_3 "get-away"
          L0
@@ -1255,6 +1343,7 @@ procedure FIND-EMPTY-SPOT:[]{-T--}:
          L1
           RETURN
 [4]_asm_procedurefindemptyspot_goto_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 8
@@ -1263,6 +1352,9 @@ procedure FIND-EMPTY-SPOT:[]{-T--}:
           RETURN
 [5]_asm_procedurefindemptyspot_setturtlevariable_5 "set" Object => void
       _randomconst:360 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -1285,9 +1377,6 @@ procedure FIND-EMPTY-SPOT:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurefindemptyspot_setturtlevariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1302,27 +1391,34 @@ procedure FIND-EMPTY-SPOT:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [6]_asm_procedurefindemptyspot_fd1_6 "fd" => void
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
+          // parameter final  context
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
           DCONST_1
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L2
          L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          ASTORE 2
+          GOTO L3
          L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L3
          FRAME SAME
           ALOAD 1
           BIPUSH 7
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L3
+         L4
           RETURN
 [7]_asm_procedurefindemptyspot_recursefast_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.atTopActivation ()Z
@@ -1341,6 +1437,7 @@ procedure FIND-EMPTY-SPOT:[]{-T--}:
          FRAME SAME
           RETURN
 [8]_asm_procedurefindemptyspot_return_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1353,6 +1450,9 @@ procedure FIND-EMPTY-SPOT:[]{-T--}:
 procedure GET-AWAY:[]{-T--}:
 [0]_asm_proceduregetaway_setturtlevariable_0 "set" Object => void
       _randomconst:360 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -1375,9 +1475,6 @@ procedure GET-AWAY:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduregetaway_setturtlevariable_0 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1392,13 +1489,20 @@ procedure GET-AWAY:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [1]_asm_proceduregetaway_jump_1 "jump" double => void
       _constdouble:20.0 "20" => double
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-         L2
-          LDC 20.0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  distance
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
+          LDC 20.0
+         L4
           DSTORE 2
          L0
           ALOAD 1
@@ -1406,21 +1510,29 @@ procedure GET-AWAY:[]{-T--}:
           CHECKCAST org/nlogo/agent/Turtle
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L4
          L1
+          GOTO L5
+         L2
          FRAME FULL [org/nlogo/prim/_asm_proceduregetaway_jump_1 org/nlogo/nvm/Context D] [org/nlogo/api/AgentException]
-          ASTORE 4
-         L4
+          POP
+         L5
          FRAME SAME
           ALOAD 1
           ICONST_2
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L5
+         L6
           RETURN
 [2]_asm_proceduregetaway_if_2 "if" boolean => void
       _notequal "!=" Object,double => boolean
         _patchvariable:PCOLOR "pcolor" => Object
         _constdouble:0.0 "black" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -1447,11 +1559,9 @@ procedure GET-AWAY:[]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -1462,19 +1572,19 @@ procedure GET-AWAY:[]{-T--}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetaway_if_2 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduregetaway_if_2 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_1
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -1483,14 +1593,15 @@ procedure GET-AWAY:[]{-T--}:
           ICONST_3
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetaway_if_2 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_proceduregetaway_if_2 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           ICONST_4
          L11
-         FRAME FULL [org/nlogo/prim/_asm_proceduregetaway_if_2 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_proceduregetaway_if_2 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
 [3]_asm_proceduregetaway_recursefast_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.atTopActivation ()Z
@@ -1509,6 +1620,7 @@ procedure GET-AWAY:[]{-T--}:
          FRAME SAME
           RETURN
 [4]_asm_proceduregetaway_return_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1520,23 +1632,25 @@ procedure GET-AWAY:[]{-T--}:
 
 procedure WIGGLE:[]{-T--}:
 [0]_asm_procedurewiggle_fd1_0 "fd" => void
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
+          // parameter final  context
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
           DCONST_1
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L2
          L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          ASTORE 2
+          GOTO L3
          L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L3
          FRAME SAME
           ALOAD 1
           ICONST_1
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L3
+         L4
           RETURN
 [1]_asm_procedurewiggle_setturtlevariable_1 "set" Object => void
       _minus "-" double,double => double
@@ -1544,6 +1658,17 @@ procedure WIGGLE:[]{-T--}:
           _turtlevariabledouble:HEADING "heading" => double
           _randomconst:50 "random" => double
         _randomconst:50 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -1591,9 +1716,6 @@ procedure WIGGLE:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L9
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurewiggle_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1608,8 +1730,13 @@ procedure WIGGLE:[]{-T--}:
           ATHROW
          L9
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [2]_asm_procedurewiggle_return_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V

--- a/netlogo-headless/test/benchdumps/VirusNet.txt
+++ b/netlogo-headless/test/benchdumps/VirusNet.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:2468.0 "2468" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 2468.0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -77,6 +80,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:2000.0 "2000" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 2000.0
          L1
@@ -89,7 +95,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -116,6 +123,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -149,6 +157,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -170,9 +181,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -187,8 +195,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -240,6 +253,7 @@ procedure SETUP:[]{O---}:
 [4]_asm_proceduresetup_ask_2 "ask" Object => void
       _nof "n-of"
         _asm_proceduresetup_observervariable_3 "initial-outbreak-size" => Object
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_proceduresetup_observervariable_3.world : Lorg/nlogo/agent/World;
@@ -249,12 +263,15 @@ procedure SETUP:[]{O---}:
              L1
               ARETURN
         _asm_proceduresetup_turtles_4 "turtles" => AgentSet
+              // parameter final  context
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_proceduresetup_turtles_4.world : Lorg/nlogo/agent/World;
               INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
              L1
               ARETURN
+          // parameter final  context
+          // parameter final  target
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_2.keptinstr2 : Lorg/nlogo/prim/etc/_nof;
           ALOAD 1
@@ -262,18 +279,16 @@ procedure SETUP:[]{O---}:
          L0
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L1
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L2
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_2.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -289,8 +304,8 @@ procedure SETUP:[]{O---}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_ask_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_2.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -307,18 +322,18 @@ procedure SETUP:[]{O---}:
           ATHROW
          L2
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L4
          L1
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L5
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -335,7 +350,7 @@ procedure SETUP:[]{O---}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -345,23 +360,12 @@ procedure SETUP:[]{O---}:
          L6
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_ask_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_5
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
+          GOTO L4
          L5
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -375,8 +379,16 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L4
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          ICONST_5
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetup_ask_2 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [5]_asm_proceduresetup_call_5 "become-infected"
          L0
@@ -397,6 +409,7 @@ procedure SETUP:[]{O---}:
          L1
           RETURN
 [6]_asm_proceduresetup_done_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -405,6 +418,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [7]_asm_proceduresetup_ask_7 "ask" AgentSet => void
       _links "links" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_7.world : Lorg/nlogo/agent/World;
@@ -460,6 +476,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [8]_asm_proceduresetup_setturtleorlinkvariable_8 "set" Object => void
       _constdouble:9.9 "white" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -473,9 +492,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtleorlinkvariable_8 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -490,8 +506,13 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [9]_asm_proceduresetup_done_9 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -517,6 +538,7 @@ procedure SETUP:[]{O---}:
          L1
           RETURN
 [11]_asm_proceduresetup_return_11 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -529,6 +551,7 @@ procedure SETUP:[]{O---}:
 procedure SETUP-NODES:[]{O---}:
 [0]_setdefaultshape "set-default-shape"
       _asm_proceduresetupnodes_turtles_0 "turtles" => AgentSet
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupnodes_turtles_0.world : Lorg/nlogo/agent/World;
@@ -536,12 +559,14 @@ procedure SETUP-NODES:[]{O---}:
            L1
             ARETURN
       _asm_proceduresetupnodes_conststring_1 ""circle"" => String
+            // parameter final  context
            L0
             LDC "circle"
            L1
             ARETURN
 [1]_createturtles:,+6 "crt"
       _asm_proceduresetupnodes_observervariable_2 "number-of-nodes" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupnodes_observervariable_2.world : Lorg/nlogo/agent/World;
@@ -557,6 +582,16 @@ procedure SETUP-NODES:[]{O---}:
       _mult "*" double,double => double
         _randomycor "random-ycor" => double
         _constdouble:0.95 "0.95" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -694,6 +729,11 @@ procedure SETUP-NODES:[]{O---}:
 [4]_asm_proceduresetupnodes_setturtlevariable_5 "set" Object => void
       _random "random" double => double
         _observervariable:VIRUS-CHECK-FREQUENCY "virus-check-frequency" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  maxDouble
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -726,7 +766,8 @@ procedure SETUP-NODES:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnodes_setturtlevariable_5.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnodes_setturtlevariable_5.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -795,9 +836,6 @@ procedure SETUP-NODES:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L14
          L4
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupnodes_setturtlevariable_5 org/nlogo/nvm/Context java/lang/Double T J] [org/nlogo/api/AgentException]
@@ -812,8 +850,13 @@ procedure SETUP-NODES:[]{O---}:
           ATHROW
          L14
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L15
           RETURN
 [5]_asm_proceduresetupnodes_done_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -821,6 +864,7 @@ procedure SETUP-NODES:[]{O---}:
          L1
           RETURN
 [6]_asm_proceduresetupnodes_return_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -837,6 +881,14 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           _observervariable:AVERAGE-NODE-DEGREE "average-node-degree" => Object
           _observervariable:NUMBER-OF-NODES "number-of-nodes" => Object
         _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -939,6 +991,7 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
          L13
           RETURN
 [1]_asm_proceduresetupspatiallyclusterednetwork_goto_1 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 8
@@ -948,6 +1001,11 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
 [2]_asm_proceduresetupspatiallyclusterednetwork_ask_2 "ask" Object => void
       _oneof "one-of" AgentSet => Object
         _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
+          // parameter final  context
+          // parameter final  target
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_ask_2.world : Lorg/nlogo/agent/World;
@@ -976,18 +1034,16 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
          FRAME SAME1 java/lang/Object
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L4
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L5
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_ask_2.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -1003,8 +1059,8 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_ask_2 org/nlogo/nvm/Context java/lang/Object I java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_ask_2 org/nlogo/nvm/Context java/lang/Object I org/nlogo/agent/AgentSet] []
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_ask_2.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -1021,18 +1077,18 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           ATHROW
          L5
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L7
          L4
          FRAME CHOP 1
-          ALOAD 4
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L8
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -1049,7 +1105,7 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -1057,23 +1113,12 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L9
-         FRAME APPEND [T T org/nlogo/agent/Agent]
+         FRAME APPEND [T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_ask_2 org/nlogo/nvm/Context java/lang/Object I java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_3
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L10
+          GOTO L7
          L8
          FRAME CHOP 2
           NEW org/nlogo/nvm/ArgumentTypeException
@@ -1089,8 +1134,16 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L7
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_ask_2 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet] []
+          ALOAD 1
+          ALOAD 3
+          ICONST_3
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L10
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_ask_2 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [3]_asm_proceduresetupspatiallyclusterednetwork_let_3 "let" Object => void
       _minoneof "min-one-of"
@@ -1099,6 +1152,10 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           _asm_proceduresetupspatiallyclusterednetwork_not_5 "not" boolean => boolean
             _linkneighbor:null "link-neighbor?" Turtle => boolean
               _myself "myself" => Agent
+                // parameter final  context
+                // parameter final  target
+                // parameter final  context
+                // parameter final  arg0
                 TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
                L2
                 ALOAD 1
@@ -1168,36 +1225,43 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_not_5.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.linkManager ()Lorg/nlogo/agent/LinkManager;
-                ASTORE 5
-                GETSTATIC scala/Predef$.MODULE$ : Lscala/Predef$;
-                ALOAD 5
                 ALOAD 3
                 ALOAD 2
                 ALOAD 4
                 INVOKEINTERFACE org/nlogo/agent/LinkManager.linksWith (Lorg/nlogo/agent/Turtle;Lorg/nlogo/agent/Turtle;Lorg/nlogo/agent/AgentSet;)[Lorg/nlogo/agent/Link;
-                CHECKCAST [Ljava/lang/Object;
-                INVOKEVIRTUAL scala/Predef$.refArrayOps ([Ljava/lang/Object;)Lscala/collection/mutable/ArrayOps;
-                INVOKEINTERFACE scala/collection/mutable/ArrayOps.nonEmpty ()Z
+                ARRAYLENGTH
+                ICONST_0
+                IF_ICMPLE L9
+                ICONST_1
+                GOTO L10
                L9
+               FRAME APPEND [org/nlogo/agent/AgentSet]
+                ICONST_0
+               L10
+               FRAME SAME1 I
                 ISTORE 2
                 ILOAD 2
-                IFEQ L10
-                ICONST_0
-                GOTO L11
-               L10
-               FRAME FULL [org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_not_5 org/nlogo/nvm/Context I org/nlogo/agent/Turtle org/nlogo/agent/AgentSet org/nlogo/agent/LinkManager] []
+                IFNE L11
                 ICONST_1
+                GOTO L12
                L11
-               FRAME SAME1 I
-                IFEQ L12
-                GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
-                GOTO L13
+               FRAME FULL [org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_not_5 org/nlogo/nvm/Context I org/nlogo/agent/Turtle org/nlogo/agent/AgentSet] []
+                ICONST_0
                L12
+               FRAME SAME1 I
+                IFEQ L13
+                GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
+                GOTO L14
+               L13
                FRAME SAME
                 GETSTATIC java/lang/Boolean.FALSE : Ljava/lang/Boolean;
-               L13
+               L14
                FRAME SAME1 java/lang/Boolean
                 ARETURN
+              // parameter final  context
+              // parameter final  context
+              // parameter final  sourceSet
+              // parameter final  reporterBlock
              L0
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_otherwith_4.world : Lorg/nlogo/agent/World;
@@ -1236,7 +1300,7 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
               ALOAD 7
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
-              IF_ACMPEQ L4
+              IF_ACMPEQ L2
               ALOAD 4
               ALOAD 7
               ALOAD 3
@@ -1244,27 +1308,18 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
               ASTORE 8
               ALOAD 8
               INSTANCEOF java/lang/Boolean
-              IFEQ L5
+              IFEQ L4
               ALOAD 8
               CHECKCAST java/lang/Boolean
-              ASTORE 9
-              ALOAD 9
               INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-              IFEQ L6
+              IFEQ L2
               ALOAD 5
               ALOAD 7
               INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-              GOTO L7
-             L6
-             FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-              GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-             L7
-             FRAME SAME1 java/lang/Object
-              ASTORE 10
-              ALOAD 10
-              GOTO L8
-             L5
-             FRAME CHOP 1
+              POP
+              GOTO L2
+             L4
+             FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
@@ -1295,15 +1350,8 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
               INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
               INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
               ATHROW
-             L4
-             FRAME CHOP 1
-              GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-             L8
-             FRAME SAME1 java/lang/Object
-              POP
-              GOTO L2
              L3
-             FRAME CHOP 1
+             FRAME CHOP 2
               GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
               ALOAD 2
               INVOKEVIRTUAL org/nlogo/agent/AgentSet.kind ()Lorg/nlogo/core/AgentKind;
@@ -1314,7 +1362,7 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
               INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
               CHECKCAST [Lorg/nlogo/agent/Agent;
               INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-             L9
+             L5
               ARETURN
         _asm_proceduresetupspatiallyclusterednetwork_distance_6 "distance" Agent => double
           _myself "myself" => Agent
@@ -1395,6 +1443,8 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
               DLOAD 2
               INVOKESPECIAL java/lang/Double.<init> (D)V
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_let_3.keptinstr2 : Lorg/nlogo/prim/etc/_minoneof;
           ALOAD 1
@@ -1415,6 +1465,13 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
       _notequal "!=" Object,Object => boolean
         _letvariable(Let(CHOICE)) "choice" => Object
         _nobody "nobody" => Nobody$
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           ALOAD 0
@@ -1429,12 +1486,12 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           ALOAD 2
           ALOAD 3
           INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-          IFEQ L3
-          ICONST_0
+          IFNE L3
+          ICONST_1
           GOTO L4
          L3
          FRAME APPEND [java/lang/Object org/nlogo/core/Nobody$]
-          ICONST_1
+          ICONST_0
          L4
          FRAME SAME1 I
           ISTORE 2
@@ -1453,6 +1510,7 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           RETURN
 [5]_createlinkwith:,+7 "create-link-with"
       _asm_proceduresetupspatiallyclusterednetwork_letvariable_8 "choice" => Object
+            // parameter final  context
            L0
             ALOAD 1
             ALOAD 0
@@ -1461,6 +1519,7 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
            L1
             ARETURN
 [6]_asm_proceduresetupspatiallyclusterednetwork_done_9 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1468,6 +1527,7 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
          L1
           RETURN
 [7]_asm_proceduresetupspatiallyclusterednetwork_done_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1479,6 +1539,13 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
         _count "count" AgentSet => double
           _links "links" => AgentSet
         _procedurevariable:NUM-LINKS "num-links" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_while_11.world : Lorg/nlogo/agent/World;
@@ -1498,11 +1565,9 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L4
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -1513,15 +1578,14 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           ICONST_1
           GOTO L6
          L5
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_while_11 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_while_11 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L6
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L7
          L4
-         FRAME CHOP 1
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -1550,23 +1614,28 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_while_11 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
+         L8
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L8
+          IFEQ L9
           ICONST_2
-          GOTO L9
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_while_11 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 9
+          GOTO L10
          L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_while_11 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_while_11 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context]
+          BIPUSH 9
          L10
+         FRAME FULL [org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_while_11 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [9]_asm_proceduresetupspatiallyclusterednetwork_repeatlocal_12 "repeat" double => void
       _constdouble:10.0 "10" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 10.0
          L1
@@ -1579,7 +1648,8 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_repeatlocal_12.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_repeatlocal_12.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -1589,6 +1659,7 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           RETURN
 [10]_layoutspring "layout-spring"
       _asm_proceduresetupspatiallyclusterednetwork_turtles_13 "turtles" => AgentSet
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_turtles_13.world : Lorg/nlogo/agent/World;
@@ -1596,6 +1667,7 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
            L1
             ARETURN
       _asm_proceduresetupspatiallyclusterednetwork_links_14 "links" => AgentSet
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_links_14.world : Lorg/nlogo/agent/World;
@@ -1603,6 +1675,7 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
            L1
             ARETURN
       _asm_proceduresetupspatiallyclusterednetwork_constdouble_15 "0.3" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_constdouble_15.kept1_value : Ljava/lang/Double;
@@ -1612,6 +1685,8 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
         _worldwidth "world-width" => double
         _sqrt "sqrt" double => double
           _observervariable:NUMBER-OF-NODES "number-of-nodes" => Object
+            // parameter final  context
+            // parameter final  context
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
            L2
             ALOAD 0
@@ -1699,12 +1774,14 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
       _asm_proceduresetupspatiallyclusterednetwork_constdouble_17 "1" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_constdouble_17.kept1_value : Ljava/lang/Double;
            L1
             ARETURN
 [11]_asm_proceduresetupspatiallyclusterednetwork_repeatlocalinternal_18 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -1737,6 +1814,7 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
          FRAME SAME
           RETURN
 [12]_asm_proceduresetupspatiallyclusterednetwork_return_19 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1752,6 +1830,9 @@ procedure GO:[]{O---}:
         _turtles "turtles" => AgentSet
         _asm_procedurego_not_1 "not" boolean => boolean
           _turtlevariable:INFECTED? "infected?" => Object
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
               TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
              L0
@@ -1796,12 +1877,12 @@ procedure GO:[]{O---}:
              FRAME SAME1 I
               ISTORE 2
               ILOAD 2
-              IFEQ L7
-              ICONST_0
+              IFNE L7
+              ICONST_1
               GOTO L8
              L7
              FRAME FULL [org/nlogo/prim/_asm_procedurego_not_1 org/nlogo/nvm/Context I] []
-              ICONST_1
+              ICONST_0
              L8
              FRAME SAME1 I
               IFEQ L9
@@ -1813,6 +1894,9 @@ procedure GO:[]{O---}:
              L10
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_if_0.world : Lorg/nlogo/agent/World;
@@ -1946,6 +2030,9 @@ procedure GO:[]{O---}:
           RETURN
 [2]_asm_procedurego_ask_3 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_3.world : Lorg/nlogo/agent/World;
@@ -2003,6 +2090,13 @@ procedure GO:[]{O---}:
       _plus "+" double,double => double
         _turtlevariable:VIRUS-CHECK-TIMER "virus-check-timer" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -2067,9 +2161,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setturtlevariable_4 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -2084,11 +2175,19 @@ procedure GO:[]{O---}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [4]_asm_procedurego_if_5 "if" boolean => void
       _greaterorequal ">=" Object,Object => boolean
         _turtlevariable:VIRUS-CHECK-TIMER "virus-check-timer" => Object
         _observervariable:VIRUS-CHECK-FREQUENCY "virus-check-frequency" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -2234,6 +2333,9 @@ procedure GO:[]{O---}:
           RETURN
 [5]_asm_procedurego_setturtlevariable_6 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2247,9 +2349,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setturtlevariable_6 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -2264,8 +2363,13 @@ procedure GO:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [6]_asm_procedurego_done_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2328,6 +2432,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [11]_asm_procedurego_return_11 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2340,6 +2445,9 @@ procedure GO:[]{O---}:
 procedure BECOME-INFECTED:[]{-T--}:
 [0]_asm_procedurebecomeinfected_setturtlevariable_0 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2353,9 +2461,6 @@ procedure BECOME-INFECTED:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebecomeinfected_setturtlevariable_0 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -2370,9 +2475,16 @@ procedure BECOME-INFECTED:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [1]_asm_procedurebecomeinfected_setturtlevariable_1 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2386,9 +2498,6 @@ procedure BECOME-INFECTED:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebecomeinfected_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -2403,9 +2512,16 @@ procedure BECOME-INFECTED:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedurebecomeinfected_setturtleorlinkvariable_2 "set" Object => void
       _constdouble:15.0 "red" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2419,9 +2535,6 @@ procedure BECOME-INFECTED:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebecomeinfected_setturtleorlinkvariable_2 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -2436,8 +2549,13 @@ procedure BECOME-INFECTED:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_procedurebecomeinfected_return_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2450,6 +2568,9 @@ procedure BECOME-INFECTED:[]{-T--}:
 procedure BECOME-SUSCEPTIBLE:[]{-T--}:
 [0]_asm_procedurebecomesusceptible_setturtlevariable_0 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2463,9 +2584,6 @@ procedure BECOME-SUSCEPTIBLE:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebecomesusceptible_setturtlevariable_0 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -2480,9 +2598,16 @@ procedure BECOME-SUSCEPTIBLE:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [1]_asm_procedurebecomesusceptible_setturtlevariable_1 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2496,9 +2621,6 @@ procedure BECOME-SUSCEPTIBLE:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebecomesusceptible_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -2513,9 +2635,16 @@ procedure BECOME-SUSCEPTIBLE:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedurebecomesusceptible_setturtleorlinkvariable_2 "set" Object => void
       _constdouble:55.0 "green" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2529,9 +2658,6 @@ procedure BECOME-SUSCEPTIBLE:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebecomesusceptible_setturtleorlinkvariable_2 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -2546,8 +2672,13 @@ procedure BECOME-SUSCEPTIBLE:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_procedurebecomesusceptible_return_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2560,6 +2691,9 @@ procedure BECOME-SUSCEPTIBLE:[]{-T--}:
 procedure BECOME-RESISTANT:[]{-T--}:
 [0]_asm_procedurebecomeresistant_setturtlevariable_0 "set" Object => void
       _constboolean:false "false" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2573,9 +2707,6 @@ procedure BECOME-RESISTANT:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebecomeresistant_setturtlevariable_0 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -2590,9 +2721,16 @@ procedure BECOME-RESISTANT:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [1]_asm_procedurebecomeresistant_setturtlevariable_1 "set" Object => void
       _constboolean:true "true" => Boolean
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2606,9 +2744,6 @@ procedure BECOME-RESISTANT:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebecomeresistant_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Boolean] [org/nlogo/api/AgentException]
@@ -2623,9 +2758,16 @@ procedure BECOME-RESISTANT:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedurebecomeresistant_setturtleorlinkvariable_2 "set" Object => void
       _constdouble:5.0 "gray" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2639,9 +2781,6 @@ procedure BECOME-RESISTANT:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebecomeresistant_setturtleorlinkvariable_2 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -2656,9 +2795,15 @@ procedure BECOME-RESISTANT:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_procedurebecomeresistant_ask_3 "ask" Object => void
       _mylinks:null "my-links"
+          // parameter final  context
+          // parameter final  target
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurebecomeresistant_ask_3.keptinstr2 : Lorg/nlogo/prim/etc/_mylinks;
           ALOAD 1
@@ -2666,18 +2811,16 @@ procedure BECOME-RESISTANT:[]{-T--}:
          L0
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L1
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L2
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurebecomeresistant_ask_3.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -2693,8 +2836,8 @@ procedure BECOME-RESISTANT:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
-         FRAME FULL [org/nlogo/prim/_asm_procedurebecomeresistant_ask_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurebecomeresistant_ask_3.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -2711,18 +2854,18 @@ procedure BECOME-RESISTANT:[]{-T--}:
           ATHROW
          L2
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L4
          L1
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L5
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -2739,7 +2882,7 @@ procedure BECOME-RESISTANT:[]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -2749,23 +2892,12 @@ procedure BECOME-RESISTANT:[]{-T--}:
          L6
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L4
-         FRAME FULL [org/nlogo/prim/_asm_procedurebecomeresistant_ask_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_4
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L7
+          GOTO L4
          L5
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -2779,11 +2911,22 @@ procedure BECOME-RESISTANT:[]{-T--}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L4
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          ICONST_4
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurebecomeresistant_ask_3 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [4]_asm_procedurebecomeresistant_setturtleorlinkvariable_4 "set" Object => void
       _constdouble:3.0 "-" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2797,9 +2940,6 @@ procedure BECOME-RESISTANT:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebecomeresistant_setturtleorlinkvariable_4 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -2814,8 +2954,13 @@ procedure BECOME-RESISTANT:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [5]_asm_procedurebecomeresistant_done_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2823,6 +2968,7 @@ procedure BECOME-RESISTANT:[]{-T--}:
          L1
           RETURN
 [6]_asm_procedurebecomeresistant_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2837,6 +2983,7 @@ procedure SPREAD-VIRUS:[]{OTPL}:
       _with "with" AgentSet,Reporter => AgentSet
         _turtles "turtles" => AgentSet
         _asm_procedurespreadvirus_turtlevariable_1 "infected?" => Object
+              // parameter final  context
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -2859,6 +3006,12 @@ procedure SPREAD-VIRUS:[]{OTPL}:
              L3
              FRAME SAME1 java/lang/Object
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurespreadvirus_ask_0.world : Lorg/nlogo/agent/World;
@@ -2904,25 +3057,15 @@ procedure SPREAD-VIRUS:[]{OTPL}:
           IFEQ L4
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L5
+          IFEQ L2
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L6
-         FRAME SAME1 java/lang/Object
-          ASTORE 10
-          ALOAD 10
           POP
           GOTO L2
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2965,17 +3108,17 @@ procedure SPREAD-VIRUS:[]{OTPL}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L7
+         L5
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
-          IFNE L8
+          IFNE L6
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurespreadvirus_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-          IF_ACMPNE L9
+          IF_ACMPNE L7
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2986,13 +3129,13 @@ procedure SPREAD-VIRUS:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
+         L7
          FRAME FULL [org/nlogo/prim/_asm_procedurespreadvirus_ask_0 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurespreadvirus_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
-          IF_ACMPNE L8
+          IF_ACMPNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3003,7 +3146,7 @@ procedure SPREAD-VIRUS:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L8
+         L6
          FRAME SAME
           ALOAD 1
           ALOAD 2
@@ -3012,13 +3155,16 @@ procedure SPREAD-VIRUS:[]{OTPL}:
           ALOAD 1
           BIPUSH 6
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L10
+         L8
           RETURN
 [1]_asm_procedurespreadvirus_ask_2 "ask" AgentSet => void
       _with "with" AgentSet,Reporter => AgentSet
         _linkneighbors:null "link-neighbors" => AgentSet
         _asm_procedurespreadvirus_not_3 "not" boolean => boolean
           _turtlevariable:RESISTANT? "resistant?" => Object
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
               TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
              L0
@@ -3063,12 +3209,12 @@ procedure SPREAD-VIRUS:[]{OTPL}:
              FRAME SAME1 I
               ISTORE 2
               ILOAD 2
-              IFEQ L7
-              ICONST_0
+              IFNE L7
+              ICONST_1
               GOTO L8
              L7
              FRAME FULL [org/nlogo/prim/_asm_procedurespreadvirus_not_3 org/nlogo/nvm/Context I] []
-              ICONST_1
+              ICONST_0
              L8
              FRAME SAME1 I
               IFEQ L9
@@ -3080,6 +3226,12 @@ procedure SPREAD-VIRUS:[]{OTPL}:
              L10
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurespreadvirus_ask_2.kept3_breedName : Ljava/lang/String;
@@ -3151,25 +3303,15 @@ procedure SPREAD-VIRUS:[]{OTPL}:
           IFEQ L6
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L7
+          IFEQ L4
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L8
-         L7
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L8
-         FRAME SAME1 java/lang/Object
-          ASTORE 10
-          ALOAD 10
           POP
           GOTO L4
          L6
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3212,17 +3354,17 @@ procedure SPREAD-VIRUS:[]{OTPL}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L9
+         L7
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
-          IFNE L10
+          IFNE L8
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurespreadvirus_ask_2.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-          IF_ACMPNE L11
+          IF_ACMPNE L9
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3233,13 +3375,13 @@ procedure SPREAD-VIRUS:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L11
+         L9
          FRAME SAME
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurespreadvirus_ask_2.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
-          IF_ACMPNE L10
+          IF_ACMPNE L8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3250,7 +3392,7 @@ procedure SPREAD-VIRUS:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L10
+         L8
          FRAME SAME
           ALOAD 1
           ALOAD 2
@@ -3259,13 +3401,22 @@ procedure SPREAD-VIRUS:[]{OTPL}:
           ALOAD 1
           ICONST_5
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L12
+         L10
           RETURN
 [2]_asm_procedurespreadvirus_if_4 "if" boolean => void
       _lessthan "<" double,Object => boolean
         _randomfloat "random-float" double => double
           _constdouble:100.0 "100" => double
         _observervariable:VIRUS-SPREAD-CHANCE "virus-spread-chance" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 100.0
          L1
@@ -3286,11 +3437,9 @@ procedure SPREAD-VIRUS:[]{OTPL}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L4
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -3301,15 +3450,14 @@ procedure SPREAD-VIRUS:[]{OTPL}:
           ICONST_1
           GOTO L6
          L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurespreadvirus_if_4 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurespreadvirus_if_4 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L6
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L7
          L4
-         FRAME CHOP 1
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3338,20 +3486,22 @@ procedure SPREAD-VIRUS:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurespreadvirus_if_4 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
+         L8
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L8
+          IFEQ L9
           ICONST_3
-          GOTO L9
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurespreadvirus_if_4 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          ICONST_4
+          GOTO L10
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurespreadvirus_if_4 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurespreadvirus_if_4 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context]
+          ICONST_4
          L10
+         FRAME FULL [org/nlogo/prim/_asm_procedurespreadvirus_if_4 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [3]_asm_procedurespreadvirus_call_5 "become-infected"
          L0
@@ -3372,6 +3522,7 @@ procedure SPREAD-VIRUS:[]{OTPL}:
          L1
           RETURN
 [4]_asm_procedurespreadvirus_done_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -3379,6 +3530,7 @@ procedure SPREAD-VIRUS:[]{OTPL}:
          L1
           RETURN
 [5]_asm_procedurespreadvirus_done_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -3386,6 +3538,7 @@ procedure SPREAD-VIRUS:[]{OTPL}:
          L1
           RETURN
 [6]_asm_procedurespreadvirus_return_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -3404,6 +3557,12 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
           _equal "=" Object,double => boolean
             _turtlevariable:VIRUS-CHECK-TIMER "virus-check-timer" => Object
             _constdouble:0.0 "0" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
               TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
               TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -3473,11 +3632,9 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L13
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -3488,23 +3645,23 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
               ICONST_1
               GOTO L15
              L14
-             FRAME APPEND [D java/lang/Object java/lang/Double]
+             FRAME APPEND [D T java/lang/Double]
               ICONST_0
              L15
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L16
              L13
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L16
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L17
               GOTO L18
              L10
-             FRAME FULL [org/nlogo/prim/_asm_proceduredoviruschecks_and_1 org/nlogo/nvm/Context java/lang/Object] []
+             FRAME CHOP 2
               ICONST_0
              L18
              FRAME SAME1 I
@@ -3517,6 +3674,12 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
              L20
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduredoviruschecks_ask_0.world : Lorg/nlogo/agent/World;
@@ -3562,25 +3725,15 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
           IFEQ L4
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L5
+          IFEQ L2
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L6
-         FRAME SAME1 java/lang/Object
-          ASTORE 10
-          ALOAD 10
           POP
           GOTO L2
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3623,17 +3776,17 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L7
+         L5
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
-          IFNE L8
+          IFNE L6
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduredoviruschecks_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-          IF_ACMPNE L9
+          IF_ACMPNE L7
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3644,13 +3797,13 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
+         L7
          FRAME FULL [org/nlogo/prim/_asm_proceduredoviruschecks_ask_0 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduredoviruschecks_ask_0.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
-          IF_ACMPNE L8
+          IF_ACMPNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3661,7 +3814,7 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L8
+         L6
          FRAME SAME
           ALOAD 1
           ALOAD 2
@@ -3670,12 +3823,19 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
           ALOAD 1
           BIPUSH 7
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L10
+         L8
           RETURN
 [1]_asm_proceduredoviruschecks_if_2 "if" boolean => void
       _lessthan "<" double,Object => boolean
         _randomconst:100 "random" => double
         _observervariable:RECOVERY-CHANCE "recovery-chance" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -3693,11 +3853,9 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -3708,15 +3866,14 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduredoviruschecks_if_2 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduredoviruschecks_if_2 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3745,25 +3902,34 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduredoviruschecks_if_2 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
+         L7
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L7
+          IFEQ L8
           ICONST_2
-          GOTO L8
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduredoviruschecks_if_2 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 6
+          GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_proceduredoviruschecks_if_2 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_proceduredoviruschecks_if_2 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context]
+          BIPUSH 6
          L9
+         FRAME FULL [org/nlogo/prim/_asm_proceduredoviruschecks_if_2 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [2]_asm_proceduredoviruschecks_ifelse_3 "ifelse" boolean => void
       _lessthan "<" double,Object => boolean
         _randomconst:100 "random" => double
         _observervariable:GAIN-RESISTANCE-CHANCE "gain-resistance-chance" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -3781,11 +3947,9 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L3
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -3796,15 +3960,14 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
           ICONST_1
           GOTO L5
          L4
-         FRAME FULL [org/nlogo/prim/_asm_proceduredoviruschecks_ifelse_3 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduredoviruschecks_ifelse_3 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L5
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L6
          L3
-         FRAME CHOP 1
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3833,20 +3996,22 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduredoviruschecks_ifelse_3 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
+         L7
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L7
+          IFEQ L8
           ICONST_3
-          GOTO L8
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_proceduredoviruschecks_ifelse_3 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          ICONST_5
+          GOTO L9
          L8
-         FRAME FULL [org/nlogo/prim/_asm_proceduredoviruschecks_ifelse_3 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_proceduredoviruschecks_ifelse_3 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context]
+          ICONST_5
          L9
+         FRAME FULL [org/nlogo/prim/_asm_proceduredoviruschecks_ifelse_3 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L10
           RETURN
 [3]_asm_proceduredoviruschecks_call_4 "become-resistant"
          L0
@@ -3867,6 +4032,7 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
          L1
           RETURN
 [4]_asm_proceduredoviruschecks_goto_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 6
@@ -3892,6 +4058,7 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
          L1
           RETURN
 [6]_asm_proceduredoviruschecks_done_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -3899,6 +4066,7 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
          L1
           RETURN
 [7]_asm_proceduredoviruschecks_return_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -3911,12 +4079,14 @@ procedure DO-VIRUS-CHECKS:[]{OTPL}:
 procedure UPDATE-PLOT:[]{OTPL}:
 [0]_setcurrentplot "set-current-plot"
       _asm_procedureupdateplot_conststring_0 ""Network Status"" => String
+            // parameter final  context
            L0
             LDC "Network Status"
            L1
             ARETURN
 [1]_setcurrentplotpen "set-current-plot-pen"
       _asm_procedureupdateplot_conststring_1 ""susceptible"" => String
+            // parameter final  context
            L0
             LDC "susceptible"
            L1
@@ -3931,6 +4101,12 @@ procedure UPDATE-PLOT:[]{OTPL}:
                 _turtlevariable:INFECTED? "infected?" => Object
               _not "not" boolean => boolean
                 _turtlevariable:RESISTANT? "resistant?" => Object
+                  // parameter final  context
+                  // parameter final  context
+                  // parameter final  arg0
+                  // parameter final  context
+                  // parameter final  context
+                  // parameter final  arg0
                   TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                   TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
                   TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -3977,12 +4153,12 @@ procedure UPDATE-PLOT:[]{OTPL}:
                  FRAME SAME1 I
                   ISTORE 2
                   ILOAD 2
-                  IFEQ L12
-                  ICONST_0
+                  IFNE L12
+                  ICONST_1
                   GOTO L13
                  L12
                  FRAME FULL [org/nlogo/prim/_asm_procedureupdateplot_and_3 org/nlogo/nvm/Context I] []
-                  ICONST_1
+                  ICONST_0
                  L13
                  FRAME SAME1 I
                   IFEQ L14
@@ -4028,12 +4204,12 @@ procedure UPDATE-PLOT:[]{OTPL}:
                  FRAME SAME1 I
                   ISTORE 2
                   ILOAD 2
-                  IFEQ L17
-                  ICONST_0
+                  IFNE L17
+                  ICONST_1
                   GOTO L18
                  L17
                  FRAME FULL [org/nlogo/prim/_asm_procedureupdateplot_and_3 org/nlogo/nvm/Context I] []
-                  ICONST_1
+                  ICONST_0
                  L18
                  FRAME SAME1 I
                   GOTO L19
@@ -4054,6 +4230,17 @@ procedure UPDATE-PLOT:[]{OTPL}:
           _count "count" AgentSet => double
             _turtles "turtles" => AgentSet
         _constdouble:100.0 "100" => double
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  block
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdateplot_mult_2.world : Lorg/nlogo/agent/World;
@@ -4096,25 +4283,15 @@ procedure UPDATE-PLOT:[]{OTPL}:
             IFEQ L4
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L5
+            IFEQ L2
             ILOAD 5
             ICONST_1
             IADD
             ISTORE 5
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-            GOTO L6
-           L5
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L6
-           FRAME SAME1 scala/runtime/BoxedUnit
-            ASTORE 10
             GOTO L2
            L4
-           FRAME CHOP 1
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -4149,22 +4326,22 @@ procedure UPDATE-PLOT:[]{OTPL}:
            FRAME CHOP 2
             ILOAD 5
             I2D
-           L7
+           L5
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdateplot_mult_2.world : Lorg/nlogo/agent/World;
             INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-           L8
+           L6
             ASTORE 2
             ALOAD 2
             INVOKEVIRTUAL org/nlogo/agent/AgentSet.count ()I
             I2D
-           L9
+           L7
             DSTORE 4
             DSTORE 2
             DLOAD 4
             DCONST_0
             DCMPL
-            IFNE L10
+            IFNE L8
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -4174,20 +4351,20 @@ procedure UPDATE-PLOT:[]{OTPL}:
             INVOKEINTERFACE org/nlogo/core/I18NJava.get (Ljava/lang/String;)Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L10
+           L8
            FRAME FULL [org/nlogo/prim/_asm_procedureupdateplot_mult_2 org/nlogo/nvm/Context D D org/nlogo/agent/AgentIterator] []
             DLOAD 2
             DLOAD 4
             DDIV
-           L11
+           L9
             LDC 100.0
-           L12
+           L10
             DSTORE 4
             DSTORE 2
             DLOAD 2
             DLOAD 4
             DMUL
-           L13
+           L11
             DSTORE 2
             NEW java/lang/Double
             DUP
@@ -4196,6 +4373,7 @@ procedure UPDATE-PLOT:[]{OTPL}:
             ARETURN
 [3]_setcurrentplotpen "set-current-plot-pen"
       _asm_procedureupdateplot_conststring_4 ""infected"" => String
+            // parameter final  context
            L0
             LDC "infected"
            L1
@@ -4206,6 +4384,7 @@ procedure UPDATE-PLOT:[]{OTPL}:
           _countwith "count" AgentSet,Reporter => double
             _turtles "turtles" => AgentSet
             _asm_procedureupdateplot_turtlevariable_6 "infected?" => Object
+                  // parameter final  context
                   TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                  L0
                   ALOAD 1
@@ -4231,6 +4410,17 @@ procedure UPDATE-PLOT:[]{OTPL}:
           _count "count" AgentSet => double
             _turtles "turtles" => AgentSet
         _constdouble:100.0 "100" => double
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  block
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdateplot_mult_5.world : Lorg/nlogo/agent/World;
@@ -4273,25 +4463,15 @@ procedure UPDATE-PLOT:[]{OTPL}:
             IFEQ L4
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L5
+            IFEQ L2
             ILOAD 5
             ICONST_1
             IADD
             ISTORE 5
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-            GOTO L6
-           L5
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L6
-           FRAME SAME1 scala/runtime/BoxedUnit
-            ASTORE 10
             GOTO L2
            L4
-           FRAME CHOP 1
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -4326,22 +4506,22 @@ procedure UPDATE-PLOT:[]{OTPL}:
            FRAME CHOP 2
             ILOAD 5
             I2D
-           L7
+           L5
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdateplot_mult_5.world : Lorg/nlogo/agent/World;
             INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-           L8
+           L6
             ASTORE 2
             ALOAD 2
             INVOKEVIRTUAL org/nlogo/agent/AgentSet.count ()I
             I2D
-           L9
+           L7
             DSTORE 4
             DSTORE 2
             DLOAD 4
             DCONST_0
             DCMPL
-            IFNE L10
+            IFNE L8
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -4351,20 +4531,20 @@ procedure UPDATE-PLOT:[]{OTPL}:
             INVOKEINTERFACE org/nlogo/core/I18NJava.get (Ljava/lang/String;)Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L10
+           L8
            FRAME FULL [org/nlogo/prim/_asm_procedureupdateplot_mult_5 org/nlogo/nvm/Context D D org/nlogo/agent/AgentIterator] []
             DLOAD 2
             DLOAD 4
             DDIV
-           L11
+           L9
             LDC 100.0
-           L12
+           L10
             DSTORE 4
             DSTORE 2
             DLOAD 2
             DLOAD 4
             DMUL
-           L13
+           L11
             DSTORE 2
             NEW java/lang/Double
             DUP
@@ -4373,6 +4553,7 @@ procedure UPDATE-PLOT:[]{OTPL}:
             ARETURN
 [5]_setcurrentplotpen "set-current-plot-pen"
       _asm_procedureupdateplot_conststring_7 ""resistant"" => String
+            // parameter final  context
            L0
             LDC "resistant"
            L1
@@ -4383,6 +4564,7 @@ procedure UPDATE-PLOT:[]{OTPL}:
           _countwith "count" AgentSet,Reporter => double
             _turtles "turtles" => AgentSet
             _asm_procedureupdateplot_turtlevariable_9 "resistant?" => Object
+                  // parameter final  context
                   TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                  L0
                   ALOAD 1
@@ -4408,6 +4590,17 @@ procedure UPDATE-PLOT:[]{OTPL}:
           _count "count" AgentSet => double
             _turtles "turtles" => AgentSet
         _constdouble:100.0 "100" => double
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  block
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdateplot_mult_8.world : Lorg/nlogo/agent/World;
@@ -4450,25 +4643,15 @@ procedure UPDATE-PLOT:[]{OTPL}:
             IFEQ L4
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L5
+            IFEQ L2
             ILOAD 5
             ICONST_1
             IADD
             ISTORE 5
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-            GOTO L6
-           L5
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L6
-           FRAME SAME1 scala/runtime/BoxedUnit
-            ASTORE 10
             GOTO L2
            L4
-           FRAME CHOP 1
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -4503,22 +4686,22 @@ procedure UPDATE-PLOT:[]{OTPL}:
            FRAME CHOP 2
             ILOAD 5
             I2D
-           L7
+           L5
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdateplot_mult_8.world : Lorg/nlogo/agent/World;
             INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-           L8
+           L6
             ASTORE 2
             ALOAD 2
             INVOKEVIRTUAL org/nlogo/agent/AgentSet.count ()I
             I2D
-           L9
+           L7
             DSTORE 4
             DSTORE 2
             DLOAD 4
             DCONST_0
             DCMPL
-            IFNE L10
+            IFNE L8
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -4528,20 +4711,20 @@ procedure UPDATE-PLOT:[]{OTPL}:
             INVOKEINTERFACE org/nlogo/core/I18NJava.get (Ljava/lang/String;)Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L10
+           L8
            FRAME FULL [org/nlogo/prim/_asm_procedureupdateplot_mult_8 org/nlogo/nvm/Context D D org/nlogo/agent/AgentIterator] []
             DLOAD 2
             DLOAD 4
             DDIV
-           L11
+           L9
             LDC 100.0
-           L12
+           L10
             DSTORE 4
             DSTORE 2
             DLOAD 2
             DLOAD 4
             DMUL
-           L13
+           L11
             DSTORE 2
             NEW java/lang/Double
             DUP
@@ -4549,6 +4732,7 @@ procedure UPDATE-PLOT:[]{OTPL}:
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
 [7]_asm_procedureupdateplot_return_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V

--- a/netlogo-headless/test/benchdumps/Wealth.txt
+++ b/netlogo-headless/test/benchdumps/Wealth.txt
@@ -9,6 +9,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:48281.0 "48281" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 48281.0
          L1
@@ -30,16 +33,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -77,6 +80,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:2400.0 "2400" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 2400.0
          L1
@@ -89,7 +95,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -116,6 +123,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -149,6 +157,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -170,9 +181,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -187,8 +195,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -203,6 +216,9 @@ procedure SETUP:[]{O---}:
 [1]_resetticks "reset-ticks"
 [2]_asm_proceduresetup_setobservervariable_0 "set" Object => void
       _constdouble:50.0 "50" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -217,9 +233,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setobservervariable_0 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -234,6 +247,10 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_proceduresetup_call_1 "setup-patches"
          L0
@@ -308,6 +325,7 @@ procedure SETUP:[]{O---}:
          L1
           RETURN
 [7]_asm_proceduresetup_return_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -320,6 +338,9 @@ procedure SETUP:[]{O---}:
 procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
 [0]_asm_proceduresetuppatches_ask_0 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetuppatches_ask_0.world : Lorg/nlogo/agent/World;
@@ -375,6 +396,9 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           RETURN
 [1]_asm_proceduresetuppatches_setpatchvariable_1 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -388,9 +412,6 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetuppatches_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -405,12 +426,22 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_proceduresetuppatches_if_2 "if" boolean => void
       _lessorequal "<=" double,Object => boolean
         _randomfloat "random-float" double => double
           _constdouble:100.0 "100.0" => double
         _observervariable:PERCENT-BEST-LAND "percent-best-land" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 100.0
          L1
@@ -489,6 +520,9 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           RETURN
 [3]_asm_proceduresetuppatches_setpatchvariable_3 "set" Object => void
       _observervariable:MAX-GRAIN "max-grain" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -505,9 +539,6 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetuppatches_setpatchvariable_3 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -522,9 +553,16 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduresetuppatches_setpatchvariable_4 "set" Object => void
       _patchvariable:MAX-GRAIN-HERE "max-grain-here" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -555,9 +593,6 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L4
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L5
          FRAME FULL [org/nlogo/prim/_asm_proceduresetuppatches_setpatchvariable_4 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -572,8 +607,13 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [5]_asm_proceduresetuppatches_done_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -582,6 +622,9 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           RETURN
 [6]_asm_proceduresetuppatches_repeatlocal_6 "repeat" double => void
       _constdouble:5.0 "5" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 5.0
          L1
@@ -594,7 +637,8 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuppatches_repeatlocal_6.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuppatches_repeatlocal_6.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -608,6 +652,11 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
         _asm_proceduresetuppatches_notequal_8 "!=" Object,double => boolean
           _patchvariable:MAX-GRAIN-HERE "max-grain-here" => Object
           _constdouble:0.0 "0" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -634,11 +683,9 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -649,19 +696,19 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_proceduresetuppatches_notequal_8 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduresetuppatches_notequal_8 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_1
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -672,6 +719,12 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  reporterBlock
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetuppatches_ask_7.world : Lorg/nlogo/agent/World;
@@ -717,25 +770,15 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           IFEQ L4
           ALOAD 8
           CHECKCAST java/lang/Boolean
-          ASTORE 9
-          ALOAD 9
           INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-          IFEQ L5
+          IFEQ L2
           ALOAD 5
           ALOAD 7
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.$plus$eq (Ljava/lang/Object;)Lscala/collection/mutable/ArrayBuffer;
-          GOTO L6
-         L5
-         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-         L6
-         FRAME SAME1 java/lang/Object
-          ASTORE 10
-          ALOAD 10
           POP
           GOTO L2
          L4
-         FRAME CHOP 1
+         FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -778,17 +821,17 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           INVOKEVIRTUAL scala/collection/mutable/ArrayBuffer.toArray (Lscala/reflect/ClassTag;)Ljava/lang/Object;
           CHECKCAST [Lorg/nlogo/agent/Agent;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromArray (Lorg/nlogo/core/AgentKind;[Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-         L7
+         L5
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
-          IFNE L8
+          IFNE L6
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetuppatches_ask_7.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-          IF_ACMPNE L9
+          IF_ACMPNE L7
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -799,13 +842,13 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L9
+         L7
          FRAME FULL [org/nlogo/prim/_asm_proceduresetuppatches_ask_7 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet org/nlogo/nvm/Reporter org/nlogo/nvm/Context scala/collection/mutable/ArrayBuffer org/nlogo/agent/AgentIterator] []
           ALOAD 2
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetuppatches_ask_7.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
-          IF_ACMPNE L8
+          IF_ACMPNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -816,7 +859,7 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.get (Ljava/lang/String;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L8
+         L6
          FRAME SAME
           ALOAD 1
           ALOAD 2
@@ -825,10 +868,13 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           ALOAD 1
           BIPUSH 10
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L10
+         L8
           RETURN
 [8]_asm_proceduresetuppatches_setpatchvariable_9 "set" Object => void
       _patchvariable:MAX-GRAIN-HERE "max-grain-here" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -859,9 +905,6 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L4
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L5
          FRAME FULL [org/nlogo/prim/_asm_proceduresetuppatches_setpatchvariable_9 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -876,8 +919,13 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [9]_asm_proceduresetuppatches_done_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -886,12 +934,14 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           RETURN
 [10]_diffuse:GRAIN-HERE "diffuse"
       _asm_proceduresetuppatches_constdouble_11 "0.25" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuppatches_constdouble_11.kept1_value : Ljava/lang/Double;
            L1
             ARETURN
 [11]_asm_proceduresetuppatches_repeatlocalinternal_12 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -925,6 +975,9 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           RETURN
 [12]_asm_proceduresetuppatches_repeatlocal_13 "repeat" double => void
       _constdouble:10.0 "10" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 10.0
          L1
@@ -937,7 +990,8 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuppatches_repeatlocal_13.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuppatches_repeatlocal_13.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -947,12 +1001,14 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           RETURN
 [13]_diffuse:GRAIN-HERE "diffuse"
       _asm_proceduresetuppatches_constdouble_14 "0.25" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetuppatches_constdouble_14.kept1_value : Ljava/lang/Double;
            L1
             ARETURN
 [14]_asm_proceduresetuppatches_repeatlocalinternal_15 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -986,6 +1042,9 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           RETURN
 [15]_asm_proceduresetuppatches_ask_16 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetuppatches_ask_16.world : Lorg/nlogo/agent/World;
@@ -1042,6 +1101,11 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
 [16]_asm_proceduresetuppatches_setpatchvariable_17 "set" Object => void
       _floor "floor" double => double
         _patchvariable:GRAIN-HERE "grain-here" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -1102,9 +1166,6 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          BIPUSH 17
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L11
          L7
          FRAME FULL [org/nlogo/prim/_asm_proceduresetuppatches_setpatchvariable_17 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1119,9 +1180,16 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           ATHROW
          L11
          FRAME SAME
+          ALOAD 1
+          BIPUSH 17
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [17]_asm_proceduresetuppatches_setpatchvariable_18 "set" Object => void
       _patchvariable:GRAIN-HERE "grain-here" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -1152,9 +1220,6 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L4
-          ALOAD 1
-          BIPUSH 18
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L5
          FRAME FULL [org/nlogo/prim/_asm_proceduresetuppatches_setpatchvariable_18 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -1169,6 +1234,10 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          BIPUSH 18
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [18]_asm_proceduresetuppatches_call_19 "recolor-patch"
          L0
@@ -1189,6 +1258,7 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
          L1
           RETURN
 [19]_asm_proceduresetuppatches_done_20 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1196,6 +1266,7 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
          L1
           RETURN
 [20]_asm_proceduresetuppatches_return_21 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1212,6 +1283,12 @@ procedure RECOLOR-PATCH:[]{-TP-}:
         _patchvariable:GRAIN-HERE "grain-here" => Object
         _constdouble:0.0 "0" => double
         _observervariable:MAX-GRAIN "max-grain" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -1391,7 +1468,8 @@ procedure RECOLOR-PATCH:[]{-TP-}:
           DLOAD 2
           DLOAD 10
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorpatch_setpatchvariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorpatch_setpatchvariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L24
           DSTORE 2
           NEW java/lang/Double
@@ -1406,9 +1484,6 @@ procedure RECOLOR-PATCH:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L8
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L25
          L9
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolorpatch_setpatchvariable_0 org/nlogo/nvm/Context java/lang/Double T D D D D] [org/nlogo/api/AgentException]
@@ -1423,8 +1498,13 @@ procedure RECOLOR-PATCH:[]{-TP-}:
           ATHROW
          L25
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L26
           RETURN
 [1]_asm_procedurerecolorpatch_return_1 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1437,6 +1517,7 @@ procedure RECOLOR-PATCH:[]{-TP-}:
 procedure SETUP-TURTLES:[]{O---}:
 [0]_setdefaultshape "set-default-shape"
       _asm_proceduresetupturtles_turtles_0 "turtles" => AgentSet
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupturtles_turtles_0.world : Lorg/nlogo/agent/World;
@@ -1444,12 +1525,14 @@ procedure SETUP-TURTLES:[]{O---}:
            L1
             ARETURN
       _asm_proceduresetupturtles_conststring_1 ""person"" => String
+            // parameter final  context
            L0
             LDC "person"
            L1
             ARETURN
 [1]_createorderedturtles:,+7 "cro"
       _asm_proceduresetupturtles_observervariable_2 "num-people" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupturtles_observervariable_2.world : Lorg/nlogo/agent/World;
@@ -1461,6 +1544,8 @@ procedure SETUP-TURTLES:[]{O---}:
 [2]_asm_proceduresetupturtles_setxy_3 "setxy" double,double => void
       _randompxcor "random-pxcor" => double
       _randompycor "random-pycor" => double
+          // parameter final  context
+          // parameter final  context
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1555,6 +1640,9 @@ procedure SETUP-TURTLES:[]{O---}:
           RETURN
 [3]_asm_proceduresetupturtles_setturtlevariable_4 "set" Object => void
       _constdouble:1.5 "1.5" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1568,9 +1656,6 @@ procedure SETUP-TURTLES:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupturtles_setturtlevariable_4 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1585,6 +1670,10 @@ procedure SETUP-TURTLES:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduresetupturtles_call_5 "set-initial-turtle-vars"
          L0
@@ -1607,6 +1696,11 @@ procedure SETUP-TURTLES:[]{O---}:
 [5]_asm_proceduresetupturtles_setturtlevariable_6 "set" Object => void
       _random "random" double => double
         _turtlevariable:LIFE-EXPECTANCY "life-expectancy" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  maxDouble
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -1653,7 +1747,8 @@ procedure SETUP-TURTLES:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupturtles_setturtlevariable_6.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupturtles_setturtlevariable_6.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -1722,9 +1817,6 @@ procedure SETUP-TURTLES:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L16
          L7
          FRAME FULL [org/nlogo/prim/_asm_proceduresetupturtles_setturtlevariable_6 org/nlogo/nvm/Context java/lang/Double T J] [org/nlogo/api/AgentException]
@@ -1739,8 +1831,13 @@ procedure SETUP-TURTLES:[]{O---}:
           ATHROW
          L16
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L17
           RETURN
 [6]_asm_proceduresetupturtles_done_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1766,6 +1863,7 @@ procedure SETUP-TURTLES:[]{O---}:
          L1
           RETURN
 [8]_asm_proceduresetupturtles_return_9 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1778,6 +1876,9 @@ procedure SETUP-TURTLES:[]{O---}:
 procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
 [0]_asm_proceduresetinitialturtlevars_setturtlevariable_0 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1791,9 +1892,6 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_0 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1808,11 +1906,22 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [1]_asm_proceduresetinitialturtlevars_setturtlevariable_1 "set" Object => void
       _mult "*" double,double => double
         _constdouble:90.0 "90" => double
         _randomconst:4 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           LDC 90.0
@@ -1843,9 +1952,6 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1860,6 +1966,10 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [2]_asm_proceduresetinitialturtlevars_setturtlevariable_2 "set" Object => void
       _plus "+" double,double => double
@@ -1870,6 +1980,23 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
               _observervariable:LIFE-EXPECTANCY-MAX "life-expectancy-max" => Object
               _observervariable:LIFE-EXPECTANCY-MIN "life-expectancy-min" => Object
             _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  maxDouble
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -1970,7 +2097,8 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_2.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -2045,9 +2173,6 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L7
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L26
          L8
          FRAME FULL [org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_2 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -2062,12 +2187,25 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           ATHROW
          L26
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L27
           RETURN
 [3]_asm_proceduresetinitialturtlevars_setturtlevariable_3 "set" Object => void
       _plus "+" double,double => double
         _constdouble:1.0 "1" => double
         _random "random" double => double
           _observervariable:METABOLISM-MAX "metabolism-max" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  maxDouble
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -2102,7 +2240,8 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_3.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_3.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -2177,9 +2316,6 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L16
          L4
          FRAME FULL [org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -2194,11 +2330,22 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           ATHROW
          L16
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L17
           RETURN
 [4]_asm_proceduresetinitialturtlevars_setturtlevariable_4 "set" Object => void
       _plus "+" double,double => double
         _turtlevariable:METABOLISM "metabolism" => Object
         _randomconst:50 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -2268,9 +2415,6 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L7
          FRAME FULL [org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_4 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -2285,12 +2429,25 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [5]_asm_proceduresetinitialturtlevars_setturtlevariable_5 "set" Object => void
       _plus "+" double,double => double
         _constdouble:1.0 "1" => double
         _random "random" double => double
           _observervariable:MAX-VISION "max-vision" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  maxDouble
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -2325,7 +2482,8 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_5.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_5.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -2400,9 +2558,6 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L16
          L4
          FRAME FULL [org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_5 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -2417,8 +2572,13 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           ATHROW
          L16
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L17
           RETURN
 [6]_asm_proceduresetinitialturtlevars_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2433,28 +2593,28 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
       _max "max"
         _asm_procedurerecolorturtles_turtlevariableof_1 "of" Object => Object
           _turtles "turtles" => AgentSet
-              TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-              TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-             L4
+              // parameter final  context
+              // parameter final  context
+              // parameter final  agentOrSet
+              TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+             L3
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedurerecolorturtles_turtlevariableof_1.world : Lorg/nlogo/agent/World;
               INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-             L5
+             L4
               ASTORE 2
-             L2
+             L0
               ALOAD 2
+              INSTANCEOF org/nlogo/agent/Agent
+              IFEQ L5
+              ALOAD 2
+              CHECKCAST org/nlogo/agent/Agent
               ASTORE 4
               ALOAD 4
-              INSTANCEOF org/nlogo/agent/Agent
-              IFEQ L6
-              ALOAD 4
-              CHECKCAST org/nlogo/agent/Agent
-              ASTORE 5
-              ALOAD 5
               INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
               LDC -1
               LCMP
-              IFNE L7
+              IFNE L6
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
@@ -2467,45 +2627,45 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
               ANEWARRAY java/lang/Object
               DUP
               ICONST_0
-              ALOAD 5
+              ALOAD 4
               INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
               AASTORE
               INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
               INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
               INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
               ATHROW
-             L7
-             FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtles_turtlevariableof_1 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T org/nlogo/agent/TreeAgentSet org/nlogo/agent/Agent] []
-              ALOAD 5
+             L6
+             FRAME APPEND [org/nlogo/agent/TreeAgentSet T org/nlogo/agent/Agent]
+              ALOAD 4
               BIPUSH 14
               INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-              ASTORE 6
-              GOTO L8
-             L6
-             FRAME CHOP 1
-              ALOAD 4
+              ASTORE 3
+              GOTO L7
+             L5
+             FRAME CHOP 2
+              ALOAD 2
               INSTANCEOF org/nlogo/agent/AgentSet
-              IFEQ L0
-              ALOAD 4
+              IFEQ L8
+              ALOAD 2
               CHECKCAST org/nlogo/agent/AgentSet
-              ASTORE 7
+              ASTORE 5
               NEW org/nlogo/api/LogoListBuilder
               DUP
               INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-              ASTORE 8
-              ALOAD 7
+              ASTORE 6
+              ALOAD 5
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
               GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
               INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-              ASTORE 9
+              ASTORE 7
              L9
-             FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtles_turtlevariableof_1 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T org/nlogo/agent/TreeAgentSet T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-              ALOAD 9
+             FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtles_turtlevariableof_1 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+              ALOAD 7
               INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
               IFEQ L10
-              ALOAD 8
-              ALOAD 9
+              ALOAD 6
+              ALOAD 7
               INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
               BIPUSH 14
               INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
@@ -2513,16 +2673,12 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
               GOTO L9
              L10
              FRAME SAME
-              ALOAD 8
-              INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-              ASTORE 6
-             L8
-             FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtles_turtlevariableof_1 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T org/nlogo/agent/TreeAgentSet T java/lang/Object] []
               ALOAD 6
-             L3
-              GOTO L11
-             L0
-             FRAME CHOP 2
+              INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+              ASTORE 3
+              GOTO L7
+             L8
+             FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtles_turtlevariableof_1 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet] []
               NEW org/nlogo/nvm/ArgumentTypeException
               DUP
               ALOAD 1
@@ -2536,20 +2692,27 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
               ALOAD 2
               INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
               ATHROW
+             L7
+             FRAME APPEND [java/lang/Object]
+              ALOAD 3
              L1
+              GOTO L11
+             L2
              FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtles_turtlevariableof_1 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet] [org/nlogo/api/AgentException]
-              ASTORE 3
+              ASTORE 8
               NEW org/nlogo/nvm/RuntimePrimitiveException
               DUP
               ALOAD 1
               ALOAD 0
-              ALOAD 3
+              ALOAD 8
               INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
               INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
               ATHROW
              L11
-             FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtles_turtlevariableof_1 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T org/nlogo/agent/TreeAgentSet T java/lang/Object] [java/lang/Object]
+             FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtles_turtlevariableof_1 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet java/lang/Object] [java/lang/Object]
               ARETURN
+          // parameter final  context
+          // parameter final  arg0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerecolorturtles_setprocedurevariable_0.keptinstr2 : Lorg/nlogo/prim/etc/_max;
           ALOAD 1
@@ -2569,6 +2732,9 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
           RETURN
 [1]_asm_procedurerecolorturtles_ask_2 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerecolorturtles_ask_2.world : Lorg/nlogo/agent/World;
@@ -2628,6 +2794,11 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
         _div "/" double,double => double
           _procedurevariable:MAX-WEALTH "max-wealth" => Object
           _constdouble:3.0 "3" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -2760,6 +2931,9 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
           RETURN
 [3]_asm_procedurerecolorturtles_setturtleorlinkvariable_4 "set" Object => void
       _constdouble:15.0 "red" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2773,9 +2947,6 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtles_setturtleorlinkvariable_4 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -2790,8 +2961,13 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_procedurerecolorturtles_goto_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 9
@@ -2806,6 +2982,15 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
             _procedurevariable:MAX-WEALTH "max-wealth" => Object
             _constdouble:2.0 "2" => double
           _constdouble:3.0 "3" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -2946,6 +3131,9 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
           RETURN
 [6]_asm_procedurerecolorturtles_setturtleorlinkvariable_7 "set" Object => void
       _constdouble:55.0 "green" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2959,9 +3147,6 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtles_setturtleorlinkvariable_7 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -2976,8 +3161,13 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurerecolorturtles_goto_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 9
@@ -2986,6 +3176,9 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
           RETURN
 [8]_asm_procedurerecolorturtles_setturtleorlinkvariable_9 "set" Object => void
       _constdouble:105.0 "blue" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2999,9 +3192,6 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 9
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurerecolorturtles_setturtleorlinkvariable_9 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -3016,8 +3206,13 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 9
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [9]_asm_procedurerecolorturtles_done_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -3025,6 +3220,7 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
          L1
           RETURN
 [10]_asm_procedurerecolorturtles_return_11 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -3038,6 +3234,9 @@ procedure GO:[]{O---}:
 [0]_tick "tick"
 [1]_asm_procedurego_ask_0 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_0.world : Lorg/nlogo/agent/World;
@@ -3110,6 +3309,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [3]_asm_procedurego_done_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -3122,6 +3322,13 @@ procedure GO:[]{O---}:
           _ticks "ticks" => double
           _observervariable:GRAIN-GROWTH-INTERVAL "grain-growth-interval" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -3197,7 +3404,8 @@ procedure GO:[]{O---}:
           DLOAD 4
           DMUL
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_if_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_if_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           DCONST_0
          L9
@@ -3230,6 +3438,9 @@ procedure GO:[]{O---}:
           RETURN
 [5]_asm_procedurego_ask_4 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_4.world : Lorg/nlogo/agent/World;
@@ -3302,6 +3513,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [7]_asm_procedurego_done_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -3328,6 +3540,9 @@ procedure GO:[]{O---}:
           RETURN
 [9]_asm_procedurego_ask_8 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_8.world : Lorg/nlogo/agent/World;
@@ -3400,6 +3615,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [11]_asm_procedurego_done_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -3443,6 +3659,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [14]_asm_procedurego_return_13 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -3455,6 +3672,9 @@ procedure GO:[]{O---}:
 procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
 [0]_asm_procedureturntowardsgrain_setturtlevariable_0 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3468,9 +3688,6 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureturntowardsgrain_setturtlevariable_0 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -3485,9 +3702,16 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [1]_asm_procedureturntowardsgrain_setprocedurevariable_1 "let" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureturntowardsgrain_setprocedurevariable_1.kept2_value : Ljava/lang/Double;
@@ -3506,6 +3730,8 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           RETURN
 [2]_asm_procedureturntowardsgrain_setprocedurevariable_2 "let" Object => void
       _callreport:GRAIN-AHEAD "grain-ahead"
+          // parameter final  context
+          // parameter final  arg0
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -3543,6 +3769,9 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           RETURN
 [3]_asm_procedureturntowardsgrain_setturtlevariable_3 "set" Object => void
       _constdouble:90.0 "90" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3556,9 +3785,6 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureturntowardsgrain_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -3573,11 +3799,21 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_procedureturntowardsgrain_if_4 "if" boolean => void
       _greaterthan ">" Object,Object => boolean
         _callreport:GRAIN-AHEAD "grain-ahead"
         _procedurevariable:BEST-AMOUNT "best-amount" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  o1
+          // parameter final  o2
+          // parameter final  context
+          // parameter final  arg0
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -3628,40 +3864,36 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
          L4
          FRAME APPEND [java/lang/Object java/lang/Object]
           ICONST_0
-         L5
-         FRAME SAME1 I
-          GOTO L6
+          GOTO L5
          L3
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
           ICONST_0
-          IF_ICMPLE L8
+          IF_ICMPLE L7
           ICONST_1
-          GOTO L9
-         L8
+          GOTO L5
+         L7
          FRAME SAME
           ICONST_0
-         L9
-         FRAME SAME1 I
-          GOTO L6
-         L7
+          GOTO L5
+         L6
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -3672,21 +3904,19 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L10
+          IF_ICMPNE L8
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
           ICONST_0
-          IF_ICMPLE L11
+          IF_ICMPLE L9
           ICONST_1
-          GOTO L12
-         L11
+          GOTO L5
+         L9
          FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
           ICONST_0
-         L12
-         FRAME SAME1 I
-          GOTO L6
-         L10
+          GOTO L5
+         L8
          FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -3714,24 +3944,27 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L6
+         L5
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L13
+          IFEQ L10
           ICONST_5
-          GOTO L14
-         L13
+          GOTO L11
+         L10
          FRAME FULL [org/nlogo/prim/_asm_procedureturntowardsgrain_if_4 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
           BIPUSH 7
-         L14
+         L11
          FRAME FULL [org/nlogo/prim/_asm_procedureturntowardsgrain_if_4 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L15
+         L12
           RETURN
 [5]_asm_procedureturntowardsgrain_setprocedurevariable_5 "set" Object => void
       _constdouble:90.0 "90" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureturntowardsgrain_setprocedurevariable_5.kept2_value : Ljava/lang/Double;
@@ -3750,6 +3983,8 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           RETURN
 [6]_asm_procedureturntowardsgrain_setprocedurevariable_6 "set" Object => void
       _callreport:GRAIN-AHEAD "grain-ahead"
+          // parameter final  context
+          // parameter final  arg0
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -3787,6 +4022,9 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           RETURN
 [7]_asm_procedureturntowardsgrain_setturtlevariable_7 "set" Object => void
       _constdouble:180.0 "180" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3800,9 +4038,6 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureturntowardsgrain_setturtlevariable_7 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -3817,11 +4052,21 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [8]_asm_procedureturntowardsgrain_if_8 "if" boolean => void
       _greaterthan ">" Object,Object => boolean
         _callreport:GRAIN-AHEAD "grain-ahead"
         _procedurevariable:BEST-AMOUNT "best-amount" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  o1
+          // parameter final  o2
+          // parameter final  context
+          // parameter final  arg0
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -3872,40 +4117,36 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
          L4
          FRAME APPEND [java/lang/Object java/lang/Object]
           ICONST_0
-         L5
-         FRAME SAME1 I
-          GOTO L6
+          GOTO L5
          L3
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
           ICONST_0
-          IF_ICMPLE L8
+          IF_ICMPLE L7
           ICONST_1
-          GOTO L9
-         L8
+          GOTO L5
+         L7
          FRAME SAME
           ICONST_0
-         L9
-         FRAME SAME1 I
-          GOTO L6
-         L7
+          GOTO L5
+         L6
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -3916,21 +4157,19 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L10
+          IF_ICMPNE L8
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
           ICONST_0
-          IF_ICMPLE L11
+          IF_ICMPLE L9
           ICONST_1
-          GOTO L12
-         L11
+          GOTO L5
+         L9
          FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
           ICONST_0
-         L12
-         FRAME SAME1 I
-          GOTO L6
-         L10
+          GOTO L5
+         L8
          FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -3958,24 +4197,27 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L6
+         L5
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L13
+          IFEQ L10
           BIPUSH 9
-          GOTO L14
-         L13
+          GOTO L11
+         L10
          FRAME FULL [org/nlogo/prim/_asm_procedureturntowardsgrain_if_8 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
           BIPUSH 11
-         L14
+         L11
          FRAME FULL [org/nlogo/prim/_asm_procedureturntowardsgrain_if_8 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L15
+         L12
           RETURN
 [9]_asm_procedureturntowardsgrain_setprocedurevariable_9 "set" Object => void
       _constdouble:180.0 "180" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureturntowardsgrain_setprocedurevariable_9.kept2_value : Ljava/lang/Double;
@@ -3994,6 +4236,8 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           RETURN
 [10]_asm_procedureturntowardsgrain_setprocedurevariable_10 "set" Object => void
       _callreport:GRAIN-AHEAD "grain-ahead"
+          // parameter final  context
+          // parameter final  arg0
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -4031,6 +4275,9 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           RETURN
 [11]_asm_procedureturntowardsgrain_setturtlevariable_11 "set" Object => void
       _constdouble:270.0 "270" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -4044,9 +4291,6 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 12
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureturntowardsgrain_setturtlevariable_11 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -4061,11 +4305,21 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 12
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [12]_asm_procedureturntowardsgrain_if_12 "if" boolean => void
       _greaterthan ">" Object,Object => boolean
         _callreport:GRAIN-AHEAD "grain-ahead"
         _procedurevariable:BEST-AMOUNT "best-amount" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  o1
+          // parameter final  o2
+          // parameter final  context
+          // parameter final  arg0
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -4116,40 +4370,36 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
          L4
          FRAME APPEND [java/lang/Object java/lang/Object]
           ICONST_0
-         L5
-         FRAME SAME1 I
-          GOTO L6
+          GOTO L5
          L3
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L7
+          IFEQ L6
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
           ICONST_0
-          IF_ICMPLE L8
+          IF_ICMPLE L7
           ICONST_1
-          GOTO L9
-         L8
+          GOTO L5
+         L7
          FRAME SAME
           ICONST_0
-         L9
-         FRAME SAME1 I
-          GOTO L6
-         L7
+          GOTO L5
+         L6
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L10
+          IFEQ L8
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -4160,21 +4410,19 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L10
+          IF_ICMPNE L8
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
           ICONST_0
-          IF_ICMPLE L11
+          IF_ICMPLE L9
           ICONST_1
-          GOTO L12
-         L11
+          GOTO L5
+         L9
          FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
           ICONST_0
-         L12
-         FRAME SAME1 I
-          GOTO L6
-         L10
+          GOTO L5
+         L8
          FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -4202,24 +4450,27 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L6
+         L5
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L13
+          IFEQ L10
           BIPUSH 13
-          GOTO L14
-         L13
+          GOTO L11
+         L10
          FRAME FULL [org/nlogo/prim/_asm_procedureturntowardsgrain_if_12 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
           BIPUSH 15
-         L14
+         L11
          FRAME FULL [org/nlogo/prim/_asm_procedureturntowardsgrain_if_12 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L15
+         L12
           RETURN
 [13]_asm_procedureturntowardsgrain_setprocedurevariable_13 "set" Object => void
       _constdouble:270.0 "270" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureturntowardsgrain_setprocedurevariable_13.kept2_value : Ljava/lang/Double;
@@ -4238,6 +4489,8 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           RETURN
 [14]_asm_procedureturntowardsgrain_setprocedurevariable_14 "set" Object => void
       _callreport:GRAIN-AHEAD "grain-ahead"
+          // parameter final  context
+          // parameter final  arg0
          L0
           NEW org/nlogo/nvm/Activation
           DUP
@@ -4275,6 +4528,9 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           RETURN
 [15]_asm_procedureturntowardsgrain_setturtlevariable_15 "set" Object => void
       _procedurevariable:BEST-DIRECTION "best-direction" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -4291,9 +4547,6 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 16
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureturntowardsgrain_setturtlevariable_15 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -4308,8 +4561,13 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 16
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [16]_asm_procedureturntowardsgrain_return_16 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -4322,6 +4580,9 @@ procedure TURN-TOWARDS-GRAIN:[BEST-DIRECTION BEST-AMOUNT]{-T--}:
 reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
 [0]_asm_proceduregrainahead_setprocedurevariable_0 "let" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_0.kept2_value : Ljava/lang/Double;
@@ -4340,6 +4601,9 @@ reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
           RETURN
 [1]_asm_proceduregrainahead_setprocedurevariable_1 "let" Object => void
       _constdouble:1.0 "1" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_1.kept2_value : Ljava/lang/Double;
@@ -4358,6 +4622,9 @@ reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
           RETURN
 [2]_asm_proceduregrainahead_repeatlocal_2 "repeat" double => void
       _turtlevariable:VISION "vision" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
          L0
@@ -4409,7 +4676,8 @@ reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregrainahead_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregrainahead_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -4423,6 +4691,7 @@ reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
         _patchvariableof:GRAIN-HERE "of" Object => Object
           _patchahead "patch-ahead"
             _asm_proceduregrainahead_procedurevariable_4 "how-far" => Object
+                  // parameter final  context
                  L0
                   ALOAD 1
                   GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -4431,23 +4700,30 @@ reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
                   AALOAD
                  L1
                   ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
-          TRYCATCHBLOCK L2 L3 L3 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L4 L5 L3 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L6 L7 L7 java/lang/ClassCastException
-         L8
+          TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
+          TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
+         L7
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
           INVOKEVIRTUAL org/nlogo/nvm/Activation.args ()[Ljava/lang/Object;
           ICONST_0
           AALOAD
-         L9
+         L8
           ASTORE 2
          L0
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
-          GOTO L10
+          GOTO L9
          L1
          FRAME FULL [org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
           POP
@@ -4460,28 +4736,26 @@ reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
-         L10
+         L9
          FRAME SAME1 D
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3.keptinstr5 : Lorg/nlogo/prim/etc/_patchahead;
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/prim/etc/_patchahead.report (Lorg/nlogo/nvm/Context;)Ljava/lang/Object;
-         L11
+         L10
           ASTORE 2
-         L4
+         L2
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L11
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L12
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L13
+          IFNE L12
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -4494,45 +4768,45 @@ reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L13
-         FRAME FULL [org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/Agent] [D]
-          ALOAD 5
+         L12
+         FRAME FULL [org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T org/nlogo/agent/Agent] [D]
+          ALOAD 4
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L14
-         L12
-         FRAME FULL [org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object] [D]
-          ALOAD 4
+          ASTORE 3
+          GOTO L13
+         L11
+         FRAME FULL [org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object] [D]
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L2
-          ALOAD 4
+          IFEQ L14
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L15
-         FRAME FULL [org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [D]
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] [D]
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L16
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           ICONST_5
           INVOKEVIRTUAL org/nlogo/agent/Agent.getPatchVariable (I)Ljava/lang/Object;
@@ -4540,16 +4814,12 @@ reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
           GOTO L15
          L16
          FRAME SAME1 D
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L14
-         FRAME FULL [org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [D]
           ALOAD 6
-         L5
-          GOTO L17
-         L2
-         FRAME FULL [org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object] [D]
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L13
+         L14
+         FRAME FULL [org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object] [D]
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -4566,29 +4836,34 @@ reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
           GETSTATIC org/nlogo/core/Syntax$.MODULE$ : Lorg/nlogo/core/Syntax$;
           INVOKEVIRTUAL org/nlogo/core/Syntax$.PatchsetType ()I
           IOR
-          ALOAD 4
+          ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L13
+         FRAME FULL [org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [D]
+          ALOAD 3
          L3
+          GOTO L17
+         L4
          FRAME FULL [org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L17
-         FRAME FULL [org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [D java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [D java/lang/Object]
           ASTORE 2
-         L6
+         L5
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           GOTO L18
-         L7
+         L6
          FRAME SAME1 java/lang/ClassCastException
           POP
           NEW org/nlogo/nvm/ArgumentTypeException
@@ -4601,7 +4876,7 @@ reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
          L18
-         FRAME FULL [org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [D D]
+         FRAME FULL [org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [D D]
           DSTORE 4
           DSTORE 2
           DLOAD 2
@@ -4629,6 +4904,13 @@ reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
       _plus "+" double,double => double
         _procedurevariable:HOW-FAR "how-far" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -4683,6 +4965,7 @@ reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
          L7
           RETURN
 [5]_asm_proceduregrainahead_repeatlocalinternal_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -4716,6 +4999,7 @@ reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
           RETURN
 [6]_asm_proceduregrainahead_report_7 "report" Object => void
       _procedurevariable:TOTAL "total" => Object
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -4790,6 +5074,7 @@ reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
          FRAME SAME
           RETURN
 [7]_asm_proceduregrainahead_returnreport_8 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -4810,6 +5095,13 @@ procedure GROW-GRAIN:[]{-TP-}:
       _lessthan "<" Object,Object => boolean
         _patchvariable:GRAIN-HERE "grain-here" => Object
         _patchvariable:MAX-GRAIN-HERE "max-grain-here" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  o1
+          // parameter final  o2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -4872,40 +5164,36 @@ procedure GROW-GRAIN:[]{-TP-}:
          L8
          FRAME APPEND [java/lang/Object java/lang/Object]
           ICONST_0
-         L9
-         FRAME SAME1 I
-          GOTO L10
+          GOTO L9
          L7
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L11
+          IFEQ L10
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L11
+          IFEQ L10
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
           ICONST_0
-          IF_ICMPGE L12
+          IF_ICMPGE L11
           ICONST_1
-          GOTO L13
-         L12
+          GOTO L9
+         L11
          FRAME SAME
           ICONST_0
-         L13
-         FRAME SAME1 I
-          GOTO L10
-         L11
+          GOTO L9
+         L10
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L14
+          IFEQ L12
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L14
+          IFEQ L12
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -4916,21 +5204,19 @@ procedure GROW-GRAIN:[]{-TP-}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L14
+          IF_ICMPNE L12
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
           ICONST_0
-          IF_ICMPGE L15
+          IF_ICMPGE L13
           ICONST_1
-          GOTO L16
-         L15
+          GOTO L9
+         L13
          FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
           ICONST_0
-         L16
-         FRAME SAME1 I
-          GOTO L10
-         L14
+          GOTO L9
+         L12
          FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -4958,26 +5244,33 @@ procedure GROW-GRAIN:[]{-TP-}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L10
+         L9
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L17
+          IFEQ L14
           ICONST_1
-          GOTO L18
-         L17
+          GOTO L15
+         L14
          FRAME FULL [org/nlogo/prim/_asm_proceduregrowgrain_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
           ICONST_5
-         L18
+         L15
          FRAME FULL [org/nlogo/prim/_asm_proceduregrowgrain_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L19
+         L16
           RETURN
 [1]_asm_proceduregrowgrain_setpatchvariable_1 "set" Object => void
       _plus "+" double,double => double
         _patchvariable:GRAIN-HERE "grain-here" => Object
         _observervariable:NUM-GRAIN-GROWN "num-grain-grown" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -5067,9 +5360,6 @@ procedure GROW-GRAIN:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L8
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L15
          L9
          FRAME FULL [org/nlogo/prim/_asm_proceduregrowgrain_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -5084,11 +5374,22 @@ procedure GROW-GRAIN:[]{-TP-}:
           ATHROW
          L15
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L16
           RETURN
 [2]_asm_proceduregrowgrain_if_2 "if" boolean => void
       _greaterthan ">" Object,Object => boolean
         _patchvariable:GRAIN-HERE "grain-here" => Object
         _patchvariable:MAX-GRAIN-HERE "max-grain-here" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  o1
+          // parameter final  o2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -5151,40 +5452,36 @@ procedure GROW-GRAIN:[]{-TP-}:
          L8
          FRAME APPEND [java/lang/Object java/lang/Object]
           ICONST_0
-         L9
-         FRAME SAME1 I
-          GOTO L10
+          GOTO L9
          L7
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L11
+          IFEQ L10
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L11
+          IFEQ L10
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
           ICONST_0
-          IF_ICMPLE L12
+          IF_ICMPLE L11
           ICONST_1
-          GOTO L13
-         L12
+          GOTO L9
+         L11
          FRAME SAME
           ICONST_0
-         L13
-         FRAME SAME1 I
-          GOTO L10
-         L11
+          GOTO L9
+         L10
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L14
+          IFEQ L12
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L14
+          IFEQ L12
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -5195,21 +5492,19 @@ procedure GROW-GRAIN:[]{-TP-}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L14
+          IF_ICMPNE L12
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
           ICONST_0
-          IF_ICMPLE L15
+          IF_ICMPLE L13
           ICONST_1
-          GOTO L16
-         L15
+          GOTO L9
+         L13
          FRAME APPEND [org/nlogo/agent/Agent org/nlogo/agent/Agent]
           ICONST_0
-         L16
-         FRAME SAME1 I
-          GOTO L10
-         L14
+          GOTO L9
+         L12
          FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -5237,24 +5532,27 @@ procedure GROW-GRAIN:[]{-TP-}:
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L10
+         L9
          FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L17
+          IFEQ L14
           ICONST_3
-          GOTO L18
-         L17
+          GOTO L15
+         L14
          FRAME FULL [org/nlogo/prim/_asm_proceduregrowgrain_if_2 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
           ICONST_4
-         L18
+         L15
          FRAME FULL [org/nlogo/prim/_asm_proceduregrowgrain_if_2 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L19
+         L16
           RETURN
 [3]_asm_proceduregrowgrain_setpatchvariable_3 "set" Object => void
       _patchvariable:MAX-GRAIN-HERE "max-grain-here" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
          L0
@@ -5285,9 +5583,6 @@ procedure GROW-GRAIN:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L4
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L7
          L5
          FRAME FULL [org/nlogo/prim/_asm_proceduregrowgrain_setpatchvariable_3 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -5302,6 +5597,10 @@ procedure GROW-GRAIN:[]{-TP-}:
           ATHROW
          L7
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L8
           RETURN
 [4]_asm_proceduregrowgrain_call_4 "recolor-patch"
          L0
@@ -5322,6 +5621,7 @@ procedure GROW-GRAIN:[]{-TP-}:
          L1
           RETURN
 [5]_asm_proceduregrowgrain_return_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -5334,6 +5634,9 @@ procedure GROW-GRAIN:[]{-TP-}:
 procedure HARVEST:[]{OTPL}:
 [0]_asm_procedureharvest_ask_0 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureharvest_ask_0.world : Lorg/nlogo/agent/World;
@@ -5395,6 +5698,17 @@ procedure HARVEST:[]{OTPL}:
             _patchvariable:GRAIN-HERE "grain-here" => Object
             _count "count" AgentSet => double
               _turtleshere "turtles-here" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -5549,9 +5863,6 @@ procedure HARVEST:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L11
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L24
          L12
          FRAME FULL [org/nlogo/prim/_asm_procedureharvest_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -5566,8 +5877,13 @@ procedure HARVEST:[]{OTPL}:
           ATHROW
          L24
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L25
           RETURN
 [2]_asm_procedureharvest_done_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -5576,6 +5892,9 @@ procedure HARVEST:[]{OTPL}:
           RETURN
 [3]_asm_procedureharvest_ask_3 "ask" AgentSet => void
       _turtles "turtles" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureharvest_ask_3.world : Lorg/nlogo/agent/World;
@@ -5631,6 +5950,9 @@ procedure HARVEST:[]{OTPL}:
           RETURN
 [4]_asm_procedureharvest_setpatchvariable_4 "set" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -5644,9 +5966,6 @@ procedure HARVEST:[]{OTPL}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureharvest_setpatchvariable_4 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -5661,6 +5980,10 @@ procedure HARVEST:[]{OTPL}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [5]_asm_procedureharvest_call_5 "recolor-patch"
          L0
@@ -5681,6 +6004,7 @@ procedure HARVEST:[]{OTPL}:
          L1
           RETURN
 [6]_asm_procedureharvest_done_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -5688,6 +6012,7 @@ procedure HARVEST:[]{OTPL}:
          L1
           RETURN
 [7]_asm_procedureharvest_return_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -5699,28 +6024,37 @@ procedure HARVEST:[]{OTPL}:
 
 procedure MOVE-EAT-AGE-DIE:[]{-T--}:
 [0]_asm_proceduremoveeatagedie_fd1_0 "fd" => void
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
+          // parameter final  context
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
           DCONST_1
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L2
          L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          ASTORE 2
+          GOTO L3
          L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L3
          FRAME SAME
           ALOAD 1
           ICONST_1
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L3
+         L4
           RETURN
 [1]_asm_proceduremoveeatagedie_setturtlevariable_1 "set" Object => void
       _minus "-" double,double => double
         _turtlevariable:WEALTH "wealth" => Object
         _turtlevariable:METABOLISM "metabolism" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -5824,9 +6158,6 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L11
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L17
          L12
          FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -5841,11 +6172,22 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
           ATHROW
          L17
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L18
           RETURN
 [2]_asm_proceduremoveeatagedie_setturtlevariable_2 "set" Object => void
       _plus "+" double,double => double
         _turtlevariable:AGE "age" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -5910,9 +6252,6 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L7
          FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_setturtlevariable_2 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -5927,6 +6266,10 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [3]_asm_proceduremoveeatagedie_if_3 "if" boolean => void
       _or "or"
@@ -5936,6 +6279,15 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
         _greaterorequal ">=" Object,Object => boolean
           _turtlevariable:AGE "age" => Object
           _turtlevariable:LIFE-EXPECTANCY "life-expectancy" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L5 org/nlogo/api/AgentException
           TRYCATCHBLOCK L6 L7 L8 org/nlogo/api/AgentException
@@ -5964,14 +6316,10 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L11
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
@@ -5979,15 +6327,14 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
           ICONST_1
           GOTO L13
          L12
-         FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_if_3 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L13
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L14
          L11
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -6016,8 +6363,10 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L14
-         FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_if_3 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
-          IFNE L15
+         FRAME APPEND [I]
+          ILOAD 5
+         L15
+          IFNE L16
          L3
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -6043,7 +6392,7 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
           BIPUSH 15
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
          L7
-          GOTO L16
+          GOTO L17
          L8
          FRAME SAME1 org/nlogo/api/AgentException
           ASTORE 2
@@ -6055,16 +6404,16 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L16
-         FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_if_3 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [java/lang/Object java/lang/Object]
+         L17
+         FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_if_3 org/nlogo/nvm/Context java/lang/Object D I] [java/lang/Object java/lang/Object]
           ASTORE 3
           ASTORE 2
           ALOAD 2
           INSTANCEOF java/lang/Double
-          IFEQ L17
+          IFEQ L18
           ALOAD 3
           INSTANCEOF java/lang/Double
-          IFEQ L17
+          IFEQ L18
           ALOAD 2
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
@@ -6072,45 +6421,45 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
           CHECKCAST java/lang/Double
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DCMPL
-          IFLT L18
+          IFLT L19
           ICONST_1
-          GOTO L19
-         L18
-         FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_if_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object T java/lang/Object java/lang/Double I] []
-          ICONST_0
-         L19
-         FRAME SAME1 I
           GOTO L20
-         L17
+         L19
+         FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_if_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object T I] []
+          ICONST_0
+         L20
+         FRAME SAME1 I
+          GOTO L21
+         L18
          FRAME SAME
           ALOAD 2
           INSTANCEOF java/lang/String
-          IFEQ L21
+          IFEQ L22
           ALOAD 3
           INSTANCEOF java/lang/String
-          IFEQ L21
+          IFEQ L22
           ALOAD 2
           CHECKCAST java/lang/String
           ALOAD 3
           CHECKCAST java/lang/String
           INVOKEVIRTUAL java/lang/String.compareTo (Ljava/lang/String;)I
-          IFLT L22
+          IFLT L23
           ICONST_1
-          GOTO L23
-         L22
+          GOTO L24
+         L23
          FRAME SAME
           ICONST_0
-         L23
+         L24
          FRAME SAME1 I
-          GOTO L20
-         L21
+          GOTO L21
+         L22
          FRAME SAME
           ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L24
+          IFEQ L25
           ALOAD 3
           INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L24
+          IFEQ L25
           ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
@@ -6121,21 +6470,21 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.agentBit ()I
-          IF_ICMPNE L24
+          IF_ICMPNE L25
           ALOAD 4
           ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.compareTo (Lorg/nlogo/agent/Agent;)I
-          IFLT L25
+          IFLT L26
           ICONST_1
-          GOTO L26
-         L25
-         FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_if_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object org/nlogo/agent/Agent org/nlogo/agent/Agent java/lang/Double I] []
-          ICONST_0
+          GOTO L27
          L26
+         FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_if_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object org/nlogo/agent/Agent org/nlogo/agent/Agent] []
+          ICONST_0
+         L27
          FRAME SAME1 I
-          GOTO L20
-         L24
-         FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_if_3 org/nlogo/nvm/Context java/lang/Object java/lang/Object T java/lang/Object java/lang/Double I] []
+          GOTO L21
+         L25
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -6157,27 +6506,27 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
           INVOKEINTERFACE org/nlogo/core/I18NJava.getN (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L20
+         L21
          FRAME SAME1 I
-          GOTO L27
-         L15
-         FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_if_3 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] []
+          GOTO L28
+         L16
+         FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_if_3 org/nlogo/nvm/Context java/lang/Object D I] []
           ICONST_1
-         L27
-         FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_if_3 org/nlogo/nvm/Context java/lang/Object T T java/lang/Object java/lang/Double I] [I]
+         L28
+         FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_if_3 org/nlogo/nvm/Context java/lang/Object] [I]
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L28
+          IFEQ L29
           ICONST_4
-          GOTO L29
-         L28
-         FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_if_3 org/nlogo/nvm/Context I T T java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          ICONST_5
+          GOTO L30
          L29
-         FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_if_3 org/nlogo/nvm/Context I T T java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_if_3 org/nlogo/nvm/Context I] [org/nlogo/nvm/Context]
+          ICONST_5
          L30
+         FRAME FULL [org/nlogo/prim/_asm_proceduremoveeatagedie_if_3 org/nlogo/nvm/Context I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L31
           RETURN
 [4]_asm_proceduremoveeatagedie_call_4 "set-initial-turtle-vars"
          L0
@@ -6198,6 +6547,7 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
          L1
           RETURN
 [5]_asm_proceduremoveeatagedie_return_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -6210,18 +6560,21 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
 procedure SETUP-PLOTZ:[]{OTPL}:
 [0]_setcurrentplot "set-current-plot"
       _asm_proceduresetupplotz_conststring_0 ""Class Plot"" => String
+            // parameter final  context
            L0
             LDC "Class Plot"
            L1
             ARETURN
 [1]_setplotyrange "set-plot-y-range"
       _asm_proceduresetupplotz_constdouble_1 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupplotz_constdouble_1.kept1_value : Ljava/lang/Double;
            L1
             ARETURN
       _asm_proceduresetupplotz_observervariable_2 "num-people" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupplotz_observervariable_2.world : Lorg/nlogo/agent/World;
@@ -6232,18 +6585,21 @@ procedure SETUP-PLOTZ:[]{OTPL}:
             ARETURN
 [2]_setcurrentplot "set-current-plot"
       _asm_proceduresetupplotz_conststring_3 ""Class Histogram"" => String
+            // parameter final  context
            L0
             LDC "Class Histogram"
            L1
             ARETURN
 [3]_setplotyrange "set-plot-y-range"
       _asm_proceduresetupplotz_constdouble_4 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupplotz_constdouble_4.kept1_value : Ljava/lang/Double;
            L1
             ARETURN
       _asm_proceduresetupplotz_observervariable_5 "num-people" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetupplotz_observervariable_5.world : Lorg/nlogo/agent/World;
@@ -6253,6 +6609,7 @@ procedure SETUP-PLOTZ:[]{OTPL}:
            L1
             ARETURN
 [4]_asm_proceduresetupplotz_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -6318,6 +6675,7 @@ procedure UPDATE-PLOTZ:[]{OTPL}:
          L1
           RETURN
 [3]_asm_procedureupdateplotz_return_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -6330,12 +6688,14 @@ procedure UPDATE-PLOTZ:[]{OTPL}:
 procedure UPDATE-CLASS-PLOT:[]{OTPL}:
 [0]_setcurrentplot "set-current-plot"
       _asm_procedureupdateclassplot_conststring_0 ""Class Plot"" => String
+            // parameter final  context
            L0
             LDC "Class Plot"
            L1
             ARETURN
 [1]_setcurrentplotpen "set-current-plot-pen"
       _asm_procedureupdateclassplot_conststring_1 ""low"" => String
+            // parameter final  context
            L0
             LDC "low"
            L1
@@ -6346,6 +6706,11 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
         _asm_procedureupdateclassplot_equal_3 "=" Object,double => boolean
           _turtleorlinkvariable:COLOR "color" => Object
           _constdouble:15.0 "red" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -6372,11 +6737,9 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -6387,19 +6750,19 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_procedureupdateclassplot_equal_3 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_procedureupdateclassplot_equal_3 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -6410,6 +6773,10 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  block
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdateclassplot_countwith_2.world : Lorg/nlogo/agent/World;
@@ -6452,25 +6819,15 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
             IFEQ L4
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L5
+            IFEQ L2
             ILOAD 5
             ICONST_1
             IADD
             ISTORE 5
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-            GOTO L6
-           L5
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L6
-           FRAME SAME1 scala/runtime/BoxedUnit
-            ASTORE 10
             GOTO L2
            L4
-           FRAME CHOP 1
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -6505,7 +6862,7 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
            FRAME CHOP 2
             ILOAD 5
             I2D
-           L7
+           L5
             DSTORE 2
             NEW java/lang/Double
             DUP
@@ -6514,6 +6871,7 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
             ARETURN
 [3]_setcurrentplotpen "set-current-plot-pen"
       _asm_procedureupdateclassplot_conststring_4 ""mid"" => String
+            // parameter final  context
            L0
             LDC "mid"
            L1
@@ -6524,6 +6882,11 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
         _asm_procedureupdateclassplot_equal_6 "=" Object,double => boolean
           _turtleorlinkvariable:COLOR "color" => Object
           _constdouble:55.0 "green" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -6550,11 +6913,9 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -6565,19 +6926,19 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_procedureupdateclassplot_equal_6 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_procedureupdateclassplot_equal_6 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -6588,6 +6949,10 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  block
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdateclassplot_countwith_5.world : Lorg/nlogo/agent/World;
@@ -6630,25 +6995,15 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
             IFEQ L4
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L5
+            IFEQ L2
             ILOAD 5
             ICONST_1
             IADD
             ISTORE 5
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-            GOTO L6
-           L5
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L6
-           FRAME SAME1 scala/runtime/BoxedUnit
-            ASTORE 10
             GOTO L2
            L4
-           FRAME CHOP 1
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -6683,7 +7038,7 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
            FRAME CHOP 2
             ILOAD 5
             I2D
-           L7
+           L5
             DSTORE 2
             NEW java/lang/Double
             DUP
@@ -6692,6 +7047,7 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
             ARETURN
 [5]_setcurrentplotpen "set-current-plot-pen"
       _asm_procedureupdateclassplot_conststring_7 ""up"" => String
+            // parameter final  context
            L0
             LDC "up"
            L1
@@ -6702,6 +7058,11 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
         _asm_procedureupdateclassplot_equal_9 "=" Object,double => boolean
           _turtleorlinkvariable:COLOR "color" => Object
           _constdouble:105.0 "blue" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -6728,11 +7089,9 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -6743,19 +7102,19 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_procedureupdateclassplot_equal_9 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_procedureupdateclassplot_equal_9 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -6766,6 +7125,10 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  block
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdateclassplot_countwith_8.world : Lorg/nlogo/agent/World;
@@ -6808,25 +7171,15 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
             IFEQ L4
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L5
+            IFEQ L2
             ILOAD 5
             ICONST_1
             IADD
             ISTORE 5
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-            GOTO L6
-           L5
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L6
-           FRAME SAME1 scala/runtime/BoxedUnit
-            ASTORE 10
             GOTO L2
            L4
-           FRAME CHOP 1
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -6861,7 +7214,7 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
            FRAME CHOP 2
             ILOAD 5
             I2D
-           L7
+           L5
             DSTORE 2
             NEW java/lang/Double
             DUP
@@ -6869,6 +7222,7 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
 [7]_asm_procedureupdateclassplot_return_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -6881,6 +7235,7 @@ procedure UPDATE-CLASS-PLOT:[]{OTPL}:
 procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
 [0]_setcurrentplot "set-current-plot"
       _asm_procedureupdateclasshistogram_conststring_0 ""Class Histogram"" => String
+            // parameter final  context
            L0
             LDC "Class Histogram"
            L1
@@ -6888,6 +7243,7 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
 [1]_plotpenreset "plot-pen-reset"
 [2]_setplotpencolor "set-plot-pen-color"
       _asm_procedureupdateclasshistogram_constdouble_1 "red" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdateclasshistogram_constdouble_1.kept1_value : Ljava/lang/Double;
@@ -6899,6 +7255,11 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
         _asm_procedureupdateclasshistogram_equal_3 "=" Object,double => boolean
           _turtleorlinkvariable:COLOR "color" => Object
           _constdouble:15.0 "red" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -6925,11 +7286,9 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -6940,19 +7299,19 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_procedureupdateclasshistogram_equal_3 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_procedureupdateclasshistogram_equal_3 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -6963,6 +7322,10 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  block
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdateclasshistogram_countwith_2.world : Lorg/nlogo/agent/World;
@@ -7005,25 +7368,15 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
             IFEQ L4
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L5
+            IFEQ L2
             ILOAD 5
             ICONST_1
             IADD
             ISTORE 5
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-            GOTO L6
-           L5
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L6
-           FRAME SAME1 scala/runtime/BoxedUnit
-            ASTORE 10
             GOTO L2
            L4
-           FRAME CHOP 1
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -7058,7 +7411,7 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
            FRAME CHOP 2
             ILOAD 5
             I2D
-           L7
+           L5
             DSTORE 2
             NEW java/lang/Double
             DUP
@@ -7067,6 +7420,7 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
             ARETURN
 [4]_setplotpencolor "set-plot-pen-color"
       _asm_procedureupdateclasshistogram_constdouble_4 "green" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdateclasshistogram_constdouble_4.kept1_value : Ljava/lang/Double;
@@ -7078,6 +7432,11 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
         _asm_procedureupdateclasshistogram_equal_6 "=" Object,double => boolean
           _turtleorlinkvariable:COLOR "color" => Object
           _constdouble:55.0 "green" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -7104,11 +7463,9 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -7119,19 +7476,19 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_procedureupdateclasshistogram_equal_6 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_procedureupdateclasshistogram_equal_6 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -7142,6 +7499,10 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  block
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdateclasshistogram_countwith_5.world : Lorg/nlogo/agent/World;
@@ -7184,25 +7545,15 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
             IFEQ L4
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L5
+            IFEQ L2
             ILOAD 5
             ICONST_1
             IADD
             ISTORE 5
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-            GOTO L6
-           L5
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L6
-           FRAME SAME1 scala/runtime/BoxedUnit
-            ASTORE 10
             GOTO L2
            L4
-           FRAME CHOP 1
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -7237,7 +7588,7 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
            FRAME CHOP 2
             ILOAD 5
             I2D
-           L7
+           L5
             DSTORE 2
             NEW java/lang/Double
             DUP
@@ -7246,6 +7597,7 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
             ARETURN
 [6]_setplotpencolor "set-plot-pen-color"
       _asm_procedureupdateclasshistogram_constdouble_7 "blue" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdateclasshistogram_constdouble_7.kept1_value : Ljava/lang/Double;
@@ -7257,6 +7609,11 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
         _asm_procedureupdateclasshistogram_equal_9 "=" Object,double => boolean
           _turtleorlinkvariable:COLOR "color" => Object
           _constdouble:105.0 "blue" => double
+              // parameter final  context
+              // parameter final  context
+              // parameter final  context
+              // parameter final  arg0
+              // parameter final  d1
               TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
              L0
               ALOAD 1
@@ -7283,11 +7640,9 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
               DSTORE 3
               ASTORE 2
               ALOAD 2
-              ASTORE 5
-              ALOAD 5
               INSTANCEOF java/lang/Double
               IFEQ L5
-              ALOAD 5
+              ALOAD 2
               CHECKCAST java/lang/Double
               ASTORE 6
               DLOAD 3
@@ -7298,19 +7653,19 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
               ICONST_1
               GOTO L7
              L6
-             FRAME FULL [org/nlogo/prim/_asm_procedureupdateclasshistogram_equal_9 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+             FRAME FULL [org/nlogo/prim/_asm_procedureupdateclasshistogram_equal_9 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
               ICONST_0
              L7
              FRAME SAME1 I
-              ISTORE 7
+              ISTORE 5
               GOTO L8
              L5
-             FRAME CHOP 1
+             FRAME CHOP 2
               ICONST_0
-              ISTORE 7
+              ISTORE 5
              L8
-             FRAME APPEND [T I]
-              ILOAD 7
+             FRAME APPEND [I]
+              ILOAD 5
              L9
               IFEQ L10
               GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -7321,6 +7676,10 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
              L11
              FRAME SAME1 java/lang/Boolean
               ARETURN
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  block
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdateclasshistogram_countwith_8.world : Lorg/nlogo/agent/World;
@@ -7363,25 +7722,15 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
             IFEQ L4
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L5
+            IFEQ L2
             ILOAD 5
             ICONST_1
             IADD
             ISTORE 5
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-            GOTO L6
-           L5
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L6
-           FRAME SAME1 scala/runtime/BoxedUnit
-            ASTORE 10
             GOTO L2
            L4
-           FRAME CHOP 1
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -7416,7 +7765,7 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
            FRAME CHOP 2
             ILOAD 5
             I2D
-           L7
+           L5
             DSTORE 2
             NEW java/lang/Double
             DUP
@@ -7424,6 +7773,7 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
 [8]_asm_procedureupdateclasshistogram_return_10 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -7436,6 +7786,7 @@ procedure UPDATE-CLASS-HISTOGRAM:[]{OTPL}:
 procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-SO-FAR INDEX GINI-INDEX-RESERVE _repeatlocal:5]{OTPL}:
 [0]_setcurrentplot "set-current-plot"
       _asm_procedureupdatelorenzandginiplots_conststring_0 ""Lorenz Curve"" => String
+            // parameter final  context
            L0
             LDC "Lorenz Curve"
            L1
@@ -7443,12 +7794,14 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
 [1]_clearplot "clear-plot"
 [2]_setcurrentplotpen "set-current-plot-pen"
       _asm_procedureupdatelorenzandginiplots_conststring_1 ""equal"" => String
+            // parameter final  context
            L0
             LDC "equal"
            L1
             ARETURN
 [3]_plot "plot"
       _asm_procedureupdatelorenzandginiplots_constdouble_2 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_constdouble_2.kept1_value : Ljava/lang/Double;
@@ -7456,6 +7809,7 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
             ARETURN
 [4]_plot "plot"
       _asm_procedureupdatelorenzandginiplots_constdouble_3 "100" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_constdouble_3.kept1_value : Ljava/lang/Double;
@@ -7463,6 +7817,7 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
             ARETURN
 [5]_setcurrentplotpen "set-current-plot-pen"
       _asm_procedureupdatelorenzandginiplots_conststring_4 ""lorenz"" => String
+            // parameter final  context
            L0
             LDC "lorenz"
            L1
@@ -7471,6 +7826,8 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
       _asm_procedureupdatelorenzandginiplots_div_5 "/" double,double => double
         _constdouble:100.0 "100" => double
         _observervariable:NUM-PEOPLE "num-people" => Object
+            // parameter final  context
+            // parameter final  context
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
            L2
             LDC 100.0
@@ -7530,6 +7887,7 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
             ARETURN
 [7]_plot "plot"
       _asm_procedureupdatelorenzandginiplots_constdouble_6 "0" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_constdouble_6.kept1_value : Ljava/lang/Double;
@@ -7539,28 +7897,30 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
       _sort "sort" Object => Object
         _turtlevariableof:WEALTH "of" Object => Object
           _turtles "turtles" => AgentSet
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
-          TRYCATCHBLOCK L2 L3 L1 org/nlogo/api/AgentException
-         L4
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agentOrSet
+          // parameter final  context
+          // parameter final  arg0
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
+         L3
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_7.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
-         L5
+         L4
           ASTORE 2
-         L2
+         L0
           ALOAD 2
+          INSTANCEOF org/nlogo/agent/Agent
+          IFEQ L5
+          ALOAD 2
+          CHECKCAST org/nlogo/agent/Agent
           ASTORE 4
           ALOAD 4
-          INSTANCEOF org/nlogo/agent/Agent
-          IFEQ L6
-          ALOAD 4
-          CHECKCAST org/nlogo/agent/Agent
-          ASTORE 5
-          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
-          IFNE L7
+          IFNE L6
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -7573,45 +7933,45 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 5
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
           INVOKEVIRTUAL org/nlogo/core/I18N$BundleKind.getN (Ljava/lang/String;Lscala/collection/Seq;)Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_7 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T org/nlogo/agent/TreeAgentSet org/nlogo/agent/Agent] []
-          ALOAD 5
+         L6
+         FRAME APPEND [org/nlogo/agent/TreeAgentSet T org/nlogo/agent/Agent]
+          ALOAD 4
           BIPUSH 14
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
-          ASTORE 6
-          GOTO L8
-         L6
-         FRAME CHOP 1
-          ALOAD 4
+          ASTORE 3
+          GOTO L7
+         L5
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
-          IFEQ L0
-          ALOAD 4
+          IFEQ L8
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 7
+          ASTORE 5
           NEW org/nlogo/api/LogoListBuilder
           DUP
           INVOKESPECIAL org/nlogo/api/LogoListBuilder.<init> ()V
-          ASTORE 8
-          ALOAD 7
+          ASTORE 6
+          ALOAD 5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.shufflerator (Lorg/nlogo/api/MersenneTwisterFast;)Lorg/nlogo/agent/AgentIterator;
-          ASTORE 9
+          ASTORE 7
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_7 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T org/nlogo/agent/TreeAgentSet T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
-          ALOAD 9
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_7 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T T org/nlogo/agent/AgentSet org/nlogo/api/LogoListBuilder org/nlogo/agent/AgentIterator] []
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.hasNext ()Z
           IFEQ L10
-          ALOAD 8
-          ALOAD 9
+          ALOAD 6
+          ALOAD 7
           INVOKEINTERFACE org/nlogo/agent/AgentIterator.next ()Lorg/nlogo/agent/Agent;
           BIPUSH 14
           INVOKEVIRTUAL org/nlogo/agent/Agent.getTurtleVariable (I)Ljava/lang/Object;
@@ -7619,16 +7979,12 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           GOTO L9
          L10
          FRAME SAME
-          ALOAD 8
-          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
-          ASTORE 6
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_7 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T org/nlogo/agent/TreeAgentSet T java/lang/Object] []
           ALOAD 6
-         L3
-          GOTO L11
-         L0
-         FRAME CHOP 2
+          INVOKEVIRTUAL org/nlogo/api/LogoListBuilder.toLogoList ()Lorg/nlogo/core/LogoList;
+          ASTORE 3
+          GOTO L7
+         L8
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_7 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -7642,19 +7998,24 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L7
+         FRAME APPEND [java/lang/Object]
+          ALOAD 3
          L1
+          GOTO L11
+         L2
          FRAME FULL [org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_7 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet] [org/nlogo/api/AgentException]
-          ASTORE 3
+          ASTORE 8
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
           ALOAD 0
-          ALOAD 3
+          ALOAD 8
           INVOKEVIRTUAL org/nlogo/api/AgentException.getMessage ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_7 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet T org/nlogo/agent/TreeAgentSet T java/lang/Object] [java/lang/Object]
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_7 org/nlogo/nvm/Context org/nlogo/agent/TreeAgentSet java/lang/Object] [java/lang/Object]
           ASTORE 2
           ALOAD 2
           INSTANCEOF org/nlogo/agent/AgentSet
@@ -7664,7 +8025,7 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.toLogoList ()Lorg/nlogo/core/LogoList;
           GOTO L13
          L12
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T org/nlogo/agent/TreeAgentSet T java/lang/Object] []
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object java/lang/Object] []
           ALOAD 2
           INSTANCEOF org/nlogo/core/LogoList
           IFEQ L14
@@ -7756,7 +8117,7 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           INVOKESTATIC org/nlogo/core/LogoList.fromJava (Ljava/lang/Iterable;)Lorg/nlogo/core/LogoList;
           GOTO L13
          L14
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T org/nlogo/agent/TreeAgentSet T java/lang/Object] []
+         FRAME FULL [org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object java/lang/Object] []
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -7769,7 +8130,7 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
          L13
-         FRAME FULL [org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_7 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T java/lang/Object] [org/nlogo/core/LogoList]
+         FRAME SAME1 org/nlogo/core/LogoList
           ASTORE 2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7785,6 +8146,11 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
 [9]_asm_procedureupdatelorenzandginiplots_setprocedurevariable_8 "let" Object => void
       _sum "sum" LogoList => double
         _procedurevariable:SORTED-WEALTHS "sorted-wealths" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  l0
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -7828,7 +8194,7 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           ASTORE 6
           ALOAD 6
           INSTANCEOF java/lang/Double
-          IFEQ L7
+          IFEQ L5
           ALOAD 6
           CHECKCAST java/lang/Double
           ASTORE 7
@@ -7837,20 +8203,14 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DADD
           DSTORE 3
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 8
-          GOTO L5
-         L7
-         FRAME APPEND [java/lang/Object]
-          GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-          ASTORE 8
           GOTO L5
          L6
-         FRAME CHOP 1
+         FRAME SAME
           ALOAD 0
           DLOAD 3
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_8.validDouble (D)D
-         L8
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
+         L7
           DSTORE 2
           NEW java/lang/Double
           DUP
@@ -7866,10 +8226,13 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           ALOAD 1
           BIPUSH 10
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L9
+         L8
           RETURN
 [10]_asm_procedureupdatelorenzandginiplots_setprocedurevariable_9 "let" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_9.kept2_value : Ljava/lang/Double;
@@ -7888,6 +8251,9 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           RETURN
 [11]_asm_procedureupdatelorenzandginiplots_setprocedurevariable_10 "let" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_10.kept2_value : Ljava/lang/Double;
@@ -7906,6 +8272,9 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           RETURN
 [12]_asm_procedureupdatelorenzandginiplots_setprocedurevariable_11 "let" Object => void
       _constdouble:0.0 "0" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_11.kept2_value : Ljava/lang/Double;
@@ -7924,6 +8293,9 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           RETURN
 [13]_asm_procedureupdatelorenzandginiplots_repeatlocal_12 "repeat" double => void
       _observervariable:NUM-PEOPLE "num-people" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -7961,7 +8333,8 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_repeatlocal_12.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_repeatlocal_12.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -7974,6 +8347,7 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
         _procedurevariable:WEALTH-SUM-SO-FAR "wealth-sum-so-far" => Object
         _item "item"
           _asm_procedureupdatelorenzandginiplots_procedurevariable_14 "index" => Object
+                // parameter final  context
                L0
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7983,6 +8357,7 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
                L1
                 ARETURN
           _asm_procedureupdatelorenzandginiplots_procedurevariable_15 "sorted-wealths" => Object
+                // parameter final  context
                L0
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7991,6 +8366,12 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
                 AALOAD
                L1
                 ARETURN
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
          L4
@@ -8073,6 +8454,12 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           _procedurevariable:WEALTH-SUM-SO-FAR "wealth-sum-so-far" => Object
           _procedurevariable:TOTAL-WEALTH "total-wealth" => Object
         _constdouble:100.0 "100" => double
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
+            // parameter final  arg1
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
             TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
            L4
@@ -8167,6 +8554,13 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
       _plus "+" double,double => double
         _procedurevariable:INDEX "index" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 1
@@ -8230,6 +8624,19 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
         _div "/" double,double => double
           _procedurevariable:WEALTH-SUM-SO-FAR "wealth-sum-so-far" => Object
           _procedurevariable:TOTAL-WEALTH "total-wealth" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -8438,6 +8845,7 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
          L27
           RETURN
 [18]_asm_procedureupdatelorenzandginiplots_repeatlocalinternal_19 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -8471,6 +8879,7 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           RETURN
 [19]_setcurrentplot "set-current-plot"
       _asm_procedureupdatelorenzandginiplots_conststring_20 ""Gini-Index v. Time"" => String
+            // parameter final  context
            L0
             LDC "Gini-Index v. Time"
            L1
@@ -8481,6 +8890,8 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           _procedurevariable:GINI-INDEX-RESERVE "gini-index-reserve" => Object
           _observervariable:NUM-PEOPLE "num-people" => Object
         _callreport:AREA-OF-EQUALITY-TRIANGLE "area-of-equality-triangle"
+            // parameter final  context
+            // parameter final  context
             TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
             TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
             TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -8628,6 +9039,7 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
 [21]_asm_procedureupdatelorenzandginiplots_return_22 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -8650,6 +9062,21 @@ reporter procedure AREA-OF-EQUALITY-TRIANGLE:[]{OTPL}:
         _pow "^" double,double => double
           _observervariable:NUM-PEOPLE "num-people" => Object
           _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L3 java/lang/ClassCastException
           TRYCATCHBLOCK L4 L5 L5 java/lang/ClassCastException
@@ -8777,7 +9204,8 @@ reporter procedure AREA-OF-EQUALITY-TRIANGLE:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.pow (DD)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureareaofequalitytriangle_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureareaofequalitytriangle_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L20
           DSTORE 4
           DSTORE 2
@@ -8872,6 +9300,7 @@ reporter procedure AREA-OF-EQUALITY-TRIANGLE:[]{OTPL}:
          FRAME SAME
           RETURN
 [1]_asm_procedureareaofequalitytriangle_returnreport_1 => void
+          // parameter final  context
          L0
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP

--- a/netlogo-headless/test/benchdumps/Wolf.txt
+++ b/netlogo-headless/test/benchdumps/Wolf.txt
@@ -10,6 +10,9 @@ link-breeds
 procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [0]_asm_procedurebenchmark_randomseed_0 "random-seed" double => void
       _constdouble:579.0 "579" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 579.0
          L1
@@ -31,16 +34,16 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 1
           ALOAD 0
-          NEW scala/collection/mutable/StringBuilder
+          NEW java/lang/StringBuilder
           DUP
-          INVOKESPECIAL scala/collection/mutable/StringBuilder.<init> ()V
+          INVOKESPECIAL java/lang/StringBuilder.<init> ()V
           GETSTATIC org/nlogo/api/Dump$.MODULE$ : Lorg/nlogo/api/Dump$;
           DLOAD 2
           INVOKEVIRTUAL org/nlogo/api/Dump$.number (D)Ljava/lang/String;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
           LDC " is not in the allowable range for random seeds (-2147483648 to 2147483647)"
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.append (Ljava/lang/Object;)Lscala/collection/mutable/StringBuilder;
-          INVOKEVIRTUAL scala/collection/mutable/StringBuilder.toString ()Ljava/lang/String;
+          INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
+          INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L3
@@ -78,6 +81,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
 [2]_resettimer "reset-timer"
 [3]_asm_procedurebenchmark_repeatlocal_2 "repeat" double => void
       _constdouble:10000.0 "10000" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 10000.0
          L1
@@ -90,7 +96,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -117,6 +124,7 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
          L1
           RETURN
 [5]_asm_procedurebenchmark_repeatlocalinternal_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -150,6 +158,9 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           RETURN
 [6]_asm_procedurebenchmark_setobservervariable_5 "set" Object => void
       _timer "timer" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -171,9 +182,6 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Observer.setVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 7
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurebenchmark_setobservervariable_5 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -188,8 +196,13 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 7
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [7]_asm_procedurebenchmark_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -204,6 +217,9 @@ procedure SETUP:[]{O---}:
 [1]_resetticks "reset-ticks"
 [2]_asm_proceduresetup_ask_0 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_0.world : Lorg/nlogo/agent/World;
@@ -259,6 +275,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [3]_asm_proceduresetup_setpatchvariable_1 "set" Object => void
       _constdouble:55.0 "green" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -272,9 +291,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -289,8 +305,13 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduresetup_done_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -299,6 +320,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [5]_asm_proceduresetup_if_3 "if" boolean => void
       _observervariable:GRASS? "grass?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -343,6 +367,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [6]_asm_proceduresetup_ask_4 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_4.world : Lorg/nlogo/agent/World;
@@ -399,6 +426,11 @@ procedure SETUP:[]{O---}:
 [7]_asm_proceduresetup_setpatchvariable_5 "set" Object => void
       _random "random" double => double
         _observervariable:GRASS-DELAY "grass-delay" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  maxDouble
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -431,7 +463,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_5.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_5.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -500,9 +533,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 8
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L14
          L4
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_5 org/nlogo/nvm/Context java/lang/Double T J] [org/nlogo/api/AgentException]
@@ -517,11 +547,22 @@ procedure SETUP:[]{O---}:
           ATHROW
          L14
          FRAME SAME
+          ALOAD 1
+          BIPUSH 8
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L15
           RETURN
 [8]_asm_proceduresetup_if_6 "if" boolean => void
       _equal "=" double,double => boolean
         _randomconst:2 "random" => double
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -561,6 +602,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [9]_asm_proceduresetup_setpatchvariable_7 "set" Object => void
       _constdouble:35.0 "brown" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -574,9 +618,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 10
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setpatchvariable_7 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -591,8 +632,13 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 10
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [10]_asm_proceduresetup_done_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -601,6 +647,7 @@ procedure SETUP:[]{O---}:
           RETURN
 [11]_crofast:SHEEP "create-ordered-sheep"
       _asm_proceduresetup_observervariable_9 "init-sheep" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetup_observervariable_9.world : Lorg/nlogo/agent/World;
@@ -611,6 +658,9 @@ procedure SETUP:[]{O---}:
             ARETURN
 [12]_asm_proceduresetup_ask_10 "ask" AgentSet => void
       _breed:SHEEP "sheep" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_10.world : Lorg/nlogo/agent/World;
@@ -667,6 +717,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [13]_asm_proceduresetup_setturtleorlinkvariable_11 "set" Object => void
       _constdouble:9.9 "white" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -680,9 +733,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 14
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtleorlinkvariable_11 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -697,12 +747,25 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 14
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [14]_asm_proceduresetup_setturtlevariable_12 "set" Object => void
       _randomfloat "random-float" double => double
         _mult "*" double,double => double
           _constdouble:2.0 "2" => double
           _observervariable:SHEEP-METABOLISM "sheep-metabolism" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -761,9 +824,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 15
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L11
          L4
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtlevariable_12 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -778,9 +838,16 @@ procedure SETUP:[]{O---}:
           ATHROW
          L11
          FRAME SAME
+          ALOAD 1
+          BIPUSH 15
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [15]_asm_proceduresetup_setturtleorlinkvariable_13 "set" Object => void
       _conststring:"sheep" ""sheep"" => String
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           LDC "sheep"
@@ -793,9 +860,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 16
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtleorlinkvariable_13 org/nlogo/nvm/Context java/lang/String] [org/nlogo/api/AgentException]
@@ -810,12 +874,22 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 16
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [16]_asm_proceduresetup_setxy_14 "setxy" double,double => void
       _random "random" double => double
         _worldwidth "world-width" => double
       _random "random" double => double
         _worldheight "world-height" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  maxDouble
+          // parameter final  context
+          // parameter final  context
+          // parameter final  maxDouble
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -826,7 +900,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_14.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_14.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -890,7 +965,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_14.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_14.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -995,6 +1071,7 @@ procedure SETUP:[]{O---}:
          L19
           RETURN
 [17]_asm_proceduresetup_done_15 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1003,6 +1080,7 @@ procedure SETUP:[]{O---}:
           RETURN
 [18]_crofast:WOLVES "create-ordered-wolves"
       _asm_proceduresetup_observervariable_16 "init-wolves" => Object
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduresetup_observervariable_16.world : Lorg/nlogo/agent/World;
@@ -1013,6 +1091,9 @@ procedure SETUP:[]{O---}:
             ARETURN
 [19]_asm_proceduresetup_ask_17 "ask" AgentSet => void
       _breed:WOLVES "wolves" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_ask_17.world : Lorg/nlogo/agent/World;
@@ -1069,6 +1150,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [20]_asm_proceduresetup_setturtleorlinkvariable_18 "set" Object => void
       _constdouble:0.0 "black" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1082,9 +1166,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 21
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtleorlinkvariable_18 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -1099,12 +1180,25 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 21
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [21]_asm_proceduresetup_setturtlevariable_19 "set" Object => void
       _randomfloat "random-float" double => double
         _mult "*" double,double => double
           _constdouble:2.0 "2" => double
           _observervariable:WOLF-METABOLISM "wolf-metabolism" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
           TRYCATCHBLOCK L2 L3 L4 org/nlogo/api/AgentException
          L5
@@ -1163,9 +1257,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L3
-          ALOAD 1
-          BIPUSH 22
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L11
          L4
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtlevariable_19 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1180,9 +1271,16 @@ procedure SETUP:[]{O---}:
           ATHROW
          L11
          FRAME SAME
+          ALOAD 1
+          BIPUSH 22
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [22]_asm_proceduresetup_setturtleorlinkvariable_20 "set" Object => void
       _conststring:"wolf" ""wolf"" => String
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           LDC "wolf"
@@ -1195,9 +1293,6 @@ procedure SETUP:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleOrLinkVariable (Ljava/lang/String;Ljava/lang/Object;)V
          L1
-          ALOAD 1
-          BIPUSH 23
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduresetup_setturtleorlinkvariable_20 org/nlogo/nvm/Context java/lang/String] [org/nlogo/api/AgentException]
@@ -1212,12 +1307,22 @@ procedure SETUP:[]{O---}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          BIPUSH 23
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [23]_asm_proceduresetup_setxy_21 "setxy" double,double => void
       _random "random" double => double
         _worldwidth "world-width" => double
       _random "random" double => double
         _worldheight "world-height" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  maxDouble
+          // parameter final  context
+          // parameter final  context
+          // parameter final  maxDouble
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -1228,7 +1333,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_21.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_21.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -1292,7 +1398,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_21.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_21.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -1397,6 +1504,7 @@ procedure SETUP:[]{O---}:
          L19
           RETURN
 [24]_asm_proceduresetup_done_22 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1405,6 +1513,9 @@ procedure SETUP:[]{O---}:
           RETURN
 [25]_asm_proceduresetup_if_23 "if" boolean => void
       _observervariable:PLOT? "plot?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -1466,6 +1577,7 @@ procedure SETUP:[]{O---}:
          L1
           RETURN
 [27]_asm_proceduresetup_return_25 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -1478,6 +1590,9 @@ procedure SETUP:[]{O---}:
 procedure GO:[]{O---}:
 [0]_asm_procedurego_ask_0 "ask" AgentSet => void
       _breed:SHEEP "sheep" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_0.world : Lorg/nlogo/agent/World;
@@ -1552,6 +1667,9 @@ procedure GO:[]{O---}:
           RETURN
 [2]_asm_procedurego_if_2 "if" boolean => void
       _observervariable:GRASS? "grass?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -1598,6 +1716,13 @@ procedure GO:[]{O---}:
       _minus "-" double,double => double
         _turtlevariable:ENERGY "energy" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -1662,9 +1787,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1679,6 +1801,10 @@ procedure GO:[]{O---}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [4]_asm_procedurego_call_4 "eat-grass"
          L0
@@ -1735,6 +1861,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [7]_asm_procedurego_done_7 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1743,6 +1870,9 @@ procedure GO:[]{O---}:
           RETURN
 [8]_asm_procedurego_ask_8 "ask" AgentSet => void
       _breed:WOLVES "wolves" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_8.world : Lorg/nlogo/agent/World;
@@ -1819,6 +1949,13 @@ procedure GO:[]{O---}:
       _minus "-" double,double => double
         _turtlevariable:ENERGY "energy" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -1883,9 +2020,6 @@ procedure GO:[]{O---}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          BIPUSH 11
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurego_setturtlevariable_10 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -1900,6 +2034,10 @@ procedure GO:[]{O---}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          BIPUSH 11
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [11]_asm_procedurego_call_11 "catch-sheep"
          L0
@@ -1956,6 +2094,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [14]_asm_procedurego_done_14 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -1964,6 +2103,9 @@ procedure GO:[]{O---}:
           RETURN
 [15]_asm_procedurego_if_15 "if" boolean => void
       _observervariable:GRASS? "grass?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -2008,6 +2150,9 @@ procedure GO:[]{O---}:
           RETURN
 [16]_asm_procedurego_ask_16 "ask" AgentSet => void
       _patches "patches" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_ask_16.world : Lorg/nlogo/agent/World;
@@ -2080,6 +2225,7 @@ procedure GO:[]{O---}:
          L1
           RETURN
 [18]_asm_procedurego_done_18 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2088,6 +2234,9 @@ procedure GO:[]{O---}:
           RETURN
 [19]_asm_procedurego_if_19 "if" boolean => void
       _observervariable:PLOT? "plot?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -2154,6 +2303,15 @@ procedure GO:[]{O---}:
         _count "count" AgentSet => double
           _turtles "turtles" => AgentSet
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_if_21.world : Lorg/nlogo/agent/World;
@@ -2232,6 +2390,7 @@ procedure GO:[]{O---}:
          L3
           RETURN
 [24]_asm_procedurego_return_23 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2246,6 +2405,13 @@ procedure MOVE:[]{-T--}:
       _minus "-" double,double => double
         _randomconst:50 "random" => double
         _randomconst:50 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  delta
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -2279,25 +2445,28 @@ procedure MOVE:[]{-T--}:
          L4
           RETURN
 [1]_asm_proceduremove_fd1_1 "fd" => void
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
+          // parameter final  context
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
           DCONST_1
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L2
          L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          ASTORE 2
+          GOTO L3
          L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L3
          FRAME SAME
           ALOAD 1
           ICONST_2
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L3
+         L4
           RETURN
 [2]_asm_proceduremove_return_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2312,6 +2481,13 @@ procedure EAT-GRASS:[]{-T--}:
       _equal "=" Object,double => boolean
         _patchvariable:PCOLOR "pcolor" => Object
         _constdouble:55.0 "green" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -2338,11 +2514,9 @@ procedure EAT-GRASS:[]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -2353,19 +2527,19 @@ procedure EAT-GRASS:[]{-T--}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedureeatgrass_if_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedureeatgrass_if_0 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -2374,15 +2548,18 @@ procedure EAT-GRASS:[]{-T--}:
           ICONST_1
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedureeatgrass_if_0 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_procedureeatgrass_if_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           ICONST_3
          L11
-         FRAME FULL [org/nlogo/prim/_asm_procedureeatgrass_if_0 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_procedureeatgrass_if_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
 [1]_asm_procedureeatgrass_setpatchvariable_1 "set" Object => void
       _constdouble:35.0 "brown" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -2396,9 +2573,6 @@ procedure EAT-GRASS:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedureeatgrass_setpatchvariable_1 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -2413,11 +2587,22 @@ procedure EAT-GRASS:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [2]_asm_procedureeatgrass_setturtlevariable_2 "set" Object => void
       _plus "+" double,double => double
         _turtlevariable:ENERGY "energy" => Object
         _observervariable:SHEEP-METABOLISM "sheep-metabolism" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -2507,9 +2692,6 @@ procedure EAT-GRASS:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L8
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L15
          L9
          FRAME FULL [org/nlogo/prim/_asm_procedureeatgrass_setturtlevariable_2 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -2524,8 +2706,13 @@ procedure EAT-GRASS:[]{-T--}:
           ATHROW
          L15
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L16
           RETURN
 [3]_asm_procedureeatgrass_return_3 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2541,6 +2728,15 @@ procedure REPRODUCE-SHEEP:[]{-T--}:
         _randomfloat "random-float" double => double
           _constdouble:100.0 "100" => double
         _observervariable:SHEEP-REPRODUCE "sheep-reproduce" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 100.0
          L1
@@ -2561,11 +2757,9 @@ procedure REPRODUCE-SHEEP:[]{-T--}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L4
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -2576,15 +2770,14 @@ procedure REPRODUCE-SHEEP:[]{-T--}:
           ICONST_1
           GOTO L6
          L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurereproducesheep_if_0 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurereproducesheep_if_0 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L6
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L7
          L4
-         FRAME CHOP 1
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2613,26 +2806,34 @@ procedure REPRODUCE-SHEEP:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurereproducesheep_if_0 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
+         L8
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L8
+          IFEQ L9
           ICONST_1
-          GOTO L9
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurereproducesheep_if_0 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 6
+          GOTO L10
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurereproducesheep_if_0 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurereproducesheep_if_0 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context]
+          BIPUSH 6
          L10
+         FRAME FULL [org/nlogo/prim/_asm_procedurereproducesheep_if_0 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [1]_asm_procedurereproducesheep_setturtlevariable_1 "set" Object => void
       _round "round" double => double
         _div "/" double,double => double
           _turtlevariable:ENERGY "energy" => Object
           _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -2718,9 +2919,6 @@ procedure REPRODUCE-SHEEP:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L14
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurereproducesheep_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -2735,9 +2933,14 @@ procedure REPRODUCE-SHEEP:[]{-T--}:
           ATHROW
          L14
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L15
           RETURN
 [2]_hatch:,+6 "hatch"
       _asm_procedurereproducesheep_constdouble_2 "1" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurereproducesheep_constdouble_2.kept1_value : Ljava/lang/Double;
@@ -2745,6 +2948,9 @@ procedure REPRODUCE-SHEEP:[]{-T--}:
             ARETURN
 [3]_asm_procedurereproducesheep_right_3 "rt" double => void
       _randomconst:360 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  delta
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -2765,25 +2971,28 @@ procedure REPRODUCE-SHEEP:[]{-T--}:
          L2
           RETURN
 [4]_asm_procedurereproducesheep_fd1_4 "fd" => void
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
+          // parameter final  context
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
           DCONST_1
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L2
          L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          ASTORE 2
+          GOTO L3
          L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L3
          FRAME SAME
           ALOAD 1
           ICONST_5
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L3
+         L4
           RETURN
 [5]_asm_procedurereproducesheep_done_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -2791,6 +3000,7 @@ procedure REPRODUCE-SHEEP:[]{-T--}:
          L1
           RETURN
 [6]_asm_procedurereproducesheep_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -2806,6 +3016,15 @@ procedure REPRODUCE-WOLVES:[]{-T--}:
         _randomfloat "random-float" double => double
           _constdouble:100.0 "100" => double
         _observervariable:WOLF-REPRODUCE "wolf-reproduce" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
          L0
           LDC 100.0
          L1
@@ -2826,11 +3045,9 @@ procedure REPRODUCE-WOLVES:[]{-T--}:
           ASTORE 4
           DSTORE 2
           ALOAD 4
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L4
-          ALOAD 5
+          ALOAD 4
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 2
@@ -2841,15 +3058,14 @@ procedure REPRODUCE-WOLVES:[]{-T--}:
           ICONST_1
           GOTO L6
          L5
-         FRAME FULL [org/nlogo/prim/_asm_procedurereproducewolves_if_0 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurereproducewolves_if_0 org/nlogo/nvm/Context D java/lang/Object T java/lang/Double] []
           ICONST_0
          L6
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L7
          L4
-         FRAME CHOP 1
+         FRAME CHOP 2
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -2878,26 +3094,34 @@ procedure REPRODUCE-WOLVES:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurereproducewolves_if_0 org/nlogo/nvm/Context D java/lang/Object java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I java/lang/Double]
+          ILOAD 5
+         L8
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L8
+          IFEQ L9
           ICONST_1
-          GOTO L9
-         L8
-         FRAME FULL [org/nlogo/prim/_asm_procedurereproducewolves_if_0 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          BIPUSH 6
+          GOTO L10
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurereproducewolves_if_0 org/nlogo/nvm/Context I T java/lang/Object java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_procedurereproducewolves_if_0 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context]
+          BIPUSH 6
          L10
+         FRAME FULL [org/nlogo/prim/_asm_procedurereproducewolves_if_0 org/nlogo/nvm/Context I T java/lang/Object I java/lang/Double] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L11
           RETURN
 [1]_asm_procedurereproducewolves_setturtlevariable_1 "set" Object => void
       _round "round" double => double
         _div "/" double,double => double
           _turtlevariable:ENERGY "energy" => Object
           _constdouble:2.0 "2" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -2983,9 +3207,6 @@ procedure REPRODUCE-WOLVES:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          ICONST_2
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L14
          L7
          FRAME FULL [org/nlogo/prim/_asm_procedurereproducewolves_setturtlevariable_1 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -3000,9 +3221,14 @@ procedure REPRODUCE-WOLVES:[]{-T--}:
           ATHROW
          L14
          FRAME SAME
+          ALOAD 1
+          ICONST_2
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L15
           RETURN
 [2]_hatch:,+6 "hatch"
       _asm_procedurereproducewolves_constdouble_2 "1" => Double
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_procedurereproducewolves_constdouble_2.kept1_value : Ljava/lang/Double;
@@ -3010,6 +3236,9 @@ procedure REPRODUCE-WOLVES:[]{-T--}:
             ARETURN
 [3]_asm_procedurereproducewolves_right_3 "rt" double => void
       _randomconst:360 "random" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  delta
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -3030,25 +3259,28 @@ procedure REPRODUCE-WOLVES:[]{-T--}:
          L2
           RETURN
 [4]_asm_procedurereproducewolves_fd1_4 "fd" => void
-          TRYCATCHBLOCK L0 L1 L1 org/nlogo/api/AgentException
+          // parameter final  context
+          TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           CHECKCAST org/nlogo/agent/Turtle
           DCONST_1
           INVOKEVIRTUAL org/nlogo/agent/Turtle.jump (D)V
-          GOTO L2
          L1
-         FRAME SAME1 org/nlogo/api/AgentException
-          ASTORE 2
+          GOTO L3
          L2
+         FRAME SAME1 org/nlogo/api/AgentException
+          POP
+         L3
          FRAME SAME
           ALOAD 1
           ICONST_5
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L3
+         L4
           RETURN
 [5]_asm_procedurereproducewolves_done_5 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -3056,6 +3288,7 @@ procedure REPRODUCE-WOLVES:[]{-T--}:
          L1
           RETURN
 [6]_asm_procedurereproducewolves_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -3069,6 +3302,11 @@ procedure CATCH-SHEEP:[]{-T--}:
 [0]_asm_procedurecatchsheep_setturtlevariable_0 "set" Object => void
       _oneof "one-of" AgentSet => Object
         _breedhere:SHEEP "sheep-here" => AgentSet
+          // parameter final  context
+          // parameter final  context
+          // parameter final  agents
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 1
@@ -3079,10 +3317,8 @@ procedure CATCH-SHEEP:[]{-T--}:
           IFEQ L4
           ALOAD 3
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 4
-          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/Turtle.getPatchHere ()Lorg/nlogo/agent/Patch;
-          ASTORE 5
+          ASTORE 2
           GOTO L5
          L4
          FRAME APPEND [T org/nlogo/agent/Agent]
@@ -3091,60 +3327,55 @@ procedure CATCH-SHEEP:[]{-T--}:
           IFEQ L6
           ALOAD 3
           CHECKCAST org/nlogo/agent/Patch
-          ASTORE 6
-          ALOAD 6
-          ASTORE 5
-         L5
-         FRAME APPEND [T org/nlogo/agent/Patch]
-          ALOAD 5
           ASTORE 2
+          GOTO L5
+         L6
+         FRAME SAME
+          NEW scala/MatchError
+          DUP
+          ALOAD 3
+          INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
+          ATHROW
+         L5
+         FRAME FULL [org/nlogo/prim/_asm_procedurecatchsheep_setturtlevariable_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
           NEW org/nlogo/agent/AgentSetBuilder
           DUP
           GETSTATIC org/nlogo/core/AgentKind$Turtle$.MODULE$ : Lorg/nlogo/core/AgentKind$Turtle$;
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Patch.turtleCount ()I
           INVOKESPECIAL org/nlogo/agent/AgentSetBuilder.<init> (Lorg/nlogo/core/AgentKind;I)V
-          ASTORE 7
+          ASTORE 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecatchsheep_setturtlevariable_0.world : Lorg/nlogo/agent/World;
           LDC "SHEEP"
           INVOKEVIRTUAL org/nlogo/agent/World.getBreed (Ljava/lang/String;)Lorg/nlogo/agent/AgentSet;
-          ASTORE 8
+          ASTORE 5
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Patch.turtlesHere ()Ljava/lang/Iterable;
           INVOKEINTERFACE java/lang/Iterable.iterator ()Ljava/util/Iterator;
-          ASTORE 9
+          ASTORE 6
          L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurecatchsheep_setturtlevariable_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T org/nlogo/agent/AgentSetBuilder org/nlogo/agent/AgentSet java/util/Iterator] []
-          ALOAD 9
+         FRAME APPEND [org/nlogo/agent/AgentSetBuilder org/nlogo/agent/AgentSet java/util/Iterator]
+          ALOAD 6
           INVOKEINTERFACE java/util/Iterator.hasNext ()Z
           IFEQ L8
-          ALOAD 9
+          ALOAD 6
           INVOKEINTERFACE java/util/Iterator.next ()Ljava/lang/Object;
           CHECKCAST org/nlogo/agent/Turtle
-          ASTORE 10
-          ALOAD 10
-          INVOKEVIRTUAL org/nlogo/agent/Turtle.getBreed ()Lorg/nlogo/agent/AgentSet;
-          ALOAD 8
-          IF_ACMPNE L7
+          ASTORE 7
           ALOAD 7
-          ALOAD 10
+          INVOKEVIRTUAL org/nlogo/agent/Turtle.getBreed ()Lorg/nlogo/agent/AgentSet;
+          ALOAD 5
+          IF_ACMPNE L7
+          ALOAD 4
+          ALOAD 7
           INVOKEVIRTUAL org/nlogo/agent/AgentSetBuilder.add (Lorg/nlogo/agent/Agent;)V
           GOTO L7
          L8
          FRAME SAME
-          ALOAD 7
+          ALOAD 4
           INVOKEVIRTUAL org/nlogo/agent/AgentSetBuilder.build ()Lorg/nlogo/agent/AgentSet;
-          GOTO L9
-         L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurecatchsheep_setturtlevariable_0 org/nlogo/nvm/Context T org/nlogo/agent/Agent] []
-          NEW scala/MatchError
-          DUP
-          ALOAD 3
-          INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
-          ATHROW
          L9
-         FRAME FULL [org/nlogo/prim/_asm_procedurecatchsheep_setturtlevariable_0 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent T org/nlogo/agent/Patch T org/nlogo/agent/AgentSetBuilder org/nlogo/agent/AgentSet java/util/Iterator] [org/nlogo/agent/AgentSet]
           ASTORE 2
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/AgentSet.count ()I
@@ -3155,7 +3386,7 @@ procedure CATCH-SHEEP:[]{-T--}:
           GETSTATIC org/nlogo/core/Nobody$.MODULE$ : Lorg/nlogo/core/Nobody$;
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurecatchsheep_setturtlevariable_0 org/nlogo/nvm/Context org/nlogo/agent/AgentSet I T org/nlogo/agent/Patch T org/nlogo/agent/AgentSetBuilder org/nlogo/agent/AgentSet java/util/Iterator] []
+         FRAME FULL [org/nlogo/prim/_asm_procedurecatchsheep_setturtlevariable_0 org/nlogo/nvm/Context org/nlogo/agent/AgentSet I org/nlogo/agent/AgentSetBuilder org/nlogo/agent/AgentSet java/util/Iterator] []
           ALOAD 2
           ILOAD 3
           ALOAD 1
@@ -3174,12 +3405,9 @@ procedure CATCH-SHEEP:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_1
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L2
-         FRAME FULL [org/nlogo/prim/_asm_procedurecatchsheep_setturtlevariable_0 org/nlogo/nvm/Context java/lang/Object I T org/nlogo/agent/Patch T org/nlogo/agent/AgentSetBuilder org/nlogo/agent/AgentSet java/util/Iterator] [org/nlogo/api/AgentException]
+         FRAME FULL [org/nlogo/prim/_asm_procedurecatchsheep_setturtlevariable_0 org/nlogo/nvm/Context java/lang/Object I org/nlogo/agent/AgentSetBuilder org/nlogo/agent/AgentSet java/util/Iterator] [org/nlogo/api/AgentException]
           ASTORE 3
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
@@ -3191,11 +3419,22 @@ procedure CATCH-SHEEP:[]{-T--}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          ICONST_1
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [1]_asm_procedurecatchsheep_if_1 "if" boolean => void
       _notequal "!=" Object,Object => boolean
         _turtlevariable:PREY "prey" => Object
         _nobody "nobody" => Nobody$
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -3225,12 +3464,12 @@ procedure CATCH-SHEEP:[]{-T--}:
           ALOAD 2
           ALOAD 3
           INVOKEVIRTUAL org/nlogo/api/Equality$.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
-          IFEQ L5
-          ICONST_0
+          IFNE L5
+          ICONST_1
           GOTO L6
          L5
          FRAME APPEND [java/lang/Object org/nlogo/core/Nobody$]
-          ICONST_1
+          ICONST_0
          L6
          FRAME SAME1 I
           ISTORE 2
@@ -3249,6 +3488,9 @@ procedure CATCH-SHEEP:[]{-T--}:
           RETURN
 [2]_asm_procedurecatchsheep_ask_2 "ask" Object => void
       _turtlevariable:PREY "prey" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  target
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -3272,18 +3514,16 @@ procedure CATCH-SHEEP:[]{-T--}:
          FRAME SAME1 java/lang/Object
           ASTORE 2
           ALOAD 2
-          ASTORE 4
-          ALOAD 4
           INSTANCEOF org/nlogo/agent/AgentSet
           IFEQ L4
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/AgentSet
-          ASTORE 5
+          ASTORE 4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
           INSTANCEOF org/nlogo/agent/Observer
           IFNE L5
-          ALOAD 5
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecatchsheep_ask_2.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
@@ -3299,8 +3539,8 @@ procedure CATCH-SHEEP:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurecatchsheep_ask_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object org/nlogo/agent/AgentSet] []
-          ALOAD 5
+         FRAME APPEND [java/lang/Object T org/nlogo/agent/AgentSet]
+          ALOAD 4
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurecatchsheep_ask_2.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
@@ -3317,18 +3557,18 @@ procedure CATCH-SHEEP:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
-          ALOAD 5
-          ASTORE 6
+          ALOAD 4
+          ASTORE 3
           GOTO L7
          L4
-         FRAME CHOP 1
-          ALOAD 4
+         FRAME CHOP 2
+          ALOAD 2
           INSTANCEOF org/nlogo/agent/Agent
           IFEQ L8
-          ALOAD 4
+          ALOAD 2
           CHECKCAST org/nlogo/agent/Agent
-          ASTORE 7
-          ALOAD 7
+          ASTORE 5
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.id ()J
           LDC -1
           LCMP
@@ -3345,7 +3585,7 @@ procedure CATCH-SHEEP:[]{-T--}:
           ANEWARRAY java/lang/Object
           DUP
           ICONST_0
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/Agent.classDisplayName ()Ljava/lang/String;
           AASTORE
           INVOKEVIRTUAL scala/Predef$.wrapRefArray ([Ljava/lang/Object;)Lscala/collection/mutable/WrappedArray;
@@ -3355,23 +3595,12 @@ procedure CATCH-SHEEP:[]{-T--}:
          L9
          FRAME APPEND [T T org/nlogo/agent/Agent]
           GETSTATIC org/nlogo/agent/AgentSet$.MODULE$ : Lorg/nlogo/agent/AgentSet$;
-          ALOAD 7
+          ALOAD 5
           INVOKEVIRTUAL org/nlogo/agent/AgentSet$.fromAgent (Lorg/nlogo/agent/Agent;)Lorg/nlogo/agent/IndexedAgentSet;
-          ASTORE 6
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurecatchsheep_ask_2 org/nlogo/nvm/Context java/lang/Object T java/lang/Object T org/nlogo/agent/AgentSet] []
-          ALOAD 6
           ASTORE 3
-          ALOAD 1
-          ALOAD 3
-          ICONST_3
-          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
-          ALOAD 1
-          ICONST_5
-          PUTFIELD org/nlogo/nvm/Context.ip : I
-          GOTO L10
+          GOTO L7
          L8
-         FRAME CHOP 2
+         FRAME CHOP 3
           NEW org/nlogo/nvm/ArgumentTypeException
           DUP
           ALOAD 1
@@ -3385,11 +3614,22 @@ procedure CATCH-SHEEP:[]{-T--}:
           ALOAD 2
           INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
           ATHROW
+         L7
+         FRAME APPEND [org/nlogo/agent/AgentSet]
+          ALOAD 1
+          ALOAD 3
+          ICONST_3
+          INVOKEVIRTUAL org/nlogo/nvm/Context.runExclusiveJob (Lorg/nlogo/agent/AgentSet;I)V
+          ALOAD 1
+          ICONST_5
+          PUTFIELD org/nlogo/nvm/Context.ip : I
          L10
-         FRAME FULL [org/nlogo/prim/_asm_procedurecatchsheep_ask_2 org/nlogo/nvm/Context java/lang/Object org/nlogo/agent/AgentSet java/lang/Object T org/nlogo/agent/AgentSet] []
           RETURN
 [3]_asm_procedurecatchsheep_setturtlevariable_3 "set" Object => void
       _constdouble:-1.0 "-1" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3403,9 +3643,6 @@ procedure CATCH-SHEEP:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_procedurecatchsheep_setturtlevariable_3 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -3420,8 +3657,13 @@ procedure CATCH-SHEEP:[]{-T--}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_procedurecatchsheep_done_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           ICONST_1
@@ -3432,6 +3674,13 @@ procedure CATCH-SHEEP:[]{-T--}:
       _plus "+" double,double => double
         _turtlevariable:ENERGY "energy" => Object
         _observervariable:WOLF-METABOLISM "wolf-metabolism" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d1
+          // parameter final  d2
+          // parameter final  context
+          // parameter final  value
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L6 java/lang/ClassCastException
@@ -3521,9 +3770,6 @@ procedure CATCH-SHEEP:[]{-T--}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setTurtleVariable (ILjava/lang/Object;)V
          L8
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L15
          L9
          FRAME FULL [org/nlogo/prim/_asm_procedurecatchsheep_setturtlevariable_5 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -3538,8 +3784,13 @@ procedure CATCH-SHEEP:[]{-T--}:
           ATHROW
          L15
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L16
           RETURN
 [6]_asm_procedurecatchsheep_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -3554,6 +3805,13 @@ procedure DEATH:[]{-T--}:
       _lessthan "<" Object,double => boolean
         _turtlevariable:ENERGY "energy" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  arg1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -3580,14 +3838,10 @@ procedure DEATH:[]{-T--}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
-          ASTORE 6
-          ALOAD 6
           INVOKEVIRTUAL java/lang/Double.doubleValue ()D
           DLOAD 3
           DCMPG
@@ -3595,15 +3849,14 @@ procedure DEATH:[]{-T--}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduredeath_if_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME APPEND [java/lang/Object D]
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
-          ILOAD 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME SAME
           NEW org/nlogo/nvm/RuntimePrimitiveException
           DUP
           ALOAD 1
@@ -3632,20 +3885,22 @@ procedure DEATH:[]{-T--}:
           INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
           ATHROW
          L8
-         FRAME FULL [org/nlogo/prim/_asm_proceduredeath_if_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double I] [I]
+         FRAME APPEND [I]
+          ILOAD 5
+         L9
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L9
+          IFEQ L10
           ICONST_1
-          GOTO L10
-         L9
-         FRAME FULL [org/nlogo/prim/_asm_proceduredeath_if_0 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context]
-          ICONST_2
+          GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_proceduredeath_if_0 org/nlogo/nvm/Context I D java/lang/Object java/lang/Double I] [org/nlogo/nvm/Context I]
-          PUTFIELD org/nlogo/nvm/Context.ip : I
+         FRAME FULL [org/nlogo/prim/_asm_proceduredeath_if_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
+          ICONST_2
          L11
+         FRAME FULL [org/nlogo/prim/_asm_proceduredeath_if_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L12
           RETURN
 [1]_asm_proceduredeath_die_1 "die" => void
          L0
@@ -3672,6 +3927,7 @@ procedure DEATH:[]{-T--}:
          L3
           RETURN
 [2]_asm_proceduredeath_return_2 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -3686,6 +3942,13 @@ procedure GROW-GRASS:[]{-TP-}:
       _equal "=" Object,double => boolean
         _patchvariable:PCOLOR "pcolor" => Object
         _constdouble:35.0 "brown" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -3712,11 +3975,9 @@ procedure GROW-GRASS:[]{-TP-}:
           DSTORE 3
           ASTORE 2
           ALOAD 2
-          ASTORE 5
-          ALOAD 5
           INSTANCEOF java/lang/Double
           IFEQ L5
-          ALOAD 5
+          ALOAD 2
           CHECKCAST java/lang/Double
           ASTORE 6
           DLOAD 3
@@ -3727,19 +3988,19 @@ procedure GROW-GRASS:[]{-TP-}:
           ICONST_1
           GOTO L7
          L6
-         FRAME FULL [org/nlogo/prim/_asm_proceduregrowgrass_if_0 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+         FRAME FULL [org/nlogo/prim/_asm_proceduregrowgrass_if_0 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
           ICONST_0
          L7
          FRAME SAME1 I
-          ISTORE 7
+          ISTORE 5
           GOTO L8
          L5
-         FRAME CHOP 1
+         FRAME CHOP 2
           ICONST_0
-          ISTORE 7
+          ISTORE 5
          L8
-         FRAME APPEND [T I]
-          ILOAD 7
+         FRAME APPEND [I]
+          ILOAD 5
          L9
           ISTORE 2
           ALOAD 1
@@ -3748,10 +4009,10 @@ procedure GROW-GRASS:[]{-TP-}:
           ICONST_1
           GOTO L11
          L10
-         FRAME FULL [org/nlogo/prim/_asm_proceduregrowgrass_if_0 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context]
+         FRAME FULL [org/nlogo/prim/_asm_proceduregrowgrass_if_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context]
           BIPUSH 6
          L11
-         FRAME FULL [org/nlogo/prim/_asm_proceduregrowgrass_if_0 org/nlogo/nvm/Context I D java/lang/Object T I] [org/nlogo/nvm/Context I]
+         FRAME FULL [org/nlogo/prim/_asm_proceduregrowgrass_if_0 org/nlogo/nvm/Context I D I] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
          L12
           RETURN
@@ -3759,6 +4020,10 @@ procedure GROW-GRASS:[]{-TP-}:
       _lessorequal "<=" Object,double => boolean
         _patchvariable:COUNTDOWN "countdown" => Object
         _constdouble:0.0 "0" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L0
           ALOAD 1
@@ -3843,6 +4108,9 @@ procedure GROW-GRASS:[]{-TP-}:
           RETURN
 [2]_asm_proceduregrowgrass_setpatchvariable_2 "set" Object => void
       _constdouble:55.0 "green" => Double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3856,9 +4124,6 @@ procedure GROW-GRASS:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_3
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduregrowgrass_setpatchvariable_2 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
@@ -3873,9 +4138,16 @@ procedure GROW-GRASS:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_3
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [3]_asm_proceduregrowgrass_setpatchvariable_3 "set" Object => void
       _observervariable:GRASS-DELAY "grass-delay" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
          L3
           ALOAD 0
@@ -3892,9 +4164,6 @@ procedure GROW-GRASS:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L1
-          ALOAD 1
-          ICONST_4
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L5
          L2
          FRAME FULL [org/nlogo/prim/_asm_proceduregrowgrass_setpatchvariable_3 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
@@ -3909,8 +4178,13 @@ procedure GROW-GRASS:[]{-TP-}:
           ATHROW
          L5
          FRAME SAME
+          ALOAD 1
+          ICONST_4
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L6
           RETURN
 [4]_asm_proceduregrowgrass_goto_4 => void
+          // parameter final  context
          L0
           ALOAD 1
           BIPUSH 6
@@ -3921,6 +4195,13 @@ procedure GROW-GRASS:[]{-TP-}:
       _minus "-" double,double => double
         _patchvariable:COUNTDOWN "countdown" => Object
         _constdouble:1.0 "1" => double
+          // parameter final  context
+          // parameter final  context
+          // parameter final  context
+          // parameter final  d0
+          // parameter final  d1
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
           TRYCATCHBLOCK L3 L4 L4 java/lang/ClassCastException
           TRYCATCHBLOCK L5 L6 L7 org/nlogo/api/AgentException
@@ -3985,9 +4266,6 @@ procedure GROW-GRASS:[]{-TP-}:
           ALOAD 2
           INVOKEVIRTUAL org/nlogo/agent/Agent.setPatchVariable (ILjava/lang/Object;)V
          L6
-          ALOAD 1
-          BIPUSH 6
-          PUTFIELD org/nlogo/nvm/Context.ip : I
           GOTO L12
          L7
          FRAME FULL [org/nlogo/prim/_asm_proceduregrowgrass_setpatchvariable_5 org/nlogo/nvm/Context java/lang/Double T D] [org/nlogo/api/AgentException]
@@ -4002,8 +4280,13 @@ procedure GROW-GRASS:[]{-TP-}:
           ATHROW
          L12
          FRAME SAME
+          ALOAD 1
+          BIPUSH 6
+          PUTFIELD org/nlogo/nvm/Context.ip : I
+         L13
           RETURN
 [6]_asm_proceduregrowgrass_return_6 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V
@@ -4016,6 +4299,7 @@ procedure GROW-GRASS:[]{-TP-}:
 procedure GRAPH:[]{OTPL}:
 [0]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduregraph_conststring_0 ""sheep"" => String
+            // parameter final  context
            L0
             LDC "sheep"
            L1
@@ -4023,6 +4307,9 @@ procedure GRAPH:[]{OTPL}:
 [1]_plot "plot"
       _asm_proceduregraph_count_1 "count" AgentSet => double
         _breed:SHEEP "sheep" => AgentSet
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduregraph_count_1.world : Lorg/nlogo/agent/World;
@@ -4042,6 +4329,7 @@ procedure GRAPH:[]{OTPL}:
             ARETURN
 [2]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduregraph_conststring_2 ""wolves"" => String
+            // parameter final  context
            L0
             LDC "wolves"
            L1
@@ -4049,6 +4337,9 @@ procedure GRAPH:[]{OTPL}:
 [3]_plot "plot"
       _asm_proceduregraph_count_3 "count" AgentSet => double
         _breed:WOLVES "wolves" => AgentSet
+            // parameter final  context
+            // parameter final  context
+            // parameter final  arg0
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduregraph_count_3.world : Lorg/nlogo/agent/World;
@@ -4068,6 +4359,9 @@ procedure GRAPH:[]{OTPL}:
             ARETURN
 [4]_asm_proceduregraph_if_4 "if" boolean => void
       _observervariable:GRASS? "grass?" => Object
+          // parameter final  context
+          // parameter final  context
+          // parameter final  arg0
           TRYCATCHBLOCK L0 L1 L1 java/lang/ClassCastException
          L2
           ALOAD 0
@@ -4112,6 +4406,7 @@ procedure GRAPH:[]{OTPL}:
           RETURN
 [5]_setcurrentplotpen "set-current-plot-pen"
       _asm_proceduregraph_conststring_5 ""grass / 4"" => String
+            // parameter final  context
            L0
             LDC "grass / 4"
            L1
@@ -4123,6 +4418,11 @@ procedure GRAPH:[]{OTPL}:
           _asm_proceduregraph_equal_7 "=" Object,double => boolean
             _patchvariable:PCOLOR "pcolor" => Object
             _constdouble:55.0 "green" => double
+                // parameter final  context
+                // parameter final  context
+                // parameter final  context
+                // parameter final  arg0
+                // parameter final  d1
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L0
                 ALOAD 1
@@ -4149,11 +4449,9 @@ procedure GRAPH:[]{OTPL}:
                 DSTORE 3
                 ASTORE 2
                 ALOAD 2
-                ASTORE 5
-                ALOAD 5
                 INSTANCEOF java/lang/Double
                 IFEQ L5
-                ALOAD 5
+                ALOAD 2
                 CHECKCAST java/lang/Double
                 ASTORE 6
                 DLOAD 3
@@ -4164,19 +4462,19 @@ procedure GRAPH:[]{OTPL}:
                 ICONST_1
                 GOTO L7
                L6
-               FRAME FULL [org/nlogo/prim/_asm_proceduregraph_equal_7 org/nlogo/nvm/Context java/lang/Object D java/lang/Object java/lang/Double] []
+               FRAME FULL [org/nlogo/prim/_asm_proceduregraph_equal_7 org/nlogo/nvm/Context java/lang/Object D T java/lang/Double] []
                 ICONST_0
                L7
                FRAME SAME1 I
-                ISTORE 7
+                ISTORE 5
                 GOTO L8
                L5
-               FRAME CHOP 1
+               FRAME CHOP 2
                 ICONST_0
-                ISTORE 7
+                ISTORE 5
                L8
-               FRAME APPEND [T I]
-                ILOAD 7
+               FRAME APPEND [I]
+                ILOAD 5
                L9
                 IFEQ L10
                 GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
@@ -4188,6 +4486,11 @@ procedure GRAPH:[]{OTPL}:
                FRAME SAME1 java/lang/Boolean
                 ARETURN
         _constdouble:4.0 "4" => double
+            // parameter final  context
+            // parameter final  context
+            // parameter final  sourceSet
+            // parameter final  block
+            // parameter final  context
            L0
             ALOAD 0
             GETFIELD org/nlogo/prim/_asm_proceduregraph_div_6.world : Lorg/nlogo/agent/World;
@@ -4230,25 +4533,15 @@ procedure GRAPH:[]{OTPL}:
             IFEQ L4
             ALOAD 8
             CHECKCAST java/lang/Boolean
-            ASTORE 9
-            ALOAD 9
             INVOKEVIRTUAL java/lang/Boolean.booleanValue ()Z
-            IFEQ L5
+            IFEQ L2
             ILOAD 5
             ICONST_1
             IADD
             ISTORE 5
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-            GOTO L6
-           L5
-           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object java/lang/Boolean]
-            GETSTATIC scala/runtime/BoxedUnit.UNIT : Lscala/runtime/BoxedUnit;
-           L6
-           FRAME SAME1 scala/runtime/BoxedUnit
-            ASTORE 10
             GOTO L2
            L4
-           FRAME CHOP 1
+           FRAME APPEND [org/nlogo/agent/Agent java/lang/Object]
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -4283,15 +4576,15 @@ procedure GRAPH:[]{OTPL}:
            FRAME CHOP 2
             ILOAD 5
             I2D
-           L7
+           L5
             LDC 4.0
-           L8
+           L6
             DSTORE 4
             DSTORE 2
             DLOAD 4
             DCONST_0
             DCMPL
-            IFNE L9
+            IFNE L7
             NEW org/nlogo/nvm/RuntimePrimitiveException
             DUP
             ALOAD 1
@@ -4301,12 +4594,12 @@ procedure GRAPH:[]{OTPL}:
             INVOKEINTERFACE org/nlogo/core/I18NJava.get (Ljava/lang/String;)Ljava/lang/String;
             INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
             ATHROW
-           L9
+           L7
            FRAME FULL [org/nlogo/prim/_asm_proceduregraph_div_6 org/nlogo/nvm/Context D D org/nlogo/agent/AgentIterator] []
             DLOAD 2
             DLOAD 4
             DDIV
-           L10
+           L8
             DSTORE 2
             NEW java/lang/Double
             DUP
@@ -4314,6 +4607,7 @@ procedure GRAPH:[]{OTPL}:
             INVOKESPECIAL java/lang/Double.<init> (D)V
             ARETURN
 [7]_asm_proceduregraph_return_8 => void
+          // parameter final  context
          L0
           ALOAD 1
           INVOKEVIRTUAL org/nlogo/nvm/Context.returnFromProcedure ()V

--- a/test/benchdumps/ANN.txt
+++ b/test/benchdumps/ANN.txt
@@ -1096,7 +1096,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_3.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_3.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -1676,7 +1677,8 @@ procedure CLICK-INPUT:[]{OTPL}:
               DLOAD 4
               ICONST_1
               INVOKEVIRTUAL org/nlogo/agent/Protractor.distance (Lorg/nlogo/api/Agent;DDZ)D
-              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureclickinput_distancexy_4.validDouble (D)D
+              ALOAD 1
+              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureclickinput_distancexy_4.validDouble (DLorg/nlogo/nvm/Context;)D
              L7
               DSTORE 2
               NEW java/lang/Double
@@ -3258,7 +3260,8 @@ procedure RANDOMIZE-WEIGHTS:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextGaussian ()D
           DMUL
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomizeweights_call_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomizeweights_call_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L5
           DSTORE 2
           NEW java/lang/Double
@@ -3383,7 +3386,8 @@ procedure RANDOMIZE-WEIGHTS:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextGaussian ()D
           DMUL
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomizeweights_call_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomizeweights_call_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L5
           DSTORE 2
           NEW java/lang/Double
@@ -3635,7 +3639,8 @@ procedure RECOLOR:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolor_setturtlevariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolor_setturtlevariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -4977,7 +4982,8 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
               DLOAD 2
               DLOAD 4
               DMUL
-              INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_list_7.validDouble (D)D
+              ALOAD 1
+              INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_list_7.validDouble (DLorg/nlogo/nvm/Context;)D
              L7
               DSTORE 2
               NEW java/lang/Double
@@ -5969,7 +5975,8 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 2
                 DLOAD 4
                 DADD
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersizesetlayerturtlesetlayerselfsetlayerturtlesetlayerselfletlayernum05numlayersmaxpxcorlet0foreachsortlayer1ask1lety205i05layersizemaxpycorsetxyxysetcolorgreysetii1setlayerslputlayerlayers_let_8.validDouble (D)D
+                ALOAD 1
+                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersizesetlayerturtlesetlayerselfsetlayerturtlesetlayerselfletlayernum05numlayersmaxpxcorlet0foreachsortlayer1ask1lety205i05layersizemaxpycorsetxyxysetcolorgreysetii1setlayerslputlayerlayers_let_8.validDouble (DLorg/nlogo/nvm/Context;)D
                L8
                 ALOAD 1
                 ALOAD 0
@@ -6017,7 +6024,8 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 2
                 DLOAD 4
                 DDIV
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersizesetlayerturtlesetlayerselfsetlayerturtlesetlayerselfletlayernum05numlayersmaxpxcorlet0foreachsortlayer1ask1lety205i05layersizemaxpycorsetxyxysetcolorgreysetii1setlayerslputlayerlayers_let_8.validDouble (D)D
+                ALOAD 1
+                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersizesetlayerturtlesetlayerselfsetlayerturtlesetlayerselfletlayernum05numlayersmaxpxcorlet0foreachsortlayer1ask1lety205i05layersizemaxpycorsetxyxysetcolorgreysetii1setlayerslputlayerlayers_let_8.validDouble (DLorg/nlogo/nvm/Context;)D
                L12
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersizesetlayerturtlesetlayerselfsetlayerturtlesetlayerselfletlayernum05numlayersmaxpxcorlet0foreachsortlayer1ask1lety205i05layersizemaxpycorsetxyxysetcolorgreysetii1setlayerslputlayerlayers_let_8.world : Lorg/nlogo/agent/World;
@@ -6030,7 +6038,8 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 2
                 DLOAD 4
                 DMUL
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersizesetlayerturtlesetlayerselfsetlayerturtlesetlayerselfletlayernum05numlayersmaxpxcorlet0foreachsortlayer1ask1lety205i05layersizemaxpycorsetxyxysetcolorgreysetii1setlayerslputlayerlayers_let_8.validDouble (D)D
+                ALOAD 1
+                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersizesetlayerturtlesetlayerselfsetlayerturtlesetlayerselfletlayernum05numlayersmaxpxcorlet0foreachsortlayer1ask1lety205i05layersizemaxpycorsetxyxysetcolorgreysetii1setlayerslputlayerlayers_let_8.validDouble (DLorg/nlogo/nvm/Context;)D
                L14
                 DSTORE 2
                 NEW java/lang/Double
@@ -6442,7 +6451,8 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 2
                 DLOAD 4
                 DADD
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorsetxyxysetcolorgreylet205i05layersizemaxpycorsetxyxysetcolorgreysetii1_let_1.validDouble (D)D
+                ALOAD 1
+                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorsetxyxysetcolorgreylet205i05layersizemaxpycorsetxyxysetcolorgreysetii1_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
                L10
                 ALOAD 1
                 ALOAD 0
@@ -6490,7 +6500,8 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 2
                 DLOAD 4
                 DDIV
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorsetxyxysetcolorgreylet205i05layersizemaxpycorsetxyxysetcolorgreysetii1_let_1.validDouble (D)D
+                ALOAD 1
+                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorsetxyxysetcolorgreylet205i05layersizemaxpycorsetxyxysetcolorgreysetii1_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
                L14
                 DSTORE 4
                 DSTORE 2
@@ -6498,7 +6509,8 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 2
                 DLOAD 4
                 DSUB
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorsetxyxysetcolorgreylet205i05layersizemaxpycorsetxyxysetcolorgreysetii1_let_1.validDouble (D)D
+                ALOAD 1
+                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorsetxyxysetcolorgreylet205i05layersizemaxpycorsetxyxysetcolorgreysetii1_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
                L15
                 DSTORE 4
                 DSTORE 2
@@ -6506,7 +6518,8 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 2
                 DLOAD 4
                 DMUL
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorsetxyxysetcolorgreylet205i05layersizemaxpycorsetxyxysetcolorgreysetii1_let_1.validDouble (D)D
+                ALOAD 1
+                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorsetxyxysetcolorgreylet205i05layersizemaxpycorsetxyxysetcolorgreysetii1_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
                L16
                 ALOAD 0
                 GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorsetxyxysetcolorgreylet205i05layersizemaxpycorsetxyxysetcolorgreysetii1_let_1.world : Lorg/nlogo/agent/World;
@@ -6519,7 +6532,8 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 2
                 DLOAD 4
                 DMUL
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorsetxyxysetcolorgreylet205i05layersizemaxpycorsetxyxysetcolorgreysetii1_let_1.validDouble (D)D
+                ALOAD 1
+                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorsetxyxysetcolorgreylet205i05layersizemaxpycorsetxyxysetcolorgreysetii1_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
                L18
                 DSTORE 2
                 NEW java/lang/Double
@@ -6728,7 +6742,8 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 2
                 DLOAD 4
                 DADD
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorsetxyxysetcolorgreylet205i05layersizemaxpycorsetxyxysetcolorgreysetii1_setletvariable_5.validDouble (D)D
+                ALOAD 1
+                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorsetxyxysetcolorgreylet205i05layersizemaxpycorsetxyxysetcolorgreysetii1_setletvariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
                L6
                 DSTORE 2
                 NEW java/lang/Double
@@ -7028,7 +7043,8 @@ reporter procedure SIGMOID:[X]{OTPL}:
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.pow (DD)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresigmoid_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresigmoid_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 4
           DSTORE 2
@@ -7036,7 +7052,8 @@ reporter procedure SIGMOID:[X]{OTPL}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresigmoid_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresigmoid_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           DSTORE 4
           DSTORE 2
@@ -7059,7 +7076,8 @@ reporter procedure SIGMOID:[X]{OTPL}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresigmoid_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresigmoid_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L12
           DSTORE 2
           NEW java/lang/Double
@@ -7343,7 +7361,8 @@ procedure UPDATE-ACTIVATION:[INCOMING]{-T--}:
                 DLOAD 2
                 DLOAD 4
                 DMUL
-                INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateactivation_mult_1.validDouble (D)D
+                ALOAD 1
+                INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateactivation_mult_1.validDouble (DLorg/nlogo/nvm/Context;)D
                L22
                 DSTORE 2
                 NEW java/lang/Double
@@ -7407,7 +7426,8 @@ procedure UPDATE-ACTIVATION:[INCOMING]{-T--}:
          FRAME CHOP 1
           ALOAD 0
           DLOAD 3
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateactivation_setprocedurevariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateactivation_setprocedurevariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L7
           DSTORE 2
           NEW java/lang/Double
@@ -7531,7 +7551,8 @@ procedure UPDATE-ACTIVATION:[INCOMING]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateactivation_call_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateactivation_call_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L13
           DSTORE 2
           NEW java/lang/Double
@@ -7974,7 +7995,8 @@ procedure UPDATE-LINK-LOOK:[W]{---L}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelinklook_setlinkvariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelinklook_setlinkvariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           DLOAD 2

--- a/test/benchdumps/Ants.txt
+++ b/test/benchdumps/Ants.txt
@@ -93,7 +93,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -1642,7 +1643,8 @@ procedure GO:[]{O---}:
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_div_3.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_div_3.validDouble (DLorg/nlogo/nvm/Context;)D
            L7
             DSTORE 2
             NEW java/lang/Double
@@ -1846,7 +1848,8 @@ procedure GO-PATCHES:[]{-TP-}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregopatches_setpatchvariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregopatches_setpatchvariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 4
           DSTORE 2
@@ -1854,7 +1857,8 @@ procedure GO-PATCHES:[]{-TP-}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregopatches_setpatchvariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregopatches_setpatchvariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L16
           LDC 100.0
          L17
@@ -1879,7 +1883,8 @@ procedure GO-PATCHES:[]{-TP-}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregopatches_setpatchvariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregopatches_setpatchvariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L19
           DSTORE 2
           NEW java/lang/Double
@@ -2358,7 +2363,8 @@ procedure LOOK-FOR-FOOD:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurelookforfood_setpatchvariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurelookforfood_setpatchvariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -3006,7 +3012,8 @@ procedure RETURN-TO-NEST:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereturntonest_setpatchvariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereturntonest_setpatchvariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L16
           DSTORE 2
           NEW java/lang/Double
@@ -3095,7 +3102,8 @@ procedure RETURN-TO-NEST:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereturntonest_setturtlevariable_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereturntonest_setturtlevariable_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -3406,7 +3414,8 @@ procedure SETUP-FOOD:[]{-TP-}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L3
           DCONST_0
          L4
@@ -3422,7 +3431,8 @@ procedure SETUP-FOOD:[]{-TP-}:
           DLOAD 4
           ICONST_1
           INVOKEVIRTUAL org/nlogo/agent/Protractor.distance (Lorg/nlogo/api/Agent;DDZ)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L5
           LDC 5.0
          L6
@@ -3513,7 +3523,8 @@ procedure SETUP-FOOD:[]{-TP-}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L3
           LDC -0.6
          L4
@@ -3528,7 +3539,8 @@ procedure SETUP-FOOD:[]{-TP-}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 4
           DSTORE 2
@@ -3542,7 +3554,8 @@ procedure SETUP-FOOD:[]{-TP-}:
           DLOAD 4
           ICONST_1
           INVOKEVIRTUAL org/nlogo/agent/Protractor.distance (Lorg/nlogo/api/Agent;DDZ)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L7
           LDC 5.0
          L8
@@ -3633,7 +3646,8 @@ procedure SETUP-FOOD:[]{-TP-}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L3
           LDC 0.8
          L4
@@ -3648,7 +3662,8 @@ procedure SETUP-FOOD:[]{-TP-}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 4
           DSTORE 2
@@ -3662,7 +3677,8 @@ procedure SETUP-FOOD:[]{-TP-}:
           DLOAD 4
           ICONST_1
           INVOKEVIRTUAL org/nlogo/agent/Protractor.distance (Lorg/nlogo/api/Agent;DDZ)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_if_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L7
           LDC 5.0
          L8
@@ -3836,7 +3852,8 @@ procedure SETUP-FOOD:[]{-TP-}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_setpatchvariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupfood_setpatchvariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -3905,7 +3922,8 @@ procedure SETUP-NEST:[]{-TP-}:
           DLOAD 4
           ICONST_1
           INVOKEVIRTUAL org/nlogo/agent/Protractor.distance (Lorg/nlogo/api/Agent;DDZ)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnest_setpatchvariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnest_setpatchvariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           LDC 5.0
          L7
@@ -3983,7 +4001,8 @@ procedure SETUP-NEST:[]{-TP-}:
           DLOAD 4
           ICONST_1
           INVOKEVIRTUAL org/nlogo/agent/Protractor.distance (Lorg/nlogo/api/Agent;DDZ)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnest_setpatchvariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnest_setpatchvariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L7
           DSTORE 4
           DSTORE 2
@@ -3991,7 +4010,8 @@ procedure SETUP-NEST:[]{-TP-}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnest_setpatchvariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnest_setpatchvariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           DSTORE 2
           NEW java/lang/Double
@@ -4336,7 +4356,8 @@ procedure SETUP-TURTLES:[]{O---}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupturtles_right_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupturtles_right_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L2
           DSTORE 2
           ALOAD 1
@@ -5073,7 +5094,8 @@ procedure UPDATE-DISPLAY:[]{-TP-}:
           DLOAD 2
           DLOAD 10
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatedisplay_setpatchvariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatedisplay_setpatchvariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L21
           DSTORE 2
           NEW java/lang/Double
@@ -6575,7 +6597,8 @@ procedure WIGGLE:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurewiggle_right_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurewiggle_right_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L3
           DSTORE 2
           ALOAD 1

--- a/test/benchdumps/BZ.txt
+++ b/test/benchdumps/BZ.txt
@@ -93,7 +93,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -941,12 +942,14 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L17
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8.validLong (DLorg/nlogo/nvm/Context;)J
           L2D
          L18
           ALOAD 1
@@ -1021,12 +1024,14 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L24
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8.validLong (DLorg/nlogo/nvm/Context;)J
           L2D
          L25
           DSTORE 4
@@ -1035,7 +1040,8 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L26
           DSTORE 2
           NEW java/lang/Double
@@ -1196,7 +1202,8 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
          FRAME FULL [org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10 org/nlogo/nvm/Context org/nlogo/agent/Patch D org/nlogo/agent/AgentIterator] [D]
           ALOAD 0
           DLOAD 3
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L12
           DSTORE 4
           DSTORE 2
@@ -1204,7 +1211,8 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setprocedurevariable_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L13
           DSTORE 2
           NEW java/lang/Double
@@ -1327,7 +1335,8 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L18
           DCONST_1
          L19
@@ -1337,7 +1346,8 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L20
           DSTORE 4
           DSTORE 2
@@ -1360,12 +1370,14 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L22
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_11.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_11.validLong (DLorg/nlogo/nvm/Context;)J
           L2D
          L23
           ALOAD 1
@@ -1399,7 +1411,8 @@ procedure FIND-NEW-STATE:[A B S]{-TP-}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindnewstate_setpatchvariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L26
           DSTORE 2
           NEW java/lang/Double
@@ -1998,7 +2011,8 @@ procedure GO:[]{O---}:
           DLOAD 2
           DLOAD 10
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L24
           DSTORE 2
           NEW java/lang/Double
@@ -2149,12 +2163,14 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_1.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_1.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -2425,7 +2441,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 10
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L24
           DSTORE 2
           NEW java/lang/Double

--- a/test/benchdumps/Bureaucrats.txt
+++ b/test/benchdumps/Bureaucrats.txt
@@ -93,7 +93,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -623,7 +624,8 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -697,7 +699,8 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -1141,7 +1144,8 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -1215,7 +1219,8 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -1390,7 +1395,8 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_15.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_15.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -1464,7 +1470,8 @@ procedure GO:[ACTIVE-PATCHES OVERLOADED-PATCHES]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_16.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_16.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -1791,7 +1798,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L7
           DSTORE 2
           NEW java/lang/Double

--- a/test/benchdumps/CA1D.txt
+++ b/test/benchdumps/CA1D.txt
@@ -98,7 +98,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L3
           DSTORE 2
           ALOAD 1
@@ -109,7 +110,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -333,7 +335,8 @@ reporter procedure BINDIGIT:[NUMBER POWER-OF-TWO]{OTPL}:
           DLOAD 4
           DMUL
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebindigit_report_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebindigit_report_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           DSTORE 2
           NEW java/lang/Double
@@ -492,7 +495,8 @@ reporter procedure BINDIGIT:[NUMBER POWER-OF-TWO]{OTPL}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebindigit_report_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebindigit_report_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -538,7 +542,8 @@ reporter procedure BINDIGIT:[NUMBER POWER-OF-TWO]{OTPL}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebindigit_report_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebindigit_report_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L16
           DSTORE 2
           NEW java/lang/Double
@@ -744,7 +749,8 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -847,7 +853,8 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -950,7 +957,8 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -1053,7 +1061,8 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -1156,7 +1165,8 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -1259,7 +1269,8 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -1362,7 +1373,8 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_14.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_14.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -1465,7 +1477,8 @@ reporter procedure CALCULATE-RULE:[RRESULT]{OTPL}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_16.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculaterule_setprocedurevariable_16.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -5012,7 +5025,8 @@ procedure GO:[]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -5869,7 +5883,8 @@ procedure PRINT-BLOCK:[STATE _repeatlocal:1]{-T--}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureprintblock_repeatlocal_5.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureprintblock_repeatlocal_5.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -6801,7 +6816,8 @@ procedure SETUP-CONTINUE:[ON?-LIST]{O---}:
               DLOAD 2
               DLOAD 4
               DADD
-              INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupcontinue_plus_11.validDouble (D)D
+              ALOAD 1
+              INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupcontinue_plus_11.validDouble (DLorg/nlogo/nvm/Context;)D
              L5
               DSTORE 2
               NEW java/lang/Double
@@ -7429,7 +7445,8 @@ procedure SHOW-RULES:[RULES]{O---}:
               DLOAD 2
               DLOAD 4
               DSUB
-              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureshowrules_greaterthan_3.validDouble (D)D
+              ALOAD 1
+              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureshowrules_greaterthan_3.validDouble (DLorg/nlogo/nvm/Context;)D
              L6
               DSTORE 4
               DSTORE 2
@@ -7728,7 +7745,8 @@ procedure SHOW-RULES:[RULES]{O---}:
               DLOAD 2
               DLOAD 4
               DADD
-              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureshowrules_and_7.validDouble (D)D
+              ALOAD 1
+              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureshowrules_and_7.validDouble (DLorg/nlogo/nvm/Context;)D
              L13
               ALOAD 0
               GETFIELD org/nlogo/prim/_asm_procedureshowrules_and_7.world : Lorg/nlogo/agent/World;
@@ -7758,7 +7776,8 @@ procedure SHOW-RULES:[RULES]{O---}:
               DLOAD 2
               DLOAD 4
               DDIV
-              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureshowrules_and_7.validDouble (D)D
+              ALOAD 1
+              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureshowrules_and_7.validDouble (DLorg/nlogo/nvm/Context;)D
              L17
               DSTORE 2
               DLOAD 2
@@ -7790,7 +7809,8 @@ procedure SHOW-RULES:[RULES]{O---}:
               DLOAD 4
               DMUL
               DSUB
-              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureshowrules_and_7.validDouble (D)D
+              ALOAD 1
+              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureshowrules_and_7.validDouble (DLorg/nlogo/nvm/Context;)D
              L20
               DCONST_0
              L21

--- a/test/benchdumps/Erosion.txt
+++ b/test/benchdumps/Erosion.txt
@@ -93,7 +93,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -322,7 +323,8 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
               DLOAD 2
               DLOAD 4
               DADD
-              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_plus_2.validDouble (D)D
+              ALOAD 1
+              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_plus_2.validDouble (DLorg/nlogo/nvm/Context;)D
              L13
               DSTORE 2
               NEW java/lang/Double
@@ -496,7 +498,8 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L33
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -656,7 +659,8 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L43
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -816,7 +820,8 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L53
           DSTORE 4
           DSTORE 2
@@ -824,7 +829,8 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L54
           DSTORE 2
           NEW java/lang/Double
@@ -1059,7 +1065,8 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           DSTORE 4
           DSTORE 2
@@ -1067,7 +1074,8 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -1168,7 +1176,8 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setpatchvariable_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setpatchvariable_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -1351,7 +1360,8 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L33
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -1511,7 +1521,8 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L43
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -1671,7 +1682,8 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L53
           DSTORE 4
           DSTORE 2
@@ -1679,7 +1691,8 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setprocedurevariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L54
           DSTORE 2
           NEW java/lang/Double
@@ -1854,7 +1867,8 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setpatchvariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setpatchvariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -2080,7 +2094,8 @@ procedure FLOW:[TARGET AMOUNT EROSION]{-TP-}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setpatchvariable_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflow_setpatchvariable_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -2257,7 +2272,8 @@ procedure GO:[]{O---}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_if_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_if_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -2379,7 +2395,8 @@ procedure GO:[]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -3419,7 +3436,8 @@ procedure RECOLOR:[]{-TP-}:
           DLOAD 2
           DLOAD 10
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolor_setpatchvariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolor_setpatchvariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L21
           DSTORE 2
           NEW java/lang/Double
@@ -3683,7 +3701,8 @@ procedure RECOLOR:[]{-TP-}:
           DLOAD 2
           DLOAD 10
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolor_setpatchvariable_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolor_setpatchvariable_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L28
           DSTORE 2
           NEW java/lang/Double
@@ -3938,7 +3957,8 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           DLOAD 4
           ICONST_1
           INVOKEVIRTUAL org/nlogo/agent/Protractor.distance (Lorg/nlogo/api/Agent;DDZ)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L7
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.world : Lorg/nlogo/agent/World;
@@ -3966,7 +3986,8 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           DSTORE 4
           DSTORE 2
@@ -3974,7 +3995,8 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           LDC 100.0
          L12
@@ -3984,7 +4006,8 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L13
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -3999,7 +4022,8 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -4284,7 +4308,8 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_repeatlocal_13.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_repeatlocal_13.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1

--- a/test/benchdumps/Fire.txt
+++ b/test/benchdumps/Fire.txt
@@ -93,7 +93,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -806,7 +807,8 @@ procedure GO:[]{O---}:
          FRAME CHOP 1
           ALOAD 0
           DLOAD 3
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -1157,7 +1159,8 @@ procedure GO:[]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -1314,7 +1317,8 @@ procedure GO:[]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_15.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_15.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -1519,7 +1523,8 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepercentburned_report_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepercentburned_report_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           LDC 100.0
          L11
@@ -1529,7 +1534,8 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepercentburned_report_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepercentburned_report_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L12
           DSTORE 2
           NEW java/lang/Double
@@ -1831,7 +1837,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_if_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_if_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 4
           DSTORE 2
@@ -2015,7 +2022,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_if_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_if_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 4
           DSTORE 2

--- a/test/benchdumps/FireBig.txt
+++ b/test/benchdumps/FireBig.txt
@@ -93,7 +93,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -806,7 +807,8 @@ procedure GO:[]{O---}:
          FRAME CHOP 1
           ALOAD 0
           DLOAD 3
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -1157,7 +1159,8 @@ procedure GO:[]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -1314,7 +1317,8 @@ procedure GO:[]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_15.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setpatchvariable_15.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -1519,7 +1523,8 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepercentburned_report_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepercentburned_report_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           LDC 100.0
          L11
@@ -1529,7 +1534,8 @@ reporter procedure PERCENT-BURNED:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepercentburned_report_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepercentburned_report_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L12
           DSTORE 2
           NEW java/lang/Double
@@ -1831,7 +1837,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_if_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_if_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 4
           DSTORE 2
@@ -2015,7 +2022,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_if_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_if_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 4
           DSTORE 2

--- a/test/benchdumps/Flocking.txt
+++ b/test/benchdumps/Flocking.txt
@@ -262,7 +262,8 @@ reporter procedure AVERAGE-FLOCKMATE-HEADING:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageflockmateheading_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageflockmateheading_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureaverageflockmateheading_report_0.keptinstr6 : Lorg/nlogo/prim/_of;
@@ -357,7 +358,8 @@ reporter procedure AVERAGE-FLOCKMATE-HEADING:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageflockmateheading_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageflockmateheading_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L17
           DSTORE 4
           DSTORE 2
@@ -423,7 +425,8 @@ reporter procedure AVERAGE-FLOCKMATE-HEADING:[]{-T--}:
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageflockmateheading_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageflockmateheading_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
           LDC 360.0
           DREM
          L22
@@ -583,7 +586,8 @@ reporter procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
                   DLOAD 2
                   DLOAD 4
                   DADD
-                  INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_sin_1.validDouble (D)D
+                  ALOAD 1
+                  INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_sin_1.validDouble (DLorg/nlogo/nvm/Context;)D
                  L5
                   DSTORE 2
                   DLOAD 2
@@ -685,7 +689,8 @@ reporter procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
                   DLOAD 2
                   DLOAD 4
                   DADD
-                  INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_cos_4.validDouble (D)D
+                  ALOAD 1
+                  INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_cos_4.validDouble (DLorg/nlogo/nvm/Context;)D
                  L5
                   DSTORE 2
                   DLOAD 2
@@ -816,7 +821,8 @@ reporter procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_report_0.keptinstr6 : Lorg/nlogo/prim/_of;
@@ -911,7 +917,8 @@ reporter procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L17
           DSTORE 4
           DSTORE 2
@@ -977,7 +984,8 @@ reporter procedure AVERAGE-HEADING-TOWARDS-FLOCKMATES:[]{-T--}:
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureaverageheadingtowardsflockmates_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
           LDC 360.0
           DREM
          L22
@@ -1155,7 +1163,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -2168,7 +2177,8 @@ reporter procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_ifelse_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_ifelse_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           DLOAD 2
@@ -2279,7 +2289,8 @@ reporter procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_report_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_report_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -2563,7 +2574,8 @@ reporter procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_report_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_report_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           LDC 360.0
          L10
@@ -2573,7 +2585,8 @@ reporter procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_report_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_report_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -2722,7 +2735,8 @@ reporter procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_report_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_report_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           LDC 360.0
          L10
@@ -2732,7 +2746,8 @@ reporter procedure MY-SUBTRACT-HEADINGS:[H1 H2]{OTPL}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_report_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremysubtractheadings_report_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -3034,7 +3049,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtleorlinkvariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtleorlinkvariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -3090,7 +3106,8 @@ procedure SETUP:[]{O---}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L5
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetup_setxy_2.world : Lorg/nlogo/agent/World;
@@ -3105,7 +3122,8 @@ procedure SETUP:[]{O---}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L7
           DSTORE 4
           DSTORE 2
@@ -3169,7 +3187,8 @@ procedure SETUP:[]{O---}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_right_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_right_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L2
           DSTORE 2
           ALOAD 1

--- a/test/benchdumps/GasLabCirc.txt
+++ b/test/benchdumps/GasLabCirc.txt
@@ -493,7 +493,8 @@ procedure ASSIGN-COLLIDING-WALL:[TIME-TO-COLLISION WALL COLLIDING-PAIR]{-TPL}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureassigncollidingwall_setprocedurevariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureassigncollidingwall_setprocedurevariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           DSTORE 2
           NEW java/lang/Double
@@ -732,7 +733,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_3.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_3.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -1075,7 +1077,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_setprocedurevariable_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_setprocedurevariable_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -1217,7 +1220,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_setprocedurevariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_setprocedurevariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -1374,7 +1378,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -1439,7 +1444,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -1582,7 +1588,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -1725,7 +1732,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_9.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_9.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -1811,7 +1819,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -1897,7 +1906,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -1981,7 +1991,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L12
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -2071,7 +2082,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L18
           DSTORE 4
           DSTORE 2
@@ -2079,7 +2091,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L19
           DSTORE 2
           NEW java/lang/Double
@@ -2178,7 +2191,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_13.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_13.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           ALOAD 1
           ALOAD 0
@@ -2236,7 +2250,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_13.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_13.validDouble (DLorg/nlogo/nvm/Context;)D
          L20
           DSTORE 4
           DSTORE 2
@@ -2244,7 +2259,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_13.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_13.validDouble (DLorg/nlogo/nvm/Context;)D
          L21
           ALOAD 1
           ALOAD 0
@@ -2279,7 +2295,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.pow (DD)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_13.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_13.validDouble (DLorg/nlogo/nvm/Context;)D
          L25
           DSTORE 4
           DSTORE 2
@@ -2287,7 +2304,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_13.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_13.validDouble (DLorg/nlogo/nvm/Context;)D
          L26
           DSTORE 2
           NEW java/lang/Double
@@ -2384,7 +2402,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_14.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_14.validDouble (DLorg/nlogo/nvm/Context;)D
          L14
           ALOAD 1
           ALOAD 0
@@ -2442,7 +2461,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_14.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_14.validDouble (DLorg/nlogo/nvm/Context;)D
          L19
           DSTORE 4
           DSTORE 2
@@ -2450,7 +2470,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_14.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_14.validDouble (DLorg/nlogo/nvm/Context;)D
          L20
           DSTORE 4
           DSTORE 2
@@ -2458,7 +2479,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_14.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_14.validDouble (DLorg/nlogo/nvm/Context;)D
          L21
           DSTORE 2
           NEW java/lang/Double
@@ -2551,7 +2573,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_15.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_15.validDouble (DLorg/nlogo/nvm/Context;)D
          L13
           ALOAD 1
           ALOAD 0
@@ -2609,7 +2632,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_15.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_15.validDouble (DLorg/nlogo/nvm/Context;)D
          L18
           DSTORE 4
           DSTORE 2
@@ -2617,7 +2641,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_15.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_15.validDouble (DLorg/nlogo/nvm/Context;)D
          L19
           DSTORE 2
           NEW java/lang/Double
@@ -2687,7 +2712,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.pow (DD)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_16.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_16.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           LDC 4.0
          L11
@@ -2722,7 +2748,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_16.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_16.validDouble (DLorg/nlogo/nvm/Context;)D
          L14
           ALOAD 1
           ALOAD 0
@@ -2755,7 +2782,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_16.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_16.validDouble (DLorg/nlogo/nvm/Context;)D
          L17
           DSTORE 4
           DSTORE 2
@@ -2763,7 +2791,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_16.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_16.validDouble (DLorg/nlogo/nvm/Context;)D
          L18
           DSTORE 2
           NEW java/lang/Double
@@ -2977,7 +3006,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_setletvariable_19.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_setletvariable_19.validDouble (DLorg/nlogo/nvm/Context;)D
          L14
           LDC 2.0
          L15
@@ -3012,7 +3042,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_setletvariable_19.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_setletvariable_19.validDouble (DLorg/nlogo/nvm/Context;)D
          L18
           DSTORE 4
           DSTORE 2
@@ -3035,7 +3066,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_setletvariable_19.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_setletvariable_19.validDouble (DLorg/nlogo/nvm/Context;)D
          L20
           DSTORE 2
           NEW java/lang/Double
@@ -3195,7 +3227,8 @@ procedure CHECK-FOR-PARTICLE-COLLISION:[MY-X MY-Y MY-PARTICLE-SIZE MY-X-SPEED MY
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_21.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforparticlecollision_let_21.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           DSTORE 2
           NEW java/lang/Double
@@ -3460,7 +3493,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -3602,7 +3636,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -3660,7 +3695,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -3723,7 +3759,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L7
           DSTORE 2
           NEW java/lang/Double
@@ -3781,7 +3818,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -3844,7 +3882,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L7
           DSTORE 2
           NEW java/lang/Double
@@ -3905,7 +3944,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L5
           DSTORE 4
           DSTORE 2
@@ -3913,7 +3953,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -3974,7 +4015,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L5
           DSTORE 4
           DSTORE 2
@@ -3982,7 +4024,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -4043,7 +4086,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L5
           DSTORE 4
           DSTORE 2
@@ -4051,7 +4095,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -4112,7 +4157,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_9.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_9.validDouble (DLorg/nlogo/nvm/Context;)D
          L5
           DSTORE 4
           DSTORE 2
@@ -4120,7 +4166,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_9.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_9.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -4206,7 +4253,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -4292,7 +4340,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -4378,7 +4427,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -4464,7 +4514,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_13.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_13.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -4631,7 +4682,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_16.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_16.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           DSTORE 2
           NEW java/lang/Double
@@ -4935,7 +4987,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_23.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_23.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           DSTORE 2
           NEW java/lang/Double
@@ -5239,7 +5292,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_30.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_30.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           DSTORE 2
           NEW java/lang/Double
@@ -5543,7 +5597,8 @@ procedure CHECK-FOR-WALL-COLLISION:[X-SPEED Y-SPEED XPOS-PLANE XNEG-PLANE YPOS-P
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_37.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforwallcollision_setprocedurevariable_37.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           DSTORE 2
           NEW java/lang/Double
@@ -6224,7 +6279,8 @@ procedure COLLIDE-WINNERS:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewinners_setturtlevariable_9.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewinners_setturtlevariable_9.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -6773,7 +6829,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L12
           DSTORE 2
           DLOAD 2
@@ -6786,7 +6843,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -6895,7 +6953,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L12
           DSTORE 2
           DLOAD 2
@@ -6908,7 +6967,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -7025,7 +7085,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_9.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_9.validDouble (DLorg/nlogo/nvm/Context;)D
          L13
           DSTORE 2
           DLOAD 2
@@ -7038,7 +7099,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_9.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_9.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -7155,7 +7217,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L13
           DSTORE 2
           DLOAD 2
@@ -7168,7 +7231,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -7285,7 +7349,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L22
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7345,7 +7410,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L27
           DSTORE 4
           DSTORE 2
@@ -7353,7 +7419,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -7426,7 +7493,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L32
           DSTORE 4
           DSTORE 2
@@ -7449,7 +7517,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L34
           DSTORE 2
           NEW java/lang/Double
@@ -7513,7 +7582,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7547,7 +7617,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -7611,7 +7682,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_13.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_13.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7645,7 +7717,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_13.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_13.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -7740,7 +7813,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_14.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_14.validDouble (DLorg/nlogo/nvm/Context;)D
            L13
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -7800,7 +7874,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_14.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_14.validDouble (DLorg/nlogo/nvm/Context;)D
            L18
             DSTORE 4
             DSTORE 2
@@ -7808,7 +7883,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DADD
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_14.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_14.validDouble (DLorg/nlogo/nvm/Context;)D
            L19
             DSTORE 2
             DLOAD 2
@@ -8087,7 +8163,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_16.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_16.validDouble (DLorg/nlogo/nvm/Context;)D
           LDC 360.0
           DREM
          L20
@@ -8098,7 +8175,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_16.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_16.validDouble (DLorg/nlogo/nvm/Context;)D
          L24
           DSTORE 2
           NEW java/lang/Double
@@ -8318,7 +8396,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (DLorg/nlogo/nvm/Context;)D
            L13
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -8378,7 +8457,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (DLorg/nlogo/nvm/Context;)D
            L18
             DSTORE 4
             DSTORE 2
@@ -8386,7 +8466,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DADD
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (DLorg/nlogo/nvm/Context;)D
            L19
             DSTORE 2
             DLOAD 2
@@ -8783,7 +8864,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_22.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_22.validDouble (DLorg/nlogo/nvm/Context;)D
           LDC 360.0
           DREM
          L20
@@ -8794,7 +8876,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_22.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_22.validDouble (DLorg/nlogo/nvm/Context;)D
          L24
           DSTORE 2
           NEW java/lang/Double
@@ -10485,7 +10568,8 @@ procedure GO:[]{O---}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_jump_37.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_jump_37.validDouble (DLorg/nlogo/nvm/Context;)D
          L14
           DSTORE 2
          L7
@@ -10644,7 +10728,8 @@ procedure GO:[]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_if_42.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_if_42.validDouble (DLorg/nlogo/nvm/Context;)D
          L7
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -11426,7 +11511,8 @@ procedure MAKE-PARTICLES:[]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeparticles_setturtlevariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeparticles_setturtlevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L16
           DSTORE 2
           ALOAD 0
@@ -11436,7 +11522,8 @@ procedure MAKE-PARTICLES:[]{O---}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeparticles_setturtlevariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeparticles_setturtlevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L17
           DSTORE 4
           DSTORE 2
@@ -11444,7 +11531,8 @@ procedure MAKE-PARTICLES:[]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeparticles_setturtlevariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeparticles_setturtlevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L18
           DSTORE 2
           NEW java/lang/Double
@@ -11501,7 +11589,8 @@ procedure MAKE-PARTICLES:[]{O---}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeparticles_mult_3.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeparticles_mult_3.validDouble (DLorg/nlogo/nvm/Context;)D
            L3
             DSTORE 2
             NEW java/lang/Double
@@ -11542,7 +11631,8 @@ procedure MAKE-PARTICLES:[]{O---}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeparticles_setturtlevariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeparticles_setturtlevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L5
           DSTORE 2
           NEW java/lang/Double
@@ -11813,7 +11903,8 @@ reporter procedure OVERLAPPING?:[]{-T--}:
               DLOAD 2
               DLOAD 4
               DADD
-              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureoverlapping_lessthan_1.validDouble (D)D
+              ALOAD 1
+              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureoverlapping_lessthan_1.validDouble (DLorg/nlogo/nvm/Context;)D
              L18
               LDC 2.0
              L19
@@ -11838,7 +11929,8 @@ reporter procedure OVERLAPPING?:[]{-T--}:
               DLOAD 2
               DLOAD 4
               DDIV
-              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureoverlapping_lessthan_1.validDouble (D)D
+              ALOAD 1
+              INVOKEVIRTUAL org/nlogo/prim/_asm_procedureoverlapping_lessthan_1.validDouble (DLorg/nlogo/nvm/Context;)D
              L21
               DSTORE 4
               DSTORE 2
@@ -11907,7 +11999,8 @@ reporter procedure OVERLAPPING?:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureoverlapping_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureoverlapping_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L7
           LDC 2.0
          L8
@@ -11932,7 +12025,8 @@ reporter procedure OVERLAPPING?:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureoverlapping_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureoverlapping_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           DSTORE 3
           ASTORE 2
@@ -12279,7 +12373,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L19
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -12310,7 +12405,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L23
           DSTORE 4
           DSTORE 2
@@ -12318,7 +12414,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L24
           DSTORE 2
           ALOAD 0
@@ -12328,7 +12425,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L25
           DSTORE 4
           DSTORE 2
@@ -12336,7 +12434,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L26
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurerandomposition_setxy_0.kept15_value : Lorg/nlogo/core/LogoList;
@@ -12425,7 +12524,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L34
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -12456,7 +12556,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L38
           DSTORE 4
           DSTORE 2
@@ -12464,7 +12565,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L39
           DSTORE 2
           ALOAD 0
@@ -12474,7 +12576,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L40
           DSTORE 4
           DSTORE 2
@@ -12482,7 +12585,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L41
           DSTORE 4
           DSTORE 2
@@ -12993,7 +13097,8 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorbanded_ifelse_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorbanded_ifelse_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 3
           ASTORE 2
@@ -13159,7 +13264,8 @@ procedure RECOLOR-BANDED:[AVG-SPEED]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorbanded_ifelse_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorbanded_ifelse_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 3
           ASTORE 2
@@ -13433,7 +13539,8 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorshaded_ifelse_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorshaded_ifelse_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 3
           ASTORE 2
@@ -13560,7 +13667,8 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorshaded_setturtleorlinkvariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorshaded_setturtleorlinkvariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L14
           LDC 3.0
          L15
@@ -13596,7 +13704,8 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorshaded_setturtleorlinkvariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorshaded_setturtleorlinkvariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L18
           DSTORE 4
           DSTORE 2
@@ -13619,7 +13728,8 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorshaded_setturtleorlinkvariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorshaded_setturtleorlinkvariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L20
           DSTORE 4
           DSTORE 2
@@ -13627,7 +13737,8 @@ procedure RECOLOR-SHADED:[AVG-SPEED]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorshaded_setturtleorlinkvariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorshaded_setturtleorlinkvariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L21
           DSTORE 2
           NEW java/lang/Double
@@ -13944,7 +14055,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -14063,7 +14175,8 @@ procedure SETUP:[]{O---}:
           ALOAD 0
           DLOAD 2
           INVOKESTATIC java/lang/StrictMath.ceil (D)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 4
           DSTORE 2
@@ -14086,7 +14199,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -14845,7 +14959,8 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresortcollisions_ifelse_18.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresortcollisions_ifelse_18.validDouble (DLorg/nlogo/nvm/Context;)D
          L7
           DCONST_1
          L8
@@ -14937,7 +15052,8 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresortcollisions_setobservervariable_19.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresortcollisions_setobservervariable_19.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           DSTORE 2
           NEW java/lang/Double
@@ -15769,7 +15885,8 @@ procedure TEST-TIME-REVERSAL:[N OLD-CLOCK]{O---}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduretesttimereversal_while_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduretesttimereversal_while_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           DSTORE 4
           DSTORE 2

--- a/test/benchdumps/GasLabNew.txt
+++ b/test/benchdumps/GasLabNew.txt
@@ -95,7 +95,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -1275,7 +1276,8 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
             DLOAD 2
             DLOAD 4
             DADD
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_16.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_16.validDouble (DLorg/nlogo/nvm/Context;)D
            L8
             DSTORE 2
             NEW java/lang/Double
@@ -1366,7 +1368,8 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_17.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_17.validDouble (DLorg/nlogo/nvm/Context;)D
            L5
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -1413,7 +1416,8 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_17.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_17.validDouble (DLorg/nlogo/nvm/Context;)D
            L10
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -1460,7 +1464,8 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_17.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_17.validDouble (DLorg/nlogo/nvm/Context;)D
            L26
             DSTORE 2
             DLOAD 2
@@ -1521,7 +1526,8 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_17.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_17.validDouble (DLorg/nlogo/nvm/Context;)D
            L32
             DSTORE 4
             DSTORE 2
@@ -1529,7 +1535,8 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
             DLOAD 2
             DLOAD 4
             DADD
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_17.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_17.validDouble (DLorg/nlogo/nvm/Context;)D
            L33
             DSTORE 2
             NEW java/lang/Double
@@ -1641,7 +1648,8 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_setturtlevariable_19.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_setturtlevariable_19.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -1730,7 +1738,8 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
             DLOAD 2
             DLOAD 4
             DADD
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_20.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_20.validDouble (DLorg/nlogo/nvm/Context;)D
            L8
             DSTORE 2
             NEW java/lang/Double
@@ -1821,7 +1830,8 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_21.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_21.validDouble (DLorg/nlogo/nvm/Context;)D
            L5
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -1868,7 +1878,8 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_21.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_21.validDouble (DLorg/nlogo/nvm/Context;)D
            L10
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -1915,7 +1926,8 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_21.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_21.validDouble (DLorg/nlogo/nvm/Context;)D
            L26
             DSTORE 2
             DLOAD 2
@@ -1976,7 +1988,8 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_21.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_21.validDouble (DLorg/nlogo/nvm/Context;)D
            L32
             DSTORE 4
             DSTORE 2
@@ -1984,7 +1997,8 @@ procedure BOUNCE:[NEW-PATCH NEW-PX NEW-PY]{-T--}:
             DLOAD 2
             DLOAD 4
             DADD
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_21.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_plus_21.validDouble (DLorg/nlogo/nvm/Context;)D
            L33
             DSTORE 2
             NEW java/lang/Double
@@ -2291,7 +2305,8 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
          FRAME FULL [org/nlogo/prim/_asm_procedurecalculatepressure_setobservervariable_0 org/nlogo/nvm/Context org/nlogo/core/LogoList D java/util/Iterator] [D]
           ALOAD 0
           DLOAD 3
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatepressure_setobservervariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatepressure_setobservervariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L12
           DSTORE 4
           DSTORE 2
@@ -2299,7 +2314,8 @@ procedure CALCULATE-PRESSURE:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatepressure_setobservervariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatepressure_setobservervariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L13
           DSTORE 2
           NEW java/lang/Double
@@ -2803,7 +2819,8 @@ procedure CALCULATE-TICK-LENGTH:[]{OTPL}:
           ALOAD 0
           DLOAD 2
           INVOKESTATIC java/lang/StrictMath.ceil (D)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculateticklength_setobservervariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculateticklength_setobservervariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 4
           DSTORE 2
@@ -2826,7 +2843,8 @@ procedure CALCULATE-TICK-LENGTH:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculateticklength_setobservervariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculateticklength_setobservervariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -4060,7 +4078,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L2
           DSTORE 2
           NEW java/lang/Double
@@ -4169,7 +4188,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L12
           DSTORE 2
           DLOAD 2
@@ -4182,7 +4202,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -4291,7 +4312,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L12
           DSTORE 2
           DLOAD 2
@@ -4304,7 +4326,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -4421,7 +4444,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L13
           DSTORE 2
           DLOAD 2
@@ -4434,7 +4458,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -4551,7 +4576,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_9.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_9.validDouble (DLorg/nlogo/nvm/Context;)D
          L13
           DSTORE 2
           DLOAD 2
@@ -4564,7 +4590,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_9.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_9.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -4681,7 +4708,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L22
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -4741,7 +4769,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L27
           DSTORE 4
           DSTORE 2
@@ -4749,7 +4778,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -4822,7 +4852,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L32
           DSTORE 4
           DSTORE 2
@@ -4845,7 +4876,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L34
           DSTORE 2
           NEW java/lang/Double
@@ -4909,7 +4941,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -4943,7 +4976,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -5007,7 +5041,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5041,7 +5076,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setprocedurevariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -5136,7 +5172,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_13.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_13.validDouble (DLorg/nlogo/nvm/Context;)D
            L13
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5196,7 +5233,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_13.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_13.validDouble (DLorg/nlogo/nvm/Context;)D
            L18
             DSTORE 4
             DSTORE 2
@@ -5204,7 +5242,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DADD
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_13.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_13.validDouble (DLorg/nlogo/nvm/Context;)D
            L19
             DSTORE 2
             DLOAD 2
@@ -5303,7 +5342,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_14.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_14.validDouble (DLorg/nlogo/nvm/Context;)D
            L5
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -5350,7 +5390,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_14.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_14.validDouble (DLorg/nlogo/nvm/Context;)D
            L10
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -5397,7 +5438,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_14.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_14.validDouble (DLorg/nlogo/nvm/Context;)D
            L22
             DSTORE 2
             NEW java/lang/Double
@@ -5650,7 +5692,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_16.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_16.validDouble (DLorg/nlogo/nvm/Context;)D
           LDC 360.0
           DREM
          L20
@@ -5661,7 +5704,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_16.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_16.validDouble (DLorg/nlogo/nvm/Context;)D
          L24
           DSTORE 2
           NEW java/lang/Double
@@ -5881,7 +5925,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (DLorg/nlogo/nvm/Context;)D
            L13
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -5941,7 +5986,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (DLorg/nlogo/nvm/Context;)D
            L18
             DSTORE 4
             DSTORE 2
@@ -5949,7 +5995,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DADD
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_sqrt_18.validDouble (DLorg/nlogo/nvm/Context;)D
            L19
             DSTORE 2
             DLOAD 2
@@ -6166,7 +6213,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_21.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_21.validDouble (DLorg/nlogo/nvm/Context;)D
            L5
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -6213,7 +6261,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_21.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_21.validDouble (DLorg/nlogo/nvm/Context;)D
            L10
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -6260,7 +6309,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_21.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_mult_21.validDouble (DLorg/nlogo/nvm/Context;)D
            L22
             DSTORE 2
             NEW java/lang/Double
@@ -6631,7 +6681,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_25.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_25.validDouble (DLorg/nlogo/nvm/Context;)D
           LDC 360.0
           DREM
          L20
@@ -6642,7 +6693,8 @@ procedure COLLIDE-WITH:[OTHER-PARTICLE MASS2 SPEED2 HEADING2 THETA V1T V1L V2T V
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_25.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecollidewith_setturtlevariable_25.validDouble (DLorg/nlogo/nvm/Context;)D
          L24
           DSTORE 2
           NEW java/lang/Double
@@ -7093,7 +7145,8 @@ procedure DO-PLOTTING:[]{OTPL}:
             INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
             I2D
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplotting_mean_3.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplotting_mean_3.validDouble (DLorg/nlogo/nvm/Context;)D
            L13
             DSTORE 2
             NEW java/lang/Double
@@ -7758,7 +7811,8 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefadepatches_setpatchvariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefadepatches_setpatchvariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -7886,7 +7940,8 @@ procedure FADE-PATCHES:[TRACE-PATCHES]{OTPL}:
           DLOAD 2
           ICONST_0
           INVOKESTATIC org/nlogo/api/Approximate.approximate (DI)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefadepatches_if_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefadepatches_if_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DCONST_0
          L16
@@ -8357,7 +8412,8 @@ procedure GO:[OLD-CLOCK]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_ask_11.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_ask_11.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           LLOAD 4
           L2D
@@ -8778,7 +8834,8 @@ procedure GO:[OLD-CLOCK]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_if_17.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_if_17.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           DSTORE 2
           DLOAD 2
@@ -8953,7 +9010,8 @@ procedure GO:[OLD-CLOCK]{O---}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_19.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_19.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -9321,7 +9379,8 @@ procedure GO:[OLD-CLOCK]{O---}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setturtlevariable_33.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setturtlevariable_33.validDouble (DLorg/nlogo/nvm/Context;)D
          L7
           DSTORE 2
           NEW java/lang/Double
@@ -9441,7 +9500,8 @@ procedure GO:[OLD-CLOCK]{O---}:
               DLOAD 2
               DLOAD 4
               DSUB
-              INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_greaterthan_36.validDouble (D)D
+              ALOAD 1
+              INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_greaterthan_36.validDouble (DLorg/nlogo/nvm/Context;)D
              L9
               LDC 0.4
              L10
@@ -10698,7 +10758,8 @@ procedure MAKE-CLOCKER:[]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeclocker_setxy_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeclocker_setxy_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -10733,7 +10794,8 @@ procedure MAKE-CLOCKER:[]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeclocker_setxy_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremakeclocker_setxy_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 4
           DSTORE 2
@@ -11104,7 +11166,8 @@ procedure MOVE:[OLD-PATCH]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremove_jump_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremove_jump_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L14
           DSTORE 2
          L7
@@ -12290,7 +12353,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           LDC 2.0
          L16
@@ -12325,7 +12389,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L19
           LDC 2.0
          L20
@@ -12335,7 +12400,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L21
           DSTORE 2
           ALOAD 0
@@ -12345,7 +12411,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L22
           DSTORE 4
           DSTORE 2
@@ -12353,7 +12420,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L23
           DCONST_1
          L24
@@ -12388,7 +12456,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L27
           LDC 2.0
          L28
@@ -12423,7 +12492,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L31
           LDC 2.0
          L32
@@ -12433,7 +12503,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L33
           DSTORE 2
           ALOAD 0
@@ -12443,7 +12514,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L34
           DSTORE 4
           DSTORE 2
@@ -12451,7 +12523,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L35
           DSTORE 4
           DSTORE 2
@@ -12516,7 +12589,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setturtlevariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setturtlevariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L5
           DSTORE 2
           NEW java/lang/Double
@@ -12933,7 +13007,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -13013,7 +13088,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           DSTORE 4
           DSTORE 2
@@ -13021,7 +13097,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DCONST_1
          L12
@@ -13031,7 +13108,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L13
           DSTORE 2
           NEW java/lang/Double
@@ -13111,7 +13189,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           DSTORE 4
           DSTORE 2
@@ -13119,7 +13198,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DCONST_1
          L12
@@ -13129,7 +13209,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L13
           DSTORE 2
           NEW java/lang/Double
@@ -13491,7 +13572,8 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_2.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_2.validDouble (DLorg/nlogo/nvm/Context;)D
            L6
             DSTORE 2
             NEW java/lang/Double
@@ -13560,13 +13642,15 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_ceil_4.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_ceil_4.validDouble (DLorg/nlogo/nvm/Context;)D
            L7
             DSTORE 2
             ALOAD 0
             DLOAD 2
             INVOKESTATIC java/lang/StrictMath.ceil (D)D
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_ceil_4.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_ceil_4.validDouble (DLorg/nlogo/nvm/Context;)D
            L8
             DSTORE 2
             NEW java/lang/Double
@@ -13711,7 +13795,8 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_15.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_15.validDouble (DLorg/nlogo/nvm/Context;)D
            L11
             DSTORE 4
             DSTORE 2
@@ -13719,7 +13804,8 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_15.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_15.validDouble (DLorg/nlogo/nvm/Context;)D
            L12
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -13754,7 +13840,8 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_15.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_15.validDouble (DLorg/nlogo/nvm/Context;)D
            L16
             DSTORE 4
             DSTORE 2
@@ -13762,7 +13849,8 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_15.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_15.validDouble (DLorg/nlogo/nvm/Context;)D
            L17
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -13795,7 +13883,8 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_15.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_15.validDouble (DLorg/nlogo/nvm/Context;)D
            L20
             DSTORE 2
             NEW java/lang/Double
@@ -13864,13 +13953,15 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_ceil_17.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_ceil_17.validDouble (DLorg/nlogo/nvm/Context;)D
            L7
             DSTORE 2
             ALOAD 0
             DLOAD 2
             INVOKESTATIC java/lang/StrictMath.ceil (D)D
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_ceil_17.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_ceil_17.validDouble (DLorg/nlogo/nvm/Context;)D
            L8
             DSTORE 2
             NEW java/lang/Double
@@ -14046,7 +14137,8 @@ procedure SETUP-PARTICLE:[]{-T--}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupparticle_mult_2.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupparticle_mult_2.validDouble (DLorg/nlogo/nvm/Context;)D
            L5
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -14093,7 +14185,8 @@ procedure SETUP-PARTICLE:[]{-T--}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupparticle_mult_2.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupparticle_mult_2.validDouble (DLorg/nlogo/nvm/Context;)D
            L10
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -14140,7 +14233,8 @@ procedure SETUP-PARTICLE:[]{-T--}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupparticle_mult_2.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupparticle_mult_2.validDouble (DLorg/nlogo/nvm/Context;)D
            L22
             DSTORE 2
             NEW java/lang/Double
@@ -14247,13 +14341,15 @@ procedure SETUP-PLOTZ:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupplotz_ceil_2.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupplotz_ceil_2.validDouble (DLorg/nlogo/nvm/Context;)D
            L7
             DSTORE 2
             ALOAD 0
             DLOAD 2
             INVOKESTATIC java/lang/StrictMath.ceil (D)D
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupplotz_ceil_2.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupplotz_ceil_2.validDouble (DLorg/nlogo/nvm/Context;)D
            L8
             DSTORE 2
             NEW java/lang/Double
@@ -14892,7 +14988,8 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -15033,7 +15130,8 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double

--- a/test/benchdumps/GasLabOld.txt
+++ b/test/benchdumps/GasLabOld.txt
@@ -93,7 +93,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -395,7 +396,8 @@ procedure BOUNCE:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_if_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_if_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L31
           DSTORE 4
           DSTORE 2
@@ -508,7 +510,8 @@ procedure BOUNCE:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_setturtlevariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_setturtlevariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -728,7 +731,8 @@ procedure BOUNCE:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_if_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_if_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L31
           DSTORE 4
           DSTORE 2
@@ -812,7 +816,8 @@ procedure BOUNCE:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_setturtlevariable_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebounce_setturtlevariable_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -1004,7 +1009,8 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L17
           DSTORE 2
           DLOAD 2
@@ -1017,7 +1023,8 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L19
           DSTORE 2
           NEW java/lang/Double
@@ -1154,7 +1161,8 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L17
           DSTORE 2
           DLOAD 2
@@ -1167,7 +1175,8 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L19
           DSTORE 2
           NEW java/lang/Double
@@ -1339,7 +1348,8 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L22
           DSTORE 2
           DLOAD 2
@@ -1352,7 +1362,8 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L24
           DSTORE 2
           NEW java/lang/Double
@@ -1524,7 +1535,8 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L22
           DSTORE 2
           DLOAD 2
@@ -1537,7 +1549,8 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L24
           DSTORE 2
           NEW java/lang/Double
@@ -1680,7 +1693,8 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setprocedurevariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setprocedurevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -1766,7 +1780,8 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setprocedurevariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setprocedurevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L36
           DSTORE 4
           DSTORE 2
@@ -1774,7 +1789,8 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setprocedurevariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setprocedurevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L20
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -1860,7 +1876,8 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setprocedurevariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setprocedurevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L40
           DSTORE 4
           DSTORE 2
@@ -1883,7 +1900,8 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setprocedurevariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setprocedurevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L42
           DSTORE 2
           NEW java/lang/Double
@@ -1974,7 +1992,8 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -2021,7 +2040,8 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L19
           DSTORE 2
           NEW java/lang/Double
@@ -2127,7 +2147,8 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L4
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -2174,7 +2195,8 @@ procedure CALCULATE-VELOCITY-COMPONENTS:[VCM]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecalculatevelocitycomponents_setturtlevariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L19
           DSTORE 2
           NEW java/lang/Double
@@ -2782,7 +2804,8 @@ procedure CHECK-FOR-COLLISION:[]{-T--}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforcollision_call_4.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecheckforcollision_call_4.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           LLOAD 4
           L2D
@@ -5004,7 +5027,8 @@ procedure FADE:[]{-TP-}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefade_setpatchvariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefade_setpatchvariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -5091,7 +5115,8 @@ procedure FADE:[]{-TP-}:
           DLOAD 2
           ICONST_0
           INVOKESTATIC org/nlogo/api/Approximate.approximate (DI)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefade_if_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefade_if_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L7
           LDC 40.0
          L8
@@ -5924,7 +5949,8 @@ procedure GO:[]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setobservervariable_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -6791,7 +6817,8 @@ procedure MOVE:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremove_jump_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremove_jump_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
          L7
@@ -7074,7 +7101,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           LDC 2.0
          L16
@@ -7109,7 +7137,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L19
           LDC 2.0
          L20
@@ -7119,12 +7148,14 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L21
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -7184,7 +7215,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L28
           DCONST_1
          L29
@@ -7219,7 +7251,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L32
           LDC 2.0
          L33
@@ -7254,7 +7287,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L36
           LDC 2.0
          L37
@@ -7264,12 +7298,14 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L38
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -7329,7 +7365,8 @@ procedure RANDOM-POSITION:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerandomposition_setxy_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L45
           DSTORE 4
           DSTORE 2
@@ -7552,7 +7589,8 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L18
           DSTORE 3
           ASTORE 2
@@ -7934,7 +7972,8 @@ procedure RECOLOR-TURTLE:[THE-TURTLE]{OTPL}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorturtle_ifelse_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L18
           DSTORE 3
           ASTORE 2
@@ -8420,7 +8459,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -8506,7 +8546,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L29
           DSTORE 4
           DSTORE 2
@@ -8514,7 +8555,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L30
           DSTORE 2
           DLOAD 2
@@ -8934,7 +8976,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
           LDC 360.0
           DREM
          L26
@@ -8945,7 +8988,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L30
           DSTORE 2
           NEW java/lang/Double
@@ -9214,7 +9258,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -9358,7 +9403,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
           LDC 360.0
           DREM
          L28
@@ -9369,7 +9415,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L32
           DSTORE 2
           NEW java/lang/Double
@@ -9638,7 +9685,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -9782,7 +9830,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
           LDC 360.0
           DREM
          L28
@@ -9793,7 +9842,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L32
           DSTORE 2
           NEW java/lang/Double
@@ -10194,7 +10244,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
           LDC 360.0
           DREM
          L26
@@ -10205,7 +10256,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L30
           DSTORE 2
           NEW java/lang/Double
@@ -10341,7 +10393,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setprocedurevariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setprocedurevariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -10427,7 +10480,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setprocedurevariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setprocedurevariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L26
           DSTORE 4
           DSTORE 2
@@ -10435,7 +10489,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setprocedurevariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setprocedurevariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L27
           DSTORE 2
           DLOAD 2
@@ -11009,7 +11064,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_17.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_17.validDouble (DLorg/nlogo/nvm/Context;)D
           LDC 360.0
           DREM
          L26
@@ -11020,7 +11076,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_17.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_17.validDouble (DLorg/nlogo/nvm/Context;)D
          L30
           DSTORE 2
           NEW java/lang/Double
@@ -11289,7 +11346,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_20.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_20.validDouble (DLorg/nlogo/nvm/Context;)D
          L5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -11433,7 +11491,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_20.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_20.validDouble (DLorg/nlogo/nvm/Context;)D
           LDC 360.0
           DREM
          L28
@@ -11444,7 +11503,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_20.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_20.validDouble (DLorg/nlogo/nvm/Context;)D
          L32
           DSTORE 2
           NEW java/lang/Double
@@ -11713,7 +11773,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_23.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_23.validDouble (DLorg/nlogo/nvm/Context;)D
          L5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -11857,7 +11918,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_23.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_23.validDouble (DLorg/nlogo/nvm/Context;)D
           LDC 360.0
           DREM
          L28
@@ -11868,7 +11930,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_23.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_23.validDouble (DLorg/nlogo/nvm/Context;)D
          L32
           DSTORE 2
           NEW java/lang/Double
@@ -12269,7 +12332,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           INVOKESTATIC java/lang/StrictMath.toDegrees (D)D
           LDC 360.0
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_26.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_26.validDouble (DLorg/nlogo/nvm/Context;)D
           LDC 360.0
           DREM
          L26
@@ -12280,7 +12344,8 @@ procedure SET-NEW-SPEED-AND-HEADINGS:[NEW-NEW-SPEED NEW-HEADING]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_26.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetnewspeedandheadings_setturtlevariable_26.validDouble (DLorg/nlogo/nvm/Context;)D
          L30
           DSTORE 2
           NEW java/lang/Double
@@ -12622,7 +12687,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           LDC 100.0
          L10
@@ -12647,14 +12713,16 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L12
           DSTORE 2
           ALOAD 0
           DLOAD 2
           ICONST_0
           INVOKESTATIC org/nlogo/api/Approximate.approximate (DI)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L13
           DSTORE 2
           NEW java/lang/Double
@@ -12980,7 +13048,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_call_10.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_call_10.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           LLOAD 4
           L2D
@@ -13258,7 +13327,8 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_2.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_2.validDouble (DLorg/nlogo/nvm/Context;)D
            L6
             DSTORE 2
             NEW java/lang/Double
@@ -13327,14 +13397,16 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_round_4.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_round_4.validDouble (DLorg/nlogo/nvm/Context;)D
            L7
             DSTORE 2
             ALOAD 0
             DLOAD 2
             ICONST_0
             INVOKESTATIC org/nlogo/api/Approximate.approximate (DI)D
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_round_4.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_round_4.validDouble (DLorg/nlogo/nvm/Context;)D
            L8
             DSTORE 2
             NEW java/lang/Double
@@ -13444,7 +13516,8 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_13.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_13.validDouble (DLorg/nlogo/nvm/Context;)D
            L11
             DSTORE 4
             DSTORE 2
@@ -13452,7 +13525,8 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_13.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_13.validDouble (DLorg/nlogo/nvm/Context;)D
            L12
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -13487,7 +13561,8 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_13.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_13.validDouble (DLorg/nlogo/nvm/Context;)D
            L16
             DSTORE 4
             DSTORE 2
@@ -13495,7 +13570,8 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_13.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_13.validDouble (DLorg/nlogo/nvm/Context;)D
            L17
             ALOAD 1
             GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -13528,7 +13604,8 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_13.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_mult_13.validDouble (DLorg/nlogo/nvm/Context;)D
            L20
             DSTORE 2
             NEW java/lang/Double
@@ -13597,14 +13674,16 @@ procedure SETUP-HISTOGRAMS:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_round_15.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_round_15.validDouble (DLorg/nlogo/nvm/Context;)D
            L7
             DSTORE 2
             ALOAD 0
             DLOAD 2
             ICONST_0
             INVOKESTATIC org/nlogo/api/Approximate.approximate (DI)D
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_round_15.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuphistograms_round_15.validDouble (DLorg/nlogo/nvm/Context;)D
            L8
             DSTORE 2
             NEW java/lang/Double
@@ -13862,7 +13941,8 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setturtlevariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setturtlevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L5
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -13909,7 +13989,8 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setturtlevariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setturtlevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -13956,7 +14037,8 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setturtlevariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setturtlevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L25
           DSTORE 2
           NEW java/lang/Double
@@ -14632,7 +14714,8 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -14790,7 +14873,8 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
           I2D
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_11.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_11.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -14986,14 +15070,16 @@ procedure UPDATE-VARIABLES:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           DSTORE 2
           ALOAD 0
           DLOAD 2
           ICONST_0
           INVOKESTATIC org/nlogo/api/Approximate.approximate (DI)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatevariables_setobservervariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double

--- a/test/benchdumps/GridWalk.txt
+++ b/test/benchdumps/GridWalk.txt
@@ -93,7 +93,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1

--- a/test/benchdumps/Heatbugs.txt
+++ b/test/benchdumps/Heatbugs.txt
@@ -93,7 +93,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -394,7 +395,8 @@ procedure BUG-MOVE:[TARGET TRIES]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebugmove_setprocedurevariable_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebugmove_setprocedurevariable_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -1435,7 +1437,8 @@ procedure RECOLOR-PATCHES:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorpatches_setpatchvariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorpatches_setpatchvariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 4
           DSTORE 2
@@ -1443,7 +1446,8 @@ procedure RECOLOR-PATCHES:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorpatches_setpatchvariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorpatches_setpatchvariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L16
           DSTORE 2
           NEW java/lang/Double
@@ -1638,7 +1642,8 @@ procedure RECOLOR-PATCHES:[]{OTPL}:
           DLOAD 2
           DLOAD 10
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorpatches_setpatchvariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorpatches_setpatchvariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L21
           DSTORE 2
           NEW java/lang/Double
@@ -1985,7 +1990,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L16
           DSTORE 2
           DLOAD 2
@@ -2003,7 +2009,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_6.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_6.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -2063,7 +2070,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L25
           DSTORE 2
           NEW java/lang/Double
@@ -2191,7 +2199,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L16
           DSTORE 2
           DLOAD 2
@@ -2209,7 +2218,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_7.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_7.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -2269,7 +2279,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L25
           DSTORE 2
           NEW java/lang/Double
@@ -2399,7 +2410,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L16
           DSTORE 2
           DLOAD 2
@@ -2569,7 +2581,8 @@ procedure STEP:[TARGET]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurestep_setturtlevariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurestep_setturtlevariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L16
           DSTORE 2
           DLOAD 2
@@ -2770,7 +2783,8 @@ procedure STEP:[TARGET]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurestep_setpatchvariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurestep_setpatchvariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L16
           DSTORE 2
           NEW java/lang/Double
@@ -3088,7 +3102,8 @@ procedure STEP:[TARGET]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurestep_setpatchvariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurestep_setpatchvariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L16
           DSTORE 2
           NEW java/lang/Double

--- a/test/benchdumps/Ising.txt
+++ b/test/benchdumps/Ising.txt
@@ -102,7 +102,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -381,7 +382,8 @@ procedure FLIP:[]{-TP-}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflip_setobservervariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflip_setobservervariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 4
           DSTORE 2
@@ -389,7 +391,8 @@ procedure FLIP:[]{-TP-}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflip_setobservervariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureflip_setobservervariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L16
           DSTORE 2
           NEW java/lang/Double
@@ -700,7 +703,8 @@ reporter procedure MAGNETIZATION:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremagnetization_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremagnetization_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           DSTORE 2
           NEW java/lang/Double
@@ -1278,7 +1282,8 @@ procedure SETUP:[INITIAL-MAGNETIZATION]{O---}:
          FRAME CHOP 1
           ALOAD 0
           DLOAD 3
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_7.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setobservervariable_7.validDouble (DLorg/nlogo/nvm/Context;)D
          L16
           DSTORE 2
           NEW java/lang/Double
@@ -1467,7 +1472,8 @@ procedure UPDATE:[EDIFF]{-TP-}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -1542,7 +1548,8 @@ procedure UPDATE:[EDIFF]{-TP-}:
          FRAME FULL [org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0 org/nlogo/nvm/Context org/nlogo/agent/Patch D org/nlogo/agent/AgentIterator] [D]
           ALOAD 0
           DLOAD 3
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L14
           DSTORE 4
           DSTORE 2
@@ -1550,7 +1557,8 @@ procedure UPDATE:[EDIFF]{-TP-}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_setprocedurevariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -1710,7 +1718,8 @@ procedure UPDATE:[EDIFF]{-TP-}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_if_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_if_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L22
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -1788,13 +1797,15 @@ procedure UPDATE:[EDIFF]{-TP-}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_if_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_if_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L29
           DSTORE 2
           ALOAD 0
           DLOAD 2
           INVOKESTATIC java/lang/StrictMath.exp (D)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_if_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdate_if_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L30
           DSTORE 4
           DSTORE 2

--- a/test/benchdumps/Life.txt
+++ b/test/benchdumps/Life.txt
@@ -93,7 +93,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -894,7 +895,8 @@ procedure SETUP-RANDOM:[]{O---}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuprandom_ifelse_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuprandom_ifelse_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;

--- a/test/benchdumps/PrefAttach.txt
+++ b/test/benchdumps/PrefAttach.txt
@@ -93,7 +93,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -317,7 +318,8 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
          FRAME CHOP 1
           ALOAD 0
           DLOAD 3
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindpartner_setprocedurevariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindpartner_setprocedurevariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L7
           DSTORE 2
           ALOAD 0
@@ -327,7 +329,8 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindpartner_setprocedurevariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindpartner_setprocedurevariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           DSTORE 2
           NEW java/lang/Double
@@ -737,7 +740,8 @@ reporter procedure FIND-PARTNER:[TOTAL PARTNER]{OTPL}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindpartner_setprocedurevariable_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurefindpartner_setprocedurevariable_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -1026,7 +1030,8 @@ procedure LAYOUT:[_repeatlocal:0]{OTPL}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurelayout_repeatlocal_0.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurelayout_repeatlocal_0.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -1471,7 +1476,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_call_3.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_call_3.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           LLOAD 4
           L2D

--- a/test/benchdumps/Team.txt
+++ b/test/benchdumps/Team.txt
@@ -93,7 +93,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -1837,7 +1838,8 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -2117,7 +2119,8 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -2397,7 +2400,8 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_19.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_19.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -2677,7 +2681,8 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_26.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_setprocedurevariable_26.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -2853,7 +2858,8 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_div_33.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_div_33.validDouble (DLorg/nlogo/nvm/Context;)D
            L8
             DSTORE 2
             NEW java/lang/Double
@@ -2994,7 +3000,8 @@ procedure DO-PLOT:[TOTAL]{OTPL}:
             INVOKEVIRTUAL org/nlogo/core/LogoList.size ()I
             I2D
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_mean_36.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduredoplot_mean_36.validDouble (DLorg/nlogo/nvm/Context;)D
            L9
             DSTORE 2
             NEW java/lang/Double
@@ -3183,7 +3190,8 @@ procedure EXPLORE:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureexplore_setobservervariable_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureexplore_setobservervariable_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           NEW java/lang/Double
@@ -4761,7 +4769,8 @@ procedure GO:[]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setturtlevariable_15.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setturtlevariable_15.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -4953,7 +4962,8 @@ procedure LAYOUT:[_repeatlocal:0]{OTPL}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurelayout_repeatlocal_0.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurelayout_repeatlocal_0.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -5364,7 +5374,8 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepickteammembers_repeatlocal_1.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepickteammembers_repeatlocal_1.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -5388,7 +5399,8 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepickteammembers_ifelse_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepickteammembers_ifelse_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -5746,7 +5758,8 @@ procedure PICK-TEAM-MEMBERS:[NEW-TEAM-MEMBER _repeatlocal:1]{O---}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurepickteammembers_ifelse_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -6740,7 +6753,8 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -7076,7 +7090,8 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -7090,7 +7105,8 @@ procedure SETUP:[_repeatlocal:0]{O---}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L12
           DSTORE 2
           NEW java/lang/Double

--- a/test/benchdumps/Termites.txt
+++ b/test/benchdumps/Termites.txt
@@ -101,7 +101,8 @@ procedure BENCHMARK:[]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeat_3.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeat_3.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           INVOKEVIRTUAL org/nlogo/nvm/Context.let (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
           ALOAD 1
@@ -1295,7 +1296,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_7.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_7.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -1357,7 +1359,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_7.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_7.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -1527,7 +1530,8 @@ procedure WIGGLE:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurewiggle_setturtlevariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurewiggle_setturtlevariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.job : Lorg/nlogo/nvm/Job;
@@ -1542,7 +1546,8 @@ procedure WIGGLE:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurewiggle_setturtlevariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurewiggle_setturtlevariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           DSTORE 2
           NEW java/lang/Double

--- a/test/benchdumps/VirusNet.txt
+++ b/test/benchdumps/VirusNet.txt
@@ -581,7 +581,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -1462,7 +1463,8 @@ procedure GO:[]{O---}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setturtlevariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setturtlevariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -2129,7 +2131,8 @@ procedure SETUP-NODES:[]{O---}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnodes_setxy_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnodes_setxy_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_proceduresetupnodes_setxy_3.world : Lorg/nlogo/agent/World;
@@ -2164,7 +2167,8 @@ procedure SETUP-NODES:[]{O---}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnodes_setxy_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnodes_setxy_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 4
           DSTORE 2
@@ -2266,7 +2270,8 @@ procedure SETUP-NODES:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnodes_setturtlevariable_5.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupnodes_setturtlevariable_5.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -2436,7 +2441,8 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_setprocedurevariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_setprocedurevariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           LDC 2.0
          L10
@@ -2461,7 +2467,8 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_setprocedurevariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_setprocedurevariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L12
           DSTORE 2
           NEW java/lang/Double
@@ -3090,7 +3097,8 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_repeatlocal_12.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_repeatlocal_12.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -3205,7 +3213,8 @@ procedure SETUP-SPATIALLY-CLUSTERED-NETWORK:[NUM-LINKS _repeatlocal:1]{OTPL}:
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_div_16.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupspatiallyclusterednetwork_div_16.validDouble (DLorg/nlogo/nvm/Context;)D
            L9
             DSTORE 2
             NEW java/lang/Double
@@ -3675,7 +3684,8 @@ procedure SPREAD-VIRUS:[]{OTPL}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurespreadvirus_if_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurespreadvirus_if_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -4043,7 +4053,8 @@ procedure UPDATE-PLOT:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_2.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_2.validDouble (DLorg/nlogo/nvm/Context;)D
            L10
             LDC 100.0
            L11
@@ -4053,7 +4064,8 @@ procedure UPDATE-PLOT:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_2.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_2.validDouble (DLorg/nlogo/nvm/Context;)D
            L12
             DSTORE 2
             NEW java/lang/Double
@@ -4210,7 +4222,8 @@ procedure UPDATE-PLOT:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_5.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_5.validDouble (DLorg/nlogo/nvm/Context;)D
            L10
             LDC 100.0
            L11
@@ -4220,7 +4233,8 @@ procedure UPDATE-PLOT:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_5.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_5.validDouble (DLorg/nlogo/nvm/Context;)D
            L12
             DSTORE 2
             NEW java/lang/Double
@@ -4377,7 +4391,8 @@ procedure UPDATE-PLOT:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_8.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_8.validDouble (DLorg/nlogo/nvm/Context;)D
            L10
             LDC 100.0
            L11
@@ -4387,7 +4402,8 @@ procedure UPDATE-PLOT:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_8.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdateplot_mult_8.validDouble (DLorg/nlogo/nvm/Context;)D
            L12
             DSTORE 2
             NEW java/lang/Double

--- a/test/benchdumps/Wealth.txt
+++ b/test/benchdumps/Wealth.txt
@@ -81,7 +81,8 @@ reporter procedure AREA-OF-EQUALITY-TRIANGLE:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureareaofequalitytriangle_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureareaofequalitytriangle_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L12
           DSTORE 4
           DSTORE 2
@@ -89,7 +90,8 @@ reporter procedure AREA-OF-EQUALITY-TRIANGLE:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureareaofequalitytriangle_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureareaofequalitytriangle_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L13
           LDC 2.0
          L14
@@ -114,7 +116,8 @@ reporter procedure AREA-OF-EQUALITY-TRIANGLE:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureareaofequalitytriangle_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureareaofequalitytriangle_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L16
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -149,7 +152,8 @@ reporter procedure AREA-OF-EQUALITY-TRIANGLE:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           INVOKESTATIC java/lang/StrictMath.pow (DD)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureareaofequalitytriangle_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureareaofequalitytriangle_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L20
           DSTORE 4
           DSTORE 2
@@ -172,7 +176,8 @@ reporter procedure AREA-OF-EQUALITY-TRIANGLE:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureareaofequalitytriangle_report_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureareaofequalitytriangle_report_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L22
           DSTORE 2
           NEW java/lang/Double
@@ -347,7 +352,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -620,7 +626,8 @@ procedure GO:[]{O---}:
           DLOAD 4
           DMUL
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_if_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_if_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           DCONST_0
          L9
@@ -967,7 +974,8 @@ reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregrainahead_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregrainahead_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -1181,7 +1189,8 @@ reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L21
           DSTORE 2
           NEW java/lang/Double
@@ -1241,7 +1250,8 @@ reporter procedure GRAIN-AHEAD:[TOTAL HOW-FAR _repeatlocal:2]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregrainahead_setprocedurevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -1628,7 +1638,8 @@ procedure GROW-GRAIN:[]{-TP-}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregrowgrain_setpatchvariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregrowgrain_setpatchvariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -2100,7 +2111,8 @@ procedure HARVEST:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureharvest_setturtlevariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureharvest_setturtlevariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L21
           DSTORE 4
           DSTORE 2
@@ -2108,7 +2120,8 @@ procedure HARVEST:[]{OTPL}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureharvest_setturtlevariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureharvest_setturtlevariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L22
           DSTORE 2
           DLOAD 2
@@ -2393,7 +2406,8 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremoveeatagedie_setturtlevariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremoveeatagedie_setturtlevariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L16
           DSTORE 2
           NEW java/lang/Double
@@ -2482,7 +2496,8 @@ procedure MOVE-EAT-AGE-DIE:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremoveeatagedie_setturtlevariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremoveeatagedie_setturtlevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -2970,7 +2985,8 @@ procedure RECOLOR-PATCH:[]{-TP-}:
           DLOAD 2
           DLOAD 10
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorpatch_setpatchvariable_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorpatch_setpatchvariable_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L24
           DSTORE 2
           NEW java/lang/Double
@@ -3288,7 +3304,8 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorturtles_ifelse_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorturtles_ifelse_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           DSTORE 3
           ASTORE 2
@@ -3455,7 +3472,8 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorturtles_ifelse_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorturtles_ifelse_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           LDC 3.0
          L10
@@ -3480,7 +3498,8 @@ procedure RECOLOR-TURTLES:[MAX-WEALTH]{OTPL}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorturtles_ifelse_6.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurerecolorturtles_ifelse_6.validDouble (DLorg/nlogo/nvm/Context;)D
          L12
           DSTORE 3
           ASTORE 2
@@ -3691,7 +3710,8 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -3820,7 +3840,8 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L16
           DCONST_1
          L17
@@ -3830,12 +3851,14 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L18
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_2.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -3895,7 +3918,8 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L25
           DSTORE 2
           NEW java/lang/Double
@@ -3967,7 +3991,8 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_3.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_3.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -4027,7 +4052,8 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -4122,7 +4148,8 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_4.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_4.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -4194,7 +4221,8 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_5.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_5.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -4254,7 +4282,8 @@ procedure SET-INITIAL-TURTLE-VARS:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetinitialturtlevars_setturtlevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L15
           DSTORE 2
           NEW java/lang/Double
@@ -4522,7 +4551,8 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuppatches_if_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuppatches_if_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -4700,7 +4730,8 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuppatches_repeatlocal_6.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuppatches_repeatlocal_6.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -5022,7 +5053,8 @@ procedure SETUP-PATCHES:[_repeatlocal:0 _repeatlocal:1]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuppatches_repeatlocal_13.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetuppatches_repeatlocal_13.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -5570,7 +5602,8 @@ procedure SETUP-TURTLES:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupturtles_setturtlevariable_6.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetupturtles_setturtlevariable_6.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -7567,7 +7600,8 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_div_5.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_div_5.validDouble (DLorg/nlogo/nvm/Context;)D
            L7
             DSTORE 2
             NEW java/lang/Double
@@ -7892,7 +7926,8 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
          FRAME CHOP 1
           ALOAD 0
           DLOAD 3
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_8.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_8.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           DSTORE 2
           NEW java/lang/Double
@@ -8005,7 +8040,8 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_repeatlocal_12.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_repeatlocal_12.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -8097,7 +8133,8 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_13.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_13.validDouble (DLorg/nlogo/nvm/Context;)D
          L8
           DSTORE 2
           NEW java/lang/Double
@@ -8200,7 +8237,8 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_mult_16.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_mult_16.validDouble (DLorg/nlogo/nvm/Context;)D
            L10
             LDC 100.0
            L11
@@ -8210,7 +8248,8 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
             DLOAD 2
             DLOAD 4
             DMUL
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_mult_16.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_mult_16.validDouble (DLorg/nlogo/nvm/Context;)D
            L12
             DSTORE 2
             NEW java/lang/Double
@@ -8259,7 +8298,8 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_17.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_17.validDouble (DLorg/nlogo/nvm/Context;)D
          L6
           DSTORE 2
           NEW java/lang/Double
@@ -8396,7 +8436,8 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_18.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_18.validDouble (DLorg/nlogo/nvm/Context;)D
          L18
           DSTORE 4
           DSTORE 2
@@ -8404,7 +8445,8 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_18.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_18.validDouble (DLorg/nlogo/nvm/Context;)D
          L19
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
@@ -8479,7 +8521,8 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_18.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_18.validDouble (DLorg/nlogo/nvm/Context;)D
          L25
           DSTORE 4
           DSTORE 2
@@ -8487,7 +8530,8 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_18.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_setprocedurevariable_18.validDouble (DLorg/nlogo/nvm/Context;)D
          L26
           DSTORE 2
           NEW java/lang/Double
@@ -8628,7 +8672,8 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_div_21.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_div_21.validDouble (DLorg/nlogo/nvm/Context;)D
            L12
             NEW org/nlogo/nvm/Activation
             DUP
@@ -8693,7 +8738,8 @@ procedure UPDATE-LORENZ-AND-GINI-PLOTS:[SORTED-WEALTHS TOTAL-WEALTH WEALTH-SUM-S
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_div_21.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_procedureupdatelorenzandginiplots_div_21.validDouble (DLorg/nlogo/nvm/Context;)D
            L16
             DSTORE 2
             NEW java/lang/Double

--- a/test/benchdumps/Wolf.txt
+++ b/test/benchdumps/Wolf.txt
@@ -94,7 +94,8 @@ procedure BENCHMARK:[_repeatlocal:0]{O---}:
           DUP
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurebenchmark_repeatlocal_2.validLong (DLorg/nlogo/nvm/Context;)J
           INVOKESPECIAL org/nlogo/nvm/MutableLong.<init> (J)V
           AASTORE
           ALOAD 1
@@ -636,7 +637,8 @@ procedure CATCH-SHEEP:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecatchsheep_setturtlevariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurecatchsheep_setturtlevariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -975,7 +977,8 @@ procedure EAT-GRASS:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DADD
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureeatgrass_setturtlevariable_2.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedureeatgrass_setturtlevariable_2.validDouble (DLorg/nlogo/nvm/Context;)D
          L14
           DSTORE 2
           NEW java/lang/Double
@@ -1191,7 +1194,8 @@ procedure GO:[]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setturtlevariable_3.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setturtlevariable_3.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -1415,7 +1419,8 @@ procedure GO:[]{O---}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setturtlevariable_10.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurego_setturtlevariable_10.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -2056,7 +2061,8 @@ procedure GRAPH:[]{OTPL}:
             DLOAD 2
             DLOAD 4
             DDIV
-            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregraph_div_6.validDouble (D)D
+            ALOAD 1
+            INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregraph_div_6.validDouble (DLorg/nlogo/nvm/Context;)D
            L9
             DSTORE 2
             NEW java/lang/Double
@@ -2355,7 +2361,8 @@ procedure GROW-GRASS:[]{-TP-}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregrowgrass_setpatchvariable_5.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduregrowgrass_setpatchvariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
          L11
           DSTORE 2
           NEW java/lang/Double
@@ -2427,7 +2434,8 @@ procedure MOVE:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DSUB
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremove_right_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduremove_right_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L3
           DSTORE 2
           ALOAD 1
@@ -2487,7 +2495,8 @@ procedure REPRODUCE-SHEEP:[]{-T--}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducesheep_if_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducesheep_if_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -2624,14 +2633,16 @@ procedure REPRODUCE-SHEEP:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducesheep_setturtlevariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducesheep_setturtlevariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L12
           DSTORE 2
           ALOAD 0
           DLOAD 2
           ICONST_0
           INVOKESTATIC org/nlogo/api/Approximate.approximate (DI)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducesheep_setturtlevariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducesheep_setturtlevariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L13
           DSTORE 2
           NEW java/lang/Double
@@ -2749,7 +2760,8 @@ procedure REPRODUCE-WOLVES:[]{-T--}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducewolves_if_0.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducewolves_if_0.validDouble (DLorg/nlogo/nvm/Context;)D
          L2
           ALOAD 1
           GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -2886,14 +2898,16 @@ procedure REPRODUCE-WOLVES:[]{-T--}:
           DLOAD 2
           DLOAD 4
           DDIV
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducewolves_setturtlevariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducewolves_setturtlevariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L12
           DSTORE 2
           ALOAD 0
           DLOAD 2
           ICONST_0
           INVOKESTATIC org/nlogo/api/Approximate.approximate (DI)D
-          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducewolves_setturtlevariable_1.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_procedurereproducewolves_setturtlevariable_1.validDouble (DLorg/nlogo/nvm/Context;)D
          L13
           DSTORE 2
           NEW java/lang/Double
@@ -3224,7 +3238,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_5.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setpatchvariable_5.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -3533,7 +3548,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           ALOAD 0
@@ -3543,7 +3559,8 @@ procedure SETUP:[]{O---}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_12.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_12.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           DSTORE 2
           NEW java/lang/Double
@@ -3627,7 +3644,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_14.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_14.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -3689,7 +3707,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_14.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_14.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -3938,7 +3957,8 @@ procedure SETUP:[]{O---}:
           DLOAD 2
           DLOAD 4
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_19.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_19.validDouble (DLorg/nlogo/nvm/Context;)D
          L9
           DSTORE 2
           ALOAD 0
@@ -3948,7 +3968,8 @@ procedure SETUP:[]{O---}:
           GETFIELD org/nlogo/nvm/Job.random : Lorg/nlogo/api/MersenneTwisterFast;
           INVOKEVIRTUAL org/nlogo/api/MersenneTwisterFast.nextDouble ()D
           DMUL
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_19.validDouble (D)D
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setturtlevariable_19.validDouble (DLorg/nlogo/nvm/Context;)D
          L10
           DSTORE 2
           NEW java/lang/Double
@@ -4032,7 +4053,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_21.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_21.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4
@@ -4094,7 +4116,8 @@ procedure SETUP:[]{O---}:
           DSTORE 2
           ALOAD 0
           DLOAD 2
-          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_21.validLong (D)J
+          ALOAD 1
+          INVOKEVIRTUAL org/nlogo/prim/_asm_proceduresetup_setxy_21.validLong (DLorg/nlogo/nvm/Context;)J
           LSTORE 4
           DLOAD 2
           LLOAD 4

--- a/test/commands/StackTraces.txt
+++ b/test/commands/StackTraces.txt
@@ -132,3 +132,10 @@
     called by procedure GO\
     called by procedure GO2\
     called by procedure __EVALUATOR
+
+*StackTraces-NumericRangeExceeded
+  turtles-own [ n ]
+  O> crt 10000 [ set n e ^ 706 ]
+  O> show sum [ n ] of turtles => STACKTRACE math operation produced a number too large for NetLogo\
+  error while observer running SUM\
+    called by procedure __EVALUATOR

--- a/test/commands/Sum.txt
+++ b/test/commands/Sum.txt
@@ -68,3 +68,8 @@ SumOf4
   mean [lvar] of directed-edge 0 1 => 2
   min [lvar] of directed-edge 0 1 => 1
   max [lvar] of directed-edge 0 1 => 3
+
+SumOfExceedsNumericRange
+  turtles-own [ n ]
+  O> crt 10000 [ set n e ^ 706 ]
+  sum [ n ] of turtles => ERROR math operation produced a number too large for NetLogo

--- a/test/reporters/Numbers.txt
+++ b/test/reporters/Numbers.txt
@@ -160,6 +160,9 @@ Exponentiation6
 Exponentiation7
   2 ^ 0 => 1
 
+Exponentiation8
+  e ^ 1024 => ERROR math operation produced a number too large for NetLogo
+
 Ceiling1
   ceiling 4.5 => 5
 


### PR DESCRIPTION
This broke in #1174 and we didn't notice because we didn't have a test covering it! The error is correct, but computing the stack trace raises an NPE. 