### PR TITLE
Very confusing dialog warnings loading 3D model into 2D version

### DIFF
--- a/netlogo-gui/src/main/workspace/OpenModel.scala
+++ b/netlogo-gui/src/main/workspace/OpenModel.scala
@@ -43,7 +43,7 @@ object OpenModel {
             if (! model.version.startsWith("NetLogo")) {
               controller.invalidModelVersion(uri, model.version)
               None
-            } else if (shouldNotContinueOpeningModel(model, controller, currentVersion))
+            } else if (shouldCancelOpeningModel(model, controller, currentVersion))
               None
             else
               modelConverter(model, Paths.get(uri)) match {
@@ -58,11 +58,16 @@ object OpenModel {
       }
   }
 
-  private def shouldNotContinueOpeningModel(model: Model, controller: Controller, currentVersion: Version): Boolean = {
+  private def shouldCancelOpeningModel(model: Model, controller: Controller, currentVersion: Version): Boolean = {
     val modelArity = if (Version.is3D(model.version)) 3 else 2
     val modelArityDiffers = Version.is3D(model.version) != currentVersion.is3D
-    ((modelArityDiffers && ! controller.shouldOpenModelOfDifferingArity(modelArity, model.version)) ||
-      (! currentVersion.knownVersion(model.version) && ! controller.shouldOpenModelOfUnknownVersion(model.version)) ||
-      (! currentVersion.compatibleVersion(model.version) && ! controller.shouldOpenModelOfLegacyVersion(model.version)))
+    if (modelArityDiffers)
+      ! controller.shouldOpenModelOfDifferingArity(modelArity, model.version)
+    else if (! currentVersion.knownVersion(model.version))
+      ! controller.shouldOpenModelOfUnknownVersion(model.version)
+    else if (! currentVersion.compatibleVersion(model.version))
+      ! controller.shouldOpenModelOfLegacyVersion(model.version)
+    else
+      false
   }
 }

--- a/netlogo-gui/src/test/workspace/OpenModelTests.scala
+++ b/netlogo-gui/src/test/workspace/OpenModelTests.scala
@@ -61,6 +61,7 @@ class OpenModelTests extends FunSuite {
     assert(openedModel.isDefined)
     assert(controller.notifiedModelArity == 3)
     assert(controller.notifiedModelVersion == "NetLogo 3D 6.0")
+    assert(! controller.notifiedVersionUnknown)
   } }
 
   test("doesn't open different-arity model unless the user approves") { new OpenTest {
@@ -125,6 +126,7 @@ class MockController extends OpenModel.Controller {
   var notifiedModelArity: Int = 0
   var notifiedModelVersion: String = _
   var notifiedException: Exception = _
+  var notifiedVersionUnknown: Boolean = false
   var willOpenModel = false
 
   def openModel(willDo: Boolean): MockController = {
@@ -155,6 +157,7 @@ class MockController extends OpenModel.Controller {
   }
   def shouldOpenModelOfUnknownVersion(version: String): Boolean = {
     notifiedModelVersion = version
+    notifiedVersionUnknown = true
     willOpenModel
   }
   def shouldOpenModelOfLegacyVersion(version: String): Boolean = {


### PR DESCRIPTION
Launch NetLogo 6.0 and open a model in the 3D library. First one sees

![image](https://cloud.githubusercontent.com/assets/2138696/21599969/2d16f84a-d1b0-11e6-894a-ab92976835c7.png)

and then after clicking continue:

![image](https://cloud.githubusercontent.com/assets/2138696/21599972/427f20b8-d1b0-11e6-9bd9-d627b091f8bb.png)
