### PR TITLE
String representations of anonymous procedures don't include arguments 

### DIFF
--- a/netlogo-core/src/main/compile/middle/LambdaLifter.scala
+++ b/netlogo-core/src/main/compile/middle/LambdaLifter.scala
@@ -37,7 +37,8 @@ class LambdaLifter(lambdaNumbers: Iterator[Int]) extends AstTransformer {
         val formals = c.argumentNames.map(n => Let(n))
         val name = "__lambda-" + lambdaNumbers.next()
         c.proc = new nvm.LiftedLambda(
-          name, c.token, parent = p, lambdaFormals = formals, closedLets = resolveClosedVariables(c.closedVariables))
+          name, c.token, c.argTokens, parent = p, lambdaFormals = formals,
+          closedLets = resolveClosedVariables(c.closedVariables))
         c.proc.pos = expr.start
         c.proc.end = expr.end
         p.addChild(c.proc)

--- a/netlogo-core/src/main/nvm/LiftedLambda.scala
+++ b/netlogo-core/src/main/nvm/LiftedLambda.scala
@@ -5,12 +5,15 @@ package org.nlogo.nvm
 import org.nlogo.core.{ ClosedVariable, Let, StructureDeclarations, Token, prim => coreprim }
 
 final class LiftedLambda(
-  name:          String,
-  nameToken:     Token,
-  val parent:        Procedure,
-  val lambdaFormals: Seq[Let],
-  val closedLets:    Set[Let]
-  ) extends Procedure(false, name, nameToken, Seq.empty[Token], null) {
+  name:               String,
+  nameToken:          Token,
+  argTokens:          Seq[Token],
+  val parent:         Procedure,
+  val lambdaFormals:  Seq[Let],
+  val closedLets:     Set[Let]
+  ) extends Procedure(false, name, nameToken, argTokens, null) {
+
+    args = Vector[String]()
 
     val lambdaFormalsArray: Array[Let] = lambdaFormals.toArray[Let]
 
@@ -21,17 +24,6 @@ final class LiftedLambda(
         case parentLambda: LiftedLambda => parentLambda.getLambdaFormal(name)
         case _ => None
       })
-
-    override lazy val displayName = {
-      def topParent(p: Procedure): Procedure =
-        p match {
-          case ll: LiftedLambda => topParent(ll.parent)
-          case _ => p
-        }
-
-      val sourceCode = code.map(_.fullSource).filterNot(_ == null).mkString("[", " ", "]")
-      "(anonymous command from: " + topParent(parent).displayName + ": " + sourceCode + ")"
-    }
 
     override def dump: String = {
       val buf = new StringBuilder

--- a/netlogo-core/src/main/nvm/Procedure.scala
+++ b/netlogo-core/src/main/nvm/Procedure.scala
@@ -19,7 +19,7 @@ class Procedure(
   val nameToken:            Token,
   val argTokens:            Seq[Token],
   val procedureDeclaration: StructureDeclarations.Procedure,
-  baseDisplayName:          Option[String] = None) extends ProcedureJ with FrontEndProcedure {
+  val baseDisplayName:      Option[String] = None) extends ProcedureJ with FrontEndProcedure {
 
     args = argTokens.map(_.text).toVector
 
@@ -37,7 +37,8 @@ class Procedure(
     var size = 0
     var owner: SourceOwner = null
 
-    lazy val displayName = buildDisplayName(baseDisplayName)
+    // This is filled in by SourceTagger
+    var displayName = baseDisplayName.getOrElse("")
 
     protected var children = collection.mutable.Buffer[Procedure]()
 

--- a/netlogo-gui/src/main/compile/Backifier.scala
+++ b/netlogo-gui/src/main/compile/Backifier.scala
@@ -173,11 +173,11 @@ class Backifier(program: Program,
       case core.prim._constcodeblock(toks) =>
         new nvmprim._constcodeblock(toks)
 
-      case core.prim._commandlambda(argNames, _, closedLambdaVariables) =>
-        new nvmprim._commandlambda(argNames, null, closedLambdaVariables)
+      case core.prim._commandlambda(argNames, argTokens, _, closedLambdaVariables) =>
+        new nvmprim._commandlambda(argNames, argTokens, null, closedLambdaVariables)
 
-      case core.prim._reporterlambda(argNames, _, closedLambdaVariables) =>
-        new nvmprim._reporterlambda(argNames, closedLambdaVariables)
+      case core.prim._reporterlambda(argNames, argTokens, _, closedLambdaVariables) =>
+        new nvmprim._reporterlambda(argNames, argTokens, closedLambdaVariables)
 
       case core.prim._externreport(_) =>
         new nvmprim._externreport(

--- a/netlogo-gui/src/main/prim/_commandlambda.scala
+++ b/netlogo-gui/src/main/prim/_commandlambda.scala
@@ -2,12 +2,16 @@
 
 package org.nlogo.prim
 
-import org.nlogo.core.ClosedVariable
+import org.nlogo.core.{ ClosedVariable, Token }
 import org.nlogo.nvm.{ AnonymousCommand, Context, LiftedLambda, Reporter }
 
 import scala.collection.JavaConversions._
 
-class _commandlambda(val argumentNames: Seq[String], var proc: LiftedLambda, val closedVariables: Set[ClosedVariable]) extends Reporter {
+class _commandlambda(
+  val argumentNames:   Seq[String],
+  val argTokens:       Seq[Token],
+  var proc:            LiftedLambda,
+  val closedVariables: Set[ClosedVariable]) extends Reporter {
   override def report(c: Context): AnyRef = {
     AnonymousCommand(procedure = proc,
                 formals   = proc.lambdaFormalsArray,

--- a/netlogo-gui/src/main/prim/_reporterlambda.scala
+++ b/netlogo-gui/src/main/prim/_reporterlambda.scala
@@ -2,17 +2,20 @@
 
 package org.nlogo.prim
 
-import org.nlogo.core.Syntax
-import org.nlogo.core.{ ClosedVariable, Let }
+import org.nlogo.core.{ ClosedVariable, Let, Syntax, Token }
 import org.nlogo.nvm.{ AnonymousReporter, Context, Reporter }
 
 import scala.collection.JavaConversions._
 
-class _reporterlambda(argumentNames: Seq[String], val closedVariables: Set[ClosedVariable]) extends Reporter {
+class _reporterlambda(
+  argumentNames:       Seq[String],
+  argumentTokens:      Seq[Token],
+  val closedVariables: Set[ClosedVariable]) extends Reporter {
+
   val formals: Seq[Let] = argumentNames.map(name => new Let(name))
   def formalsArray: Array[Let] = formals.toArray
 
   override def report(c: Context): AnyRef = {
-    AnonymousReporter(body = args(0), formals = formalsArray, binding = c.activation.binding, locals = c.activation.args)
+    AnonymousReporter(body = args(0), formals = formalsArray, binding = c.activation.binding, locals = c.activation.args, argumentTokens = argumentTokens)
   }
 }

--- a/netlogo-gui/src/test/compile/AssemblerTests.scala
+++ b/netlogo-gui/src/test/compile/AssemblerTests.scala
@@ -13,6 +13,7 @@ class AssemblerTests extends FunSuite {
     val procdefs = TestHelper.compiledProcedures(keyword + " foo " + source + "\nend", program)
     assertResult(1)(procdefs.size)
     val procedure = procdefs.head.procedure
+    procedure.displayName = "procedure FOO"
     for (procdef <- procdefs) {
       procdef.accept(new ArgumentStuffer)
       new Assembler().assemble(procdef)

--- a/netlogo-headless/src/main/compile/Backifier.scala
+++ b/netlogo-headless/src/main/compile/Backifier.scala
@@ -61,11 +61,11 @@ class Backifier(
       case core.prim._const(value) =>
         new prim._const(value)
 
-      case core.prim._commandlambda(args, _, closedLambdaVariables) =>
-        new prim._commandlambda(args, null, closedLambdaVariables) // LambdaLifter will fill in
+      case core.prim._commandlambda(args, argTokens, _, closedLambdaVariables) =>
+        new prim._commandlambda(args, argTokens, null, closedLambdaVariables) // LambdaLifter will fill in
 
-      case core.prim._reporterlambda(args, _, closedLambdaVariables) =>
-        new prim._reporterlambda(args, closedLambdaVariables)
+      case core.prim._reporterlambda(args, argTokens, _, closedLambdaVariables) =>
+        new prim._reporterlambda(args, argTokens, closedLambdaVariables)
 
       case core.prim._externreport(_) =>
         new prim._externreport(

--- a/netlogo-headless/src/main/prim/_commandlambda.scala
+++ b/netlogo-headless/src/main/prim/_commandlambda.scala
@@ -2,10 +2,14 @@
 
 package org.nlogo.prim
 
-import org.nlogo.core.ClosedVariable
+import org.nlogo.core.{ ClosedVariable, Token }
 import org.nlogo.nvm.{ AnonymousCommand, Context, LiftedLambda, Procedure, Reporter }
 
-class _commandlambda(val argumentNames: Seq[String], var proc: LiftedLambda, val closedVariables: Set[ClosedVariable]) extends Reporter {
+class _commandlambda(
+  val argumentNames:   Seq[String],
+  val argTokens:       Seq[Token],
+  var proc:            LiftedLambda,
+  val closedVariables: Set[ClosedVariable]) extends Reporter {
 
   override def toString =
     super.toString +

--- a/netlogo-headless/src/main/prim/_reporterlambda.scala
+++ b/netlogo-headless/src/main/prim/_reporterlambda.scala
@@ -2,18 +2,22 @@
 
 package org.nlogo.prim
 
-import org.nlogo.core.{ ClosedVariable, Let }
+import org.nlogo.core.{ ClosedVariable, Let, Token }
 import org.nlogo.nvm.{ AnonymousReporter, Context, Reporter }
 
 import scala.collection.JavaConversions._
 
-class _reporterlambda(argumentNames: Seq[String], val closedVariables: Set[ClosedVariable]) extends Reporter {
+class _reporterlambda(
+  argumentNames:       Seq[String],
+  argumentTokens:      Seq[Token],
+  val closedVariables: Set[ClosedVariable]) extends Reporter {
+
   val formals: Seq[Let] = argumentNames.map(name => new Let(name))
   def formalsArray: Array[Let] = formals.toArray
 
   def getFormal(name: String): Option[Let] = formals.find(_.name == name)
 
   override def report(c: Context): AnyRef = {
-    AnonymousReporter(body = args(0), formals = formalsArray, binding = c.activation.binding, locals = c.activation.args)
+    AnonymousReporter(body = args(0), formals = formalsArray, binding = c.activation.binding, locals = c.activation.args, argumentTokens = argumentTokens)
   }
 }

--- a/netlogo-headless/src/test/compile/back/AssemblerTests.scala
+++ b/netlogo-headless/src/test/compile/back/AssemblerTests.scala
@@ -16,6 +16,7 @@ class AssemblerTests extends FunSuite {
     assertResult(1)(defs.size)
     for (procdef <- defs) {
       procdef.accept(new ArgumentStuffer)
+      procdef.procedure.displayName = "procedure FOO"
       new Assembler().assemble(procdef)
     }
     defs.head.procedure

--- a/netlogo-headless/test/benchdumps/GasLabCirc.txt
+++ b/netlogo-headless/test/benchdumps/GasLabCirc.txt
@@ -8834,7 +8834,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
             INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
            L1
             ARETURN
-      _commandlambda:(anonymous command from: procedure SORT-COLLISIONS: [if first collision < first winner [ set winner collision ] set winner collision]) "[ [collision] -> if first collision < first winner [set winner collision]]"
+      _commandlambda:(anonymous command: [collision -> if first collision < first winner [ set winner collision ]]) "[ [collision] -> if first collision < first winner [set winner collision]]"
 [8]_asm_proceduresortcollisions_setprocedurevariable_14 "let item 0 winner" Object => void
       _item "item 0 winner"
         _asm_proceduresortcollisions_constdouble_15 "0" => Double
@@ -9326,8 +9326,8 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
          L1
           RETURN
 
-   (anonymous command from: procedure SORT-COLLISIONS: [if first collision < first winner [ set winner collision ] set winner collision]):procedure SORT-COLLISIONS[]{OTPL}:
-   [0]_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_if_0 "if first collision < first winner [ set winner collision ]" boolean => void
+   (anonymous command: [collision -> if first collision < first winner [ set winner collision ]]):procedure SORT-COLLISIONS[]{OTPL}:
+   [0]_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 "if first collision < first winner [ set winner collision ]" boolean => void
             _lessthan "first collision < first winner" Object,Object => boolean
               _first "first collision" Object => Object
                 _letvariable(Let(COLLISION)) "collision" => Object
@@ -9345,7 +9345,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_if_0.kept4__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0.kept4__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L1
                 ASTORE 2
@@ -9413,12 +9413,12 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
                L4
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_if_0.kept6__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0.kept6__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L7
                 ASTORE 2
@@ -9441,12 +9441,12 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
                L9
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_if_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/core/LogoList] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/core/LogoList] [java/lang/Object]
                 ALOAD 3
                 INVOKEVIRTUAL org/nlogo/core/LogoList.first ()Ljava/lang/Object;
                 GOTO L10
                L8
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
                 ALOAD 2
                 INSTANCEOF java/lang/String
                 IFEQ L11
@@ -9466,14 +9466,14 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
                L12
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/String] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/String] [java/lang/Object]
                 ALOAD 3
                 ICONST_0
                 ICONST_1
                 INVOKEVIRTUAL java/lang/String.substring (II)Ljava/lang/String;
                 GOTO L10
                L11
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
                 ALOAD 1
@@ -9486,7 +9486,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
                L10
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object java/lang/Object]
                 ASTORE 3
                 ASTORE 2
                 ALOAD 2
@@ -9597,26 +9597,26 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 ICONST_1
                 GOTO L21
                L20
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
                 ICONST_2
                L21
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L22
                 RETURN
    [1]_setletvariable:WINNER "set winner collision"
-            _asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_letvariable_1 "collision" => Object
+            _asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_letvariable_1 "collision" => Object
                   // parameter final  context
                  L0
                   ALOAD 1
                   GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                   GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                   ALOAD 0
-                  GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_letvariable_1.kept1__let : Lorg/nlogo/core/Let;
+                  GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_letvariable_1.kept1__let : Lorg/nlogo/core/Let;
                   INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                  L1
                   ARETURN
-   [2]_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinnercollisionsetwinnercollision_done_2 => void
+   [2]_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_done_2 => void
                 // parameter final  context
                L0
                 ALOAD 1

--- a/parser-core/src/main/core/prim/misc.scala
+++ b/parser-core/src/main/core/prim/misc.scala
@@ -73,10 +73,19 @@ case class _carefully() extends Command {
       right = List(Syntax.CommandBlockType, Syntax.CommandBlockType),
       introducesContext = true)
 }
-case class _commandlambda(argumentNames: Seq[String], synthetic: Boolean, closedVariables: Set[ClosedVariable]) extends Lambda with Reporter {
-  def this() = this(Seq(), false, Set())
-  def this(arguments: Seq[String]) = this(arguments, false, Set())
-  def this(arguments: Seq[String], synthetic: Boolean) = this(arguments, synthetic, Set())
+case class _commandlambda(
+  argumentNames:   Seq[String],
+  argumentTokens:  Seq[Token],
+  synthetic:       Boolean,
+  closedVariables: Set[ClosedVariable]) extends Lambda with Reporter {
+  def this() = this(Seq(), Seq(), false, Set())
+  def this(arguments: Seq[Token]) =
+    this(arguments.map(_.text.toUpperCase), arguments, false, Set())
+  def this(arguments: Seq[Token], synthetic: Boolean) =
+    this(arguments.map(_.text.toUpperCase), arguments, synthetic, Set())
+  def this(arguments: Seq[String], argumentTokens: Seq[Token], synthetic: Boolean) =
+    this(arguments, argumentTokens, synthetic, Set())
+
   override def syntax =
     Syntax.reporterSyntax(ret = Syntax.CommandType)
 
@@ -85,8 +94,11 @@ case class _commandlambda(argumentNames: Seq[String], synthetic: Boolean, closed
 
   def minArgCount: Int = argumentNames.length
 
-  def copy(argumentNames: Seq[String] = argumentNames, closedVariables: Set[ClosedVariable] = closedVariables): _commandlambda = {
-    val ct = new _commandlambda(argumentNames, synthetic, closedVariables)
+  def copy(
+    argumentNames:   Seq[String] = argumentNames,
+    argumentTokens:  Seq[Token] = argumentTokens,
+    closedVariables: Set[ClosedVariable] = closedVariables): _commandlambda = {
+    val ct = new _commandlambda(argumentNames, argumentTokens, synthetic, closedVariables)
     copyInstruction(ct)
   }
 }
@@ -382,10 +394,19 @@ case class _report() extends Command {
     Syntax.commandSyntax(
       right = List(Syntax.WildcardType))
 }
-case class _reporterlambda(argumentNames: Seq[String], synthetic: Boolean, closedVariables: Set[ClosedVariable]) extends Lambda with Reporter {
-  def this() = this(Seq(), false, Set())
-  def this(arguments: Seq[String]) = this(arguments, false, Set())
-  def this(arguments: Seq[String], synthetic: Boolean) = this(arguments, synthetic, Set())
+case class _reporterlambda(
+  argumentNames:   Seq[String],
+  argumentTokens:  Seq[Token],
+  synthetic:       Boolean,
+  closedVariables: Set[ClosedVariable]) extends Lambda with Reporter {
+
+  def this() = this(Seq(), Seq(), false, Set())
+  def this(arguments: Seq[Token]) =
+    this(arguments.map(_.text.toUpperCase), arguments, false, Set())
+  def this(arguments: Seq[Token], synthetic: Boolean) =
+    this(arguments.map(_.text.toUpperCase), arguments, synthetic, Set())
+  def this(arguments: Seq[String], argumentTokens: Seq[Token], synthetic: Boolean) =
+    this(arguments, argumentTokens, synthetic, Set())
   override def syntax = {
     Syntax.reporterSyntax(
       right = List(Syntax.CodeBlockType, Syntax.ReporterType),
@@ -395,8 +416,11 @@ case class _reporterlambda(argumentNames: Seq[String], synthetic: Boolean, close
   override def toString =
     "_reporterlambda" + argumentNames.mkString("(", ", ", ")")
 
-  def copy(argumentNames: Seq[String] = argumentNames, closedVariables: Set[ClosedVariable] = closedVariables): _reporterlambda = {
-    val cr = new _reporterlambda(argumentNames, synthetic, closedVariables)
+  def copy(
+    argumentNames:   Seq[String]         = argumentNames,
+    argumentTokens:  Seq[Token]          = argumentTokens,
+    closedVariables: Set[ClosedVariable] = closedVariables): _reporterlambda = {
+    val cr = new _reporterlambda(argumentNames, argumentTokens, synthetic, closedVariables)
     copyInstruction(cr)
   }
 }

--- a/parser-core/src/main/parse/ClosureTagger.scala
+++ b/parser-core/src/main/parse/ClosureTagger.scala
@@ -30,8 +30,8 @@ class ClosedVariableFinder(lambdaVarNames: Seq[String]) extends AstFolder[Set[Cl
       case _letvariable(let)                   => closedVars + ClosedLet(let)
       case _lambdavariable(name, _) if ! lambdaVarNames.contains(name) =>
         closedVars + ClosedLambdaVariable(name)
-      case _reporterlambda(_, _, reporterLets) => closedVars ++ reporterLets
-      case _commandlambda(_, _, reporterLets)  => closedVars ++ reporterLets
+      case _reporterlambda(_, _, _, reporterLets) => closedVars ++ reporterLets
+      case _commandlambda(_, _, _, reporterLets)  => closedVars ++ reporterLets
       case _                                   => super.visitReporterApp(app)
     }
   }

--- a/parser-core/src/main/parse/Lambdaizer.scala
+++ b/parser-core/src/main/parse/Lambdaizer.scala
@@ -140,10 +140,10 @@ class Lambdaizer extends PositionalAstFolder[Map[AstPath, Operation]] {
           case ReporterApp(Lambda(_, true, _), _, _) =>
             // this case makes sure `let foo task pi` doesn't get converted to `let foo pi`
             super.visitReporterApp(app, position)(ops + (position -> wrapConciseForClarity(position)))
-          case lambdaApp@ReporterApp(_reporterlambda(args, _, _), _, _) if args.isEmpty =>
+          case lambdaApp@ReporterApp(_reporterlambda(args, _, _, _), _, _) if args.isEmpty =>
             // This case makes sure `let foo task [pi]` doesn't get converted to `let foo [pi]`
             super.visitReporterApp(app, position)(ops + (position -> wrapTaskBlockArgument(lambdaApp)))
-          case lambdaApp@ReporterApp(_commandlambda(args, false, _), _, _) if args.isEmpty =>
+          case lambdaApp@ReporterApp(_commandlambda(args, _, false, _), _, _) if args.isEmpty =>
             // This case makes sure `let foo task [tick]` doesn't get converted to `let foo [tick]`
             super.visitReporterApp(app, position)(ops + (position -> wrapTaskBlockArgument(lambdaApp)))
           case _ =>

--- a/parser-core/src/test/parse/ArrowLambdaScoperTests.scala
+++ b/parser-core/src/test/parse/ArrowLambdaScoperTests.scala
@@ -94,7 +94,7 @@ class ArrowLambdaScoperTests extends FunSuite {
     "MEAN" -> SymbolType.PrimitiveReporter,
     "BAR"  -> SymbolType.GlobalVariable)
 
-  def scope(ts: Seq[Token], otherSymbols: SymbolTable = SymbolTable.empty): Option[(Seq[String], Seq[Token], SymbolTable)] =
+  def scope(ts: Seq[Token], otherSymbols: SymbolTable = SymbolTable.empty): Option[(Seq[Token], Seq[Token], SymbolTable)] =
     ArrowLambdaScoper(ts, testSymbols ++ otherSymbols)
 
   def testScopes(toks: Seq[Token], expectedArgs: Seq[String], expectedBody: Seq[Token], expectedSymbols: SymbolTable = SymbolTable.empty) = {
@@ -102,7 +102,7 @@ class ArrowLambdaScoperTests extends FunSuite {
     assert(res.isDefined)
     res.foreach {
       case (args, body, symbols) =>
-        assertResult(expectedArgs)(args)
+        assertResult(expectedArgs)(args.map(_.text.toUpperCase))
         assertResult(expectedBody)(body)
         expectedSymbols.foreach {
           case (key, symType) =>

--- a/test/benchdumps/ANN.txt
+++ b/test/benchdumps/ANN.txt
@@ -3042,8 +3042,8 @@ procedure PROPOGATE:[]{OTPL}:
          L1
           RETURN
 
-   (anonymous command from: procedure PROPOGATE: [ask ?1 [ update-activation ] update-activation]):procedure PROPOGATE[]{OTPL}:
-   [0]_asm_anonymouscommandfromprocedurepropogateask1updateactivationupdateactivation_ask_0 "ask ?1 [ update-activation ]" Object => void
+   (anonymous command: [ ?1 -> ask ?1 [ update-activation ] ]):procedure PROPOGATE[]{OTPL}:
+   [0]_asm_propogate_anonymouscommand1ask1updateactivation_ask_0 "ask ?1 [ update-activation ]" Object => void
             _letvariable(?1) "?1" => Object
                 // parameter final  context
                L0
@@ -3051,7 +3051,7 @@ procedure PROPOGATE:[]{OTPL}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromprocedurepropogateask1updateactivationupdateactivation_ask_0.kept2__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_propogate_anonymouscommand1ask1updateactivation_ask_0.kept2__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L1
                 ASTORE 2
@@ -3067,7 +3067,7 @@ procedure PROPOGATE:[]{OTPL}:
                 IFNE L3
                 ALOAD 3
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromprocedurepropogateask1updateactivationupdateactivation_ask_0.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm_propogate_anonymouscommand1ask1updateactivation_ask_0.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
                 IF_ACMPNE L4
                 NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -3083,7 +3083,7 @@ procedure PROPOGATE:[]{OTPL}:
                FRAME APPEND [java/lang/Object org/nlogo/agent/AgentSet]
                 ALOAD 3
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromprocedurepropogateask1updateactivationupdateactivation_ask_0.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm_propogate_anonymouscommand1ask1updateactivation_ask_0.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
                 IF_ACMPNE L3
                 NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -3154,12 +3154,12 @@ procedure PROPOGATE:[]{OTPL}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L7
                 RETURN
-   [1]_asm_anonymouscommandfromprocedurepropogateask1updateactivationupdateactivation_call_1 "update-activation"
+   [1]_asm_propogate_anonymouscommand1ask1updateactivation_call_1 "update-activation"
                L0
                 NEW org/nlogo/nvm/Activation
                 DUP
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromprocedurepropogateask1updateactivationupdateactivation_call_1.kept1_procedure : Lorg/nlogo/nvm/Procedure;
+                GETFIELD org/nlogo/prim/_asm_propogate_anonymouscommand1ask1updateactivation_call_1.kept1_procedure : Lorg/nlogo/nvm/Procedure;
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 SIPUSH 1
@@ -3174,7 +3174,7 @@ procedure PROPOGATE:[]{OTPL}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L1
                 RETURN
-   [2]_asm_anonymouscommandfromprocedurepropogateask1updateactivationupdateactivation_done_2 => void
+   [2]_asm_propogate_anonymouscommand1ask1updateactivation_done_2 => void
                 // parameter final  context
                L0
                 ALOAD 1
@@ -3182,7 +3182,7 @@ procedure PROPOGATE:[]{OTPL}:
                 PUTFIELD org/nlogo/nvm/Context.finished : Z
                L1
                 RETURN
-   [3]_asm_anonymouscommandfromprocedurepropogateask1updateactivationupdateactivation_done_3 => void
+   [3]_asm_propogate_anonymouscommand1ask1updateactivation_done_3 => void
                 // parameter final  context
                L0
                 ALOAD 1
@@ -4106,8 +4106,8 @@ procedure SET-BIASES:[BIASES]{OTPL}:
          L1
           RETURN
 
-   (anonymous command from: procedure SET-BIASES: [ask ?1 [ set-bias ?2 ] set-bias ?2]):procedure SET-BIASES[]{OTPL}:
-   [0]_asm_anonymouscommandfromproceduresetbiasesask1setbias2setbias2_ask_0 "ask ?1 [ set-bias ?2 ]" Object => void
+   (anonymous command: [ [?1 ?2] -> ask ?1 [ set-bias ?2 ] ]):procedure SET-BIASES[]{OTPL}:
+   [0]_asm_setbiases_anonymouscommand12ask1setbias2_ask_0 "ask ?1 [ set-bias ?2 ]" Object => void
             _letvariable(?1) "?1" => Object
                 // parameter final  context
                L0
@@ -4115,7 +4115,7 @@ procedure SET-BIASES:[BIASES]{OTPL}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetbiasesask1setbias2setbias2_ask_0.kept2__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setbiases_anonymouscommand12ask1setbias2_ask_0.kept2__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L1
                 ASTORE 2
@@ -4131,7 +4131,7 @@ procedure SET-BIASES:[BIASES]{OTPL}:
                 IFNE L3
                 ALOAD 3
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetbiasesask1setbias2setbias2_ask_0.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm_setbiases_anonymouscommand12ask1setbias2_ask_0.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
                 IF_ACMPNE L4
                 NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -4147,7 +4147,7 @@ procedure SET-BIASES:[BIASES]{OTPL}:
                FRAME APPEND [java/lang/Object org/nlogo/agent/AgentSet]
                 ALOAD 3
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetbiasesask1setbias2setbias2_ask_0.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm_setbiases_anonymouscommand12ask1setbias2_ask_0.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
                 IF_ACMPNE L3
                 NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -4218,14 +4218,14 @@ procedure SET-BIASES:[BIASES]{OTPL}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L7
                 RETURN
-   [1]_asm_anonymouscommandfromproceduresetbiasesask1setbias2setbias2_call_1 "set-bias ?2"
+   [1]_asm_setbiases_anonymouscommand12ask1setbias2_call_1 "set-bias ?2"
             _letvariable(?2) "?2" => Object
                 // parameter final  context
                L0
                 NEW org/nlogo/nvm/Activation
                 DUP
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetbiasesask1setbias2setbias2_call_1.kept1_procedure : Lorg/nlogo/nvm/Procedure;
+                GETFIELD org/nlogo/prim/_asm_setbiases_anonymouscommand12ask1setbias2_call_1.kept1_procedure : Lorg/nlogo/nvm/Procedure;
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 SIPUSH 1
@@ -4237,7 +4237,7 @@ procedure SET-BIASES:[BIASES]{OTPL}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetbiasesask1setbias2setbias2_call_1.kept2__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setbiases_anonymouscommand12ask1setbias2_call_1.kept2__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L2
                 AASTORE
@@ -4251,7 +4251,7 @@ procedure SET-BIASES:[BIASES]{OTPL}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L3
                 RETURN
-   [2]_asm_anonymouscommandfromproceduresetbiasesask1setbias2setbias2_done_2 => void
+   [2]_asm_setbiases_anonymouscommand12ask1setbias2_done_2 => void
                 // parameter final  context
                L0
                 ALOAD 1
@@ -4259,7 +4259,7 @@ procedure SET-BIASES:[BIASES]{OTPL}:
                 PUTFIELD org/nlogo/nvm/Context.finished : Z
                L1
                 RETURN
-   [3]_asm_anonymouscommandfromproceduresetbiasesask1setbias2setbias2_done_3 => void
+   [3]_asm_setbiases_anonymouscommand12ask1setbias2_done_3 => void
                 // parameter final  context
                L0
                 ALOAD 1
@@ -4303,8 +4303,8 @@ procedure SET-INPUT:[INPUT]{OTPL}:
          L1
           RETURN
 
-   (anonymous command from: procedure SET-INPUT: [ask ?1 [ set-activation ?2 ] set-activation ?2]):procedure SET-INPUT[]{OTPL}:
-   [0]_asm_anonymouscommandfromproceduresetinputask1setactivation2setactivation2_ask_0 "ask ?1 [ set-activation ?2 ]" Object => void
+   (anonymous command: [ [?1 ?2] -> ask ?1 [ set-activation ?2 ] ]):procedure SET-INPUT[]{OTPL}:
+   [0]_asm_setinput_anonymouscommand12ask1setactivation2_ask_0 "ask ?1 [ set-activation ?2 ]" Object => void
             _letvariable(?1) "?1" => Object
                 // parameter final  context
                L0
@@ -4312,7 +4312,7 @@ procedure SET-INPUT:[INPUT]{OTPL}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetinputask1setactivation2setactivation2_ask_0.kept2__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setinput_anonymouscommand12ask1setactivation2_ask_0.kept2__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L1
                 ASTORE 2
@@ -4328,7 +4328,7 @@ procedure SET-INPUT:[INPUT]{OTPL}:
                 IFNE L3
                 ALOAD 3
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetinputask1setactivation2setactivation2_ask_0.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm_setinput_anonymouscommand12ask1setactivation2_ask_0.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
                 IF_ACMPNE L4
                 NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -4344,7 +4344,7 @@ procedure SET-INPUT:[INPUT]{OTPL}:
                FRAME APPEND [java/lang/Object org/nlogo/agent/AgentSet]
                 ALOAD 3
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetinputask1setactivation2setactivation2_ask_0.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm_setinput_anonymouscommand12ask1setactivation2_ask_0.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
                 IF_ACMPNE L3
                 NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -4415,14 +4415,14 @@ procedure SET-INPUT:[INPUT]{OTPL}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L7
                 RETURN
-   [1]_asm_anonymouscommandfromproceduresetinputask1setactivation2setactivation2_call_1 "set-activation ?2"
+   [1]_asm_setinput_anonymouscommand12ask1setactivation2_call_1 "set-activation ?2"
             _letvariable(?2) "?2" => Object
                 // parameter final  context
                L0
                 NEW org/nlogo/nvm/Activation
                 DUP
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetinputask1setactivation2setactivation2_call_1.kept1_procedure : Lorg/nlogo/nvm/Procedure;
+                GETFIELD org/nlogo/prim/_asm_setinput_anonymouscommand12ask1setactivation2_call_1.kept1_procedure : Lorg/nlogo/nvm/Procedure;
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 SIPUSH 1
@@ -4434,7 +4434,7 @@ procedure SET-INPUT:[INPUT]{OTPL}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetinputask1setactivation2setactivation2_call_1.kept2__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setinput_anonymouscommand12ask1setactivation2_call_1.kept2__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L2
                 AASTORE
@@ -4448,7 +4448,7 @@ procedure SET-INPUT:[INPUT]{OTPL}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L3
                 RETURN
-   [2]_asm_anonymouscommandfromproceduresetinputask1setactivation2setactivation2_done_2 => void
+   [2]_asm_setinput_anonymouscommand12ask1setactivation2_done_2 => void
                 // parameter final  context
                L0
                 ALOAD 1
@@ -4456,7 +4456,7 @@ procedure SET-INPUT:[INPUT]{OTPL}:
                 PUTFIELD org/nlogo/nvm/Context.finished : Z
                L1
                 RETURN
-   [3]_asm_anonymouscommandfromproceduresetinputask1setactivation2setactivation2_done_3 => void
+   [3]_asm_setinput_anonymouscommand12ask1setactivation2_done_3 => void
                 // parameter final  context
                L0
                 ALOAD 1
@@ -4684,8 +4684,8 @@ procedure SET-WEIGHTS:[WEIGHTS]{OTPL}:
          L1
           RETURN
 
-   (anonymous command from: procedure SET-WEIGHTS: [ask ?1 [ set-weight ?2 ] set-weight ?2]):procedure SET-WEIGHTS[]{OTPL}:
-   [0]_asm_anonymouscommandfromproceduresetweightsask1setweight2setweight2_ask_0 "ask ?1 [ set-weight ?2 ]" Object => void
+   (anonymous command: [ [?1 ?2] -> ask ?1 [ set-weight ?2 ] ]):procedure SET-WEIGHTS[]{OTPL}:
+   [0]_asm_setweights_anonymouscommand12ask1setweight2_ask_0 "ask ?1 [ set-weight ?2 ]" Object => void
             _letvariable(?1) "?1" => Object
                 // parameter final  context
                L0
@@ -4693,7 +4693,7 @@ procedure SET-WEIGHTS:[WEIGHTS]{OTPL}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetweightsask1setweight2setweight2_ask_0.kept2__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setweights_anonymouscommand12ask1setweight2_ask_0.kept2__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L1
                 ASTORE 2
@@ -4709,7 +4709,7 @@ procedure SET-WEIGHTS:[WEIGHTS]{OTPL}:
                 IFNE L3
                 ALOAD 3
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetweightsask1setweight2setweight2_ask_0.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm_setweights_anonymouscommand12ask1setweight2_ask_0.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
                 IF_ACMPNE L4
                 NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -4725,7 +4725,7 @@ procedure SET-WEIGHTS:[WEIGHTS]{OTPL}:
                FRAME APPEND [java/lang/Object org/nlogo/agent/AgentSet]
                 ALOAD 3
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetweightsask1setweight2setweight2_ask_0.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm_setweights_anonymouscommand12ask1setweight2_ask_0.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
                 IF_ACMPNE L3
                 NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -4796,14 +4796,14 @@ procedure SET-WEIGHTS:[WEIGHTS]{OTPL}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L7
                 RETURN
-   [1]_asm_anonymouscommandfromproceduresetweightsask1setweight2setweight2_call_1 "set-weight ?2"
+   [1]_asm_setweights_anonymouscommand12ask1setweight2_call_1 "set-weight ?2"
             _letvariable(?2) "?2" => Object
                 // parameter final  context
                L0
                 NEW org/nlogo/nvm/Activation
                 DUP
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetweightsask1setweight2setweight2_call_1.kept1_procedure : Lorg/nlogo/nvm/Procedure;
+                GETFIELD org/nlogo/prim/_asm_setweights_anonymouscommand12ask1setweight2_call_1.kept1_procedure : Lorg/nlogo/nvm/Procedure;
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 SIPUSH 1
@@ -4815,7 +4815,7 @@ procedure SET-WEIGHTS:[WEIGHTS]{OTPL}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetweightsask1setweight2setweight2_call_1.kept2__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setweights_anonymouscommand12ask1setweight2_call_1.kept2__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L2
                 AASTORE
@@ -4829,7 +4829,7 @@ procedure SET-WEIGHTS:[WEIGHTS]{OTPL}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L3
                 RETURN
-   [2]_asm_anonymouscommandfromproceduresetweightsask1setweight2setweight2_done_2 => void
+   [2]_asm_setweights_anonymouscommand12ask1setweight2_done_2 => void
                 // parameter final  context
                L0
                 ALOAD 1
@@ -4837,7 +4837,7 @@ procedure SET-WEIGHTS:[WEIGHTS]{OTPL}:
                 PUTFIELD org/nlogo/nvm/Context.finished : Z
                L1
                 RETURN
-   [3]_asm_anonymouscommandfromproceduresetweightsask1setweight2setweight2_done_3 => void
+   [3]_asm_setweights_anonymouscommand12ask1setweight2_done_3 => void
                 // parameter final  context
                L0
                 ALOAD 1
@@ -5819,15 +5819,15 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
          L1
           RETURN
 
-   (anonymous command from: procedure SETUP: [let ?1 let length layers let no-turtles crt layer-size [ set layer (turtle-set layer self) ] set layer (turtle-set layer self) let layer-num + 0.5 / num-layers * max-pxcor let 0 foreach sort layer [ [??1] ->
+   (anonymous command: [ ?1 -> let ?1 let length layers let no-turtles crt layer-size [ set layer (turtle-set layer self) ] let layer-num + 0.5 / num-layers * max-pxcor let 0 foreach sort layer [ [??1] ->
       ask ??1 [
         let y 2 * (0.5 - (i + 0.5) / layer-size) * max-pycor
         setxy x y
         set color grey
       ]
       set i i + 1
-    ] set layers lput layer layers]):procedure SETUP[]{OTPL}:
-   [0]_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_0 "let ?1" Object => void
+    ] set layers lput layer layers ]):procedure SETUP[]{OTPL}:
+   [0]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_0 "let ?1" Object => void
             _letvariable(?1) "?1" => Object
                 // parameter final  context
                 // parameter final  context
@@ -5837,7 +5837,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_0.kept2__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_0.kept2__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L1
                 ASTORE 2
@@ -5845,7 +5845,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_0.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_0.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.let (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -5853,7 +5853,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L2
                 RETURN
-   [1]_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_1 "let length layers" Object => void
+   [1]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_1 "let length layers" Object => void
             _length "length layers" Object => double
               _observervariable:LAYERS "layers" => Object
                 // parameter final  context
@@ -5908,7 +5908,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_1.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_1.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.let (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -5916,12 +5916,12 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L5
                 RETURN
-   [2]_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_2 "let no-turtles" Object => void
+   [2]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_2 "let no-turtles" Object => void
             _noturtles "no-turtles"
                 // parameter final  context
                 // parameter final  value
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_2.keptinstr2 : Lorg/nlogo/prim/etc/_noturtles;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_2.keptinstr2 : Lorg/nlogo/prim/etc/_noturtles;
                 ALOAD 1
                 INVOKEVIRTUAL org/nlogo/prim/etc/_noturtles.report (Lorg/nlogo/nvm/Context;)Ljava/lang/Object;
                L0
@@ -5930,7 +5930,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_2.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_2.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.let (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -5939,31 +5939,31 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                L1
                 RETURN
    [3]_createturtles:,+6 "crt layer-size [ set layer (turtle-set layer self) ]"
-            _asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_letvariable_3 "layer-size" => Object
+            _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_letvariable_3 "layer-size" => Object
                   // parameter final  context
                  L0
                   ALOAD 1
                   GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                   GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                   ALOAD 0
-                  GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_letvariable_3.kept1__let : Lorg/nlogo/core/Let;
+                  GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_letvariable_3.kept1__let : Lorg/nlogo/core/Let;
                   INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                  L1
                   ARETURN
-   [4]_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_setletvariable_4 "set layer (turtle-set layer self)" Object => void
+   [4]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_setletvariable_4 "set layer (turtle-set layer self)" Object => void
             _turtleset "(turtle-set layer self)"
-              _asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_letvariable_5 "layer" => Object
+              _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_letvariable_5 "layer" => Object
                     // parameter final  context
                    L0
                     ALOAD 1
                     GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                     GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                     ALOAD 0
-                    GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_letvariable_5.kept1__let : Lorg/nlogo/core/Let;
+                    GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_letvariable_5.kept1__let : Lorg/nlogo/core/Let;
                     INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                    L1
                     ARETURN
-              _asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_self_6 "self" => Agent
+              _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_self_6 "self" => Agent
                     // parameter final  context
                    L0
                     ALOAD 1
@@ -5973,7 +5973,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 // parameter final  context
                 // parameter final  value
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_setletvariable_4.keptinstr2 : Lorg/nlogo/prim/etc/_turtleset;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_setletvariable_4.keptinstr2 : Lorg/nlogo/prim/etc/_turtleset;
                 ALOAD 1
                 INVOKEVIRTUAL org/nlogo/prim/etc/_turtleset.report (Lorg/nlogo/nvm/Context;)Ljava/lang/Object;
                L0
@@ -5982,7 +5982,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_setletvariable_4.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_setletvariable_4.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.setLet (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -5990,7 +5990,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L1
                 RETURN
-   [5]_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_done_7 => void
+   [5]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_done_7 => void
                 // parameter final  context
                L0
                 ALOAD 1
@@ -5998,7 +5998,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.finished : Z
                L1
                 RETURN
-   [6]_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_8 "let layer-num + 0.5 / num-layers * max-pxcor" Object => void
+   [6]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8 "let layer-num + 0.5 / num-layers * max-pxcor" Object => void
             _mult "layer-num + 0.5 / num-layers * max-pxcor" double,double => double
               _div "layer-num + 0.5 / num-layers" double,double => double
                 _plus "layer-num + 0.5" double,double => double
@@ -6018,7 +6018,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_8.kept5__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8.kept5__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L5
                 ASTORE 2
@@ -6028,7 +6028,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKEVIRTUAL java/lang/Double.doubleValue ()D
                 GOTO L6
                L1
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_8 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
+               FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
                 POP
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
@@ -6050,13 +6050,13 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 4
                 DADD
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_8.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8.validDouble (DLorg/nlogo/nvm/Context;)D
                L8
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_8.kept7__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8.kept7__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L9
                 ASTORE 2
@@ -6066,7 +6066,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKEVIRTUAL java/lang/Double.doubleValue ()D
                 GOTO L10
                L3
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_8 org/nlogo/nvm/Context java/lang/Object T D] [java/lang/ClassCastException]
+               FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8 org/nlogo/nvm/Context java/lang/Object T D] [java/lang/ClassCastException]
                 POP
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
@@ -6078,7 +6078,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
                L10
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_8 org/nlogo/nvm/Context java/lang/Object T D] [D D]
+               FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8 org/nlogo/nvm/Context java/lang/Object T D] [D D]
                 DSTORE 4
                 DSTORE 2
                 DLOAD 4
@@ -6095,16 +6095,16 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
                L11
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_8 org/nlogo/nvm/Context D D] []
+               FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8 org/nlogo/nvm/Context D D] []
                 ALOAD 0
                 DLOAD 2
                 DLOAD 4
                 DDIV
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_8.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8.validDouble (DLorg/nlogo/nvm/Context;)D
                L12
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_8.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.maxPxcor ()I
                 I2D
                L13
@@ -6115,7 +6115,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 4
                 DMUL
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_8.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8.validDouble (DLorg/nlogo/nvm/Context;)D
                L14
                 DSTORE 2
                 NEW java/lang/Double
@@ -6127,7 +6127,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_8.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.let (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -6135,20 +6135,20 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L15
                 RETURN
-   [7]_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_9 "let 0" Object => void
+   [7]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_9 "let 0" Object => void
             _constdouble:0.0 "0" => Double
                 // parameter final  context
                 // parameter final  value
                L0
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_9.kept2_value : Ljava/lang/Double;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_9.kept2_value : Ljava/lang/Double;
                L1
                 ASTORE 2
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_let_9.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_9.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.let (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -6164,7 +6164,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
       ]
       set i i + 1
     ]"
-            _asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_sort_10 "sort layer" Object => Object
+            _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_sort_10 "sort layer" Object => Object
               _letvariable(LAYER) "layer" => Object
                   // parameter final  context
                  L0
@@ -6172,7 +6172,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                   GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                   GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                   ALOAD 0
-                  GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_sort_10.kept2__let : Lorg/nlogo/core/Let;
+                  GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_sort_10.kept2__let : Lorg/nlogo/core/Let;
                   INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                  L1
                   ASTORE 2
@@ -6207,7 +6207,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                   INVOKEVIRTUAL org/nlogo/core/LogoList.javaIterator ()Ljava/util/Iterator;
                   ASTORE 7
                  L5
-                 FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_sort_10 org/nlogo/nvm/Context java/lang/Object org/nlogo/core/LogoList java/util/ArrayList java/util/ArrayList java/util/ArrayList java/util/Iterator] []
+                 FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_sort_10 org/nlogo/nvm/Context java/lang/Object org/nlogo/core/LogoList java/util/ArrayList java/util/ArrayList java/util/ArrayList java/util/Iterator] []
                   ALOAD 7
                   INVOKEINTERFACE java/util/Iterator.hasNext ()Z
                   IFEQ L6
@@ -6275,7 +6275,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                   INVOKESTATIC org/nlogo/core/LogoList.fromJava (Ljava/lang/Iterable;)Lorg/nlogo/core/LogoList;
                   GOTO L3
                  L4
-                 FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_sort_10 org/nlogo/nvm/Context java/lang/Object] []
+                 FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_sort_10 org/nlogo/nvm/Context java/lang/Object] []
                   NEW org/nlogo/nvm/ArgumentTypeException
                   DUP
                   ALOAD 1
@@ -6298,20 +6298,20 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
       ]
       set i i + 1
     ]"
-   [9]_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_setobservervariable_11 "set layers lput layer layers" Object => void
+   [9]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_setobservervariable_11 "set layers lput layer layers" Object => void
             _lput "lput layer layers"
-              _asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_letvariable_12 "layer" => Object
+              _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_letvariable_12 "layer" => Object
                     // parameter final  context
                    L0
                     ALOAD 1
                     GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                     GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                     ALOAD 0
-                    GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_letvariable_12.kept1__let : Lorg/nlogo/core/Let;
+                    GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_letvariable_12.kept1__let : Lorg/nlogo/core/Let;
                     INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                    L1
                     ARETURN
-              _asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_observervariable_13 "layers" => Object
+              _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_observervariable_13 "layers" => Object
                    L0
                     ALOAD 1
                     GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -6321,7 +6321,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                     ARETURN
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_setobservervariable_11.keptinstr2 : Lorg/nlogo/prim/etc/_lput;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_setobservervariable_11.keptinstr2 : Lorg/nlogo/prim/etc/_lput;
                 ALOAD 1
                 INVOKEVIRTUAL org/nlogo/prim/etc/_lput.report (Lorg/nlogo/nvm/Context;)Ljava/lang/Object;
                L3
@@ -6335,7 +6335,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                L1
                 GOTO L4
                L2
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_setobservervariable_11 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
+               FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_setobservervariable_11 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
                 ASTORE 3
                 NEW org/nlogo/nvm/RuntimePrimitiveException
                 DUP
@@ -6352,7 +6352,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L5
                 RETURN
-   [10]_asm_anonymouscommandfromproceduresetuplet1letlengthlayersletnoturtlescrtlayersize$1dc5440fc537bd25ae08d808c7d13e5c$_done_14 => void
+   [10]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_done_14 => void
                 // parameter final  context
                L0
                 ALOAD 1
@@ -6361,15 +6361,15 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                L1
                 RETURN
 
-   (anonymous command from: procedure SETUP: [ask ??1 let 2 * 0.5 - i + 0.5 / layer-size * max-pycor setxy x y [ set color grey ] let 2 * 0.5 - i + 0.5 / layer-size * max-pycor setxy x y set color grey set i i + 1]):(anonymous command from: procedure SETUP: [let ?1 let length layers let no-turtles crt layer-size [ set layer (turtle-set layer self) ] set layer (turtle-set layer self) let layer-num + 0.5 / num-layers * max-pxcor let 0 foreach sort layer [ [??1] ->
+   (anonymous command: [ ??1 -> ask ??1 let 2 * 0.5 - i + 0.5 / layer-size * max-pycor setxy x y [ set color grey ] set i i + 1 ]):(anonymous command: [ ?1 -> let ?1 let length layers let no-turtles crt layer-size [ set layer (turtle-set layer self) ] let layer-num + 0.5 / num-layers * max-pxcor let 0 foreach sort layer [ [??1] ->
       ask ??1 [
         let y 2 * (0.5 - (i + 0.5) / layer-size) * max-pycor
         setxy x y
         set color grey
       ]
       set i i + 1
-    ] set layers lput layer layers])[]{OTPL}:
-   [0]_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_ask_0 "ask ??1 let 2 * 0.5 - i + 0.5 / layer-size * max-pycor setxy x y [ set color grey ]" Object => void
+    ] set layers lput layer layers ])[]{OTPL}:
+   [0]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_ask_0 "ask ??1 let 2 * 0.5 - i + 0.5 / layer-size * max-pycor setxy x y [ set color grey ]" Object => void
             _letvariable(??1) "??1" => Object
                 // parameter final  context
                L0
@@ -6377,7 +6377,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_ask_0.kept2__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_ask_0.kept2__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L1
                 ASTORE 2
@@ -6393,7 +6393,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 IFNE L3
                 ALOAD 3
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_ask_0.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_ask_0.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
                 IF_ACMPNE L4
                 NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -6409,7 +6409,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                FRAME APPEND [java/lang/Object org/nlogo/agent/AgentSet]
                 ALOAD 3
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_ask_0.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_ask_0.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
                 IF_ACMPNE L3
                 NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -6480,7 +6480,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L7
                 RETURN
-   [1]_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_let_1 "let 2 * 0.5 - i + 0.5 / layer-size * max-pycor" Object => void
+   [1]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1 "let 2 * 0.5 - i + 0.5 / layer-size * max-pycor" Object => void
             _mult "2 * 0.5 - i + 0.5 / layer-size * max-pycor" double,double => double
               _mult "2 * 0.5 - i + 0.5 / layer-size" double,double => double
                 _constdouble:2.0 "2" => double
@@ -6508,7 +6508,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_let_1.kept9__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.kept9__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L7
                 ASTORE 2
@@ -6518,7 +6518,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKEVIRTUAL java/lang/Double.doubleValue ()D
                 GOTO L8
                L1
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_let_1 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
                 POP
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
@@ -6530,7 +6530,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
                L8
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_let_1 org/nlogo/nvm/Context java/lang/Object] [D D D]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1 org/nlogo/nvm/Context java/lang/Object] [D D D]
                 LDC 0.5
                L9
                 DSTORE 4
@@ -6540,13 +6540,13 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 4
                 DADD
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
                L10
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_let_1.kept11__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.kept11__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L11
                 ASTORE 2
@@ -6556,7 +6556,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKEVIRTUAL java/lang/Double.doubleValue ()D
                 GOTO L12
                L3
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_let_1 org/nlogo/nvm/Context java/lang/Object T D] [java/lang/ClassCastException]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1 org/nlogo/nvm/Context java/lang/Object T D] [java/lang/ClassCastException]
                 POP
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
@@ -6568,7 +6568,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
                L12
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_let_1 org/nlogo/nvm/Context java/lang/Object T D] [D D D D]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1 org/nlogo/nvm/Context java/lang/Object T D] [D D D D]
                 DSTORE 4
                 DSTORE 2
                 DLOAD 4
@@ -6585,13 +6585,13 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
                L13
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_let_1 org/nlogo/nvm/Context D D] [D D]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1 org/nlogo/nvm/Context D D] [D D]
                 ALOAD 0
                 DLOAD 2
                 DLOAD 4
                 DDIV
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
                L14
                 DSTORE 4
                 DSTORE 2
@@ -6600,7 +6600,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 4
                 DSUB
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
                L15
                 DSTORE 4
                 DSTORE 2
@@ -6609,10 +6609,10 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 4
                 DMUL
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
                L16
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_let_1.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.maxPycor ()I
                 I2D
                L17
@@ -6623,7 +6623,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 4
                 DMUL
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
                L18
                 DSTORE 2
                 NEW java/lang/Double
@@ -6635,7 +6635,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_let_1.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.let (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -6643,7 +6643,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L19
                 RETURN
-   [2]_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_setxy_2 "setxy x y" double,double => void
+   [2]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setxy_2 "setxy x y" double,double => void
             _letvariable(X) "x" => Object
             _letvariable(Y) "y" => Object
                 // parameter final  context
@@ -6656,7 +6656,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_setxy_2.kept2__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setxy_2.kept2__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L8
                 ASTORE 2
@@ -6666,7 +6666,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKEVIRTUAL java/lang/Double.doubleValue ()D
                 GOTO L9
                L1
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_setxy_2 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setxy_2 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
                 POP
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
@@ -6683,7 +6683,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_setxy_2.kept3__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setxy_2.kept3__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L10
                 ASTORE 2
@@ -6705,7 +6705,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
                L11
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_setxy_2 org/nlogo/nvm/Context java/lang/Object] [D D]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setxy_2 org/nlogo/nvm/Context java/lang/Object] [D D]
                 DSTORE 4
                 DSTORE 2
                 ALOAD 1
@@ -6724,7 +6724,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                L5
                 GOTO L12
                L6
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_setxy_2 org/nlogo/nvm/Context D D org/nlogo/agent/Turtle] [org/nlogo/api/AgentException]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setxy_2 org/nlogo/nvm/Context D D org/nlogo/agent/Turtle] [org/nlogo/api/AgentException]
                 ASTORE 7
                 NEW org/nlogo/nvm/RuntimePrimitiveException
                 DUP
@@ -6754,12 +6754,12 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L13
                 RETURN
-   [3]_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_setturtleorlinkvariable_3 "set color grey" Object => void
+   [3]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setturtleorlinkvariable_3 "set color grey" Object => void
             _constdouble:5.0 "grey" => Double
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L3
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_setturtleorlinkvariable_3.kept2_value : Ljava/lang/Double;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setturtleorlinkvariable_3.kept2_value : Ljava/lang/Double;
                L4
                 ASTORE 2
                L0
@@ -6771,7 +6771,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                L1
                 GOTO L5
                L2
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_setturtleorlinkvariable_3 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setturtleorlinkvariable_3 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
                 ASTORE 3
                 NEW org/nlogo/nvm/RuntimePrimitiveException
                 DUP
@@ -6788,7 +6788,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L6
                 RETURN
-   [4]_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_done_4 => void
+   [4]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_done_4 => void
                 // parameter final  context
                L0
                 ALOAD 1
@@ -6796,7 +6796,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.finished : Z
                L1
                 RETURN
-   [5]_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_setletvariable_5 "set i i + 1" Object => void
+   [5]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setletvariable_5 "set i i + 1" Object => void
             _plus "i + 1" double,double => double
               _letvariable(I) "i" => Object
               _constdouble:1.0 "1" => double
@@ -6809,7 +6809,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_setletvariable_5.kept3__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setletvariable_5.kept3__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L3
                 ASTORE 2
@@ -6819,7 +6819,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKEVIRTUAL java/lang/Double.doubleValue ()D
                 GOTO L4
                L1
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_setletvariable_5 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setletvariable_5 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
                 POP
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
@@ -6841,7 +6841,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 4
                 DADD
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_setletvariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setletvariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
                L6
                 DSTORE 2
                 NEW java/lang/Double
@@ -6853,7 +6853,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_setletvariable_5.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setletvariable_5.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.setLet (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -6861,7 +6861,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L7
                 RETURN
-   [6]_asm_anonymouscommandfromproceduresetupask1let205i05layersizemaxpycorse$7f3aeb5a0490bbe20e868557232bc760$_done_6 => void
+   [6]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_done_6 => void
                 // parameter final  context
                L0
                 ALOAD 1
@@ -6870,8 +6870,8 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                L1
                 RETURN
 
-   (anonymous command from: procedure SETUP: [ask ?1 [ create-links-from ?2 [ set-weight 0 ] ] create-links-from ?2 [ set-weight 0 ] set-weight 0]):procedure SETUP[]{OTPL}:
-   [0]_asm_anonymouscommandfromproceduresetupask1createlinksfrom2setweight0createl$e17ebf132c2d4874e342082f90aaed7e$_ask_0 "ask ?1 [ create-links-from ?2 [ set-weight 0 ] ]" Object => void
+   (anonymous command: [ [?1 ?2] -> ask ?1 [ create-links-from ?2 [ set-weight 0 ] ] ]):procedure SETUP[]{OTPL}:
+   [0]_asm_setup_anonymouscommand12ask1createlinksfrom2setweight0_ask_0 "ask ?1 [ create-links-from ?2 [ set-weight 0 ] ]" Object => void
             _letvariable(?1) "?1" => Object
                 // parameter final  context
                L0
@@ -6879,7 +6879,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1createlinksfrom2setweight0createl$e17ebf132c2d4874e342082f90aaed7e$_ask_0.kept2__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand12ask1createlinksfrom2setweight0_ask_0.kept2__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L1
                 ASTORE 2
@@ -6895,7 +6895,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 IFNE L3
                 ALOAD 3
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1createlinksfrom2setweight0createl$e17ebf132c2d4874e342082f90aaed7e$_ask_0.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand12ask1createlinksfrom2setweight0_ask_0.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
                 IF_ACMPNE L4
                 NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -6911,7 +6911,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                FRAME APPEND [java/lang/Object org/nlogo/agent/AgentSet]
                 ALOAD 3
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1createlinksfrom2setweight0createl$e17ebf132c2d4874e342082f90aaed7e$_ask_0.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand12ask1createlinksfrom2setweight0_ask_0.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
                 IF_ACMPNE L3
                 NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -6983,24 +6983,24 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                L7
                 RETURN
    [1]_createlinksfrom:,+4 "create-links-from ?2 [ set-weight 0 ]"
-            _asm_anonymouscommandfromproceduresetupask1createlinksfrom2setweight0createl$e17ebf132c2d4874e342082f90aaed7e$_letvariable_1 "?2" => Object
+            _asm_setup_anonymouscommand12ask1createlinksfrom2setweight0_letvariable_1 "?2" => Object
                   // parameter final  context
                  L0
                   ALOAD 1
                   GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                   GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                   ALOAD 0
-                  GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1createlinksfrom2setweight0createl$e17ebf132c2d4874e342082f90aaed7e$_letvariable_1.kept1__let : Lorg/nlogo/core/Let;
+                  GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand12ask1createlinksfrom2setweight0_letvariable_1.kept1__let : Lorg/nlogo/core/Let;
                   INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                  L1
                   ARETURN
-   [2]_asm_anonymouscommandfromproceduresetupask1createlinksfrom2setweight0createl$e17ebf132c2d4874e342082f90aaed7e$_call_2 "set-weight 0"
+   [2]_asm_setup_anonymouscommand12ask1createlinksfrom2setweight0_call_2 "set-weight 0"
             _constdouble:0.0 "0" => Double
                L0
                 NEW org/nlogo/nvm/Activation
                 DUP
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1createlinksfrom2setweight0createl$e17ebf132c2d4874e342082f90aaed7e$_call_2.kept1_procedure : Lorg/nlogo/nvm/Procedure;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand12ask1createlinksfrom2setweight0_call_2.kept1_procedure : Lorg/nlogo/nvm/Procedure;
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 SIPUSH 1
@@ -7009,7 +7009,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 ICONST_0
                L1
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresetupask1createlinksfrom2setweight0createl$e17ebf132c2d4874e342082f90aaed7e$_call_2.kept2_value : Ljava/lang/Double;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand12ask1createlinksfrom2setweight0_call_2.kept2_value : Ljava/lang/Double;
                L2
                 AASTORE
                 ICONST_3
@@ -7022,7 +7022,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L3
                 RETURN
-   [3]_asm_anonymouscommandfromproceduresetupask1createlinksfrom2setweight0createl$e17ebf132c2d4874e342082f90aaed7e$_done_3 => void
+   [3]_asm_setup_anonymouscommand12ask1createlinksfrom2setweight0_done_3 => void
                 // parameter final  context
                L0
                 ALOAD 1
@@ -7030,7 +7030,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.finished : Z
                L1
                 RETURN
-   [4]_asm_anonymouscommandfromproceduresetupask1createlinksfrom2setweight0createl$e17ebf132c2d4874e342082f90aaed7e$_done_4 => void
+   [4]_asm_setup_anonymouscommand12ask1createlinksfrom2setweight0_done_4 => void
                 // parameter final  context
                L0
                 ALOAD 1
@@ -7038,7 +7038,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.finished : Z
                L1
                 RETURN
-   [5]_asm_anonymouscommandfromproceduresetupask1createlinksfrom2setweight0createl$e17ebf132c2d4874e342082f90aaed7e$_done_5 => void
+   [5]_asm_setup_anonymouscommand12ask1createlinksfrom2setweight0_done_5 => void
                 // parameter final  context
                L0
                 ALOAD 1

--- a/test/benchdumps/GasLabCirc.txt
+++ b/test/benchdumps/GasLabCirc.txt
@@ -15503,8 +15503,8 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
          L1
           RETURN
 
-   (anonymous command from: procedure SORT-COLLISIONS: [if first collision < first winner [ set winner collision ] set winner collision]):procedure SORT-COLLISIONS[]{OTPL}:
-   [0]_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinner$577ad86d72ec11cd04e1ea3b7563249e$_if_0 "if first collision < first winner [ set winner collision ]" boolean => void
+   (anonymous command: [ collision -> if first collision < first winner [ set winner collision ] ]):procedure SORT-COLLISIONS[]{OTPL}:
+   [0]_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 "if first collision < first winner [ set winner collision ]" boolean => void
             _lessthan "first collision < first winner" Object,Object => boolean
               _first "first collision" Object => Object
                 _letvariable(COLLISION) "collision" => Object
@@ -15517,7 +15517,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinner$577ad86d72ec11cd04e1ea3b7563249e$_if_0.kept4__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0.kept4__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L1
                 ASTORE 2
@@ -15585,12 +15585,12 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
                L4
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinner$577ad86d72ec11cd04e1ea3b7563249e$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinner$577ad86d72ec11cd04e1ea3b7563249e$_if_0.kept6__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0.kept6__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L7
                 ASTORE 2
@@ -15613,12 +15613,12 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
                L9
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinner$577ad86d72ec11cd04e1ea3b7563249e$_if_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/core/LogoList] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/core/LogoList] [java/lang/Object]
                 ALOAD 3
                 INVOKEVIRTUAL org/nlogo/core/LogoList.first ()Ljava/lang/Object;
                 GOTO L10
                L8
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinner$577ad86d72ec11cd04e1ea3b7563249e$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
                 ALOAD 2
                 INSTANCEOF java/lang/String
                 IFEQ L11
@@ -15638,14 +15638,14 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
                L12
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinner$577ad86d72ec11cd04e1ea3b7563249e$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/String] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/String] [java/lang/Object]
                 ALOAD 3
                 ICONST_0
                 ICONST_1
                 INVOKEVIRTUAL java/lang/String.substring (II)Ljava/lang/String;
                 GOTO L10
                L11
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinner$577ad86d72ec11cd04e1ea3b7563249e$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
                 ALOAD 1
@@ -15658,7 +15658,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
                L10
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinner$577ad86d72ec11cd04e1ea3b7563249e$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object java/lang/Object]
                 ASTORE 3
                 ASTORE 2
                 ALOAD 2
@@ -15768,14 +15768,14 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 ICONST_1
                 GOTO L24
                L23
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinner$577ad86d72ec11cd04e1ea3b7563249e$_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
                 ICONST_2
                L24
-               FRAME FULL [org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinner$577ad86d72ec11cd04e1ea3b7563249e$_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L25
                 RETURN
-   [1]_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinner$577ad86d72ec11cd04e1ea3b7563249e$_setletvariable_1 "set winner collision" Object => void
+   [1]_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_setletvariable_1 "set winner collision" Object => void
             _letvariable(COLLISION) "collision" => Object
                 // parameter final  context
                 // parameter final  context
@@ -15785,7 +15785,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinner$577ad86d72ec11cd04e1ea3b7563249e$_setletvariable_1.kept2__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_setletvariable_1.kept2__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L1
                 ASTORE 2
@@ -15793,7 +15793,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinner$577ad86d72ec11cd04e1ea3b7563249e$_setletvariable_1.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_setletvariable_1.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.setLet (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -15801,7 +15801,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L2
                 RETURN
-   [2]_asm_anonymouscommandfromproceduresortcollisionsiffirstcollisionfirstwinnersetwinner$577ad86d72ec11cd04e1ea3b7563249e$_done_2 => void
+   [2]_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_done_2 => void
                 // parameter final  context
                L0
                 ALOAD 1

--- a/test/reporters/CommandLambda.txt
+++ b/test/reporters/CommandLambda.txt
@@ -1,15 +1,24 @@
+*ToString1
+  (word [ -> fd 5 ]) => "(anonymous command: [ fd 5 ])"
+
+*ToString2
+  (word [[x] -> ask turtles [ set color red] ]) => "(anonymous command: [ x -> ask turtles [ set color red ] ])"
+
 *ToString3
-  (word [ x -> print x]) => "(anonymous command from: procedure __EVALUATOR: [print x])"
+  (word [ x -> print x]) => "(anonymous command: [ x -> print x ])"
 
 *ToString4
-  (word [ -> print 5]) => "(anonymous command from: procedure __EVALUATOR: [print 5])"
+  (word [ -> print 5]) => "(anonymous command: [ print 5 ])"
 
 *ToString5
-  (word [ x -> (foreach [1 2] [3 4] [ -> __ignore x + x])]) => "(anonymous command from: procedure __EVALUATOR: [(foreach [1 2] [3 4] [ -> __ignore x + x])])"
+  (word [ x -> (foreach [1 2] [3 4] [ -> __ignore x + x])]) => "(anonymous command: [ x -> (foreach [1 2] [3 4] [ -> __ignore x + x]) ])"
 
 *ToString6
+  (word [ [a b] -> rt a fd b ]) => "(anonymous command: [ [a b] -> rt a fd b ])"
+
+*ToString7
   to foo end
-  (word [ -> foo]) => "(anonymous command from: procedure __EVALUATOR: [foo])"
+  (word [ -> foo]) => "(anonymous command: [ foo ])"
 
 CallTask
   globals [ glob1 ]
@@ -129,14 +138,14 @@ command-and-reporter-tasks-close-over-same-procedure-input
 *command-task-stack-trace
   O> run [ -> print __boom] => STACKTRACE boom!\
   error while observer running __BOOM\
-    called by (anonymous command from: procedure __EVALUATOR: [print __boom])\
+    called by (anonymous command: [ print __boom ])\
     called by procedure __EVALUATOR
 
 *command-task-in-command-task-stack-trace
   O> run [run [print __boom]] => STACKTRACE boom!\
   error while observer running __BOOM\
-    called by (anonymous command from: procedure __EVALUATOR: [print __boom])\
-    called by (anonymous command from: procedure __EVALUATOR: [run [print __boom]])\
+    called by (anonymous command: [ print __boom ])\
+    called by (anonymous command: [ run [print __boom] ])\
     called by procedure __EVALUATOR
 
 turtle-executing-command-task

--- a/test/reporters/ReporterLambda.txt
+++ b/test/reporters/ReporterLambda.txt
@@ -223,3 +223,8 @@ AlternateReporterSyntaxesSupported
   zero-argument-arrow-omitted => 3
   one-argument-bracketed => [2 3 4]
   one-argument-unbracketed => [3 4 5]
+
+PrintReporterLambda
+  (word [ -> 5 ]) => "(anonymous reporter: [ 5 ])"
+  (word [ a -> a ]) => "(anonymous reporter: [ a -> a ])"
+  (word [ [a b] -> a + b ]) => "(anonymous reporter: [ [a b] -> a + b ])"


### PR DESCRIPTION
For example:

```
observer> show (word [ [t l] -> test-link-neighbors t l ])
observer: "(anonymous reporter: [ test-link-neighbors t l ])"
```

Should they?
