### PR TITLE
NetLogo ".nlogo" delimiter splits anywhere, not just on entire line

### DIFF
--- a/netlogo-core/src/main/fileformat/NLogoFormat.scala
+++ b/netlogo-core/src/main/fileformat/NLogoFormat.scala
@@ -28,7 +28,7 @@ trait AbstractNLogoFormat[A <: ModelFormat[Array[String], A]] extends ModelForma
   def is3DFormat: Boolean
   def name: String
   val Separator = "@#$#@#$#@"
-  val SeparatorRegex = "@#\\$#@#\\$#@"
+  val SeparatorRegex = "(?m)^@#\\$#@#\\$#@$"
 
   def widgetReaders: Map[String, WidgetReader]
 

--- a/netlogo-gui/src/test/fileformat/NLogoFormatTests.scala
+++ b/netlogo-gui/src/test/fileformat/NLogoFormatTests.scala
@@ -67,6 +67,14 @@ class NLogoFormatIOTest extends FunSuite {
     assert(xmlResult.isFailure)
     assert(xmlResult.failed.get.getMessage.contains("nlogo"))
   }
+
+  test("opens models with code containing the delimiter if it doesn't take up the whole line") {
+    val code = "to foo show \"@#$#@#$#@\" end"
+    val modelSource = code + ("\n@#$#@#$#@" * 12)
+    val result = format.sectionsFromSource(modelSource)
+    assert(result.isSuccess)
+    assert(result.get("org.nlogo.modelsection.code")(0) == code)
+  }
 }
 
 class NLogoFormatConversionTest extends FunSuite with ConversionHelper {


### PR DESCRIPTION
Should only split on lines with exactly the delimiter, not just the delimiter itself.