### PR TITLE
Autosuggest expanded primitive list

### DIFF
--- a/netlogo-core/src/main/api/CompilerServices.scala
+++ b/netlogo-core/src/main/api/CompilerServices.scala
@@ -2,9 +2,10 @@
 
 package org.nlogo.api
 
-import org.nlogo.core.{ CompilerException, LiteralParser, ProcedureSyntax, Token }
+import org.nlogo.core.{ CompilerException, Dialect, LiteralParser, ProcedureSyntax, Token }
 
 trait CompilerServices extends LiteralParser {
+  def dialect: Dialect
   def isConstant(s: String): Boolean
   @throws(classOf[CompilerException])
   def readFromString(s: String): AnyRef

--- a/netlogo-core/src/main/api/DummyExtensionManager.scala
+++ b/netlogo-core/src/main/api/DummyExtensionManager.scala
@@ -17,5 +17,7 @@ class DummyExtensionManager extends CoreDummyExtensionManager with ExtensionMana
   override def loadedExtensions = java.util.Collections.emptyList[ClassManager]
   override def dumpExtensions: String = unsupported
   override def dumpExtensionPrimitives(): String = unsupported
+  def extensionCommandNames: Set[String] = Set.empty[String]
+  def extensionReporterNames: Set[String] = Set.empty[String]
   private def unsupported = throw new UnsupportedOperationException
 }

--- a/netlogo-core/src/main/nvm/DefaultCompilerServices.scala
+++ b/netlogo-core/src/main/nvm/DefaultCompilerServices.scala
@@ -2,7 +2,7 @@
 
 package org.nlogo.nvm
 
-import org.nlogo.core.{ CompilationEnvironment, DummyCompilationEnvironment }
+import org.nlogo.core.{ CompilationEnvironment, Dialect, DummyCompilationEnvironment }
 import org.nlogo.api.{ CompilerServices, Version }
 import org.nlogo.core.Program
 import scala.collection.immutable.ListMap
@@ -13,6 +13,7 @@ import scala.collection.immutable.ListMap
 // BehaviorSpace XML. - ST 2/23/09, 3/4/09
 
 class DefaultCompilerServices(compiler: CompilerInterface with AuxiliaryCompilerInterface) extends CompilerServices {
+  def dialect: Dialect = compiler.defaultDialect
   def emptyProgram = Program.fromDialect(compiler.defaultDialect)
   def autoConvert(modelVersion: String)(source: String) = source
   def readNumberFromString(source: String) =

--- a/netlogo-core/src/main/nvm/ExtensionManager.scala
+++ b/netlogo-core/src/main/nvm/ExtensionManager.scala
@@ -18,4 +18,14 @@ trait ExtensionManager extends ApiExtensionManager {
    * the extension lifecycle hooks. It is cleared when clearAll is run.
    */
   def cachedType(name: String): Option[TokenType]
+
+  /**
+   * Return cached lists of the names of extension primitives
+   * (commands and reporters respectively)
+   *
+   * These are cached so that they can be run without interrupting
+   * the extension lifecycle hooks.
+   */
+  def extensionCommandNames:  Set[String]
+  def extensionReporterNames: Set[String]
 }

--- a/netlogo-gui/src/main/api/DummyCompilerServices.scala
+++ b/netlogo-gui/src/main/api/DummyCompilerServices.scala
@@ -2,11 +2,12 @@
 
 package org.nlogo.api
 
-import org.nlogo.core.{ CompilerException, ProcedureSyntax, Token }
+import org.nlogo.core.{ CompilerException, Dialect, NetLogoCore, ProcedureSyntax, Token }
 
 // just enough functionality to make the tests pass
 
 class DummyCompilerServices extends CompilerServices {
+  def dialect: Dialect = NetLogoCore
   private def unsupported = throw new UnsupportedOperationException
   def readFromString(s: String): AnyRef =
     try { s.toDouble: java.lang.Double }

--- a/netlogo-gui/src/main/app/App.scala
+++ b/netlogo-gui/src/main/app/App.scala
@@ -186,6 +186,8 @@ object App{
       new ComponentParameter(), new ComponentParameter())
     pico.add(classOf[MenuBar], "org.nlogo.app.MenuBar",
       new ConstantParameter(AbstractWorkspace.isApp))
+    pico.add("org.nlogo.app.interfacetab.CommandCenter")
+    pico.add("org.nlogo.app.interfacetab.InterfaceTab")
     pico.addComponent(classOf[Tabs])
     pico.addComponent(classOf[AgentMonitorManager])
     app = pico.getComponent(classOf[App])
@@ -339,12 +341,8 @@ class App extends
     }
     pico.add(classOf[HubNetManagerFactory], "org.nlogo.hubnet.server.gui.HubNetManagerFactory",
           Array[Parameter] (
-            new ComponentParameter(classOf[AppFrame]),
-            new ComponentParameter(), new ComponentParameter(),
-            new ComponentParameter()))
+            new ComponentParameter(classOf[AppFrame]), new ComponentParameter(), new ComponentParameter()))
     pico.addComponent(interfaceFactory)
-    val editorFactory = new EditorFactory(pico.getComponent(classOf[CompilerServices]))
-    pico.addComponent(editorFactory)
     pico.addComponent(new MenuBarFactory())
 
     val controlSet = new AppControlSet()
@@ -397,8 +395,6 @@ class App extends
         model.withOptionalSection("org.nlogo.modelsection.modelsettings", Some(ModelSettings(snapOn)), Some(ModelSettings(false)))
       }
     }
-
-    editorFactory.useExtensionManager(workspace.getExtensionManager)
 
     pico.addComponent(new EditorColorizer(workspace))
 

--- a/netlogo-gui/src/main/app/Tabs.scala
+++ b/netlogo-gui/src/main/app/Tabs.scala
@@ -25,8 +25,7 @@ import org.nlogo.window.Events._
 import org.nlogo.window.{ EditDialogFactoryInterface, Event, ExternalFileInterface, GUIWorkspace, JobWidget, MonitorWidget }
 
 class Tabs(val workspace:       GUIWorkspace,
-           monitorManager:      AgentMonitorManager,
-           dialogFactory:       EditDialogFactoryInterface,
+           val interfaceTab:    InterfaceTab,
            private var menu:    MenuBar,
            externalFileManager: ExternalFileManager)
   extends JTabbedPane(SwingConstants.TOP)
@@ -72,7 +71,6 @@ class Tabs(val workspace:       GUIWorkspace,
   var fileManager: FileManager = null
   var dirtyMonitor: DirtyMonitor = null
 
-  val interfaceTab = new InterfaceTab(workspace, monitorManager, dialogFactory)
   val infoTab = new InfoTab(workspace.attachModelDir(_))
   val codeTab = new MainCodeTab(workspace, this, menu)
   var externalFileTabs = Set.empty[TemporaryCodeTab]

--- a/netlogo-gui/src/main/app/common/CommandLine.scala
+++ b/netlogo-gui/src/main/app/common/CommandLine.scala
@@ -49,7 +49,7 @@ class CommandLine(commandCenter: CommandCenterInterface,
   private var historyBaseClass: AgentKind = AgentKind.Observer
   private var history: List[ExecutionString] = List()
 
-  val codeCompletionPopup = new CodeCompletionPopup()
+  val codeCompletionPopup = CodeCompletionPopup(workspace.dialect, workspace.getExtensionManager)
   val actionMap = Map(KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_SPACE, java.awt.event.InputEvent.CTRL_DOWN_MASK)
     -> new AutoSuggestAction("auto-suggest", codeCompletionPopup))
 

--- a/netlogo-gui/src/main/app/common/EditorFactory.scala
+++ b/netlogo-gui/src/main/app/common/EditorFactory.scala
@@ -15,22 +15,21 @@ import org.nlogo.ide.{ AutoSuggestAction, CodeCompletionPopup, JumpToDeclaration
   NetLogoFoldParser, NetLogoTokenMakerFactory, ShiftActions, ShowUsageBox, ShowUsageBoxAction, ToggleComments }
 import org.nlogo.editor.{ AbstractEditorArea, AdvancedEditorArea, EditorArea, EditorConfiguration, EditorScrollPane, LineNumberScrollPane }
 import org.nlogo.nvm.ExtensionManager
-import org.nlogo.window.{ EditorColorizer, DefaultEditorFactory }
+import org.nlogo.window.DefaultEditorFactory
 
 import org.fife.ui.rsyntaxtextarea.{ folding, AbstractTokenMakerFactory, TokenMakerFactory },
   folding.FoldParserManager
 import org.fife.ui.rtextarea.RTextScrollPane
 
-class EditorFactory(compiler: CompilerServices, optionalExtensionManager: Option[ExtensionManager]) extends DefaultEditorFactory(compiler) {
-  def this(compiler: CompilerServices) = this(compiler, None)
-  def this(compiler: CompilerServices, extensionManager: ExtensionManager) = this(compiler, Some(extensionManager))
-
+class EditorFactory(compiler: CompilerServices, extensionManager: ExtensionManager) extends DefaultEditorFactory(compiler) {
   System.setProperty(TokenMakerFactory.PROPERTY_DEFAULT_TOKEN_MAKER_FACTORY,
     "org.nlogo.ide.NetLogoTokenMakerFactory")
-  optionalExtensionManager.foreach(useExtensionManager)
+  useExtensionManager(extensionManager)
+
+  def autoSuggestAction =
+    new AutoSuggestAction("auto-suggest", CodeCompletionPopup(compiler.dialect, extensionManager))
 
   override def defaultConfiguration(rows: Int, cols: Int): EditorConfiguration = {
-    val codeCompletionPopup = new CodeCompletionPopup
     val showUsageBox = new ShowUsageBox(colorizer)
     val shiftTabAction = new ShiftActions.LeftTab()
     val actions = Seq[Action](
@@ -43,7 +42,7 @@ class EditorFactory(compiler: CompilerServices, optionalExtensionManager: Option
       .withContextActions(actions)
       .addKeymap(
         KeyStroke.getKeyStroke(KeyEvent.VK_SPACE, InputEvent.CTRL_DOWN_MASK),
-        new AutoSuggestAction("auto-suggest", codeCompletionPopup))
+        autoSuggestAction)
       .addKeymap(
         KeyStroke.getKeyStroke(KeyEvent.VK_TAB, InputEvent.SHIFT_MASK), shiftTabAction)
       .withLineNumbers(

--- a/netlogo-gui/src/main/app/interfacetab/CommandCenter.scala
+++ b/netlogo-gui/src/main/app/interfacetab/CommandCenter.scala
@@ -18,8 +18,7 @@ import org.nlogo.window.{ CommandCenterInterface, Events => WindowEvents,
   InterfaceColors, OutputArea, TextMenuActions, Zoomable }
 import org.nlogo.workspace.{ AbstractWorkspace, ExportOutput }
 
-class CommandCenter(workspace: AbstractWorkspace,
-                    locationToggleAction: Action) extends JPanel
+class CommandCenter(workspace: AbstractWorkspace) extends JPanel
   with Zoomable with CommandCenterInterface
   with WindowEvents.LoadBeginEvent.Handler
   with WindowEvents.ZoomedEvent.Handler {
@@ -35,6 +34,16 @@ class CommandCenter(workspace: AbstractWorkspace,
     override def mouseReleased(e: MouseEvent) { if(e.isPopupTrigger) { e.consume(); doPopup(e) }}
   })
 
+  private val locationToggleButton =
+    new JButton() {
+      setText("")
+      setFocusable(false)
+      setVisible(false)
+      // this is very ad hoc. we want to save vertical screen real estate and also keep the
+      // button from being too wide on Windows and Linux - ST 7/13/04, 11/24/04
+      override def getInsets = new Insets(2, 4, 3, 4)
+    }
+
   locally {
     setOpaque(true)  // so background color shows up - ST 10/4/05
     setBackground(InterfaceColors.COMMAND_CENTER_BACKGROUND)
@@ -43,16 +52,6 @@ class CommandCenter(workspace: AbstractWorkspace,
     //NORTH
     //-----------------------------------------
     val titleLabel = new JLabel(I18N.gui.get("tabs.run.commandcenter"))
-
-    val locationToggleButton =
-      if(locationToggleAction == null) null
-      else new JButton(locationToggleAction) {
-        setText("")
-        setFocusable(false)
-        // this is very ad hoc. we want to save vertical screen real estate and also keep the
-        // button from being too wide on Windows and Linux - ST 7/13/04, 11/24/04
-        override def getInsets = new Insets(2, 4, 3, 4)
-      }
 
     val clearButton = new JButton(RichAction(I18N.gui.get("tabs.run.commandcenter.clearButton")) { _ => output.clear() }) {
       setFocusable(false)
@@ -78,7 +77,7 @@ class CommandCenter(workspace: AbstractWorkspace,
     northPanel.add(Box.createGlue)
     Fonts.adjustDefaultFont(titleLabel)
     titleLabel.setFont(titleLabel.getFont.deriveFont(Font.BOLD))
-    if(locationToggleButton != null) northPanel.add(locationToggleButton)
+    northPanel.add(locationToggleButton)
     northPanel.add(clearButton)
     resizeNorthPanel()
 
@@ -101,6 +100,15 @@ class CommandCenter(workspace: AbstractWorkspace,
     southPanel.add(historyPanel, BorderLayout.EAST)
     add(southPanel, BorderLayout.SOUTH)
   }
+
+  private[interfacetab] def locationToggleAction_=(a: Action): Unit = {
+    locationToggleButton.setAction(a)
+    locationToggleButton.setText("")
+    locationToggleButton.setVisible(a != null)
+  }
+
+  private[interfacetab] def locationToggleAction: Action =
+    locationToggleButton.getAction
 
   override def getMinimumSize =
     new Dimension(0, 2 + northPanel.getMinimumSize.height +

--- a/netlogo-gui/src/main/app/interfacetab/InterfaceTab.scala
+++ b/netlogo-gui/src/main/app/interfacetab/InterfaceTab.scala
@@ -28,7 +28,8 @@ import InterfaceTab._
 
 class InterfaceTab(workspace: GUIWorkspace,
                    monitorManager: AgentMonitorManager,
-                   dialogFactory: EditDialogFactoryInterface) extends JPanel
+                   dialogFactory: EditDialogFactoryInterface,
+                   val commandCenter: CommandCenter) extends JPanel
   with LoadBeginEvent.Handler
   with OutputEvent.Handler
   with Enable2DEvent.Handler
@@ -38,7 +39,7 @@ class InterfaceTab(workspace: GUIWorkspace,
 
   setFocusCycleRoot(true)
   setFocusTraversalPolicy(new InterfaceTabFocusTraversalPolicy)
-  val commandCenter = new CommandCenter(workspace, new CommandCenterLocationToggleAction)
+  commandCenter.locationToggleAction = new CommandCenterLocationToggleAction
   val iP = new InterfacePanel(workspace.viewWidget, workspace)
 
   activeMenuActions =

--- a/netlogo-gui/src/main/hubnet/client/App.scala
+++ b/netlogo-gui/src/main/hubnet/client/App.scala
@@ -25,6 +25,6 @@ object App {
     VMCheck.detectBadJVMs()
     val compiler = new org.nlogo.nvm.DefaultCompilerServices(
       Femto.get[PresentationCompilerInterface]("org.nlogo.compile.Compiler", if (Version.is3D) NetLogoThreeDDialect else NetLogoLegacyDialect))
-    ClientApp.mainHelper(args, new DefaultEditorFactory(compiler), compiler)
+    ClientApp.mainHelper(args, compiler)
   }
 }

--- a/netlogo-gui/src/main/hubnet/server/gui/GUIHubNetManager.scala
+++ b/netlogo-gui/src/main/hubnet/server/gui/GUIHubNetManager.scala
@@ -21,7 +21,6 @@ import java.awt.Component
 
 class GUIHubNetManager(workspace: GUIWorkspace,
                        linkParent: Component,
-                       editorFactory: EditorFactory,
                        ifactory: InterfaceFactory,
                        menuFactory: MenuBarFactory,
                        loader: ModelLoader,
@@ -56,7 +55,7 @@ class GUIHubNetManager(workspace: GUIWorkspace,
     val host = try Some(InetAddress.getLocalHost.getHostAddress.toString)
     catch {case ex: java.net.UnknownHostException => None}
     // TODO: this seems like a bunch of bugs waiting to happen
-    clientApp.startup(editorFactory, "", host.orNull, connectionManager.port, true,
+    clientApp.startup("", host.orNull, connectionManager.port, true,
       isRobo, waitTime, new DefaultCompilerServices(workspace.compiler))
   }
 

--- a/netlogo-gui/src/main/hubnet/server/gui/HubNetManagerFactory.scala
+++ b/netlogo-gui/src/main/hubnet/server/gui/HubNetManagerFactory.scala
@@ -5,12 +5,11 @@ package org.nlogo.hubnet.server.gui
 import org.nlogo.api.{ HubNetInterface, ModelLoader, NetLogoLegacyDialect }
 import org.nlogo.fileformat
 import org.nlogo.workspace.{ AbstractWorkspaceScala, HubNetManagerFactory => WSHubNetManagerFactory }
-import org.nlogo.window.{ EditorFactory, GUIWorkspace, InterfaceFactory, MenuBarFactory }
+import org.nlogo.window.{ GUIWorkspace, InterfaceFactory, MenuBarFactory }
 
 import java.awt.Component
 
 class HubNetManagerFactory(linkParent: Component,
-                       editorFactory: EditorFactory,
                        ifactory: InterfaceFactory,
                        menuFactory: MenuBarFactory) extends WSHubNetManagerFactory {
   def newInstance(workspace: AbstractWorkspaceScala): HubNetInterface = {
@@ -20,7 +19,7 @@ class HubNetManagerFactory(linkParent: Component,
           fileformat.converter(workspace.getExtensionManager, workspace.getCompilationEnvironment,
             workspace, fileformat.defaultAutoConvertables) _
         val loader = fileformat.standardLoader(workspace)
-        new GUIHubNetManager(g, linkParent, editorFactory, ifactory, menuFactory, loader, converter(NetLogoLegacyDialect))
+        new GUIHubNetManager(g, linkParent, ifactory, menuFactory, loader, converter(NetLogoLegacyDialect))
       case _ => throw new Exception("Expected GUIWorkspace, got: " + workspace)
     }
   }

--- a/netlogo-gui/src/main/ide/AutoSuggestAction.scala
+++ b/netlogo-gui/src/main/ide/AutoSuggestAction.scala
@@ -21,13 +21,14 @@ class AutoSuggestAction(name: String, codeCompletionPopup: CodeCompletionPopup) 
     editorArea.getDocument().addDocumentListener(autoSuggestDocumentListener)
   }
 }
+
 class AutoSuggestDocumentListener(codeCompletionPopup: CodeCompletionPopup) extends DocumentListener {
   override def changedUpdate(e: DocumentEvent): Unit = {
-}
+  }
   override def insertUpdate(e: DocumentEvent): Unit = {
-  codeCompletionPopup.fireUpdatePopup(Some(e))
-}
+    codeCompletionPopup.fireUpdatePopup(Some(e))
+  }
   override def removeUpdate(e: DocumentEvent): Unit = {
-  codeCompletionPopup.fireUpdatePopup(Some(e))
-}
+    codeCompletionPopup.fireUpdatePopup(Some(e))
+  }
 }

--- a/netlogo-gui/src/main/window/ClientAppInterface.java
+++ b/netlogo-gui/src/main/window/ClientAppInterface.java
@@ -5,7 +5,7 @@ package org.nlogo.window;
 import org.nlogo.api.CompilerServices;
 
 public interface ClientAppInterface {
-  void startup(final EditorFactory editorFactory, final String userid, final String hostip,
+  void startup(final String userid, final String hostip,
                final int port, final boolean isLocal, final boolean isRobo, final long waitTime,
                final CompilerServices workspace);
 }

--- a/netlogo-gui/src/main/workspace/AbstractWorkspace.java
+++ b/netlogo-gui/src/main/workspace/AbstractWorkspace.java
@@ -375,40 +375,4 @@ public abstract strictfp class AbstractWorkspace
   public org.nlogo.api.MersenneTwisterFast mainRNG() {
     return _world.mainRNG();
   }
-
-  public Double readNumberFromString(String source)
-      throws CompilerException {
-    return compiler().readNumberFromString(source, _world, getExtensionManager());
-  }
-
-  public boolean isConstant(String s) {
-    try {
-      compiler().readFromString(s);
-      return true;
-    }
-    catch(CompilerException e) {
-      return false;
-    }
-  }
-
-  public boolean isValidIdentifier(String s) {
-    return compiler().isValidIdentifier(s);
-  }
-
-  public Token[] tokenizeForColorization(String s) {
-    return compiler().tokenizeForColorization(s, getExtensionManager());
-  }
-
-  public scala.collection.Iterator<Token> tokenizeForColorizationIterator(String s) {
-    return compiler().tokenizeForColorizationIterator(s, getExtensionManager());
-  }
-
-  public Token getTokenAtPosition(String s, int pos) {
-    return compiler().getTokenAtPosition(s, pos);
-  }
-
-  public scala.collection.immutable.Map<String, org.nlogo.core.ProcedureSyntax> findProcedurePositions(String source) {
-    return compiler().findProcedurePositions(source);
-  }
-
 }

--- a/netlogo-gui/src/main/workspace/AbstractWorkspaceScala.scala
+++ b/netlogo-gui/src/main/workspace/AbstractWorkspaceScala.scala
@@ -167,21 +167,6 @@ object AbstractWorkspaceTraits {
       Checksummer.calculateGraphicsChecksum(this)
   }
 
-  trait Compiling { this: AbstractWorkspace =>
-    @throws(classOf[CompilerException])
-    def checkReporterSyntax(source: String): Unit = {
-      compiler.checkReporterSyntax(source, _world.program, procedures, getExtensionManager, false, getCompilationEnvironment)
-    }
-
-    @throws(classOf[CompilerException])
-    def checkCommandSyntax(source: String): Unit = {
-      compiler.checkCommandSyntax(source, _world.program, procedures, getExtensionManager, false, getCompilationEnvironment)
-    }
-
-    def isReporter(s: String): Boolean =
-      compiler.isReporter(s, _world.program, procedures, getExtensionManager, getCompilationEnvironment);
-  }
-
   trait APIConformant { this: AbstractWorkspace =>
     // Members declared in org.nlogo.api.ViewSettings
     def drawSpotlight: Boolean = true

--- a/netlogo-gui/src/main/workspace/Compiling.scala
+++ b/netlogo-gui/src/main/workspace/Compiling.scala
@@ -1,0 +1,52 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.workspace
+
+import org.nlogo.core.{ CompilerException, Dialect, ProcedureSyntax, Token }
+
+// This trait implements all the api.CompilerServices methods *except* readFromString, which
+// is in the Evaluating trait - RG 5/23/2017
+trait Compiling { this: AbstractWorkspace =>
+  def dialect = world.program.dialect
+
+  def isConstant(s: String): Boolean = {
+    try {
+      compiler.readFromString(s)
+      true
+    } catch {
+      case e: CompilerException => false
+    }
+  }
+
+  @throws(classOf[CompilerException])
+  def readNumberFromString(source: String): java.lang.Double =
+    compiler.readNumberFromString(source, _world, getExtensionManager)
+
+  @throws(classOf[CompilerException])
+  def checkReporterSyntax(source: String): Unit = {
+    compiler.checkReporterSyntax(source, _world.program, procedures, getExtensionManager, false, getCompilationEnvironment)
+  }
+
+  @throws(classOf[CompilerException])
+  def checkCommandSyntax(source: String): Unit = {
+    compiler.checkCommandSyntax(source, _world.program, procedures, getExtensionManager, false, getCompilationEnvironment)
+  }
+
+  def isReporter(s: String): Boolean =
+    compiler.isReporter(s, _world.program, procedures, getExtensionManager, getCompilationEnvironment);
+
+  def isValidIdentifier(s: String): Boolean =
+    compiler.isValidIdentifier(s)
+
+  def tokenizeForColorization(s: String): Array[Token] =
+    compiler.tokenizeForColorization(s, getExtensionManager)
+
+  def tokenizeForColorizationIterator(s: String): Iterator[Token] =
+    compiler.tokenizeForColorizationIterator(s, getExtensionManager)
+
+  def getTokenAtPosition(s: String, pos: Int): Token =
+    compiler.getTokenAtPosition(s, pos)
+
+  def findProcedurePositions(source: String): Map[String, ProcedureSyntax] =
+    compiler.findProcedurePositions(source)
+}

--- a/netlogo-gui/src/main/workspace/ExtensionManager.scala
+++ b/netlogo-gui/src/main/workspace/ExtensionManager.scala
@@ -261,6 +261,12 @@ class ExtensionManager(val workspace: ExtendableWorkspace, loader: ExtensionLoad
 
   def cachedType(name: String): Option[TokenType] = typeCache.get(name.toUpperCase)
 
+  def extensionCommandNames: Set[String] =
+    typeCache.filter(_._2 == TokenType.Command).map(_._1).toSet
+
+  def extensionReporterNames: Set[String] =
+    typeCache.filter(_._2 == TokenType.Reporter).map(_._1).toSet
+
   /**
    * Returns a String describing all the loaded extensions.
    */

--- a/netlogo-gui/src/test/ide/AutoSuggestTests.scala
+++ b/netlogo-gui/src/test/ide/AutoSuggestTests.scala
@@ -5,7 +5,7 @@ package org.nlogo.ide
 import org.scalatest.FunSuite
 
 class AutoSuggestTests extends FunSuite {
-  val autoSuggest = new AutoSuggest()
+  val autoSuggest = new AutoSuggest(Set.empty[String], () => Set.empty[String])
   test("empty"){
     val testList = Seq()
     assertResult(testList)(autoSuggest.getSuggestions("zzzzz"))


### PR DESCRIPTION
Autosuggest provides suggestions for all built-in primitives, but it would be a nice enhancement if it also suggested agent variable names and extension primitives. 
