### PR TITLE
NPE when filtering Models Library dialog

### DIFF
--- a/netlogo-gui/src/main/app/tools/ModelsLibraryDialog.java
+++ b/netlogo-gui/src/main/app/tools/ModelsLibraryDialog.java
@@ -351,14 +351,15 @@ strictfp public class ModelsLibraryDialog
               // immediately.
               return;
             }
-            // There is a very small chance that the number of rows
-            // has changed in between our call to getRowCount above
-            // and here. But the chance is very small and if we do
-            // throw a NullPointerException it's not really a big
-            // deal since the thread is going to die anyway once it
-            // notices that the searchText has changed, so I just
-            // don't think it's worth synchronizing. ER - 12/02/07
+            // There is a chance that the number of rows has changed
+            // in between our call to getRowCount above and here.
+            // Since this thread is going to die anyway, we just
+            // null-check and allow later threads to do their job.
+            // ER - 12/02/07, RG 5/4/17
             final javax.swing.tree.TreePath path = tree.getPathForRow(i);
+            if (path == null) {
+              return;
+            }
             Node node = (Node) path.getLastPathComponent();
             if (node.isFolder()) {
               try {


### PR DESCRIPTION
```
java.lang.NullPointerException
 at org.nlogo.app.tools.ModelsLibraryDialog$14.run(ModelsLibraryDialog.java:362)

NetLogo 6.0.1
main: org.nlogo.app.AppFrame
thread: AWT-EventQueue-0
Java HotSpot(TM) 64-Bit Server VM 1.8.0_121 (Oracle Corporation; 1.8.0_121-b13)
operating system: Linux 4.4.0-21-generic (amd64 processor)
Scala version 2.12.1
JOGL: (3D View not initialized)
OpenGL Graphics: (3D View not initialized)
model: Link Breeds Example

01:47:41.308 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
01:47:41.102 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
01:47:40.902 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
01:47:40.701 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
01:47:40.501 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
01:47:40.301 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
01:47:40.100 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
01:47:39.900 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
01:47:39.700 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
01:47:39.500 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
```

To give the full context of how I got this (since I can't reproduce it):

  * I had NetLogo open for a long time
  * I had been modifying a fresh (untitled) model
  * I then opened the Models Library dialog with the keyboard shortcut and then selected Diffusion on a Directed Network
  * After playing with that model for a little bit, I opened the Models Library dialog with the keyboard shortcut again, and selected Link Breeds Example
  * After playing with *that* model for a little bit, I opened the Models Library dialog one last time with the keyboard shortcut and typed the word "link" into the filter box, and the error dialog popped up after I started typing, but before I finished typing

I'm not able to reproduce the problem, and it didn't really obstruct me in any way, so I'd say that this is pretty low-priority.