### PR TITLE
Opening a local client in Function HubNet causes an NPE

### DIFF
--- a/netlogo-core/src/main/nvm/DefaultCompilerServices.scala
+++ b/netlogo-core/src/main/nvm/DefaultCompilerServices.scala
@@ -2,7 +2,7 @@
 
 package org.nlogo.nvm
 
-import org.nlogo.core.{ CompilationEnvironment, DummyCompilationEnvironment }
+import org.nlogo.core.{ CompilationEnvironment, CompilerException, DummyCompilationEnvironment }
 import org.nlogo.api.{ CompilerServices, Version }
 import org.nlogo.core.Program
 import scala.collection.immutable.ListMap
@@ -28,7 +28,12 @@ class DefaultCompilerServices(compiler: CompilerInterface with AuxiliaryCompiler
   def readFromString(source: String) =
     compiler.readFromString(source)
   def isConstant(s: String) =
-    compiler.isValidIdentifier(s)
+    try {
+      compiler.readFromString(s)
+      true
+    } catch {
+      case e: CompilerException => false
+    }
   def isValidIdentifier(s: String) =
     compiler.isValidIdentifier(s)
   def isReporter(s: String) =

--- a/netlogo-gui/src/main/app/App.scala
+++ b/netlogo-gui/src/main/app/App.scala
@@ -337,14 +337,17 @@ class App extends
           pico.getComponent(classOf[EditDialogFactoryInterface]))
       }
     }
+
+    val compilerServices =
+      new DefaultCompilerServices(pico.getComponent(classOf[org.nlogo.nvm.PresentationCompilerInterface]))
+    val hnEditorFactory = new EditorFactory(compilerServices)
+
     pico.add(classOf[HubNetManagerFactory], "org.nlogo.hubnet.server.gui.HubNetManagerFactory",
           Array[Parameter] (
             new ComponentParameter(classOf[AppFrame]),
-            new ComponentParameter(), new ComponentParameter(),
+            new ConstantParameter(hnEditorFactory), new ComponentParameter(),
             new ComponentParameter()))
     pico.addComponent(interfaceFactory)
-    val editorFactory = new EditorFactory(pico.getComponent(classOf[CompilerServices]))
-    pico.addComponent(editorFactory)
     pico.addComponent(new MenuBarFactory())
 
     val controlSet = new AppControlSet()
@@ -398,7 +401,7 @@ class App extends
       }
     }
 
-    editorFactory.useExtensionManager(workspace.getExtensionManager)
+    hnEditorFactory.useExtensionManager(workspace.getExtensionManager)
 
     pico.addComponent(new EditorColorizer(workspace))
 


### PR DESCRIPTION
Reproducing the issue is simple and reliable:

  1. Open model **Function HubNet**
  2. Click the "Local" button in the HubNet Control Center

You'll be met with a stacktrace like this one:

> java.lang.NullPointerException
 at org.nlogo.window.EditorColorizer.tokenizeForColorization(EditorColorizer.scala:75)
 at org.nlogo.window.EditorColorizer.getCharacterTokenTypes(EditorColorizer.scala:56)
 at org.nlogo.editor.BracketMatcher.caretUpdate(BracketMatcher.java:75)
 at javax.swing.text.JTextComponent.fireCaretUpdate(JTextComponent.java:397)
 at javax.swing.text.JTextComponent$MutableCaretEvent.fire(JTextComponent.java:4394)
 at javax.swing.text.JTextComponent$MutableCaretEvent.stateChanged(JTextComponent.java:4416)
 at javax.swing.text.DefaultCaret.fireStateChanged(DefaultCaret.java:802)
 at javax.swing.text.DefaultCaret.changeCaretPosition(DefaultCaret.java:1274)
 at javax.swing.text.DefaultCaret.handleSetDot(DefaultCaret.java:1173)
 at javax.swing.text.DefaultCaret.setDot(DefaultCaret.java:1154)
 at javax.swing.text.DefaultCaret$Handler.insertUpdate(DefaultCaret.java:1723)
 at javax.swing.text.AbstractDocument.fireInsertUpdate(AbstractDocument.java:201)
 at javax.swing.text.AbstractDocument.handleInsertString(AbstractDocument.java:748)
 at javax.swing.text.AbstractDocument.insertString(AbstractDocument.java:707)
 at javax.swing.text.PlainDocument.insertString(PlainDocument.java:130)
 at javax.swing.text.DefaultEditorKit.read(DefaultEditorKit.java:273)
 at javax.swing.JEditorPane.setText(JEditorPane.java:1416)
 at org.nlogo.window.InputBoxWidget.valueObject(InputBoxWidget.scala:32)
 at org.nlogo.window.InputBox.setValue$1(InputBox.scala:332)
 at org.nlogo.window.InputBox.load(InputBox.scala:338)
 at org.nlogo.window.InputBox.load(InputBox.scala:28)
 at org.nlogo.window.InterfacePanelLite.$anonfun$loadWidget$3(InterfacePanelLite.scala:253)
 at org.nlogo.window.InterfacePanelLite.$anonfun$loadWidget$3$adapted(InterfacePanelLite.scala:252)
 at scala.Option.foreach(Option.scala:257)
 at org.nlogo.window.InterfacePanelLite.loadWidget(InterfacePanelLite.scala:252)
 at org.nlogo.window.InterfacePanelLite.$anonfun$handle$1(InterfacePanelLite.scala:268)
 at scala.collection.mutable.ArraySeq.foreach(ArraySeq.scala:74)
 at org.nlogo.window.InterfacePanelLite.handle(InterfacePanelLite.scala:268)
 at org.nlogo.window.Events$LoadWidgetsEvent.beHandledBy(Events.java:516)
 at org.nlogo.window.Event.doRaise(Event.java:198)
 at org.nlogo.window.Event.raise(Event.java:122)
 at org.nlogo.hubnet.client.ClientPanel.completeLogin(ClientPanel.scala:242)
 at org.nlogo.hubnet.client.ClientPanel.handleProtocolMessage(ClientPanel.scala:259)
 at org.nlogo.hubnet.client.ClientPanel.receiveData(ClientPanel.scala:420)
 at org.nlogo.hubnet.client.ClientPanel.processEvent(ClientPanel.scala:386)
 at java.awt.Component.dispatchEventImpl(Component.java:4889)
 at java.awt.Container.dispatchEventImpl(Container.java:2294)
 at java.awt.Component.dispatchEvent(Component.java:4711)
 at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
 at java.awt.EventQueue.access$500(EventQueue.java:97)
 at java.awt.EventQueue$3.run(EventQueue.java:709)
 at java.awt.EventQueue$3.run(EventQueue.java:703)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:90)
 at java.awt.EventQueue$4.run(EventQueue.java:731)
 at java.awt.EventQueue$4.run(EventQueue.java:729)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
 at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
 at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:109)
 at java.awt.WaitDispatchSupport$2.run(WaitDispatchSupport.java:184)
 at java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:229)
 at java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:227)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.awt.WaitDispatchSupport.enter(WaitDispatchSupport.java:227)
 at java.awt.Dialog.show(Dialog.java:1084)
 at java.awt.Component.show(Component.java:1671)
 at java.awt.Component.setVisible(Component.java:1623)
 at java.awt.Window.setVisible(Window.java:1014)
 at java.awt.Dialog.setVisible(Dialog.java:1005)
 at org.nlogo.swing.ModalProgressTask$.display(ModalProgressTask.scala:23)
 at org.nlogo.swing.ModalProgressTask$.onUIThread(ModalProgressTask.scala:27)
 at org.nlogo.hubnet.client.ClientApp.org$nlogo$hubnet$client$ClientApp$$login(ClientApp.scala:126)
 at org.nlogo.hubnet.client.ClientApp.$anonfun$startup$1(ClientApp.scala:101)
 at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
 at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:756)
 at java.awt.EventQueue.access$500(EventQueue.java:97)
 at java.awt.EventQueue$3.run(EventQueue.java:709)
 at java.awt.EventQueue$3.run(EventQueue.java:703)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
 at java.awt.EventQueue.dispatchEvent(EventQueue.java:726)
 at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
 at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
 at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
>
> NetLogo 6.0.1
main: org.nlogo.app.AppFrame
thread: AWT-EventQueue-0
Java HotSpot(TM) 64-Bit Server VM 1.8.0_121 (Oracle Corporation; 1.8.0_121-b13)
operating system: Windows 10 10.0 (amd64 processor)
Scala version 2.12.1
JOGL: (3D View not initialized)
OpenGL Graphics: (3D View not initialized)
model: Function HubNet
>
> 10:53:23.014 InterfaceGlobalEvent (org.nlogo.app.interfacetab.InterfacePanel$$anon$1 (org.nlogo.window.SliderWidget)) AWT-EventQueue-0
10:53:23.014 InterfaceGlobalEvent (org.nlogo.app.interfacetab.InterfacePanel$$anon$1 (org.nlogo.window.SliderWidget)) AWT-EventQueue-0
10:53:23.014 InterfaceGlobalEvent (org.nlogo.app.interfacetab.InterfacePanel$$anon$1 (org.nlogo.window.SliderWidget)) AWT-EventQueue-0
10:53:23.014 InterfaceGlobalEvent (org.nlogo.app.interfacetab.InterfacePanel$$anon$1 (org.nlogo.window.SliderWidget)) AWT-EventQueue-0
10:53:23.014 InterfaceGlobalEvent (org.nlogo.widget.SwitchWidget) AWT-EventQueue-0
10:53:23.014 InterfaceGlobalEvent (org.nlogo.widget.SwitchWidget) AWT-EventQueue-0
10:53:23.014 InterfaceGlobalEvent (org.nlogo.widget.SwitchWidget) AWT-EventQueue-0
10:53:23.014 PeriodicUpdateEvent (org.nlogo.app.App$$anon$1 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
10:53:22.802 AfterLoadEvent (org.nlogo.hubnet.client.ClientPanel) AWT-EventQueue-0
10:53:22.802 WidgetAddedEvent (org.nlogo.window.ButtonWidget) AWT-EventQueue-0

This happens for me on both Windows and Linux.  However, it does **not** occur when the client that connects uses the standalone HubNet client executable.