### PR TITLE
Add some little missing info to the docs for 6.0 changes

### DIFF
--- a/autogen/docs/codetab.html.mustache
+++ b/autogen/docs/codetab.html.mustache
@@ -62,15 +62,16 @@
 <p>
   For more information about writing procedures, read <a href="tutorial3.html">Tutorial #3: Procedures</a> and the <a href="programming.html">Programming Guide</a>.
 <h2>
-  <a>Includes Menu</a>
+  <a>Included Files Menu</a>
 </h2>
 <p id="includes">
   <strong>Caution:</strong> The includes facility is new and experimental.
 <p>
   When you add the <a href="dictionary.html#includes">__includes</a>
   keyword to a model a menu to the right of the procedures menu
-  appears. This is the includes menu which lists all the NetLogo source
-  files (.nls) included in this file.
+  appears. This is the "Included Files" menu which lists all the NetLogo source
+  files (.nls) included in this file. You can make this maenu always visible
+  using the Preferences dialog.
 <p class="screenshot">
   <img alt="screen shot" src="images/interface/includesmenu.gif">
 <p>

--- a/autogen/docs/interface.html.mustache
+++ b/autogen/docs/interface.html.mustache
@@ -75,17 +75,17 @@
       <tr>
         <td class="emptyLeft" />
         <td class="nameCenter">Save</td>
-        <td class="descriptionRight">Save the current model.</td>
+        <td class="descriptionRight">Save the current model, or the currently selected source file.</td>
       </tr>
       <tr>
         <td class="emptyLeft" />
         <td class="nameCenter">Save As…</td>
-        <td class="descriptionRight">Save the current model using a different name.</td>
+        <td class="descriptionRight">Save the current model, or the currently selected source file, using a different name.</td>
       </tr>
       <tr>
         <td class="emptyLeft" />
         <td class="nameCenter">Save All</td>
-        <td class="descriptionRight">Save the current model and all open ".nls" files. This option is only available when one or more ".nls" files are open.</td>
+        <td class="descriptionRight">Save the current model and all open source files. This option is only available when one or more source files are open.</td>
       </tr>
       <tr>
         <td class="emptyLeft" />
@@ -308,9 +308,8 @@
         <td class="emptyLeft" />
         <td class="nameCenter">Preferences…</td>
         <td class="descriptionRight">
-        Opens the preferences dialog, where you can customize NetLogo
-        settings, including language and editor line numbers.
-        On a Mac, this item is on the NetLogo menu instead.</td>
+        Opens the preferences dialog, where you can customize various NetLogo
+        settings. On a Mac, this item is on the NetLogo menu instead.</td>
       </tr>
       <tr>
         <td class="emptyLeft" />

--- a/autogen/docs/versions.html.mustache
+++ b/autogen/docs/versions.html.mustache
@@ -16,7 +16,7 @@
     <p>
       For help running models made in old versions, see the <a href="transition.html">Transition Guide</a>.
     <h2>
-      Version 6.0 (November 2016)
+      Version 6.0 (December 2016)
     </h2>
 
     <h3>Feature Changes</h3>


### PR DESCRIPTION
Correct 6.0 release month

NOTE: the screenshots in the Included Files Menu section (in Code Tab Interface) need to be updated with the new menu name