### PR TITLE
foreach range x fails different in code tab and command center

### DIFF
--- a/netlogo-gui/src/main/compile/prim/LegacyPrims.scala
+++ b/netlogo-gui/src/main/compile/prim/LegacyPrims.scala
@@ -54,7 +54,9 @@ package etc {
   }
 
   case class _english() extends Command {
-    def syntax = Syntax.commandSyntax(agentClassString = "O---")
+    def syntax = Syntax.commandSyntax(
+      agentClassString = "O---",
+      canBeConcise = false)
   }
 
   case class _extracthsbold() extends Reporter {
@@ -82,7 +84,8 @@ package etc {
   }
 
   case class _git() extends Command {
-    def syntax = Syntax.commandSyntax(agentClassString = "O---", right = List(StringType))
+    def syntax = Syntax.commandSyntax(agentClassString = "O---", right = List(StringType),
+      canBeConcise = false)
   }
 
   case class _hsbold() extends Reporter {

--- a/parser-core/src/main/core/Syntax.scala
+++ b/parser-core/src/main/core/Syntax.scala
@@ -46,7 +46,8 @@ case class Syntax private(
   isRightAssociative: Boolean, // only relevant if infix
   agentClassString: String,
   blockAgentClassString: Option[String],
-  introducesContext: Boolean)
+  introducesContext: Boolean,
+  canBeConcise: Boolean)
 {
 
   import Syntax._
@@ -137,7 +138,8 @@ object Syntax {
     minimumOption: Option[Int] = None, // minimum number of args might be different than the default
     agentClassString: String = "OTPL",
     blockAgentClassString: Option[String] = None,
-    introducesContext: Boolean = false
+    introducesContext: Boolean = false,
+    canBeConcise: Boolean = true
   ): Syntax =
     new Syntax(
       precedence = CommandPrecedence,
@@ -149,7 +151,8 @@ object Syntax {
       isRightAssociative = false,
       agentClassString = agentClassString,
       blockAgentClassString = blockAgentClassString,
-      introducesContext = introducesContext || blockAgentClassString.nonEmpty
+      introducesContext = introducesContext || blockAgentClassString.nonEmpty,
+      canBeConcise = canBeConcise
   )
 
   def reporterSyntax(
@@ -172,7 +175,8 @@ object Syntax {
     isRightAssociative = isRightAssociative,
     agentClassString = agentClassString,
     blockAgentClassString = blockAgentClassString,
-    introducesContext = blockAgentClassString.nonEmpty
+    introducesContext = blockAgentClassString.nonEmpty,
+    canBeConcise = true
   )
 
   /** <i>Unsupported. Do not use.</i> */

--- a/parser-core/src/main/core/prim/etc/etc.scala
+++ b/parser-core/src/main/core/prim/etc/etc.scala
@@ -531,7 +531,8 @@ case class _link() extends Reporter {
 case class _linkcode() extends Command {
   override def syntax =
     Syntax.commandSyntax(
-      agentClassString = "---L")
+      agentClassString = "---L",
+      canBeConcise = false)
 }
 case class _linklength() extends Reporter {
   override def syntax =
@@ -673,7 +674,8 @@ case class _nvalues() extends Reporter {
 case class _observercode() extends Command {
   override def syntax =
     Syntax.commandSyntax(
-      agentClassString = "O---")
+      agentClassString = "O---",
+      canBeConcise = false)
 }
 case class _patch() extends Reporter {
   override def syntax =
@@ -684,7 +686,8 @@ case class _patch() extends Reporter {
 case class _patchcode() extends Command {
   override def syntax =
     Syntax.commandSyntax(
-      agentClassString = "--P-")
+      agentClassString = "--P-",
+      canBeConcise = false)
 }
 case class _patchhere() extends Reporter {
   override def syntax =
@@ -1029,7 +1032,8 @@ case class _tostring() extends Reporter with Pure {
 case class _turtlecode() extends Command {
   override def syntax =
     Syntax.commandSyntax(
-      agentClassString = "-T--")
+      agentClassString = "-T--",
+      canBeConcise = false)
 }
 case class _untie() extends Command {
   override def syntax =

--- a/parser-core/src/main/core/prim/misc.scala
+++ b/parser-core/src/main/core/prim/misc.scala
@@ -128,7 +128,7 @@ case class _createturtles(breedName: String) extends Command {
       blockAgentClassString = Option("-T--"))
 }
 case class _done() extends Command {
-  override def syntax = Syntax.commandSyntax()
+  override def syntax = Syntax.commandSyntax(canBeConcise = false)
 }
 case class _equal() extends Reporter with Pure {
   override def syntax =

--- a/parser-core/src/main/parse/ExpressionParser.scala
+++ b/parser-core/src/main/parse/ExpressionParser.scala
@@ -462,6 +462,8 @@ object ExpressionParser {
   // expand e.g. "foreach xs print" -> "foreach xs [[x] -> print x]"
   private def expandConciseCommandLambda(token: Token, scope: SymbolTable): core.ReporterApp = {
     val coreCommand = token.value.asInstanceOf[core.Command]
+    if (! coreCommand.syntax.canBeConcise)
+      throw new UnexpectedTokenException(token)
     val (varNames, varApps) = syntheticVariables(coreCommand.syntax.totalDefault, coreCommand.token, scope)
     val stmtArgs =
       if (coreCommand.syntax.takesOptionalCommandBlock)

--- a/parser-core/src/test/parse/FrontEndTests.scala
+++ b/parser-core/src/test/parse/FrontEndTests.scala
@@ -213,6 +213,9 @@ class FrontEndTests extends FunSuite {
     runTest("foreach [1 2 3] print",
       "_foreach()[_const([1.0, 2.0, 3.0])[], _commandlambda(_0)[[_print()[_lambdavariable(_0)[]]]]]")
   }
+  test("DoParseForeachWithDone") {
+    runFailure("foreach [1 2 3] __done", "FOREACH expected at least 2 inputs, a list and an anonymous command.", 0, 7)
+  }
   test("DoParselet") {
     runTest("let x 5 __ignore x",
       "_let(Let(X))[_const(5.0)[]] _ignore()[_letvariable(Let(X))[]]")

--- a/test/commands/ControlStructures.txt
+++ b/test/commands/ControlStructures.txt
@@ -12,6 +12,10 @@ Foreach2
   O> (foreach [1 2 3] [4 5 6] [[x y] -> crt (x + y) ])
   count turtles => 21
 
+ForeachWithDone
+  to foo foreach [ 1 2 3 ] __done end
+  COMPILE> COMPILER ERROR FOREACH expected at least 2 inputs, a list and an anonymous command.
+
 Run1
   O> run "crt 10"
   count turtles => 10


### PR DESCRIPTION
writing 
```
foreach range 10
```
in the code tab gives the proper error message about `foreach` expecting at least two inputs etc.

Writing the same thing in the Command Center gives a NPE:
```

java.lang.NullPointerException
 at org.nlogo.nvm.Context.stepConcurrent(Context.java:95)
 at org.nlogo.nvm.ConcurrentJob.step(ConcurrentJob.java:84)
 at org.nlogo.job.JobThread.runPrimaryJobs(JobThread.scala:133)
 at org.nlogo.job.JobThread.$anonfun$run$1(JobThread.scala:68)
 at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
 at scala.util.control.Exception$Catch.apply(Exception.scala:224)
 at org.nlogo.api.Exceptions$.handling(Exceptions.scala:41)
 at org.nlogo.job.JobThread.run(JobThread.scala:66)

NetLogo 6.0
main: org.nlogo.app.AppFrame
thread: AWT-EventQueue-0
Java HotSpot(TM) 64-Bit Server VM 1.8.0_112 (Oracle Corporation; 1.8.0_112-b15)
operating system: Windows 10 10.0 (amd64 processor)
Scala version 2.12.1
JOGL: (3D View not initialized)
OpenGL Graphics: (3D View not initialized)
model: OstromModel

09:50:27.636 AddJobEvent (org.nlogo.app.common.CommandLine) AWT-EventQueue-0
09:50:27.636 OutputEvent (org.nlogo.app.common.CommandLine) AWT-EventQueue-0
09:50:27.636 CompiledEvent (org.nlogo.window.CompilerManager) AWT-EventQueue-0
09:50:27.636 CompileMoreSourceEvent (org.nlogo.app.common.CommandLine) AWT-EventQueue-0
09:50:27.516 InterfaceGlobalEvent (org.nlogo.app.interfacetab.InterfacePanel$$anon$1 (org.nlogo.window.SliderWidget)) AWT-EventQueue-0
09:50:27.516 InterfaceGlobalEvent (org.nlogo.window.ChooserWidget) AWT-EventQueue-0
09:50:27.516 InterfaceGlobalEvent (org.nlogo.window.InputBoxWidget) AWT-EventQueue-0
09:50:27.516 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
09:50:27.312 InterfaceGlobalEvent (org.nlogo.app.interfacetab.InterfacePanel$$anon$1 (org.nlogo.window.SliderWidget)) AWT-EventQueue-0
09:50:27.312 InterfaceGlobalEvent (org.nlogo.window.ChooserWidget) AWT-EventQueue-0
```