### PR TITLE
Autoconverter 6.0.1 showing confusing error messages for `?` tasks

### DIFF
--- a/parser-core/src/main/parse/ArrowLambdaScoper.scala
+++ b/parser-core/src/main/parse/ArrowLambdaScoper.scala
@@ -63,7 +63,7 @@ object ArrowLambdaScoper {
     def gatherArgumentToArrow(arg: Token, toks: Seq[Token], usedNames: SymbolTable): Option[(Seq[String], Seq[Token], SymbolTable)] = {
       val tok = toks.head
       if (tok.isArrow) {
-        if (arg.tpe == TokenType.Ident || arg.value.isInstanceOf[_unknownidentifier])
+        if (arg.tpe == TokenType.Ident || arg.value.isInstanceOf[_unknownidentifier] || arg.value.isInstanceOf[LambdaTokenMapper._taskvariable])
           Some((Seq(arg.text.toUpperCase), toks.tail, usedNames))
         else
           exception(s"Expected a variable name here", arg)


### PR DESCRIPTION
When trying to convert a model containing tasks with a `?` from 5.3.1 to 6.0.1 NetLogo shows the following error message: 
![grafik](https://cloud.githubusercontent.com/assets/22129968/24293918/6041ff76-1094-11e7-8de6-438272587cb1.png)

This happens e.g. when converting a file with the following simple example: 

```
to foo
  show filter [? < 3] [1 3 2]
end
```
or

```
to foo2
  foreach [1.1 2.2 2.6] [ show (word ? " -> " round ?) ]
end
```
When the `?` is missing this error message doesn't occur:

```
to foo
  foreach [1.1 2.2 2.6] show
end
```

Nevertheless: Even though in the first two cases it shows this confusing error message, if you select "Open Partially Converted Model" in the error window, it opens a perfectly functional converted model, which utilized the new concise task syntax:

```
to foo
  show filter [ ?1 -> ?1 < 3 ] [1 3 2]
end
```

This error message doesn't appear when using the NetLogo 6.0.0 autoconverter.