### PR TITLE
Remove agentType restrictions on variable references

### DIFF
--- a/netlogo-core/src/main/nvm/Referencer.scala
+++ b/netlogo-core/src/main/nvm/Referencer.scala
@@ -8,3 +8,8 @@ trait Referencer extends Command {
   def referenceIndex: Int
   def applyReference(ref: Reference): Command
 }
+
+trait ReferencerReporter extends Reporter {
+  def referenceIndex: Int
+  def applyReference(ref: Reference): Reporter
+}

--- a/netlogo-gui/resources/system/tokens.txt
+++ b/netlogo-gui/resources/system/tokens.txt
@@ -285,6 +285,7 @@ R __patchcol _patchcol
 R __patchrow _patchrow
 R __processors etc._processors
 R __random-state etc._randomstate
+R __reference etc._reference
 R __stack-trace etc._stacktrace
 R __symbol etc._symbol
 R __to-string etc._tostring

--- a/netlogo-gui/src/main/prim/etc/_reference.scala
+++ b/netlogo-gui/src/main/prim/etc/_reference.scala
@@ -1,0 +1,45 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.prim.etc
+
+import org.nlogo.api.LogoListBuilder
+import org.nlogo.core.{ AgentKind, I18N, Reference }
+import org.nlogo.nvm.{ Context, ReferencerReporter, Reporter, RuntimePrimitiveException }
+
+class _reference extends Reporter with ReferencerReporter {
+  override def referenceIndex = 0
+
+  private[this] var reference: Reference = null
+  private[this] var name: String = null
+
+  override def applyReference(ref: Reference): Reporter = {
+    reference = ref
+    this
+  }
+
+  override def report(context: Context): AnyRef = {
+    if (reference == null) {
+      throw new RuntimePrimitiveException(context, this, I18N.errors.getN("compiler.LetVariable.notDefined", args(0).token.text))
+    } else {
+      val builder = new LogoListBuilder()
+      val kindString =
+        reference.kind match {
+          case AgentKind.Turtle   => "TURTLE"
+          case AgentKind.Observer => "OBSERVER"
+          case AgentKind.Patch    => "PATCH"
+          case AgentKind.Link     => "LINK"
+        }
+      val varNames =
+        (reference.kind match {
+          case AgentKind.Turtle   => world.program.turtleVars.keys
+          case AgentKind.Observer => world.program.globals
+          case AgentKind.Patch    => world.program.patchVars.keys
+          case AgentKind.Link     => world.program.linkVars.keys
+        }).toSeq
+      builder.add(kindString)
+      builder.add(Double.box(reference.vn))
+      builder.add(varNames(reference.vn))
+      builder.toLogoList
+    }
+  }
+}

--- a/netlogo-gui/src/test/compile/TestAllSyntaxes.scala
+++ b/netlogo-gui/src/test/compile/TestAllSyntaxes.scala
@@ -227,6 +227,7 @@ class TestAllSyntaxes extends FunSuite {
                      |_range number,list,OTPL,None,10,1,1
                      |_readfromstring string,number or TRUE/FALSE or string or list or NOBODY,OTPL,None,10,1,1
                      |_reduce anonymous reporter/list,anything,OTPL,None,10,2,2
+                     |_reference variable,list,OTPL,None,10,1,1
                      |_remainder number/number,number,OTPL,None,10,2,2
                      |_remove anything/string or list,string or list,OTPL,None,10,2,2
                      |_removeduplicates list,list,OTPL,None,10,1,1

--- a/netlogo-headless/src/main/prim/etc/_reference.scala
+++ b/netlogo-headless/src/main/prim/etc/_reference.scala
@@ -1,0 +1,45 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.prim.etc
+
+import org.nlogo.api.LogoListBuilder
+import org.nlogo.core.{ AgentKind, I18N, Reference }
+import org.nlogo.nvm.{ Context, ReferencerReporter, Reporter, RuntimePrimitiveException }
+
+class _reference extends Reporter with ReferencerReporter {
+  override def referenceIndex = 0
+
+  private[this] var reference: Reference = null
+  private[this] var name: String = null
+
+  override def applyReference(ref: Reference): Reporter = {
+    reference = ref
+    this
+  }
+
+  override def report(context: Context): AnyRef = {
+    if (reference == null) {
+      throw new RuntimePrimitiveException(context, this, I18N.errors.getN("compiler.LetVariable.notDefined", args(0).token.text))
+    } else {
+      val builder = new LogoListBuilder()
+      val kindString =
+        reference.kind match {
+          case AgentKind.Turtle   => "TURTLE"
+          case AgentKind.Observer => "OBSERVER"
+          case AgentKind.Patch    => "PATCH"
+          case AgentKind.Link     => "LINK"
+        }
+      val varNames =
+        (reference.kind match {
+          case AgentKind.Turtle   => world.program.turtleVars.keys
+          case AgentKind.Observer => world.program.globals
+          case AgentKind.Patch    => world.program.patchVars.keys
+          case AgentKind.Link     => world.program.linkVars.keys
+        }).toSeq
+      builder.add(kindString)
+      builder.add(Double.box(reference.vn))
+      builder.add(varNames(reference.vn))
+      builder.toLogoList
+    }
+  }
+}

--- a/parser-core/src/main/core/prim/etc/etc.scala
+++ b/parser-core/src/main/core/prim/etc/etc.scala
@@ -841,6 +841,12 @@ case class _reduce() extends Reporter {
       right = List(Syntax.ReporterType, Syntax.ListType),
       ret = Syntax.WildcardType)
 }
+case class _reference() extends Reporter {
+  override def syntax =
+    Syntax.reporterSyntax(
+      right = List(Syntax.ReferenceType),
+      ret = Syntax.ListType)
+}
 case class _reloadextensions() extends Command {
   override def syntax =
     Syntax.commandSyntax(

--- a/parser-core/src/main/core/prim/misc.scala
+++ b/parser-core/src/main/core/prim/misc.scala
@@ -464,7 +464,9 @@ case class _turtleorlinkvariable(varName: String, returnType: Int = Syntax.Wildc
   override def syntax =
     Syntax.reporterSyntax(ret = returnType | Syntax.ReferenceType, agentClassString = "-T-L")
 }
-case class _turtlevariable(vn: Int, returnType: Int = Syntax.WildcardType) extends Reporter {
+case class _turtlevariable(vn: Int, returnType: Int = Syntax.WildcardType) extends Reporter with Referenceable {
+  def makeReference =
+    new Reference(AgentKind.Turtle, vn, this)
   override def syntax =
     Syntax.reporterSyntax(ret = returnType | Syntax.ReferenceType, agentClassString = "-T--")
 }

--- a/parser-core/src/test/parse/FrontEndTests.scala
+++ b/parser-core/src/test/parse/FrontEndTests.scala
@@ -295,8 +295,8 @@ class FrontEndTests extends FunSuite {
       "_ignore()[_nvalues()[_const(10.0)[], _reporterlambda()[_const([5.0])[]]]]")
   }
   test("ParseDiffuse") {
-    runTest("diffuse pcolor 1",
-      "_diffuse()[_patchvariable(2)[], _const(1.0)[]]")
+    runTest("clear-all diffuse pcolor 1",
+      "_clearall()[] _diffuse()[_patchvariable(2)[], _const(1.0)[]]")
   }
 
   // in SetBreed2, we are checking that since no singular form of `fish`

--- a/parser-jvm/src/test/parse/TestAllSyntaxes.scala
+++ b/parser-jvm/src/test/parse/TestAllSyntaxes.scala
@@ -203,6 +203,7 @@ class TestAllSyntaxes extends FunSuite {
                      |_range number,list,OTPL,None,10,1,1
                      |_readfromstring string,number or TRUE/FALSE or string or list or NOBODY,OTPL,None,10,1,1
                      |_reduce anonymous reporter/list,anything,OTPL,None,10,2,2
+                     |_reference variable,list,OTPL,None,10,1,1
                      |_remainder number/number,number,OTPL,None,10,2,2
                      |_remove anything/string or list,string or list,OTPL,None,10,2,2
                      |_removeduplicates list,list,OTPL,None,10,1,1

--- a/shared/resources/main/system/tokens-core.txt
+++ b/shared/resources/main/system/tokens-core.txt
@@ -202,6 +202,7 @@ R __dump1 etc._dump1
 R __nano-time etc._nanotime
 R __processors etc._processors
 R __random-state etc._randomstate
+R __reference etc._reference
 R __stack-trace etc._stacktrace
 R __symbol etc._symbolstring
 R __to-string etc._tostring

--- a/test/reporters/Reference.txt
+++ b/test/reporters/Reference.txt
@@ -1,0 +1,18 @@
+TestPatchReferences
+  patches-own [foos]
+  __reference pxcor  => ["PATCH" 0 "PXCOR"]
+  __reference pycor  => ["PATCH" 1 "PYCOR"]
+  __reference pcolor => ["PATCH" 2 "PCOLOR"]
+  __reference foos   => ["PATCH" 5 "FOOS"]
+  O> show __reference not-a-var => COMPILER ERROR Nothing named NOT-A-VAR has been defined.
+
+TestTurtleReferences
+  turtles-own [foos]
+  __reference xcor => ["TURTLE" 3 "XCOR"]
+  __reference ycor => ["TURTLE" 4 "YCOR"]
+  __reference foos => ["TURTLE" 13 "FOOS"]
+
+TestObserverReferences
+  globals [foo bar]
+  __reference foo => ["OBSERVER" 0 "FOO"]
+  __reference bar => ["OBSERVER" 1 "BAR"]


### PR DESCRIPTION
This is a fix for https://github.com/NetLogo/GIS-Extension/issues/14 . Since the bug was introduced into the NetLogo type checker, this should be the only fix necessary and should go out in the next release of NetLogo.