### PR TITLE
Add extname to manifest error messages (fix #662)

### DIFF
--- a/netlogo-gui/src/main/workspace/ExtensionManagerException.scala
+++ b/netlogo-gui/src/main/workspace/ExtensionManagerException.scala
@@ -8,20 +8,20 @@ object ExtensionManagerException {
   case class ExtensionNotFound(extName: String) extends Cause {
     override def message: String = ExtensionManager.EXTENSION_NOT_FOUND + extName
   }
-  case object NoExtensionName extends Cause {
-    override def message: String = "Bad extension: Can't find extension name in Manifest."
+  case class NoExtensionName(extName: String) extends Cause {
+    override def message: String = s"Bad extension '$extName': Can't find extension name in Manifest."
   }
-  case object NoClassManager extends Cause {
-    override def message: String = "Bad extension: Couldn't locate Class-Manager tag in Manifest File"
+  case class NoClassManager(extName: String) extends Cause {
+    override def message: String = s"Bad extension '$extName': Couldn't locate Class-Manager tag in Manifest File"
   }
-  case object InvalidClassManager extends Cause {
-    override def message: String = "Bad extension: The ClassManager doesn't implement org.nlogo.api.ClassManager"
+  case class InvalidClassManager(extName: String) extends Cause {
+    override def message: String = s"Bad extension '$extName': The ClassManager doesn't implement org.nlogo.api.ClassManager"
   }
   case class NotFoundClassManager(name: String) extends Cause {
     override def message: String = s"Can't find class $name in extension"
   }
-  case object NoManifest extends Cause {
-    override def message: String = "Bad extension: Can't find a Manifest file in extension"
+  case class NoManifest(extName: String) extends Cause {
+    override def message: String = s"Bad extension '$extName': Can't find a Manifest file in extension"
   }
   case object UserHalted extends Cause {
     override def message: String = "User halted compilation"

--- a/netlogo-gui/src/main/workspace/JarLoader.scala
+++ b/netlogo-gui/src/main/workspace/JarLoader.scala
@@ -30,11 +30,11 @@ class JarLoader(workspace: ExtendableWorkspace) extends ExtensionManager.Extensi
       val version       = Option(attr.getValue("NetLogo-Extension-API-Version"))
       // note - the prefix is not really used anywhere, the extensionName drives the behavior.
       // But no assertion is ever made that prefix == extensionName
-      val prefix        = Option(attr.getValue("Extension-Name")).getOrElse(throw new ExtensionManagerException(NoExtensionName))
-      val classMangName = Option(attr.getValue("Class-Manager")).getOrElse(throw new ExtensionManagerException(NoClassManager))
+      val prefix        = Option(attr.getValue("Extension-Name")).getOrElse(throw new ExtensionManagerException(NoExtensionName(extensionName)))
+      val classMangName = Option(attr.getValue("Class-Manager")).getOrElse(throw new ExtensionManagerException(NoClassManager(extensionName)))
 
       ExtensionData(extensionName, fileURL, prefix, classMangName, version, connection.getLastModified)
-    }.getOrElse(throw new ExtensionManagerException(NoManifest))
+    }.getOrElse(throw new ExtensionManagerException(NoManifest(extensionName)))
   }
 
   def extensionClassLoader(fileURL: URL, parentLoader: ClassLoader): ClassLoader = {
@@ -48,7 +48,7 @@ class JarLoader(workspace: ExtendableWorkspace) extends ExtensionManager.Extensi
       classLoader.loadClass(data.classManagerName).newInstance match {
         case cm: ClassManager => cm
         case _                =>
-          throw new ExtensionManagerException(InvalidClassManager)
+          throw new ExtensionManagerException(InvalidClassManager(data.extensionName))
       }
     } catch {
       case ex: ClassNotFoundException =>

--- a/netlogo-gui/src/test/workspace/InMemoryExtensionLoader.scala
+++ b/netlogo-gui/src/test/workspace/InMemoryExtensionLoader.scala
@@ -20,7 +20,7 @@ class InMemoryExtensionLoader(prefix: String, classManager: ClassManager) extend
     if (extensionName == prefix && url.toString.endsWith(s"/$extensionName"))
       new ExtensionData(extensionName, url, extensionName, classManager.getClass.getCanonicalName, Some(currentVer), 0)
     else
-      throw new ExtensionManagerException(NoManifest)
+      throw new ExtensionManagerException(NoManifest(extensionName))
   }
 
   def extensionClassLoader(fileURL: URL, parent: ClassLoader): ClassLoader = parent

--- a/netlogo-gui/src/test/workspace/JarLoaderTests.scala
+++ b/netlogo-gui/src/test/workspace/JarLoaderTests.scala
@@ -106,7 +106,8 @@ class JarLoaderTests extends FunSuite with BeforeAndAfter {
   }
 
   test("extensionData raises an error when the jar manifest doesn't have the required fields") {
-    intercept[ExtensionManagerException] { jarLoader.extensionData("empty", emptyJarFile.toURI.toURL) }
+    val exception = intercept[ExtensionManagerException] { jarLoader.extensionData("empty", emptyJarFile.toURI.toURL) }
+    assert(exception.getMessage.startsWith("Bad extension 'empty':"))
   }
 
   test("extensionClassLoader returns a URLClassLoader with the provided loader as a parent") {


### PR DESCRIPTION
- Added an extName parameter to several of the ExtensionManagerException subclasses, and updated their messages to include it.
- Updated test "extensionData raises an error when the jar manifest doesn't have the required fields" in JarLoaderTests to check that the exception's message contains the extension name.
- Updated JarLoader and InMemoryExtensionLoader to provide ExtensionManagerException subclasses with the extension name as appropriate.