### PR TITLE
Editor very slow in 6.0 for large files

### DIFF
--- a/netlogo-gui/src/main/ide/NetLogoFoldParser.scala
+++ b/netlogo-gui/src/main/ide/NetLogoFoldParser.scala
@@ -30,27 +30,27 @@ object NetLogoFoldParser {
     def takeUntilCloseBracketOrKeyword(acc: Seq[Token]): Seq[Token] =
       if (! tokens.hasNext) acc
       else tokens.head.tpe match {
-        case TokenType.CloseBracket                  => acc :+ tokens.next
+        case TokenType.CloseBracket                  => tokens.next +: acc
         case TokenType.OpenBracket if acc.length > 1 => acc
         case TokenType.Ident if tokens.head.text.equalsIgnoreCase("BREED") => acc
         case TokenType.Keyword | TokenType.Eof       => acc
-        case _ => takeUntilCloseBracketOrKeyword(acc :+ tokens.next)
+        case _ => takeUntilCloseBracketOrKeyword(tokens.next +: acc)
       }
 
     @tailrec
     def takeUntilEnd(acc: Seq[Token]): Seq[Token] =
       if (! tokens.hasNext) acc
       else tokens.head.tpe match {
-        case TokenType.Keyword if (tokens.head.value == "END") => acc :+ tokens.next
+        case TokenType.Keyword if (tokens.head.value == "END") => tokens.next +: acc
         case TokenType.Keyword | TokenType.Eof => acc
-        case _ => takeUntilEnd(acc :+ tokens.next)
+        case _ => takeUntilEnd(tokens.next +: acc)
       }
 
     @tailrec
     def takeUntilNonComment(acc: Seq[Token]): Seq[Token] =
       if (! tokens.hasNext) acc
       else tokens.head.tpe match {
-        case TokenType.Comment => takeUntilNonComment(acc :+ tokens.next)
+        case TokenType.Comment => takeUntilNonComment(tokens.next +: acc)
         case _                 => acc
       }
 
@@ -70,10 +70,10 @@ object NetLogoFoldParser {
           case _ =>
             takeUntilEnd(Seq(tokens.next))
         }
-        takeUntilEof(acc :+ next)
+        takeUntilEof(next.reverse +: acc)
       }
 
-    takeUntilEof(Seq())
+    takeUntilEof(Seq()).reverse
   }
 }
 


### PR DESCRIPTION

[big-model.zip](https://github.com/NetLogo/NetLogo/files/725872/big-model.zip)

If I go to the code tab, select anywhere in an expression, type a space, and then backspace the backspace takes 5 seconds to happen on a high-end Windows 7 64-bit laptop. Often after that clicking elsewhere in the file takes a few seconds to display the cursor at the new location.

This happens in 6.0 but not in 5.3.1