### PR TITLE
The multiline field should exist for String input box types only, rem…

### DIFF
--- a/parser-core/src/main/core/InputBox.scala
+++ b/parser-core/src/main/core/InputBox.scala
@@ -35,7 +35,6 @@ case class NumericInput(value: Double, label: NumericInput.NumericKind) extends 
   def name = label.display
   def constraint = NumericInputConstraintSpecification(name, value)
   def default = NumericInput(0, label)
-  def multiline = false
   def asString = value.toString
   def defaultString = value.toString
 }
@@ -76,7 +75,6 @@ object InputBox {
 sealed trait BoxedValue {
   def name: String
   def constraint: ConstraintSpecification
-  def multiline: Boolean
   def default: BoxedValue
   def asString: String
   def defaultString: String
@@ -98,7 +96,10 @@ case class InputBox(variable: Option[String],
     case StringInput(value, _, _) => value
   }
 
-  def multiline = boxedValue.multiline
+  def multiline = boxedValue match {
+    case NumericInput(_, _) => false
+    case StringInput(_, _, multiline) => multiline
+  }
 
   override def constraint = boxedValue.constraint
 }

--- a/parser-core/src/main/core/model/WidgetReader.scala
+++ b/parser-core/src/main/core/model/WidgetReader.scala
@@ -482,7 +482,7 @@ object InputBoxReader extends BaseWidgetReader {
     StringLine())    // inputboxtype
 
   def asList(inputbox: InputBox) = List((), inputbox.left, inputbox.top, inputbox.right, inputbox.bottom, inputbox.variable,
-    inputbox.boxedValue.asString, (), inputbox.boxedValue.multiline, inputbox.boxedValue.name)
+    inputbox.boxedValue.asString, (), inputbox.multiline, inputbox.boxedValue.name)
   def asWidget(vals: List[Any], literalParser: LiteralParser): InputBox = {
 
     val List((), left: Int, top: Int, right: Int, bottom: Int, variable: Option[String] @unchecked, value: String,


### PR DESCRIPTION
…oving from Numeric types.

This fix is related to the [Tortoise issue 182 about numeric and color inputs causing errors](https://github.com/NetLogo/Tortoise/issues/182).  These changes are not required to make the fix for 182 work, but I think it makes the purpose of multiline field clearer if it only exists on the input box type it is meant to apply to.  