### PR TITLE
Guard `getTableCellRendererComponent`

### DIFF
--- a/netlogo-gui/src/main/ide/ShowUsageBox.scala
+++ b/netlogo-gui/src/main/ide/ShowUsageBox.scala
@@ -159,9 +159,12 @@ class ShowUsageBox(colorizer: Colorizer) {
   }
   class LineNumberRenderer extends DefaultTableCellRenderer {
     override def setValue(value: AnyRef) = {
-      setText((document.offsetToLine(value.asInstanceOf[Token].start) + 1).toString)
-      setHorizontalAlignment(SwingConstants.RIGHT)
-      setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 8))
+      if (value != null) {
+        setText((document.offsetToLine(value.asInstanceOf[Token].start) + 1).toString)
+        setHorizontalAlignment(SwingConstants.RIGHT)
+        setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 8))
+      } else
+        super.setValue(null)
     }
   }
   import org.nlogo.editor.{ HighlightEditorKit, HighlightView }

--- a/netlogo-gui/src/main/properties/PlotPensEditor.scala
+++ b/netlogo-gui/src/main/properties/PlotPensEditor.scala
@@ -213,7 +213,9 @@ class PlotPensEditor(accessor: PropertyAccessor[List[PlotPen]], colorizer: Color
       setOpaque(true)
       def getTableCellRendererComponent(table: JTable, value: Object,
                                         isSelected: Boolean, hasFocus: Boolean, row: Int, col: Int) = {
-        setBackground(value.asInstanceOf[ColorInfo].color)
+        if (value != null) {
+          setBackground(value.asInstanceOf[ColorInfo].color)
+        }
         this
       }
     }
@@ -234,8 +236,10 @@ class PlotPensEditor(accessor: PropertyAccessor[List[PlotPen]], colorizer: Color
       def getCellEditorValue = currentColor
 
       def getTableCellEditorComponent(table: JTable, value: Object, isSelected: Boolean, row: Int, col: Int) = {
-        currentColor = value.asInstanceOf[ColorInfo]
-        button.setBackground(currentColor.color)
+        if (value != null) {
+          currentColor = value.asInstanceOf[ColorInfo]
+          button.setBackground(currentColor.color)
+        }
         button
       }
     }


### PR DESCRIPTION
A user recently wrote in with a report that they had encountered an NPE in the color chooser in the plot pens dialog. This mirrors #137 (although with a different instance of `getTableCellRendererComponent`). See [this SO post for more information](http://stackoverflow.com/questions/3054775/jtable-strange-behavior-from-getaccessiblechild-method-resulting-in-null-point). The simplest solution seems to be to guard all instances of `getTableCellRendererCompoinent` from being called with a null value.

This is labeled quickfix since it should be a simple `grep` through the codebase followed by adding guards to each case. 