### PR TITLE
Anonymous procedure strings

### DIFF
--- a/netlogo-core/src/main/compile/middle/LambdaLifter.scala
+++ b/netlogo-core/src/main/compile/middle/LambdaLifter.scala
@@ -27,7 +27,7 @@ class LambdaLifter(lambdaNumbers: Iterator[Int]) extends AstTransformer {
 
   override def visitReporterApp(expr: ReporterApp): ReporterApp = {
     expr.reporter match {
-      case r: _reporterlambda=>
+      case r: _reporterlambda =>
         lambdaStack = Right(r)::lambdaStack
         val res = super.visitReporterApp(expr)
         lambdaStack = lambdaStack.tail
@@ -38,7 +38,7 @@ class LambdaLifter(lambdaNumbers: Iterator[Int]) extends AstTransformer {
         val name = "__lambda-" + lambdaNumbers.next()
         c.proc = new nvm.LiftedLambda(
           name, c.token, c.argTokens, parent = p, lambdaFormals = formals,
-          closedLets = resolveClosedVariables(c.closedVariables))
+          closedLets = resolveClosedVariables(c.closedVariables), c.source)
         c.proc.pos = expr.start
         c.proc.end = expr.end
         p.addChild(c.proc)

--- a/netlogo-core/src/main/compile/middle/SourceTagger.scala
+++ b/netlogo-core/src/main/compile/middle/SourceTagger.scala
@@ -21,7 +21,7 @@ private class SourceTagger(existingSources: Map[String, String], compilationEnvi
     proc.procedure.displayName = proc.procedure match {
       case ll: LiftedLambda =>
         val bodySource = proc.statements.stmts.map(_.command.fullSource).filterNot(_ == null).mkString(" ")
-        AnonymousProcedure.displayString("command", ll.argTokens, bodySource)
+        AnonymousProcedure.displayString("command", ll.source)
       case p                => p.baseDisplayName.getOrElse(procedureDisplayName(p))
     }
   }

--- a/netlogo-core/src/main/nvm/LiftedLambda.scala
+++ b/netlogo-core/src/main/nvm/LiftedLambda.scala
@@ -10,8 +10,8 @@ final class LiftedLambda(
   argTokens:          Seq[Token],
   val parent:         Procedure,
   val lambdaFormals:  Seq[Let],
-  val closedLets:     Set[Let]
-  ) extends Procedure(false, name, nameToken, argTokens, null) {
+  val closedLets:     Set[Let],
+  val source:         String) extends Procedure(false, name, nameToken, argTokens, null) {
 
     args = Vector[String]()
 

--- a/netlogo-gui/src/main/compile/Backifier.scala
+++ b/netlogo-gui/src/main/compile/Backifier.scala
@@ -173,11 +173,13 @@ class Backifier(program: Program,
       case core.prim._constcodeblock(toks) =>
         new nvmprim._constcodeblock(toks)
 
-      case core.prim._commandlambda(argNames, argTokens, _, closedLambdaVariables) =>
-        new nvmprim._commandlambda(argNames, argTokens, null, closedLambdaVariables)
+      case core.prim._commandlambda(args, closedVariables, source) =>
+        new nvmprim._commandlambda(
+          args.argumentNames, args.argumentTokens,
+          null, closedVariables, source.getOrElse(""))
 
-      case core.prim._reporterlambda(argNames, argTokens, _, closedLambdaVariables) =>
-        new nvmprim._reporterlambda(argNames, argTokens, closedLambdaVariables)
+      case core.prim._reporterlambda(args, closedVariables, source) =>
+        new nvmprim._reporterlambda(args.argumentNames, closedVariables, source.getOrElse(""))
 
       case core.prim._externreport(_) =>
         new nvmprim._externreport(

--- a/netlogo-gui/src/main/prim/_commandlambda.scala
+++ b/netlogo-gui/src/main/prim/_commandlambda.scala
@@ -11,11 +11,17 @@ class _commandlambda(
   val argumentNames:   Seq[String],
   val argTokens:       Seq[Token],
   var proc:            LiftedLambda,
-  val closedVariables: Set[ClosedVariable]) extends Reporter {
+  val closedVariables: Set[ClosedVariable],
+  val lambdaSource:    String) extends Reporter {
+
+  source = lambdaSource
+
   override def report(c: Context): AnyRef = {
-    AnonymousCommand(procedure = proc,
-                formals   = proc.lambdaFormalsArray,
-                binding   = c.activation.binding.copy,
-                locals    = c.activation.args)
+    AnonymousCommand(
+      procedure = proc,
+      formals   = proc.lambdaFormalsArray,
+      binding   = c.activation.binding.copy,
+      locals    = c.activation.args,
+      source    = lambdaSource)
   }
 }

--- a/netlogo-gui/src/main/prim/_reporterlambda.scala
+++ b/netlogo-gui/src/main/prim/_reporterlambda.scala
@@ -9,13 +9,19 @@ import scala.collection.JavaConversions._
 
 class _reporterlambda(
   argumentNames:       Seq[String],
-  argumentTokens:      Seq[Token],
-  val closedVariables: Set[ClosedVariable]) extends Reporter {
+  val closedVariables: Set[ClosedVariable],
+  lambdaSource:        String) extends Reporter {
+    source = lambdaSource
 
   val formals: Seq[Let] = argumentNames.map(name => new Let(name))
   def formalsArray: Array[Let] = formals.toArray
 
   override def report(c: Context): AnyRef = {
-    AnonymousReporter(body = args(0), formals = formalsArray, binding = c.activation.binding, locals = c.activation.args, argumentTokens = argumentTokens)
+    AnonymousReporter(
+      body           = args(0),
+      formals        = formalsArray,
+      binding        = c.activation.binding,
+      locals         = c.activation.args,
+      source         = lambdaSource)
   }
 }

--- a/netlogo-headless/src/main/compile/Backifier.scala
+++ b/netlogo-headless/src/main/compile/Backifier.scala
@@ -61,11 +61,13 @@ class Backifier(
       case core.prim._const(value) =>
         new prim._const(value)
 
-      case core.prim._commandlambda(args, argTokens, _, closedLambdaVariables) =>
-        new prim._commandlambda(args, argTokens, null, closedLambdaVariables) // LambdaLifter will fill in
+      case core.prim._commandlambda(args, closedVariables, source) =>
+        new prim._commandlambda(
+          args.argumentNames, args.argumentTokens,
+          null, closedVariables, source.getOrElse("")) // LambdaLifter will fill in
 
-      case core.prim._reporterlambda(args, argTokens, _, closedLambdaVariables) =>
-        new prim._reporterlambda(args, argTokens, closedLambdaVariables)
+      case core.prim._reporterlambda(args, closedVariables, source) =>
+        new prim._reporterlambda(args.argumentNames, closedVariables, source.getOrElse(""))
 
       case core.prim._externreport(_) =>
         new prim._externreport(

--- a/netlogo-headless/src/main/prim/_commandlambda.scala
+++ b/netlogo-headless/src/main/prim/_commandlambda.scala
@@ -9,7 +9,10 @@ class _commandlambda(
   val argumentNames:   Seq[String],
   val argTokens:       Seq[Token],
   var proc:            LiftedLambda,
-  val closedVariables: Set[ClosedVariable]) extends Reporter {
+  val closedVariables: Set[ClosedVariable],
+  val lambdaSource:    String) extends Reporter {
+
+  source = lambdaSource
 
   override def toString =
     super.toString +
@@ -21,8 +24,9 @@ class _commandlambda(
   override def report(c: Context): AnyRef =
     AnonymousCommand(
       procedure = proc,
-      formals = proc.lambdaFormalsArray,
-      binding = c.activation.binding.copy,
-      locals = c.activation.args)
+      formals   = proc.lambdaFormalsArray,
+      binding   = c.activation.binding.copy,
+      locals    = c.activation.args,
+      source    = lambdaSource)
 
 }

--- a/netlogo-headless/src/main/prim/_reporterlambda.scala
+++ b/netlogo-headless/src/main/prim/_reporterlambda.scala
@@ -9,8 +9,8 @@ import scala.collection.JavaConversions._
 
 class _reporterlambda(
   argumentNames:       Seq[String],
-  argumentTokens:      Seq[Token],
-  val closedVariables: Set[ClosedVariable]) extends Reporter {
+  val closedVariables: Set[ClosedVariable],
+  lambdaSource:        String) extends Reporter {
 
   val formals: Seq[Let] = argumentNames.map(name => new Let(name))
   def formalsArray: Array[Let] = formals.toArray
@@ -18,6 +18,11 @@ class _reporterlambda(
   def getFormal(name: String): Option[Let] = formals.find(_.name == name)
 
   override def report(c: Context): AnyRef = {
-    AnonymousReporter(body = args(0), formals = formalsArray, binding = c.activation.binding, locals = c.activation.args, argumentTokens = argumentTokens)
+    AnonymousReporter(
+      body    = args(0),
+      formals = formalsArray,
+      binding = c.activation.binding,
+      locals  = c.activation.args,
+      source  = lambdaSource)
   }
 }

--- a/netlogo-headless/test/benchdumps/GasLabCirc.txt
+++ b/netlogo-headless/test/benchdumps/GasLabCirc.txt
@@ -8834,7 +8834,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
             INVOKEVIRTUAL org/nlogo/agent/Observer.getVariable (I)Ljava/lang/Object;
            L1
             ARETURN
-      _commandlambda:(anonymous command: [collision -> if first collision < first winner [ set winner collision ]]) "[ [collision] -> if first collision < first winner [set winner collision]]"
+      _commandlambda:(anonymous command: [ [collision] -> if first collision < first winner [ set winner collision ] ]) "[ [collision] -> if first collision < first winner [set winner collision]]"
 [8]_asm_proceduresortcollisions_setprocedurevariable_14 "let item 0 winner" Object => void
       _item "item 0 winner"
         _asm_proceduresortcollisions_constdouble_15 "0" => Double
@@ -9326,8 +9326,8 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
          L1
           RETURN
 
-   (anonymous command: [collision -> if first collision < first winner [ set winner collision ]]):procedure SORT-COLLISIONS[]{OTPL}:
-   [0]_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 "if first collision < first winner [ set winner collision ]" boolean => void
+   (anonymous command: [ [collision] -> if first collision < first winner [ set winner collision ] ]):procedure SORT-COLLISIONS[]{OTPL}:
+   [0]_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 "if first collision < first winner [ set winner collision ]" boolean => void
             _lessthan "first collision < first winner" Object,Object => boolean
               _first "first collision" Object => Object
                 _letvariable(Let(COLLISION)) "collision" => Object
@@ -9345,7 +9345,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0.kept4__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0.kept4__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L1
                 ASTORE 2
@@ -9413,12 +9413,12 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
                L4
-               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0.kept6__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0.kept6__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L7
                 ASTORE 2
@@ -9441,12 +9441,12 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
                L9
-               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/core/LogoList] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/core/LogoList] [java/lang/Object]
                 ALOAD 3
                 INVOKEVIRTUAL org/nlogo/core/LogoList.first ()Ljava/lang/Object;
                 GOTO L10
                L8
-               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
                 ALOAD 2
                 INSTANCEOF java/lang/String
                 IFEQ L11
@@ -9466,14 +9466,14 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
                L12
-               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/String] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/String] [java/lang/Object]
                 ALOAD 3
                 ICONST_0
                 ICONST_1
                 INVOKEVIRTUAL java/lang/String.substring (II)Ljava/lang/String;
                 GOTO L10
                L11
-               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
                 ALOAD 1
@@ -9486,7 +9486,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
                L10
-               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object java/lang/Object]
                 ASTORE 3
                 ASTORE 2
                 ALOAD 2
@@ -9597,26 +9597,26 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 ICONST_1
                 GOTO L21
                L20
-               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
                 ICONST_2
                L21
-               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L22
                 RETURN
    [1]_setletvariable:WINNER "set winner collision"
-            _asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_letvariable_1 "collision" => Object
+            _asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_letvariable_1 "collision" => Object
                   // parameter final  context
                  L0
                   ALOAD 1
                   GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                   GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                   ALOAD 0
-                  GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_letvariable_1.kept1__let : Lorg/nlogo/core/Let;
+                  GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_letvariable_1.kept1__let : Lorg/nlogo/core/Let;
                   INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                  L1
                   ARETURN
-   [2]_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnercol$68ffa1a5066e3d0f32834c788a4e1c9c$_done_2 => void
+   [2]_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_done_2 => void
                 // parameter final  context
                L0
                 ALOAD 1

--- a/parser-core/src/main/core/AstNode.scala
+++ b/parser-core/src/main/core/AstNode.scala
@@ -98,7 +98,7 @@ class Statements(file: String, val stmts: Seq[Statement], val nonLocalExit: Bool
 }
 
 object Statement {
-  def unapply(stmt: Statement): Option[(Command, Seq[Expression], SourceLocation)] = 
+  def unapply(stmt: Statement): Option[(Command, Seq[Expression], SourceLocation)] =
     Some((stmt.command, stmt.args, stmt.sourceLocation))
 }
 

--- a/parser-core/src/main/core/prim/Lambda.scala
+++ b/parser-core/src/main/core/prim/Lambda.scala
@@ -4,12 +4,36 @@ package org.nlogo.core
 package prim
 
 trait Lambda {
-  def argumentNames: Seq[String]
-  def synthetic: Boolean
+  def arguments: Lambda.Arguments
   def closedVariables: Set[ClosedVariable]
+  def argumentNames: Seq[String] = arguments.argumentNames
+  def minArgCount: Int = argumentNames.length
+  def synthetic: Boolean = arguments match {
+    case Lambda.ConciseArguments(_) => true
+    case _ => false
+  }
 }
 
 object Lambda {
   def unapply(l: Lambda): Option[(Seq[String], Boolean, Set[ClosedVariable])] =
     Some((l.argumentNames, l.synthetic, l.closedVariables))
+
+  sealed trait Arguments {
+    def argumentNames:  Seq[String]
+    def argumentTokens: Seq[Token]
+  }
+  case class NoArguments(usesArrow: Boolean) extends Arguments {
+    val argumentNames = Seq()
+    def argumentTokens: Seq[Token] = Seq()
+  }
+  case class ConciseArguments(argumentNames: Seq[String]) extends Arguments {
+    def argumentTokens: Seq[Token] = Seq()
+  }
+  case class UnbracketedArgument(t: Token) extends Arguments {
+    def argumentNames = Seq(t.text.toUpperCase)
+    def argumentTokens: Seq[Token] = Seq(t)
+  }
+  case class BracketedArguments(argumentTokens: Seq[Token]) extends Arguments {
+    def argumentNames = argumentTokens.map(_.text.toUpperCase)
+  }
 }

--- a/parser-core/src/main/core/prim/misc.scala
+++ b/parser-core/src/main/core/prim/misc.scala
@@ -74,17 +74,10 @@ case class _carefully() extends Command {
       introducesContext = true)
 }
 case class _commandlambda(
-  argumentNames:   Seq[String],
-  argumentTokens:  Seq[Token],
-  synthetic:       Boolean,
-  closedVariables: Set[ClosedVariable]) extends Lambda with Reporter {
-  def this() = this(Seq(), Seq(), false, Set())
-  def this(arguments: Seq[Token]) =
-    this(arguments.map(_.text.toUpperCase), arguments, false, Set())
-  def this(arguments: Seq[Token], synthetic: Boolean) =
-    this(arguments.map(_.text.toUpperCase), arguments, synthetic, Set())
-  def this(arguments: Seq[String], argumentTokens: Seq[Token], synthetic: Boolean) =
-    this(arguments, argumentTokens, synthetic, Set())
+  arguments:       Lambda.Arguments,
+  closedVariables: Set[ClosedVariable],
+  source:          Option[String]) extends Lambda with Reporter {
+  def this(args: Lambda.Arguments) = this(args, Set(), None)
 
   override def syntax =
     Syntax.reporterSyntax(ret = Syntax.CommandType)
@@ -92,13 +85,11 @@ case class _commandlambda(
   override def toString =
     "_commandlambda" + argumentNames.mkString("(", ", ", ")")
 
-  def minArgCount: Int = argumentNames.length
-
   def copy(
-    argumentNames:   Seq[String] = argumentNames,
-    argumentTokens:  Seq[Token] = argumentTokens,
-    closedVariables: Set[ClosedVariable] = closedVariables): _commandlambda = {
-    val ct = new _commandlambda(argumentNames, argumentTokens, synthetic, closedVariables)
+    arguments:       Lambda.Arguments    = arguments,
+    closedVariables: Set[ClosedVariable] = closedVariables,
+    source:          Option[String]      = source): _commandlambda = {
+    val ct = new _commandlambda(arguments, closedVariables, source)
     copyInstruction(ct)
   }
 }
@@ -395,18 +386,11 @@ case class _report() extends Command {
       right = List(Syntax.WildcardType))
 }
 case class _reporterlambda(
-  argumentNames:   Seq[String],
-  argumentTokens:  Seq[Token],
-  synthetic:       Boolean,
-  closedVariables: Set[ClosedVariable]) extends Lambda with Reporter {
+  arguments:       Lambda.Arguments,
+  closedVariables: Set[ClosedVariable],
+  source:          Option[String]) extends Lambda with Reporter {
+  def this(args: Lambda.Arguments) = this(args, Set(), None)
 
-  def this() = this(Seq(), Seq(), false, Set())
-  def this(arguments: Seq[Token]) =
-    this(arguments.map(_.text.toUpperCase), arguments, false, Set())
-  def this(arguments: Seq[Token], synthetic: Boolean) =
-    this(arguments.map(_.text.toUpperCase), arguments, synthetic, Set())
-  def this(arguments: Seq[String], argumentTokens: Seq[Token], synthetic: Boolean) =
-    this(arguments, argumentTokens, synthetic, Set())
   override def syntax = {
     Syntax.reporterSyntax(
       right = List(Syntax.CodeBlockType, Syntax.ReporterType),
@@ -417,10 +401,10 @@ case class _reporterlambda(
     "_reporterlambda" + argumentNames.mkString("(", ", ", ")")
 
   def copy(
-    argumentNames:   Seq[String]         = argumentNames,
-    argumentTokens:  Seq[Token]          = argumentTokens,
-    closedVariables: Set[ClosedVariable] = closedVariables): _reporterlambda = {
-    val cr = new _reporterlambda(argumentNames, argumentTokens, synthetic, closedVariables)
+    arguments:       Lambda.Arguments    = arguments,
+    closedVariables: Set[ClosedVariable] = closedVariables,
+    source:          Option[String]      = source): _reporterlambda = {
+    val cr = new _reporterlambda(arguments, closedVariables, source)
     copyInstruction(cr)
   }
 }

--- a/parser-core/src/main/parse/AstEdit.scala
+++ b/parser-core/src/main/parse/AstEdit.scala
@@ -1,0 +1,23 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.parse
+
+import org.nlogo.core.{ AstNode, Instruction }
+
+import AstFormat.Operation
+
+case class AstEdit(operations: Map[AstPath, Operation], wsMap: WhitespaceMap) {
+  def addOperation(position: AstPath, op: Operation) =
+    copy(operations = operations + (position -> op))
+}
+
+object AstFormat {
+  type Operation = (Formatter, AstNode, AstPath, AstFormat) => AstFormat
+}
+
+case class AstFormat(
+  text: String,
+  operations: Map[AstPath, Operation],
+  instructionToString: Instruction => String,
+  wsMap: FormattingWhitespace
+)

--- a/parser-core/src/main/parse/ClosureTagger.scala
+++ b/parser-core/src/main/parse/ClosureTagger.scala
@@ -2,7 +2,7 @@
 
 package org.nlogo.parse
 
-import org.nlogo.core.prim.{ _commandlambda, _lambdavariable, _letvariable, _reporterlambda }
+import org.nlogo.core.prim.{ _commandlambda, _lambdavariable, _letvariable, _reporterlambda, Lambda }
 import org.nlogo.core.{ AstFolder, AstTransformer, ClosedLet, ClosedLambdaVariable, ClosedVariable, Let, ProcedureDefinition, ReporterApp }
 
 class ClosureTagger extends AstTransformer {
@@ -27,12 +27,11 @@ class ClosureTagger extends AstTransformer {
 class ClosedVariableFinder(lambdaVarNames: Seq[String]) extends AstFolder[Set[ClosedVariable]] {
   override def visitReporterApp(app: ReporterApp)(implicit closedVars: Set[ClosedVariable]): Set[ClosedVariable] = {
     app.reporter match {
-      case _letvariable(let)                   => closedVars + ClosedLet(let)
+      case _letvariable(let)          => closedVars + ClosedLet(let)
       case _lambdavariable(name, _) if ! lambdaVarNames.contains(name) =>
         closedVars + ClosedLambdaVariable(name)
-      case _reporterlambda(_, _, _, reporterLets) => closedVars ++ reporterLets
-      case _commandlambda(_, _, _, reporterLets)  => closedVars ++ reporterLets
-      case _                                   => super.visitReporterApp(app)
+      case Lambda(_, _, reporterLets) => closedVars ++ reporterLets
+      case _                          => super.visitReporterApp(app)
     }
   }
 }

--- a/parser-core/src/main/parse/DelayedBlock.scala
+++ b/parser-core/src/main/parse/DelayedBlock.scala
@@ -2,7 +2,9 @@
 
 package org.nlogo.parse
 
-import org.nlogo.core.{ Expression, SourceLocation, Token, TokenType }
+import
+  org.nlogo.core.{ prim, Expression, SourceLocation, Token, TokenType },
+    prim.Lambda
 
 object DelayedBlock {
   def apply(openBracket: Token, unterminatedTokens: Seq[Token], scope: SymbolTable): DelayedBlock = {
@@ -32,23 +34,23 @@ trait DelayedBlock extends Expression {
 
 class ArrowLambdaBlock(
   val openBracket:    Token,
-  val argTokens:      Seq[Token],
+  val arguments:      Lambda.Arguments,
   val bodyTokens:     Seq[Token],
   closingBracket:     Token,
   val allTokens:      Seq[Token],
   val internalScope:  SymbolTable,
   val sourceLocation: SourceLocation) extends DelayedBlock {
 
-    val argNames = argTokens.map(_.text.toUpperCase)
+    val argNames = arguments.argumentNames
 
   def this(
     openBracket:    Token,
-    argTokens:      Seq[Token],
+    arguments:      Lambda.Arguments,
     bodyTokens:     Seq[Token],
     closingBracket: Token,
     allTokens:      Seq[Token],
     internalScope:  SymbolTable) =
-      this(openBracket, argTokens, bodyTokens, closingBracket,
+      this(openBracket, arguments, bodyTokens, closingBracket,
         allTokens, internalScope,openBracket.sourceLocation.copy(end = closingBracket.end))
 
   val isArrowLambda = true
@@ -62,7 +64,7 @@ class ArrowLambdaBlock(
   override def changeLocation(newLocation: SourceLocation): ArrowLambdaBlock =
     new ArrowLambdaBlock(
       openBracket,
-      argTokens,
+      arguments,
       bodyTokens,
       closingBracket,
       allTokens,
@@ -71,7 +73,7 @@ class ArrowLambdaBlock(
 }
 
 /**
- * represents a block whose contents we have not yet parsed. Since correctly parsing a block required
+ * represents a block whose contents we have not yet parsed. Since correctly parsing a block requires
  * knowing its expected type, we have to do it in two passes. It will eventually be resolved into
  * an ReporterBlock, CommandBlock or a literal list. */
 class AmbiguousDelayedBlock(

--- a/parser-core/src/main/parse/FrontEnd.scala
+++ b/parser-core/src/main/parse/FrontEnd.scala
@@ -26,7 +26,7 @@ trait FrontEndMain extends NetLogoParser {
     import compilationOperand.{ extensionManager, oldProcedures }
     val (rawProcDefs, structureResults) = basicParse(compilationOperand)
 
-    val topLevelDefs = transformers.foldLeft(rawProcDefs) {
+    val topLevelDefs = transformers(compilationOperand).foldLeft(rawProcDefs) {
       case (defs, transform) => defs.map(transform.visitProcedureDefinition)
     }
 
@@ -42,8 +42,8 @@ trait FrontEndMain extends NetLogoParser {
     (verifiedDefs, structureResults)
   }
 
-  private def transformers: Seq[AstTransformer] = {
-    Seq(new LetReducer, new CarefullyVisitor, new ClosureTagger)
+  private def transformers(compilationOperand: CompilationOperand): Seq[AstTransformer] = {
+    Seq(new LetReducer, new CarefullyVisitor, new ClosureTagger, new SourceTagger(compilationOperand))
   }
 
   def tokenizeForColorization(source: String, dialect: Dialect, extensionManager: ExtensionManager): Seq[core.Token] = {

--- a/parser-core/src/main/parse/Rewriters.scala
+++ b/parser-core/src/main/parse/Rewriters.scala
@@ -5,29 +5,40 @@ package org.nlogo.parse
 import org.nlogo.core.{ AstFolder, AstNode, CommandBlock, ReporterApp, ReporterBlock, Statement, prim },
   prim._unknowncommand
 
-import Formatter.Operation
+import AstFormat.Operation
+
 import WhiteSpace._
 
 import scala.util.matching.Regex
 
-object NoopFolder extends PositionalAstFolder[Map[AstPath, Operation]] {}
+import org.nlogo.core.{ Reporter, SourceLocation, Syntax, Token, TokenType }
 
-class RemovalVisitor(droppedCommand: String) extends PositionalAstFolder[Map[AstPath, Operation]] {
+class _dummyrep(text: String) extends Reporter {
+  val syntax = Syntax.reporterSyntax(ret = Syntax.WildcardType)
+  token = Token(text, TokenType.Reporter, text)(SourceLocation(0, 0, ""))
+}
 
-  def delete(formatter: Formatter, astNode: AstNode, path: AstPath, ctx: Formatter.Context): Formatter.Context = ctx
+class _dummycmd(text: String) extends Reporter {
+  val syntax = Syntax.commandSyntax()
+  token = Token(text, TokenType.Command, text)(SourceLocation(0, 0, ""))
+}
 
-  override def visitStatement(stmt: Statement, position: AstPath)(implicit ops: Map[AstPath, Operation]): Map[AstPath, Operation] = {
+object NoopFolder extends PositionalAstFolder[AstEdit] {}
+
+class RemovalVisitor(droppedCommand: String) extends PositionalAstFolder[AstEdit] {
+
+  def delete(formatter: Formatter, astNode: AstNode, path: AstPath, ctx: AstFormat): AstFormat = ctx
+
+  override def visitStatement(stmt: Statement, position: AstPath)(implicit edits: AstEdit): AstEdit = {
     if (stmt.command.token.text.equalsIgnoreCase(droppedCommand))
-      super.visitStatement(stmt, position)(ops + (position -> delete _))
+      super.visitStatement(stmt, position)(edits.addOperation(position, delete _))
     else
       super.visitStatement(stmt, position)
   }
 }
 
-class ReplaceReporterVisitor(alteration: (String, String)) extends PositionalAstFolder[Map[AstPath, Operation]] {
-  import Formatter._
-
-  def replace(formatter: Formatter, astNode: AstNode, path: AstPath, ctx: Context): Context = {
+class ReplaceReporterVisitor(alteration: (String, String)) extends PositionalAstFolder[AstEdit] {
+  def replace(formatter: Formatter, astNode: AstNode, path: AstPath, ctx: AstFormat): AstFormat = {
     astNode match {
       case app: ReporterApp =>
         ctx.copy(text = ctx.text + ctx.wsMap.leading(path) + alteration._2)
@@ -35,16 +46,16 @@ class ReplaceReporterVisitor(alteration: (String, String)) extends PositionalAst
     }
   }
 
-  override def visitReporterApp(app: ReporterApp, position: AstPath)(implicit ops: Map[AstPath, Operation]): Map[AstPath, Operation] = {
+  override def visitReporterApp(app: ReporterApp, position: AstPath)(implicit edits: AstEdit): AstEdit = {
     if (app.reporter.token.text.equalsIgnoreCase(alteration._1))
-      super.visitReporterApp(app, position)(ops + (position -> replace _))
+      super.visitReporterApp(app, position)(edits.addOperation(position, replace _))
     else
       super.visitReporterApp(app, position)
   }
 }
 
 class AddVisitor(val addition: (String, String)) extends StatementManipulationVisitor {
-  override def manipulate(formatter: Formatter, astNode: AstNode, position: AstPath, ctx: Formatter.Context): Formatter.Context = {
+  override def manipulate(formatter: Formatter, astNode: AstNode, position: AstPath, ctx: AstFormat): AstFormat = {
     astNode match {
       case stmt: Statement =>
         val newCmd = new _unknowncommand(stmt.command.syntax)
@@ -52,14 +63,12 @@ class AddVisitor(val addition: (String, String)) extends StatementManipulationVi
         val newArgs = addedArgument.map(id => Seq(stmt.args(id))).getOrElse(Seq())
         val newStmt = stmt.copy(command = newCmd, args = newArgs)
         val c1 =
-          formatter.visitStatement(newStmt, position)(ctx.copy(
+          formatter.visitStatement(newStmt, position / AstPath.Stmt(-1))(ctx.copy(
             text = ctx.text + " ",
-            operations = ctx.operations - position,
-            wsMap = newWsMap(ctx, position, stmt)))
+            operations = ctx.operations - position))
         formatter.visitStatement(stmt, position)(c1.copy(
           text = c1.text + ctx.wsMap.trailing(position),
-          operations = ctx.operations - position,
-          wsMap = ctx.wsMap))
+          operations = ctx.operations - position))
       case _               => ctx
     }
   }
@@ -67,15 +76,15 @@ class AddVisitor(val addition: (String, String)) extends StatementManipulationVi
 
 // handles argument transfer for 1 argument at the moment. Should be expanded if more arguments are needed
 class ReplaceVisitor(val addition: (String, String)) extends StatementManipulationVisitor {
-  override def manipulate(formatter: Formatter, astNode: AstNode, position: AstPath, ctx: Formatter.Context): Formatter.Context = {
+  override def manipulate(formatter: Formatter, astNode: AstNode, position: AstPath, ctx: AstFormat): AstFormat = {
     astNode match {
       case stmt: Statement =>
         stmt.command.token.refine(newPrim = stmt.command, text = addedCommand)
         val newStmt =
           if (addedArgument.isEmpty) stmt.copy(args = Seq())
           else stmt.copy(args = Seq(stmt.args(addedArgument.get)))
-        val stmtAdded = formatter.visitStatement(newStmt, position)(
-          ctx.copy(operations = ctx.operations - position, wsMap = newWsMap(ctx, position, stmt)))
+        val stmtAdded = formatter.visitStatement(newStmt, position / AstPath.Stmt(-1))(
+          ctx.copy(operations = ctx.operations - position))
         afterCommand
           .map(afterText => stmtAdded.copy(text = stmtAdded.text + afterText))
           .getOrElse(stmtAdded)
@@ -85,10 +94,7 @@ class ReplaceVisitor(val addition: (String, String)) extends StatementManipulati
 }
 
 // handles argument transfer for 1 argument at the moment. Should be expanded if more arguments are needed
-trait StatementManipulationVisitor
-  extends PositionalAstFolder[Map[AstPath, Operation]] {
-  import Formatter._
-
+trait StatementManipulationVisitor extends PositionalAstFolder[AstEdit] {
   def addition: (String, String)
 
   val pattern = new Regex("([^{]+)(\\{\\d+\\})?(.*)", "command", "arg", "afterCommand")
@@ -102,26 +108,36 @@ trait StatementManipulationVisitor
     .map(_.drop(1).dropRight(1).toInt)
   val afterCommand = pattern.findFirstMatchIn(addition._2).map(_.group("afterCommand"))
 
-  def newWsMap(ctx: Context, position: AstPath, stmt: Statement): WhitespaceMap =
+  // AstPath.Stmt(-1) delimits that the whitespace here is actually being *inserted* and
+  // is not original to the AST.
+  def newWsMap(wsMap: WhitespaceMap, position: AstPath, stmt: Statement): WhitespaceMap =
     addedArgument.map { i =>
       val oldArgPosition = position / AstPath.Expression(stmt.args(i), i)
-      val newArgPosition = position / AstPath.Expression(stmt.args(i), 0)
-      val filteredMap = if (i == 0) ctx.wsMap else (ctx.wsMap - (newArgPosition -> WhiteSpace.Content))
-      filteredMap.map {
-        case ((k, p), v) =>
-          if (oldArgPosition.isParentOf(k))
-            (k.repath(oldArgPosition, newArgPosition), p) -> v
-          else
-            (k, p) -> v
-      }
-    }.getOrElse(ctx.wsMap)
+      val newArgPosition = position / AstPath.Stmt(-1) / AstPath.Expression(stmt.args(i), 0)
+      val newPositions =
+        wsMap.toMap.filter {
+          case ((k, _), _) => oldArgPosition.isParentOf(k)
+        }.map {
+          case ((k, p), v) => (k.repath(oldArgPosition, newArgPosition), p) -> v
+        }
+      wsMap ++ new WhitespaceMap(newPositions)
+    }.getOrElse(wsMap)
 
- def manipulate(formatter: Formatter, astNode: AstNode, position: AstPath, ctx: Context): Context
+ def manipulate(formatter: Formatter, astNode: AstNode, position: AstPath, ctx: AstFormat): AstFormat
 
-  override def visitStatement(stmt: Statement, position: AstPath)(implicit ops: Map[AstPath, Operation]): Map[AstPath, Operation] = {
-    if (stmt.command.token.text.equalsIgnoreCase(targetCommand))
-      super.visitStatement(stmt, position)(ops + (position -> manipulate _))
-    else
+  override def visitStatement(stmt: Statement, position: AstPath)(implicit edits: AstEdit): AstEdit = {
+    if (stmt.command.token.text.equalsIgnoreCase(targetCommand)) {
+      val repositionedWs =
+        new WhitespaceMap(
+          edits.wsMap.toMap
+            .filter { case ((k, _), _) => k == position }
+            .map { case ((k, p), v) => (k.repath(position, position / AstPath.Stmt(-1)), p) -> v }
+          )
+      super.visitStatement(stmt, position)(
+        edits
+          .addOperation(position, manipulate _)
+          .copy(wsMap = newWsMap(edits.wsMap, position, stmt) ++ repositionedWs))
+    } else
       super.visitStatement(stmt, position)
-}
   }
+}

--- a/parser-core/src/main/parse/SourceTagger.scala
+++ b/parser-core/src/main/parse/SourceTagger.scala
@@ -1,0 +1,75 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.parse
+
+import
+  org.nlogo.core.{ prim, Dump, LogoList },
+    prim.{ _commandlambda, _const, _lambdavariable, _reporterlambda, Lambda }
+
+import
+  org.nlogo.core.{ AstFolder, AstTransformer, CompilationOperand,
+    ProcedureDefinition, ReporterApp, SourceLocation, Statement }
+
+class SourceTagger(compilationOperand: CompilationOperand) extends AstTransformer {
+  private def getSource(sourceLocation: SourceLocation): String = {
+    val sourceText =
+      compilationOperand.sources.get(sourceLocation.filename).getOrElse {
+        val env = compilationOperand.compilationEnvironment
+        env.getSource(sourceLocation.filename)
+      }
+    sourceText.substring(sourceLocation.start, sourceLocation.end)
+  }
+
+  override def visitReporterApp(app: ReporterApp): ReporterApp = {
+    app.reporter match {
+      case l: Lambda =>
+        val newApp = super.visitReporterApp(app)
+        val f = new Formatter()
+        val source =
+          f.visitReporterApp(newApp, AstPath())(
+            AstFormat("", Map(), Formatter.instructionString _, new LambdaWhitespace(app)))
+              .text.trim
+        val newPrim = l match {
+          case r: _reporterlambda => r.copy(source = Some(source))
+          case c: _commandlambda  => c.copy(source = Some(source))
+        }
+        newApp.copy(reporter = newPrim)
+      case _ => super.visitReporterApp(app)
+    }
+  }
+}
+
+class LambdaWhitespace(startNode: ReporterApp) extends FormattingWhitespace {
+  def get(path: AstPath, placement: WhiteSpace.Placement): Option[String] = None
+  def backMargin(path: AstPath): String =
+    path.components.lastOption match {
+      case Some(AstPath.CmdBlk(_)) =>
+        path.`../`.traverse(startNode) match {
+          case Some(ReporterApp(c: _commandlambda, _, _)) => " "
+          case _ => " ]"
+        }
+      case _ => " "
+    }
+  def content(path: AstPath): String =
+    path.traverse(startNode) match {
+      case Some(r: ReporterApp) =>
+        r.reporter match {
+          case _const(ll: LogoList) => Dump.logoObject(ll, true, false)
+          case other => other.token.text
+        }
+      case other => ""
+    }
+  def frontMargin(path: AstPath): String = ""
+  def leading(path: AstPath): String =
+    path.components.lastOption match {
+      case Some(AstPath.Stmt(_)) => " "
+      case Some(AstPath.RepArg(_)) => " "
+      case Some(AstPath.CmdBlk(_)) =>
+        path.`../`.traverse(startNode) match {
+          case Some(ReporterApp(c: _commandlambda, _, _)) => ""
+          case other => " ["
+        }
+      case _ => ""
+    }
+  def trailing(path: AstPath): String = ""
+}

--- a/parser-core/src/test/parse/AnonymousProcedureSourceTests.scala
+++ b/parser-core/src/test/parse/AnonymousProcedureSourceTests.scala
@@ -1,0 +1,79 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.parse
+
+import
+  org.nlogo.core.{ prim, Expression, ReporterApp },
+    prim.{ _commandlambda, _reporterlambda }
+
+import org.scalatest.{ FunSuite, Inside }
+
+class AnonymousProcedureSourceTests extends FunSuite with Inside with BaseParserTest {
+  override val PREAMBLE = "to __test __ignore "
+
+  def expression(source: String, expIndex: Int = 0, preamble: String = PREAMBLE, postamble: String = POSTAMBLE): Expression =
+    compile(source, preamble, postamble).head.stmts.head.args(expIndex)
+
+  def assertStringifies(exp: Expression, result: String): Unit = {
+    inside(exp) {
+      case ReporterApp(r: _reporterlambda, _, _) =>
+        assertResult(Some(result))(r.source)
+      case ReporterApp(c: _commandlambda, _, _) =>
+        assertResult(Some(result))(c.source)
+    }
+  }
+
+  test("simple anonymous reporter") {
+    assertStringifies(expression("[ -> 1]"), "[ -> 1 ]")
+  }
+  test("anonymous reporter with one argument") {
+    assertStringifies(expression("[a -> a]"), "[ a -> a ]")
+  }
+  test("anonymous reporter with newlines") {
+    assertStringifies(expression("[a -> a\n ]"), "[ a -> a ]")
+  }
+  test("anonymous reporter with comments") {
+    assertStringifies(expression("[a -> a ; foo \n ]"), "[ a -> a ]")
+  }
+  test("anonymous reporter with comments before the body starts") {
+    assertStringifies(expression("[ a -> ;foo \n 1 ]"), "[ a -> 1 ]")
+  }
+  test("concise anonymous reporter") {
+    assertStringifies(
+      expression("", expIndex = 0, preamble = "to __test __ignore map + [] ")
+        .asInstanceOf[ReporterApp].args(0),
+      "+")
+  }
+  test("simple anonymous command") {
+    assertStringifies(expression("[ -> fd 1]"), "[ -> fd 1 ]")
+  }
+  test("empty anonymous command") {
+    assertStringifies(
+      expression("[ -> fd 1]", expIndex = 1, preamble = "to __test foreach [] "),
+      "[ -> fd 1 ]")
+  }
+  test("anonymous command with newlines") {
+    assertStringifies(expression("[ -> \nfd 1]"), "[ -> fd 1 ]")
+  }
+  test("concise anonymous command") {
+    assertStringifies(
+      expression("fd", expIndex = 1, preamble = "to __test foreach [] "),
+      "fd")
+  }
+  test("anonymous command with arguments") {
+    assertStringifies(expression("[ [a] -> fd a ]"), "[ [a] -> fd a ]")
+  }
+  test("infix operators") {
+    assertStringifies(expression("[ [a b] -> a + b + sin b ]"), "[ [a b] -> a + b + sin b ]")
+  }
+  test("anonymous procedures and lists") {
+    assertStringifies(expression("[ [a b] -> foreach [1 2] [ -> print a ] ]"),
+      "[ [a b] -> foreach [1 2] [ -> print a ] ]")
+  }
+  test("nested anonymous procedures") {
+    assertStringifies(expression("[ [a b] -> [ c -> a ] ]"), "[ [a b] -> [ c -> a ] ]")
+  }
+  test("blocks in anonymous procedures") {
+    assertStringifies(expression("[ [a b] -> crt 10 [ fd 1 ] ]"), "[ [a b] -> crt 10 [ fd 1 ] ]")
+  }
+}

--- a/parser-core/src/test/parse/ArrowLambdaScoperTests.scala
+++ b/parser-core/src/test/parse/ArrowLambdaScoperTests.scala
@@ -5,7 +5,7 @@ package org.nlogo.parse
 import org.scalatest.FunSuite
 
 import org.nlogo.core.{ CompilerException, SourceLocation, Token, TokenType }
-import org.nlogo.core.prim.{ _procedurevariable, _lambdavariable }
+import org.nlogo.core.prim.{ _procedurevariable, _lambdavariable, Lambda }, Lambda.Arguments
 import org.nlogo.core.TokenDSL._
 import PrimDSL._
 
@@ -94,7 +94,7 @@ class ArrowLambdaScoperTests extends FunSuite {
     "MEAN" -> SymbolType.PrimitiveReporter,
     "BAR"  -> SymbolType.GlobalVariable)
 
-  def scope(ts: Seq[Token], otherSymbols: SymbolTable = SymbolTable.empty): Option[(Seq[Token], Seq[Token], SymbolTable)] =
+  def scope(ts: Seq[Token], otherSymbols: SymbolTable = SymbolTable.empty): Option[(Arguments, Seq[Token], SymbolTable)] =
     ArrowLambdaScoper(ts, testSymbols ++ otherSymbols)
 
   def testScopes(toks: Seq[Token], expectedArgs: Seq[String], expectedBody: Seq[Token], expectedSymbols: SymbolTable = SymbolTable.empty) = {
@@ -102,7 +102,7 @@ class ArrowLambdaScoperTests extends FunSuite {
     assert(res.isDefined)
     res.foreach {
       case (args, body, symbols) =>
-        assertResult(expectedArgs)(args.map(_.text.toUpperCase))
+        assertResult(expectedArgs)(args.argumentNames)
         assertResult(expectedBody)(body)
         expectedSymbols.foreach {
           case (key, symType) =>

--- a/parser-core/src/test/parse/BaseParserTest.scala
+++ b/parser-core/src/test/parse/BaseParserTest.scala
@@ -1,0 +1,43 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.parse
+
+import
+  org.nlogo.core.{ CompilerException, Statements, TestUtils },
+    TestUtils.cleanJsNumbers
+
+import org.scalatest.FunSuite
+
+trait BaseParserTest { this: FunSuite =>
+  val PREAMBLE = "to __test "
+  val POSTAMBLE = "\nend"
+
+  /// helpers
+  def compile(source: String, preamble: String = PREAMBLE, postamble: String = POSTAMBLE): Seq[Statements] =
+    FrontEnd.frontEnd(preamble + source + postamble) match {
+      case (procs, _) =>
+        procs.map(_.statements)
+    }
+  def testParse(input: String, result: String, preamble: String = PREAMBLE) {
+    assertResult(cleanJsNumbers(result))(cleanJsNumbers(compile(input, preamble).mkString))
+  }
+  def runFailure(input: String, message: String, start: Int, end: Int, preamble: String = PREAMBLE) {
+    doFailure(input, message, start, end, preamble)
+  }
+  def doFailure(input: String, message: String, start: Int, end: Int, preamble: String = PREAMBLE) {
+    val e = intercept[CompilerException] { compile(input, preamble = preamble) }
+    assertResult(message)(e.getMessage)
+    val programText = preamble + input + POSTAMBLE
+    def programTextWithContext(s: Int, e: Int) = {
+      val beforeContext = programText.slice((s - 5) max 0, s)
+      val t = programText.slice(s, e)
+      val afterContext = programText.slice(e, (e + 5) min (programText.length - 1))
+      s"... $beforeContext|$t|$afterContext ..."
+    }
+    val expectedErrorSource = programTextWithContext(start + preamble.length, end + preamble.length)
+    val actualErrorSource = programTextWithContext(e.start, e.end)
+    assert(start == e.start - preamble.length, s"incorrect start, expected: $expectedErrorSource but was actually $actualErrorSource\n")
+    assert(end   == e.end   - preamble.length, s"incorrect end, expected: $expectedErrorSource but was actually $actualErrorSource")
+  }
+
+}

--- a/parser-core/src/test/parse/FrontEndTests.scala
+++ b/parser-core/src/test/parse/FrontEndTests.scala
@@ -5,92 +5,21 @@ package org.nlogo.parse
 import org.scalatest.FunSuite
 import org.nlogo.core
 import org.nlogo.core.{ CompilerException, SourceLocation }
-import org.nlogo.core.TestUtils.cleanJsNumbers
 
 // This is where ExpressionParser gets most of its testing.  (It's a lot easier to test it as part
 // of the overall front end than it would be to test in strict isolation.)
 
-class FrontEndTests extends FunSuite {
+import FrontEndTests._
 
-  val PREAMBLE = "to __test "
-  val POSTAMBLE = "\nend"
-
-  /// helpers
-  def compile(source: String, preamble: String = PREAMBLE, postamble: String = POSTAMBLE): Seq[core.Statements] =
-    FrontEnd.frontEnd(preamble + source + postamble) match {
-      case (procs, _) =>
-        procs.map(_.statements)
-    }
-
-  /**
-   * utility method useful for testing that start()
-   * and end() return right answers everywhere
-   */
-  def statementsToString(ss: Seq[core.Statements], source: String) =
-    (for (stmts <- ss) yield {
-      val visitor = new PositionsCheckVisitor(source)
-      visitor.visitStatements(stmts)
-      visitor.buf.toString
-    }).mkString
-  /// helper
-  def testStartAndEnd(source: String, preorderDump: String) {
-    assertResult(preorderDump)(statementsToString(compile(source), source))
-  }
-  // preorder traversal
-  class PositionsCheckVisitor(source: String) extends core.AstVisitor {
-    val buf = new StringBuilder()
-    override def visitCommandBlock(node: core.CommandBlock) { visit(node); super.visitCommandBlock(node) }
-    override def visitReporterApp(node: core.ReporterApp) { visit(node); super.visitReporterApp(node) }
-    override def visitReporterBlock(node: core.ReporterBlock) { visit(node); super.visitReporterBlock(node) }
-    override def visitStatement(node: core.Statement) { visit(node); super.visitStatement(node) }
-    override def visitStatements(node: core.Statements) {
-      if (node.stmts.isEmpty)
-        buf.append(node.getClass.getSimpleName + " '' ")
-      else visit(node)
-      super.visitStatements(node)
-    }
-    def visit(node: core.AstNode) {
-      val start = node.start - PREAMBLE.length
-      val end = node.end - PREAMBLE.length
-      val text =
-        try "'" + source.substring(start, end) + "'"
-        catch { case _: StringIndexOutOfBoundsException =>
-          "out of bounds: " + ((start, end)) }
-      buf.append(node.getClass.getSimpleName + " " + text + " ")
-    }
-  }
-
-  def runTest(input: String, result: String, preamble: String = PREAMBLE) {
-    assertResult(cleanJsNumbers(result))(cleanJsNumbers(compile(input, preamble).mkString))
-  }
-  def runFailure(input: String, message: String, start: Int, end: Int, preamble: String = PREAMBLE) {
-    doFailure(input, message, start, end, preamble)
-  }
-  def doFailure(input: String, message: String, start: Int, end: Int, preamble: String = PREAMBLE) {
-    val e = intercept[CompilerException] { compile(input, preamble = preamble) }
-    assertResult(message)(e.getMessage)
-    val programText = preamble + input + POSTAMBLE
-    def programTextWithContext(s: Int, e: Int) = {
-      val beforeContext = programText.slice((s - 5) max 0, s)
-      val t = programText.slice(s, e)
-      val afterContext = programText.slice(e, (e + 5) min (programText.length - 1))
-      s"... $beforeContext|$t|$afterContext ..."
-    }
-    val expectedErrorSource = programTextWithContext(start + preamble.length, end + preamble.length)
-    val actualErrorSource = programTextWithContext(e.start, e.end)
-    assert(start == e.start - preamble.length, s"incorrect start, expected: $expectedErrorSource but was actually $actualErrorSource\n")
-    assert(end   == e.end   - preamble.length, s"incorrect end, expected: $expectedErrorSource but was actually $actualErrorSource")
-  }
-
-  /// now, the actual tests
+class FrontEndTests extends FunSuite with BaseParserTest {
   test("DoParseSimpleCommand") {
-    runTest("__ignore round 0.5", "_ignore()[_round()[_const(0.5)[]]]")
+    testParse("__ignore round 0.5", "_ignore()[_round()[_const(0.5)[]]]")
   }
   test("DoParseCommandWithInfix") {
-    runTest("__ignore 5 + 2", "_ignore()[_plus()[_const(5.0)[], _const(2.0)[]]]")
+    testParse("__ignore 5 + 2", "_ignore()[_plus()[_const(5.0)[], _const(2.0)[]]]")
   }
   test("DoParseTwoCommands") {
-    runTest("__ignore round 0.5 fd 5",
+    testParse("__ignore round 0.5 fd 5",
       "_ignore()[_round()[_const(0.5)[]]] " +
       "_fd()[_const(5.0)[]]")
   }
@@ -128,50 +57,46 @@ class FrontEndTests extends FunSuite {
     runFailure("crt foo", "Nothing named FOO has been defined.", 4, 7)
   }
   test("parseSymbolUnknownName") {
-    runTest("report __symbol foo", "_report()[_symbolstring()[_symbol()[]]]", preamble = "to-report sym ")
+    testParse("report __symbol foo", "_report()[_symbolstring()[_symbol()[]]]", preamble = "to-report sym ")
   }
   test("parseSymbolKnownName1") {
-    runTest("report __symbol turtles", "_report()[_symbolstring()[_symbol()[]]]", preamble = "to-report sym ")
+    testParse("report __symbol turtles", "_report()[_symbolstring()[_symbol()[]]]", preamble = "to-report sym ")
   }
   test("parseSymbolKnownName2") {
-    runTest("report __symbol turtle", "_report()[_symbolstring()[_symbol()[]]]", preamble = "to-report sym ")
+    testParse("report __symbol turtle", "_report()[_symbolstring()[_symbol()[]]]", preamble = "to-report sym ")
   }
   test("errorsOnParseSymbolWithArgs") {
     runFailure("report __symbol turtle 0", "Expected command.", 23, 24, preamble = "to-report sym ")
-  }
-  // https://github.com/NetLogo/NetLogo/issues/348
-  test("let of lambda variable") {
-    runFailure("foreach [1] [[x] -> let x 0 ]", "There is already a local variable here called X", 24, 25)
   }
   test("error-message used outside of carefully") {
     runFailure("let foo error-message", "error-message cannot be used outside of CAREFULLY.", 8, 21)
   }
   test("lambda parse") {
-    runTest("__ignore [[x] -> x + x]",
+    testParse("__ignore [[x] -> x + x]",
       "_ignore()[_reporterlambda(X)[_plus()[_lambdavariable(X)[], _lambdavariable(X)[]]]]")
   }
   test("unbracketed lambda parse") {
-    runTest("__ignore [x -> x + x]",
+    testParse("__ignore [x -> x + x]",
       "_ignore()[_reporterlambda(X)[_plus()[_lambdavariable(X)[], _lambdavariable(X)[]]]]")
   }
   test("unbracketed nested lambda parse") {
-    runTest("__ignore [x -> [y ->  x / y ]]",
+    testParse("__ignore [x -> [y ->  x / y ]]",
       "_ignore()[_reporterlambda(X)[_reporterlambda(Y)[_div()[_lambdavariable(X)[], _lambdavariable(Y)[]]]]]")
   }
   test("unbracketed zero-argument lambda parse") {
-    runTest("__ignore [ -> 4]",
+    testParse("__ignore [ -> 4]",
       "_ignore()[_reporterlambda()[_const(4)[]]]")
   }
   test("nested lambda parse") {
-    runTest("__ignore [[x] -> [[y] ->  x / y ]]",
+    testParse("__ignore [[x] -> [[y] ->  x / y ]]",
       "_ignore()[_reporterlambda(X)[_reporterlambda(Y)[_div()[_lambdavariable(X)[], _lambdavariable(Y)[]]]]]")
   }
   test("lambda parse with map") {
-    runTest("__ignore map [[x] -> x] [1 2 3]",
+    testParse("__ignore map [[x] -> x] [1 2 3]",
       "_ignore()[_map()[_reporterlambda(X)[_lambdavariable(X)[]], _const([1, 2, 3])[]]]")
   }
   test("lambda parse with foreach") {
-    runTest("foreach [1 2 3] [[x] -> __ignore x]",
+    testParse("foreach [1 2 3] [[x] -> __ignore x]",
       "_foreach()[_const([1, 2, 3])[], _commandlambda(X)[[_ignore()[_lambdavariable(X)[]]]]]")
   }
   test("lambda argument name is a literal") {
@@ -192,110 +117,80 @@ class FrontEndTests extends FunSuite {
   test("invalidLambda4") {
     runFailure("__ignore [ foo bar -> ]", "An anonymous procedures of two or more arguments must enclose its argument list in brackets", 11, 18)
   }
-  test("lambda argument shadows primitive name") {
-    runFailure("__ignore [[turtles] -> 2]", "There is already a primitive reporter called TURTLES", 11, 18)
-  }
-  test("unbracketed lambda argument shadows primitive name") {
-    runFailure("__ignore [turtles -> 2]", "There is already a primitive reporter called TURTLES", 10, 17)
-  }
-  test("lambda argument duplicate name") {
-    runFailure("__ignore [[bar bar] -> 2]", "There is already a local variable here called BAR", 15, 18)
-  }
-  test("lambda argument duplicate nested name") {
-    runFailure("__ignore [[bar] -> [[bar] -> 2]]", "There is already a local variable here called BAR", 21, 24)
-  }
-  test("unbracketed lambda argument duplicate nested name") {
-    runFailure("__ignore [bar -> [bar -> 2]]", "There is already a local variable here called BAR", 18, 21)
-  }
-  test("lambda argument shadows local variable") {
-    runFailure("let baz 7 __ignore [[baz] -> 3]", "There is already a local variable here called BAZ", 21, 24)
-  }
-  test("unbracketed lambda argument shadows local variable") {
-    runFailure("let baz 7 __ignore [baz -> 3]", "There is already a local variable here called BAZ", 20, 23)
-  }
-  test("lambda argument shadows procedure name") {
-    runFailure("let baz [[baz] -> 3]", "There is already a local variable here called BAZ", 10, 13)
-  }
-  test("unbracketed lambda argument shadows procedure name") {
-    runFailure("let baz [baz -> 3]", "There is already a local variable here called BAZ", 9, 12)
-  }
-  test("lambda argument shadows procedure variable") {
-    runFailure("__ignore [[bar] -> 2]", "There is already a local variable here called BAR", 11, 14, "to foo [bar] ")
-  }
   test("DoParseMap") {
-    runTest("__ignore map [[x] -> round x] [1.2 1.7 3.2]",
+    testParse("__ignore map [[x] -> round x] [1.2 1.7 3.2]",
       "_ignore()[_map()[_reporterlambda(X)[_round()[_lambdavariable(X)[]]], _const([1.2, 1.7, 3.2])[]]]")
   }
   test("DoParseMapShortSyntax") {
-    runTest("__ignore map round [1.2 1.7 3.2]",
+    testParse("__ignore map round [1.2 1.7 3.2]",
       "_ignore()[_map()[_reporterlambda(_0)[_round()[_lambdavariable(_0)[]]], _const([1.2, 1.7, 3.2])[]]]")
   }
   test("DoParseForeach") {
     runFailure("foreach [1 2 3] [__ignore ?]", "Nothing named ? has been defined.", 26, 27)
   }
   test("DoParseForeachShortSyntax") {
-    runTest("foreach [1 2 3] print",
+    testParse("foreach [1 2 3] print",
       "_foreach()[_const([1.0, 2.0, 3.0])[], _commandlambda(_0)[[_print()[_lambdavariable(_0)[]]]]]")
   }
   test("DoParseForeachWithDone") {
     runFailure("foreach [1 2 3] __done", "FOREACH expected at least 2 inputs, a list and an anonymous command.", 0, 7)
   }
   test("DoParselet") {
-    runTest("let x 5 __ignore x",
+    testParse("let x 5 __ignore x",
       "_let(Let(X))[_const(5.0)[]] _ignore()[_letvariable(Let(X))[]]")
   }
   test("DoParseParenthesizedCommand") {
-    runTest("(__ignore 5)",
+    testParse("(__ignore 5)",
       "_ignore()[_const(5.0)[]]")
   }
   test("DoParseParenthesizedCommandAsFromEvaluator") {
-    runTest("__observercode (__ignore 5) __done",
+    testParse("__observercode (__ignore 5) __done",
       "_observercode()[] " +
       "_ignore()[_const(5.0)[]] " +
       "_done()[]")
   }
   test("DoParseCarefully") {
-    runTest("carefully [ error \"foo\" ] [ __ignore error-message ]",
+    testParse("carefully [ error \"foo\" ] [ __ignore error-message ]",
       """_carefully()[[_error()[_const(foo)[]]], [_ignore()[_errormessage()[]]]]""")
   }
   test("ParseExpressionWithInfix") {
-    runTest("__ignore 5 + 2",
+    testParse("__ignore 5 + 2",
       "_ignore()[_plus()[_const(5.0)[], _const(2.0)[]]]")
   }
   test("ParseExpressionWithInfix2") {
-    runTest("__ignore 5 + 2 * 7",
+    testParse("__ignore 5 + 2 * 7",
       "_ignore()[_plus()[_const(5.0)[], _mult()[_const(2.0)[], _const(7.0)[]]]]")
   }
   test("ParseExpressionWithInfix3") {
-    runTest("__ignore 5 + 2 * 7 - 2",
+    testParse("__ignore 5 + 2 * 7 - 2",
       "_ignore()[_minus()[_plus()[_const(5.0)[], _mult()[_const(2.0)[], _const(7.0)[]]], _const(2.0)[]]]")
   }
   test("ParseExpressionWithInfixAndPrefix") {
-    runTest("__ignore round 5.2 + log 64 2 * log 64 2 - random 2",
+    testParse("__ignore round 5.2 + log 64 2 * log 64 2 - random 2",
       "_ignore()[_minus()[_plus()[_round()[_const(5.2)[]], _mult()[_log()[_const(64.0)[], _const(2.0)[]], _log()[_const(64.0)[], _const(2.0)[]]]], _random()[_const(2.0)[]]]]")
   }
   test("ParseConstantInteger") {
-    runTest("__ignore 5",
+    testParse("__ignore 5",
       "_ignore()[_const(5.0)[]]")
   }
   test("ParseConstantList") {
-    runTest("__ignore [5]",
+    testParse("__ignore [5]",
       "_ignore()[_const([5.0])[]]")
   }
   test("ParseConstantListWithSublists") {
-    runTest("__ignore [[1] [2]]",
+    testParse("__ignore [[1] [2]]",
       "_ignore()[_const([[1.0], [2.0]])[]]")
   }
   test("ParseConstantListInsideLambda1") {
-    runTest("__ignore n-values 10 [[]]",
+    testParse("__ignore n-values 10 [[]]",
       "_ignore()[_nvalues()[_const(10.0)[], _reporterlambda()[_const([])[]]]]")
   }
   test("ParseConstantListInsideLambda2") {
-    runTest("__ignore n-values 10 [[5]]",
+    testParse("__ignore n-values 10 [[5]]",
       "_ignore()[_nvalues()[_const(10.0)[], _reporterlambda()[_const([5.0])[]]]]")
   }
   test("ParseDiffuse") {
-    runTest("clear-all diffuse pcolor 1",
+    testParse("clear-all diffuse pcolor 1",
       "_clearall()[] _diffuse()[_patchvariable(2)[], _const(1.0)[]]")
   }
 
@@ -303,171 +198,15 @@ class FrontEndTests extends FunSuite {
   // is provided and it defaults to `turtle`, that the primitive `turtle`
   // isn't mistaken for a singular form and parsed as `_breedsingular` - ST 4/12/14
   test("SetBreed1") {
-    runTest("__ignore turtle 0",
+    testParse("__ignore turtle 0",
       "_ignore()[_turtle()[_const(0.0)[]]]")
   }
   test("SetBreed2") {
-    runTest("__ignore turtle 0",
+    testParse("__ignore turtle 0",
       "_ignore()[_turtle()[_const(0.0)[]]]")
   }
 
-  /// tests using testStartAndEnd
-  test("StartAndEndPositions0") {
-    testStartAndEnd("ca",
-      "Statements 'ca' " +
-      "Statement 'ca' ")
-  }
-  test("StartAndEndPositions1") {
-    testStartAndEnd("__ignore 5",
-      "Statements '__ignore 5' " +
-      "Statement '__ignore 5' " +
-      "ReporterApp '5' ")
-  }
-  test("StartAndEndPositions2") {
-    testStartAndEnd("__ignore n-values 5 [[] -> world-width]",
-      "Statements '__ignore n-values 5 [[] -> world-width]' " +
-      "Statement '__ignore n-values 5 [[] -> world-width]' " +
-      "ReporterApp 'n-values 5 [[] -> world-width]' " +
-      "ReporterApp '5' " +
-      "ReporterApp '[[] -> world-width]' " +
-      "ReporterApp 'world-width' ")
-  }
-  test("StartAndEndPositions8") {
-    testStartAndEnd("crt 1",
-      "Statements 'crt 1' " +
-      "Statement 'crt 1' " +
-      "ReporterApp '1' " +
-      "CommandBlock '' " +
-      "Statements '' ")
-  }
-  test("StartAndEndPositions9") {
-    testStartAndEnd("crt 1 [ ]",
-      "Statements 'crt 1 [ ]' " +
-      "Statement 'crt 1 [ ]' " +
-      "ReporterApp '1' " +
-      "CommandBlock '[ ]' " +
-      "Statements '' ")
-  }
-
-  test("StartAndEndPositions10") {
-    testStartAndEnd("ask turtles with [color = red ] [ fd 1 ]",
-      "Statements 'ask turtles with [color = red ] [ fd 1 ]' " +
-      "Statement 'ask turtles with [color = red ] [ fd 1 ]' " +
-      "ReporterApp 'turtles with [color = red ]' " +
-      "ReporterApp 'turtles' " +
-      "ReporterBlock '[color = red ]' " +
-      "ReporterApp 'color = red' " +
-      "ReporterApp 'color' " +
-      "ReporterApp 'red' " +
-      "CommandBlock '[ fd 1 ]' " +
-      "Statements 'fd 1' " +
-      "Statement 'fd 1' " +
-      "ReporterApp '1' ")
-  }
-
-  test("While") {
-    testStartAndEnd("while [count turtles < 10] [ crt 1 ]",
-      "Statements 'while [count turtles < 10] [ crt 1 ]' " +
-      "Statement 'while [count turtles < 10] [ crt 1 ]' " +
-      "ReporterBlock '[count turtles < 10]' " +
-      "ReporterApp 'count turtles < 10' " +
-      "ReporterApp 'count turtles' " +
-      "ReporterApp 'turtles' " +
-      "ReporterApp '10' " +
-      "CommandBlock '[ crt 1 ]' " +
-      "Statements 'crt 1' " +
-      "Statement 'crt 1' " +
-      "ReporterApp '1' " +
-      "CommandBlock '' " +
-      "Statements '' ")
-  }
-
-  // issue #417 (source positions for literal lists)
-  test("literal list") {
-    testStartAndEnd("print [1 2 3]",
-      "Statements 'print [1 2 3]' " +
-      "Statement 'print [1 2 3]' " +
-      "ReporterApp '[1 2 3]' ")
-  }
-
   /// duplicate name tests
-
-  def duplicateName(s: String, err: String) = {
-    val e = intercept[CompilerException] {
-      FrontEnd.frontEnd(s, extensionManager = extensionManager)
-    }
-    assertResult(err)(e.getMessage)
-  }
-
-  test("LetSameNameAsCommandProcedure2") {
-    duplicateName("to b let a 5 end  to a end",
-      "There is already a procedure called A")
-  }
-  test("LetSameNameAsReporterProcedure2") {
-    duplicateName("to b let a 5 end  to-report a end",
-      "There is already a procedure called A")
-  }
-  test("LetNameSameAsEnclosingCommandProcedureName") {
-    duplicateName("to bazort let bazort 5 end",
-      "There is already a procedure called BAZORT")
-  }
-  test("LetNameSameAsEnclosingReporterProcedureName") {
-    duplicateName("to-report bazort let bazort 5 report bazort end",
-      "There is already a procedure called BAZORT")
-  }
-  test("LetNameSameAsBreedVariableName") {
-    duplicateName("breed [mice mouse] mice-own [fur] to foo let fur 5 end",
-      "There is already a MICE-OWN variable called FUR")
-  }
-  test("BreedDuplicateName") {
-    duplicateName("breed [xs xs]",
-      "There is already a breed called XS")
-  }
-  test("BreedOnlyOneName") {
-    duplicateName("breed [xs]",
-      "Breed declarations must have plural and singular. BREED [XS] has only one name.")
-  }
-  test("LinkBreedOnlyOneName") {
-    duplicateName("directed-link-breed [xs]",
-      "Breed declarations must have plural and singular. DIRECTED-LINK-BREED [XS] has only one name.")
-  }
-  test("BreedPrimSameNameAsBuiltInPrim") {
-    duplicateName("breed [strings string]",
-      "Defining a breed [STRINGS STRING] redefines IS-STRING?, a primitive reporter")
-  }
-  test("BreedPrimSameAsProcedure") {
-    duplicateName("breed [mice mouse] to-report mice-at report nobody end",
-      "There is already a breed reporter called MICE-AT")
-  }
-  test("SameLocalVariableTwice1") {
-    duplicateName("to a1 locals [b b] end",
-      "Nothing named LOCALS has been defined.")
-  }
-  test("SameLocalVariableTwice2") {
-    duplicateName("to a2 [b b] end",
-      "There is already a local variable called B here")
-  }
-  test("SameLocalVariableTwice3") {
-    duplicateName("to a3 let b 5 let b 6 end",
-      "There is already a local variable here called B")
-  }
-  test("SameLocalVariableTwice4") {
-    duplicateName("to a4 locals [b] let b 5 end",
-      "Nothing named LOCALS has been defined.")
-  }
-  test("SameLocalVariableTwice5") {
-    duplicateName("to a5 [b] locals [b] end",
-      "Nothing named LOCALS has been defined.")
-  }
-  test("SameLocalVariableTwice6") {
-    duplicateName("to a6 [b] let b 5 end",
-      "There is already a local variable here called B")
-  }
-
-  test("SameNameAsExtensionPrim") {
-    duplicateName("to foo:bar end",
-      "There is already an extension command called FOO:BAR")
-  }
 
   test("findIncludes lists all includes when there is a valid includes statement") {
     assertResult(Seq())(FrontEnd.findIncludes(""))
@@ -503,52 +242,22 @@ class FrontEndTests extends FunSuite {
     val noNameProcedure = FrontEnd.findProcedurePositions("""to show "foo" end""", None)
     assert(noNameProcedure.isEmpty)
   }
+}
 
-  lazy val extensionManager = new core.DummyExtensionManager() {
-      override def anyExtensionsLoaded = true
-      override def replaceIdentifier(name: String): core.Primitive =
-        name match {
-          case "FOO:BAR" => new core.PrimitiveCommand() {
-            override def getSyntax: core.Syntax =
-              core.Syntax.commandSyntax(right = List(core.Syntax.ListType))
-          }
-          case "FOO:BAZ" => new core.PrimitiveReporter() {
-            override def getSyntax: core.Syntax =
-              core.Syntax.reporterSyntax(right = List(), ret = core.Syntax.ListType)
-          }
-          case _ => null
+object FrontEndTests {
+  val extensionManager = new core.DummyExtensionManager() {
+    override def anyExtensionsLoaded = true
+    override def replaceIdentifier(name: String): core.Primitive =
+      name match {
+        case "FOO:BAR" => new core.PrimitiveCommand() {
+          override def getSyntax: core.Syntax =
+            core.Syntax.commandSyntax(right = List(core.Syntax.ListType))
         }
-    }
-
-  def colorTokenize(source: String): Seq[core.Token] = {
-    FrontEnd.tokenizeForColorization(source, core.NetLogoCore, extensionManager)
-  }
-
-  def assertColorTokenize(source: String, expectedTypes: Seq[core.TokenType]): Unit = {
-    val toks = colorTokenize(source)
-    (toks zip expectedTypes).foreach {
-      case (t, expectedType) => assertResult(expectedType)(t.tpe)
-    }
-  }
-
-  test("tokenizeForColorization tokenizes unknown values as Ident") {
-    assertColorTokenize("foobarbaz", Seq(core.TokenType.Ident))
-  }
-  test("tokenizeForColorization tags commands with the correct token type") {
-    assertColorTokenize("fd 1", Seq(core.TokenType.Command, core.TokenType.Literal))
-  }
-  test("tokenizeForColorization tags reporters with correct token type") {
-    assertColorTokenize("list 1 2 3", Seq(core.TokenType.Reporter))
-  }
-  test("tokenizeForColorization tags keywords with correct token type") {
-    assertColorTokenize("to foo", Seq(core.TokenType.Keyword, core.TokenType.Ident))
-  }
-  test("tokenizeForColorization tags extension prims with correct token type") {
-    assertColorTokenize("foo:bar foo:baz",
-      Seq(core.TokenType.Command, core.TokenType.Reporter))
-  }
-  test("tokenizeForColorization tags agent variables with correct token type") {
-    assertColorTokenize("set pcolor color",
-      Seq(core.TokenType.Command, core.TokenType.Reporter, core.TokenType.Reporter))
+        case "FOO:BAZ" => new core.PrimitiveReporter() {
+          override def getSyntax: core.Syntax =
+            core.Syntax.reporterSyntax(right = List(), ret = core.Syntax.ListType)
+        }
+        case _ => null
+      }
   }
 }

--- a/parser-core/src/test/parse/ScopingTests.scala
+++ b/parser-core/src/test/parse/ScopingTests.scala
@@ -1,0 +1,120 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.parse
+
+import org.nlogo.core.CompilerException
+
+import org.scalatest.FunSuite
+
+import FrontEndTests.extensionManager
+
+class ScopingTests extends FunSuite with BaseParserTest {
+  def duplicateName(s: String, err: String) = {
+    val e = intercept[CompilerException] {
+      FrontEnd.frontEnd(s, extensionManager = extensionManager)
+    }
+    assertResult(err)(e.getMessage)
+  }
+  test("lambda argument shadows primitive name") {
+    runFailure("__ignore [[turtles] -> 2]", "There is already a primitive reporter called TURTLES", 11, 18)
+  }
+  test("unbracketed lambda argument shadows primitive name") {
+    runFailure("__ignore [turtles -> 2]", "There is already a primitive reporter called TURTLES", 10, 17)
+  }
+  test("lambda argument duplicate name") {
+    runFailure("__ignore [[bar bar] -> 2]", "There is already a local variable here called BAR", 15, 18)
+  }
+  test("lambda argument duplicate nested name") {
+    runFailure("__ignore [[bar] -> [[bar] -> 2]]", "There is already a local variable here called BAR", 21, 24)
+  }
+  test("unbracketed lambda argument duplicate nested name") {
+    runFailure("__ignore [bar -> [bar -> 2]]", "There is already a local variable here called BAR", 18, 21)
+  }
+  test("lambda argument shadows local variable") {
+    runFailure("let baz 7 __ignore [[baz] -> 3]", "There is already a local variable here called BAZ", 21, 24)
+  }
+  test("unbracketed lambda argument shadows local variable") {
+    runFailure("let baz 7 __ignore [baz -> 3]", "There is already a local variable here called BAZ", 20, 23)
+  }
+  test("lambda argument shadows procedure name") {
+    runFailure("let baz [[baz] -> 3]", "There is already a local variable here called BAZ", 10, 13)
+  }
+  test("unbracketed lambda argument shadows procedure name") {
+    runFailure("let baz [baz -> 3]", "There is already a local variable here called BAZ", 9, 12)
+  }
+  test("lambda argument shadows procedure variable") {
+    runFailure("__ignore [[bar] -> 2]", "There is already a local variable here called BAR", 11, 14, "to foo [bar] ")
+  }
+  // https://github.com/NetLogo/NetLogo/issues/348
+  test("let of lambda variable") {
+    runFailure("foreach [1] [[x] -> let x 0 ]", "There is already a local variable here called X", 24, 25)
+  }
+  test("LetSameNameAsCommandProcedure2") {
+    duplicateName("to b let a 5 end  to a end",
+      "There is already a procedure called A")
+  }
+  test("LetSameNameAsReporterProcedure2") {
+    duplicateName("to b let a 5 end  to-report a end",
+      "There is already a procedure called A")
+  }
+  test("LetNameSameAsEnclosingCommandProcedureName") {
+    duplicateName("to bazort let bazort 5 end",
+      "There is already a procedure called BAZORT")
+  }
+  test("LetNameSameAsEnclosingReporterProcedureName") {
+    duplicateName("to-report bazort let bazort 5 report bazort end",
+      "There is already a procedure called BAZORT")
+  }
+  test("LetNameSameAsBreedVariableName") {
+    duplicateName("breed [mice mouse] mice-own [fur] to foo let fur 5 end",
+      "There is already a MICE-OWN variable called FUR")
+  }
+  test("BreedDuplicateName") {
+    duplicateName("breed [xs xs]",
+      "There is already a breed called XS")
+  }
+  test("BreedOnlyOneName") {
+    duplicateName("breed [xs]",
+      "Breed declarations must have plural and singular. BREED [XS] has only one name.")
+  }
+  test("LinkBreedOnlyOneName") {
+    duplicateName("directed-link-breed [xs]",
+      "Breed declarations must have plural and singular. DIRECTED-LINK-BREED [XS] has only one name.")
+  }
+  test("BreedPrimSameNameAsBuiltInPrim") {
+    duplicateName("breed [strings string]",
+      "Defining a breed [STRINGS STRING] redefines IS-STRING?, a primitive reporter")
+  }
+  test("BreedPrimSameAsProcedure") {
+    duplicateName("breed [mice mouse] to-report mice-at report nobody end",
+      "There is already a breed reporter called MICE-AT")
+  }
+  test("SameLocalVariableTwice1") {
+    duplicateName("to a1 locals [b b] end",
+      "Nothing named LOCALS has been defined.")
+  }
+  test("SameLocalVariableTwice2") {
+    duplicateName("to a2 [b b] end",
+      "There is already a local variable called B here")
+  }
+  test("SameLocalVariableTwice3") {
+    duplicateName("to a3 let b 5 let b 6 end",
+      "There is already a local variable here called B")
+  }
+  test("SameLocalVariableTwice4") {
+    duplicateName("to a4 locals [b] let b 5 end",
+      "Nothing named LOCALS has been defined.")
+  }
+  test("SameLocalVariableTwice5") {
+    duplicateName("to a5 [b] locals [b] end",
+      "Nothing named LOCALS has been defined.")
+  }
+  test("SameLocalVariableTwice6") {
+    duplicateName("to a6 [b] let b 5 end",
+      "There is already a local variable here called B")
+  }
+  test("SameNameAsExtensionPrim") {
+    duplicateName("to foo:bar end",
+      "There is already an extension command called FOO:BAR")
+  }
+}

--- a/parser-core/src/test/parse/SourcePositionTests.scala
+++ b/parser-core/src/test/parse/SourcePositionTests.scala
@@ -1,0 +1,126 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.parse
+
+import org.nlogo.core
+
+import org.scalatest.FunSuite
+
+class SourcePositionTests extends FunSuite with BaseParserTest {
+  /// tests using testStartAndEnd
+  test("StartAndEndPositions0") {
+    testStartAndEnd("ca",
+      "Statements 'ca' " +
+      "Statement 'ca' ")
+  }
+  test("StartAndEndPositions1") {
+    testStartAndEnd("__ignore 5",
+      "Statements '__ignore 5' " +
+      "Statement '__ignore 5' " +
+      "ReporterApp '5' ")
+  }
+  test("StartAndEndPositions2") {
+    testStartAndEnd("__ignore n-values 5 [[] -> world-width]",
+      "Statements '__ignore n-values 5 [[] -> world-width]' " +
+      "Statement '__ignore n-values 5 [[] -> world-width]' " +
+      "ReporterApp 'n-values 5 [[] -> world-width]' " +
+      "ReporterApp '5' " +
+      "ReporterApp '[[] -> world-width]' " +
+      "ReporterApp 'world-width' ")
+  }
+  test("StartAndEndPositions8") {
+    testStartAndEnd("crt 1",
+      "Statements 'crt 1' " +
+      "Statement 'crt 1' " +
+      "ReporterApp '1' " +
+      "CommandBlock '' " +
+      "Statements '' ")
+  }
+  test("StartAndEndPositions9") {
+    testStartAndEnd("crt 1 [ ]",
+      "Statements 'crt 1 [ ]' " +
+      "Statement 'crt 1 [ ]' " +
+      "ReporterApp '1' " +
+      "CommandBlock '[ ]' " +
+      "Statements '' ")
+  }
+
+  test("StartAndEndPositions10") {
+    testStartAndEnd("ask turtles with [color = red ] [ fd 1 ]",
+      "Statements 'ask turtles with [color = red ] [ fd 1 ]' " +
+      "Statement 'ask turtles with [color = red ] [ fd 1 ]' " +
+      "ReporterApp 'turtles with [color = red ]' " +
+      "ReporterApp 'turtles' " +
+      "ReporterBlock '[color = red ]' " +
+      "ReporterApp 'color = red' " +
+      "ReporterApp 'color' " +
+      "ReporterApp 'red' " +
+      "CommandBlock '[ fd 1 ]' " +
+      "Statements 'fd 1' " +
+      "Statement 'fd 1' " +
+      "ReporterApp '1' ")
+  }
+
+  test("While") {
+    testStartAndEnd("while [count turtles < 10] [ crt 1 ]",
+      "Statements 'while [count turtles < 10] [ crt 1 ]' " +
+      "Statement 'while [count turtles < 10] [ crt 1 ]' " +
+      "ReporterBlock '[count turtles < 10]' " +
+      "ReporterApp 'count turtles < 10' " +
+      "ReporterApp 'count turtles' " +
+      "ReporterApp 'turtles' " +
+      "ReporterApp '10' " +
+      "CommandBlock '[ crt 1 ]' " +
+      "Statements 'crt 1' " +
+      "Statement 'crt 1' " +
+      "ReporterApp '1' " +
+      "CommandBlock '' " +
+      "Statements '' ")
+  }
+
+  // issue #417 (source positions for literal lists)
+  test("literal list") {
+    testStartAndEnd("print [1 2 3]",
+      "Statements 'print [1 2 3]' " +
+      "Statement 'print [1 2 3]' " +
+      "ReporterApp '[1 2 3]' ")
+  }
+
+  /**
+   * utility method useful for testing that start()
+   * and end() return right answers everywhere
+   */
+  def statementsToString(ss: Seq[core.Statements], source: String) =
+    (for (stmts <- ss) yield {
+      val visitor = new PositionsCheckVisitor(source)
+      visitor.visitStatements(stmts)
+      visitor.buf.toString
+    }).mkString
+  /// helper
+  def testStartAndEnd(source: String, preorderDump: String) {
+    assertResult(preorderDump)(statementsToString(compile(source), source))
+  }
+  // preorder traversal
+  class PositionsCheckVisitor(source: String) extends core.AstVisitor {
+    val buf = new StringBuilder()
+    override def visitCommandBlock(node: core.CommandBlock) { visit(node); super.visitCommandBlock(node) }
+    override def visitReporterApp(node: core.ReporterApp) { visit(node); super.visitReporterApp(node) }
+    override def visitReporterBlock(node: core.ReporterBlock) { visit(node); super.visitReporterBlock(node) }
+    override def visitStatement(node: core.Statement) { visit(node); super.visitStatement(node) }
+    override def visitStatements(node: core.Statements) {
+      if (node.stmts.isEmpty)
+        buf.append(node.getClass.getSimpleName + " '' ")
+      else visit(node)
+      super.visitStatements(node)
+    }
+    def visit(node: core.AstNode) {
+      val start = node.start - PREAMBLE.length
+      val end = node.end - PREAMBLE.length
+      val text =
+        try "'" + source.substring(start, end) + "'"
+        catch { case _: StringIndexOutOfBoundsException =>
+          "out of bounds: " + ((start, end)) }
+      buf.append(node.getClass.getSimpleName + " " + text + " ")
+    }
+  }
+}

--- a/parser-core/src/test/parse/TokenColorizeTests.scala
+++ b/parser-core/src/test/parse/TokenColorizeTests.scala
@@ -1,0 +1,42 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.parse
+
+import org.scalatest.FunSuite
+import org.nlogo.core
+
+class TokenColorizeTests extends FunSuite {
+  import FrontEndTests.extensionManager
+
+  def colorTokenize(source: String): Seq[core.Token] = {
+    FrontEnd.tokenizeForColorization(source, core.NetLogoCore, extensionManager)
+  }
+
+  def assertColorTokenize(source: String, expectedTypes: Seq[core.TokenType]): Unit = {
+    val toks = colorTokenize(source)
+    (toks zip expectedTypes).foreach {
+      case (t, expectedType) => assertResult(expectedType)(t.tpe)
+    }
+  }
+
+  test("tokenizeForColorization tokenizes unknown values as Ident") {
+    assertColorTokenize("foobarbaz", Seq(core.TokenType.Ident))
+  }
+  test("tokenizeForColorization tags commands with the correct token type") {
+    assertColorTokenize("fd 1", Seq(core.TokenType.Command, core.TokenType.Literal))
+  }
+  test("tokenizeForColorization tags reporters with correct token type") {
+    assertColorTokenize("list 1 2 3", Seq(core.TokenType.Reporter))
+  }
+  test("tokenizeForColorization tags keywords with correct token type") {
+    assertColorTokenize("to foo", Seq(core.TokenType.Keyword, core.TokenType.Ident))
+  }
+  test("tokenizeForColorization tags extension prims with correct token type") {
+    assertColorTokenize("foo:bar foo:baz",
+      Seq(core.TokenType.Command, core.TokenType.Reporter))
+  }
+  test("tokenizeForColorization tags agent variables with correct token type") {
+    assertColorTokenize("set pcolor color",
+      Seq(core.TokenType.Command, core.TokenType.Reporter, core.TokenType.Reporter))
+  }
+}

--- a/parser-core/src/test/parse/WhiteSpaceTests.scala
+++ b/parser-core/src/test/parse/WhiteSpaceTests.scala
@@ -102,7 +102,7 @@ class WhiteSpaceTests extends FunSuite with NetLogoParser {
     val blk = AstPath(Proc("Z"), Stmt(0), RepArg(0), RepBlk(0))
     val word = blk / RepArg(0)
     assert(result.whitespaceMap(word -> Leading) == " (")
-    assert(result.whitespaceMap(blk -> BackMargin) == ") ")
+    assert(result.whitespaceMap(blk -> BackMargin) == ") ]")
     assert(result.whitespaceMap(word / RepArg(1) -> Trailing) == ") ")
   }
 

--- a/parser-jvm/src/test/parse/AstRewriterTests.scala
+++ b/parser-jvm/src/test/parse/AstRewriterTests.scala
@@ -24,12 +24,12 @@ class AstRewriterTests extends FunSuite {
     assertPreservesSource("show [pycor] of one-of patches")
     assertPreservesSource("; comment with [\"a list\"] [1 2 3]\n")
     assertPreservesSource("__ignore (list (1 + 1) (2 - 1))")
-    assertPreservesSource("__ignore [[x] -> list (1 + 1) (2 - 1)]")
+    assertPreservesSource("__ignore [ [x] -> list (1 + 1) (2 - 1)]")
     assertPreservesSource("show [ 1 2 3 ]")
     assertPreservesSource("show [ [1] [ 2] [ 3 ] ]")
     assertPreservesSource("show [ blue green yellow ]")
     assertPreservesSource("show (list 1 2 3) ; => [1 2 3]\n")
-    assertPreservesSource("show reduce [[x y] -> x + y] [1 2 3]")
+    assertPreservesSource("show reduce [ [x y] -> x + y] [1 2 3]")
     assertPreservesSource("show __block [foo bar baz]")
   }
 
@@ -86,6 +86,7 @@ class AstRewriterTests extends FunSuite {
   }
 
   test("rename command and manipulate arguments") {
+    assertResult("bk 1  forward 1")(replaceCommand("bk 1  fd 1", "fd" -> "forward {0}"))
     assertResult("file-close-all")(replaceCommand("file-close", "file-close" -> "file-close-all"))
     assertResult("fd 1")(replaceCommand("bk 1", "bk" -> "fd 1"))
     assertResult("; bk 1")(replaceCommand("; bk 1\n", "bk" -> "fd 1"))
@@ -134,7 +135,7 @@ class AstRewriterTests extends FunSuite {
   testLambda("show is-list? [ [] -> tick ]", "show is-list? task [tick]")
   testLambda("let a-value 1 let a-task [ [] -> a-value ]", "let a-value 1 let a-task task [a-value]")
   testLambda("baz ([ [] ->  fd 1 ]) ([ [?1 ?2] -> bk ?2 ])", "baz (task [ fd 1 ]) (task [ bk ?2 ])", preamble = "TO baz [a b] END TO FOO ")
-  testLambda("show reduce [[x y] -> x + y] [1 2 3]", "show reduce [[x y] -> x + y] [1 2 3]")
+  testLambda("show reduce [ [x y] -> x + y] [1 2 3]", "show reduce [[x y] -> x + y] [1 2 3]")
   testLambda("foreach [1 2 3] [ [x] -> show x ]", "foreach [1 2 3] [ [x] -> show x ]")
   testLambda("foreach [1 2 3] [ x -> show x ]", "foreach [1 2 3] [ x -> show x ]")
   testLambda("foreach [1 2 3] [ -> show 4 ]", "foreach [1 2 3] [ -> show 4 ]")

--- a/test/benchdumps/ANN.txt
+++ b/test/benchdumps/ANN.txt
@@ -3042,7 +3042,7 @@ procedure PROPOGATE:[]{OTPL}:
          L1
           RETURN
 
-   (anonymous command: [ ?1 -> ask ?1 [ update-activation ] ]):procedure PROPOGATE[]{OTPL}:
+   (anonymous command: [ [?1] -> ask ?1 [ update-activation ] ]):procedure PROPOGATE[]{OTPL}:
    [0]_asm_propogate_anonymouscommand1ask1updateactivation_ask_0 "ask ?1 [ update-activation ]" Object => void
             _letvariable(?1) "?1" => Object
                 // parameter final  context
@@ -5819,15 +5819,8 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
          L1
           RETURN
 
-   (anonymous command: [ ?1 -> let ?1 let length layers let no-turtles crt layer-size [ set layer (turtle-set layer self) ] let layer-num + 0.5 / num-layers * max-pxcor let 0 foreach sort layer [ [??1] ->
-      ask ??1 [
-        let y 2 * (0.5 - (i + 0.5) / layer-size) * max-pycor
-        setxy x y
-        set color grey
-      ]
-      set i i + 1
-    ] set layers lput layer layers ]):procedure SETUP[]{OTPL}:
-   [0]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_0 "let ?1" Object => void
+   (anonymous command: [ [?1] -> let ?1 let length layers let no-turtles crt layer-size [ set layer turtle-set layer self ] let layer-num + 0.5 / num-layers * max-pxcor let 0 foreach sort layer [ [??1] -> ask ??1 [ let 2 * 0.5 - i + 0.5 / layer-size * max-pycor setxy x y set color grey ] set i i + 1 ] set layers lput layer layers ]):procedure SETUP[]{OTPL}:
+   [0]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_0 "let ?1" Object => void
             _letvariable(?1) "?1" => Object
                 // parameter final  context
                 // parameter final  context
@@ -5837,7 +5830,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_0.kept2__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_0.kept2__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L1
                 ASTORE 2
@@ -5845,7 +5838,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_0.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_0.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.let (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -5853,7 +5846,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L2
                 RETURN
-   [1]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_1 "let length layers" Object => void
+   [1]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_1 "let length layers" Object => void
             _length "length layers" Object => double
               _observervariable:LAYERS "layers" => Object
                 // parameter final  context
@@ -5908,7 +5901,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_1.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_1.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.let (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -5916,12 +5909,12 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L5
                 RETURN
-   [2]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_2 "let no-turtles" Object => void
+   [2]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_2 "let no-turtles" Object => void
             _noturtles "no-turtles"
                 // parameter final  context
                 // parameter final  value
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_2.keptinstr2 : Lorg/nlogo/prim/etc/_noturtles;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_2.keptinstr2 : Lorg/nlogo/prim/etc/_noturtles;
                 ALOAD 1
                 INVOKEVIRTUAL org/nlogo/prim/etc/_noturtles.report (Lorg/nlogo/nvm/Context;)Ljava/lang/Object;
                L0
@@ -5930,7 +5923,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_2.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_2.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.let (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -5939,31 +5932,31 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                L1
                 RETURN
    [3]_createturtles:,+6 "crt layer-size [ set layer (turtle-set layer self) ]"
-            _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_letvariable_3 "layer-size" => Object
+            _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_letvariable_3 "layer-size" => Object
                   // parameter final  context
                  L0
                   ALOAD 1
                   GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                   GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                   ALOAD 0
-                  GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_letvariable_3.kept1__let : Lorg/nlogo/core/Let;
+                  GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_letvariable_3.kept1__let : Lorg/nlogo/core/Let;
                   INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                  L1
                   ARETURN
-   [4]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_setletvariable_4 "set layer (turtle-set layer self)" Object => void
+   [4]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_setletvariable_4 "set layer (turtle-set layer self)" Object => void
             _turtleset "(turtle-set layer self)"
-              _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_letvariable_5 "layer" => Object
+              _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_letvariable_5 "layer" => Object
                     // parameter final  context
                    L0
                     ALOAD 1
                     GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                     GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                     ALOAD 0
-                    GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_letvariable_5.kept1__let : Lorg/nlogo/core/Let;
+                    GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_letvariable_5.kept1__let : Lorg/nlogo/core/Let;
                     INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                    L1
                     ARETURN
-              _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_self_6 "self" => Agent
+              _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_self_6 "self" => Agent
                     // parameter final  context
                    L0
                     ALOAD 1
@@ -5973,7 +5966,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 // parameter final  context
                 // parameter final  value
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_setletvariable_4.keptinstr2 : Lorg/nlogo/prim/etc/_turtleset;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_setletvariable_4.keptinstr2 : Lorg/nlogo/prim/etc/_turtleset;
                 ALOAD 1
                 INVOKEVIRTUAL org/nlogo/prim/etc/_turtleset.report (Lorg/nlogo/nvm/Context;)Ljava/lang/Object;
                L0
@@ -5982,7 +5975,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_setletvariable_4.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_setletvariable_4.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.setLet (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -5990,7 +5983,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L1
                 RETURN
-   [5]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_done_7 => void
+   [5]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_done_7 => void
                 // parameter final  context
                L0
                 ALOAD 1
@@ -5998,7 +5991,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.finished : Z
                L1
                 RETURN
-   [6]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8 "let layer-num + 0.5 / num-layers * max-pxcor" Object => void
+   [6]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_8 "let layer-num + 0.5 / num-layers * max-pxcor" Object => void
             _mult "layer-num + 0.5 / num-layers * max-pxcor" double,double => double
               _div "layer-num + 0.5 / num-layers" double,double => double
                 _plus "layer-num + 0.5" double,double => double
@@ -6018,7 +6011,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8.kept5__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_8.kept5__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L5
                 ASTORE 2
@@ -6028,7 +6021,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKEVIRTUAL java/lang/Double.doubleValue ()D
                 GOTO L6
                L1
-               FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
+               FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_8 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
                 POP
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
@@ -6050,13 +6043,13 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 4
                 DADD
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_8.validDouble (DLorg/nlogo/nvm/Context;)D
                L8
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8.kept7__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_8.kept7__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L9
                 ASTORE 2
@@ -6066,7 +6059,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKEVIRTUAL java/lang/Double.doubleValue ()D
                 GOTO L10
                L3
-               FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8 org/nlogo/nvm/Context java/lang/Object T D] [java/lang/ClassCastException]
+               FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_8 org/nlogo/nvm/Context java/lang/Object T D] [java/lang/ClassCastException]
                 POP
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
@@ -6078,7 +6071,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
                L10
-               FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8 org/nlogo/nvm/Context java/lang/Object T D] [D D]
+               FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_8 org/nlogo/nvm/Context java/lang/Object T D] [D D]
                 DSTORE 4
                 DSTORE 2
                 DLOAD 4
@@ -6095,16 +6088,16 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
                L11
-               FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8 org/nlogo/nvm/Context D D] []
+               FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_8 org/nlogo/nvm/Context D D] []
                 ALOAD 0
                 DLOAD 2
                 DLOAD 4
                 DDIV
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_8.validDouble (DLorg/nlogo/nvm/Context;)D
                L12
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_8.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.maxPxcor ()I
                 I2D
                L13
@@ -6115,7 +6108,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 4
                 DMUL
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_8.validDouble (DLorg/nlogo/nvm/Context;)D
                L14
                 DSTORE 2
                 NEW java/lang/Double
@@ -6127,7 +6120,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_8.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_8.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.let (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -6135,20 +6128,20 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L15
                 RETURN
-   [7]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_9 "let 0" Object => void
+   [7]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_9 "let 0" Object => void
             _constdouble:0.0 "0" => Double
                 // parameter final  context
                 // parameter final  value
                L0
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_9.kept2_value : Ljava/lang/Double;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_9.kept2_value : Ljava/lang/Double;
                L1
                 ASTORE 2
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_let_9.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_let_9.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.let (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -6164,7 +6157,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
       ]
       set i i + 1
     ]"
-            _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_sort_10 "sort layer" Object => Object
+            _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_sort_10 "sort layer" Object => Object
               _letvariable(LAYER) "layer" => Object
                   // parameter final  context
                  L0
@@ -6172,7 +6165,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                   GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                   GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                   ALOAD 0
-                  GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_sort_10.kept2__let : Lorg/nlogo/core/Let;
+                  GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_sort_10.kept2__let : Lorg/nlogo/core/Let;
                   INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                  L1
                   ASTORE 2
@@ -6207,7 +6200,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                   INVOKEVIRTUAL org/nlogo/core/LogoList.javaIterator ()Ljava/util/Iterator;
                   ASTORE 7
                  L5
-                 FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_sort_10 org/nlogo/nvm/Context java/lang/Object org/nlogo/core/LogoList java/util/ArrayList java/util/ArrayList java/util/ArrayList java/util/Iterator] []
+                 FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_sort_10 org/nlogo/nvm/Context java/lang/Object org/nlogo/core/LogoList java/util/ArrayList java/util/ArrayList java/util/ArrayList java/util/Iterator] []
                   ALOAD 7
                   INVOKEINTERFACE java/util/Iterator.hasNext ()Z
                   IFEQ L6
@@ -6275,7 +6268,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                   INVOKESTATIC org/nlogo/core/LogoList.fromJava (Ljava/lang/Iterable;)Lorg/nlogo/core/LogoList;
                   GOTO L3
                  L4
-                 FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_sort_10 org/nlogo/nvm/Context java/lang/Object] []
+                 FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_sort_10 org/nlogo/nvm/Context java/lang/Object] []
                   NEW org/nlogo/nvm/ArgumentTypeException
                   DUP
                   ALOAD 1
@@ -6298,20 +6291,20 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
       ]
       set i i + 1
     ]"
-   [9]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_setobservervariable_11 "set layers lput layer layers" Object => void
+   [9]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_setobservervariable_11 "set layers lput layer layers" Object => void
             _lput "lput layer layers"
-              _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_letvariable_12 "layer" => Object
+              _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_letvariable_12 "layer" => Object
                     // parameter final  context
                    L0
                     ALOAD 1
                     GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                     GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                     ALOAD 0
-                    GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_letvariable_12.kept1__let : Lorg/nlogo/core/Let;
+                    GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_letvariable_12.kept1__let : Lorg/nlogo/core/Let;
                     INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                    L1
                     ARETURN
-              _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_observervariable_13 "layers" => Object
+              _asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_observervariable_13 "layers" => Object
                    L0
                     ALOAD 1
                     GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -6321,7 +6314,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                     ARETURN
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_setobservervariable_11.keptinstr2 : Lorg/nlogo/prim/etc/_lput;
+                GETFIELD org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_setobservervariable_11.keptinstr2 : Lorg/nlogo/prim/etc/_lput;
                 ALOAD 1
                 INVOKEVIRTUAL org/nlogo/prim/etc/_lput.report (Lorg/nlogo/nvm/Context;)Ljava/lang/Object;
                L3
@@ -6335,7 +6328,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                L1
                 GOTO L4
                L2
-               FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_setobservervariable_11 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
+               FRAME FULL [org/nlogo/prim/_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_setobservervariable_11 org/nlogo/nvm/Context java/lang/Object] [org/nlogo/api/AgentException]
                 ASTORE 3
                 NEW org/nlogo/nvm/RuntimePrimitiveException
                 DUP
@@ -6352,7 +6345,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L5
                 RETURN
-   [10]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlayer$f44ec9d06db541a3cc10b648569a010e$_done_14 => void
+   [10]_asm_setup_anonymouscommand1let1letlengthlayersletnoturtlescrtlayersizesetlay$05ef47d605b7a2d05912dab76b091cda$_done_14 => void
                 // parameter final  context
                L0
                 ALOAD 1
@@ -6361,15 +6354,8 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                L1
                 RETURN
 
-   (anonymous command: [ ??1 -> ask ??1 let 2 * 0.5 - i + 0.5 / layer-size * max-pycor setxy x y [ set color grey ] set i i + 1 ]):(anonymous command: [ ?1 -> let ?1 let length layers let no-turtles crt layer-size [ set layer (turtle-set layer self) ] let layer-num + 0.5 / num-layers * max-pxcor let 0 foreach sort layer [ [??1] ->
-      ask ??1 [
-        let y 2 * (0.5 - (i + 0.5) / layer-size) * max-pycor
-        setxy x y
-        set color grey
-      ]
-      set i i + 1
-    ] set layers lput layer layers ])[]{OTPL}:
-   [0]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_ask_0 "ask ??1 let 2 * 0.5 - i + 0.5 / layer-size * max-pycor setxy x y [ set color grey ]" Object => void
+   (anonymous command: [ [??1] -> ask ??1 [ let 2 * 0.5 - i + 0.5 / layer-size * max-pycor setxy x y set color grey ] set i i + 1 ]):(anonymous command: [ [?1] -> let ?1 let length layers let no-turtles crt layer-size [ set layer turtle-set layer self ] let layer-num + 0.5 / num-layers * max-pxcor let 0 foreach sort layer [ [??1] -> ask ??1 [ let 2 * 0.5 - i + 0.5 / layer-size * max-pycor setxy x y set color grey ] set i i + 1 ] set layers lput layer layers ])[]{OTPL}:
+   [0]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_ask_0 "ask ??1 let 2 * 0.5 - i + 0.5 / layer-size * max-pycor setxy x y [ set color grey ]" Object => void
             _letvariable(??1) "??1" => Object
                 // parameter final  context
                L0
@@ -6377,7 +6363,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_ask_0.kept2__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_ask_0.kept2__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L1
                 ASTORE 2
@@ -6393,7 +6379,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 IFNE L3
                 ALOAD 3
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_ask_0.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_ask_0.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
                 IF_ACMPNE L4
                 NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -6409,7 +6395,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                FRAME APPEND [java/lang/Object org/nlogo/agent/AgentSet]
                 ALOAD 3
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_ask_0.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_ask_0.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.patches ()Lorg/nlogo/agent/AgentSet;
                 IF_ACMPNE L3
                 NEW org/nlogo/nvm/RuntimePrimitiveException
@@ -6480,7 +6466,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L7
                 RETURN
-   [1]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1 "let 2 * 0.5 - i + 0.5 / layer-size * max-pycor" Object => void
+   [1]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_let_1 "let 2 * 0.5 - i + 0.5 / layer-size * max-pycor" Object => void
             _mult "2 * 0.5 - i + 0.5 / layer-size * max-pycor" double,double => double
               _mult "2 * 0.5 - i + 0.5 / layer-size" double,double => double
                 _constdouble:2.0 "2" => double
@@ -6508,7 +6494,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.kept9__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_let_1.kept9__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L7
                 ASTORE 2
@@ -6518,7 +6504,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKEVIRTUAL java/lang/Double.doubleValue ()D
                 GOTO L8
                L1
-               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_let_1 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
                 POP
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
@@ -6530,7 +6516,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
                L8
-               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1 org/nlogo/nvm/Context java/lang/Object] [D D D]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_let_1 org/nlogo/nvm/Context java/lang/Object] [D D D]
                 LDC 0.5
                L9
                 DSTORE 4
@@ -6540,13 +6526,13 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 4
                 DADD
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
                L10
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.kept11__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_let_1.kept11__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L11
                 ASTORE 2
@@ -6556,7 +6542,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKEVIRTUAL java/lang/Double.doubleValue ()D
                 GOTO L12
                L3
-               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1 org/nlogo/nvm/Context java/lang/Object T D] [java/lang/ClassCastException]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_let_1 org/nlogo/nvm/Context java/lang/Object T D] [java/lang/ClassCastException]
                 POP
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
@@ -6568,7 +6554,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
                L12
-               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1 org/nlogo/nvm/Context java/lang/Object T D] [D D D D]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_let_1 org/nlogo/nvm/Context java/lang/Object T D] [D D D D]
                 DSTORE 4
                 DSTORE 2
                 DLOAD 4
@@ -6585,13 +6571,13 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
                L13
-               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1 org/nlogo/nvm/Context D D] [D D]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_let_1 org/nlogo/nvm/Context D D] [D D]
                 ALOAD 0
                 DLOAD 2
                 DLOAD 4
                 DDIV
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
                L14
                 DSTORE 4
                 DSTORE 2
@@ -6600,7 +6586,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 4
                 DSUB
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
                L15
                 DSTORE 4
                 DSTORE 2
@@ -6609,10 +6595,10 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 4
                 DMUL
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
                L16
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.world : Lorg/nlogo/agent/World;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_let_1.world : Lorg/nlogo/agent/World;
                 INVOKEVIRTUAL org/nlogo/agent/World.maxPycor ()I
                 I2D
                L17
@@ -6623,7 +6609,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 4
                 DMUL
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_let_1.validDouble (DLorg/nlogo/nvm/Context;)D
                L18
                 DSTORE 2
                 NEW java/lang/Double
@@ -6635,7 +6621,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_let_1.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_let_1.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.let (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -6643,7 +6629,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L19
                 RETURN
-   [2]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setxy_2 "setxy x y" double,double => void
+   [2]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_setxy_2 "setxy x y" double,double => void
             _letvariable(X) "x" => Object
             _letvariable(Y) "y" => Object
                 // parameter final  context
@@ -6656,7 +6642,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setxy_2.kept2__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_setxy_2.kept2__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L8
                 ASTORE 2
@@ -6666,7 +6652,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKEVIRTUAL java/lang/Double.doubleValue ()D
                 GOTO L9
                L1
-               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setxy_2 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_setxy_2 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
                 POP
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
@@ -6683,7 +6669,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setxy_2.kept3__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_setxy_2.kept3__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L10
                 ASTORE 2
@@ -6705,7 +6691,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
                L11
-               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setxy_2 org/nlogo/nvm/Context java/lang/Object] [D D]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_setxy_2 org/nlogo/nvm/Context java/lang/Object] [D D]
                 DSTORE 4
                 DSTORE 2
                 ALOAD 1
@@ -6724,7 +6710,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                L5
                 GOTO L12
                L6
-               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setxy_2 org/nlogo/nvm/Context D D org/nlogo/agent/Turtle] [org/nlogo/api/AgentException]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_setxy_2 org/nlogo/nvm/Context D D org/nlogo/agent/Turtle] [org/nlogo/api/AgentException]
                 ASTORE 7
                 NEW org/nlogo/nvm/RuntimePrimitiveException
                 DUP
@@ -6754,12 +6740,12 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L13
                 RETURN
-   [3]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setturtleorlinkvariable_3 "set color grey" Object => void
+   [3]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_setturtleorlinkvariable_3 "set color grey" Object => void
             _constdouble:5.0 "grey" => Double
                 TRYCATCHBLOCK L0 L1 L2 org/nlogo/api/AgentException
                L3
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setturtleorlinkvariable_3.kept2_value : Ljava/lang/Double;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_setturtleorlinkvariable_3.kept2_value : Ljava/lang/Double;
                L4
                 ASTORE 2
                L0
@@ -6771,7 +6757,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                L1
                 GOTO L5
                L2
-               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setturtleorlinkvariable_3 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_setturtleorlinkvariable_3 org/nlogo/nvm/Context java/lang/Double] [org/nlogo/api/AgentException]
                 ASTORE 3
                 NEW org/nlogo/nvm/RuntimePrimitiveException
                 DUP
@@ -6788,7 +6774,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L6
                 RETURN
-   [4]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_done_4 => void
+   [4]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_done_4 => void
                 // parameter final  context
                L0
                 ALOAD 1
@@ -6796,7 +6782,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.finished : Z
                L1
                 RETURN
-   [5]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setletvariable_5 "set i i + 1" Object => void
+   [5]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_setletvariable_5 "set i i + 1" Object => void
             _plus "i + 1" double,double => double
               _letvariable(I) "i" => Object
               _constdouble:1.0 "1" => double
@@ -6809,7 +6795,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setletvariable_5.kept3__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_setletvariable_5.kept3__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L3
                 ASTORE 2
@@ -6819,7 +6805,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 INVOKEVIRTUAL java/lang/Double.doubleValue ()D
                 GOTO L4
                L1
-               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setletvariable_5 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
+               FRAME FULL [org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_setletvariable_5 org/nlogo/nvm/Context java/lang/Object] [java/lang/ClassCastException]
                 POP
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
@@ -6841,7 +6827,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 DLOAD 4
                 DADD
                 ALOAD 1
-                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setletvariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
+                INVOKEVIRTUAL org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_setletvariable_5.validDouble (DLorg/nlogo/nvm/Context;)D
                L6
                 DSTORE 2
                 NEW java/lang/Double
@@ -6853,7 +6839,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_setletvariable_5.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_setletvariable_5.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.setLet (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -6861,7 +6847,7 @@ procedure SETUP:[LAYER-COUNTS MAX-LAYER-SIZE MAX-X MAX-Y]{O---}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L7
                 RETURN
-   [6]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycorsetxy$bae056ef17773b04bceba48c7dd26b18$_done_6 => void
+   [6]_asm___lambda1_anonymouscommand1ask1let205i05layersizemaxpycors$7ae1007da3741b69ba94c1268c800197$_done_6 => void
                 // parameter final  context
                L0
                 ALOAD 1

--- a/test/benchdumps/GasLabCirc.txt
+++ b/test/benchdumps/GasLabCirc.txt
@@ -15503,8 +15503,8 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
          L1
           RETURN
 
-   (anonymous command: [ collision -> if first collision < first winner [ set winner collision ] ]):procedure SORT-COLLISIONS[]{OTPL}:
-   [0]_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 "if first collision < first winner [ set winner collision ]" boolean => void
+   (anonymous command: [ [collision] -> if first collision < first winner [ set winner collision ] ]):procedure SORT-COLLISIONS[]{OTPL}:
+   [0]_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 "if first collision < first winner [ set winner collision ]" boolean => void
             _lessthan "first collision < first winner" Object,Object => boolean
               _first "first collision" Object => Object
                 _letvariable(COLLISION) "collision" => Object
@@ -15517,7 +15517,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0.kept4__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0.kept4__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L1
                 ASTORE 2
@@ -15585,12 +15585,12 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
                L4
-               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
                 ALOAD 1
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0.kept6__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0.kept6__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L7
                 ASTORE 2
@@ -15613,12 +15613,12 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
                L9
-               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/core/LogoList] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 org/nlogo/nvm/Context java/lang/Object org/nlogo/core/LogoList] [java/lang/Object]
                 ALOAD 3
                 INVOKEVIRTUAL org/nlogo/core/LogoList.first ()Ljava/lang/Object;
                 GOTO L10
                L8
-               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
                 ALOAD 2
                 INSTANCEOF java/lang/String
                 IFEQ L11
@@ -15638,14 +15638,14 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKESPECIAL org/nlogo/nvm/RuntimePrimitiveException.<init> (Lorg/nlogo/api/Context;Lorg/nlogo/nvm/Instruction;Ljava/lang/String;)V
                 ATHROW
                L12
-               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/String] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/String] [java/lang/Object]
                 ALOAD 3
                 ICONST_0
                 ICONST_1
                 INVOKEVIRTUAL java/lang/String.substring (II)Ljava/lang/String;
                 GOTO L10
                L11
-               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object]
                 NEW org/nlogo/nvm/ArgumentTypeException
                 DUP
                 ALOAD 1
@@ -15658,7 +15658,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 INVOKESPECIAL org/nlogo/nvm/ArgumentTypeException.<init> (Lorg/nlogo/nvm/Context;Lorg/nlogo/nvm/Instruction;IILjava/lang/Object;)V
                 ATHROW
                L10
-               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object java/lang/Object]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 org/nlogo/nvm/Context java/lang/Object java/lang/Object] [java/lang/Object java/lang/Object]
                 ASTORE 3
                 ASTORE 2
                 ALOAD 2
@@ -15768,14 +15768,14 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 ICONST_1
                 GOTO L24
                L23
-               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context]
                 ICONST_2
                L24
-               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
+               FRAME FULL [org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_if_0 org/nlogo/nvm/Context I java/lang/Object] [org/nlogo/nvm/Context I]
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L25
                 RETURN
-   [1]_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_setletvariable_1 "set winner collision" Object => void
+   [1]_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_setletvariable_1 "set winner collision" Object => void
             _letvariable(COLLISION) "collision" => Object
                 // parameter final  context
                 // parameter final  context
@@ -15785,7 +15785,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_setletvariable_1.kept2__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_setletvariable_1.kept2__let : Lorg/nlogo/core/Let;
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.getLet (Lorg/nlogo/core/Let;)Ljava/lang/Object;
                L1
                 ASTORE 2
@@ -15793,7 +15793,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 GETFIELD org/nlogo/nvm/Context.activation : Lorg/nlogo/nvm/Activation;
                 GETFIELD org/nlogo/nvm/Activation.binding : Lorg/nlogo/nvm/Binding;
                 ALOAD 0
-                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_setletvariable_1.kept1__let : Lorg/nlogo/core/Let;
+                GETFIELD org/nlogo/prim/_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_setletvariable_1.kept1__let : Lorg/nlogo/core/Let;
                 ALOAD 2
                 INVOKEVIRTUAL org/nlogo/nvm/Binding.setLet (Lorg/nlogo/core/Let;Ljava/lang/Object;)V
                 ALOAD 1
@@ -15801,7 +15801,7 @@ procedure SORT-COLLISIONS:[DT]{OTPL}:
                 PUTFIELD org/nlogo/nvm/Context.ip : I
                L2
                 RETURN
-   [2]_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinnerco$c73af87024ea345597bc2ffabe2bb05e$_done_2 => void
+   [2]_asm_sortcollisions_anonymouscommandcollisioniffirstcollisionfirstwinnersetwinner$3291741d80d499b5735d9fe0559b5d3a$_done_2 => void
                 // parameter final  context
                L0
                 ALOAD 1

--- a/test/reporters/CommandLambda.txt
+++ b/test/reporters/CommandLambda.txt
@@ -1,24 +1,24 @@
 *ToString1
-  (word [ -> fd 5 ]) => "(anonymous command: [ fd 5 ])"
+  (word [ -> fd 5 ]) => "(anonymous command: [ -> fd 5 ])"
 
 *ToString2
-  (word [[x] -> ask turtles [ set color red] ]) => "(anonymous command: [ x -> ask turtles [ set color red ] ])"
+  (word [[x] -> ask turtles [ set color red] ]) => "(anonymous command: [ [x] -> ask turtles [ set color red ] ])"
 
 *ToString3
   (word [ x -> print x]) => "(anonymous command: [ x -> print x ])"
 
 *ToString4
-  (word [ -> print 5]) => "(anonymous command: [ print 5 ])"
+  (word [ -> print 5]) => "(anonymous command: [ -> print 5 ])"
 
 *ToString5
-  (word [ x -> (foreach [1 2] [3 4] [ -> __ignore x + x])]) => "(anonymous command: [ x -> (foreach [1 2] [3 4] [ -> __ignore x + x]) ])"
+  (word [ x -> (foreach [1 2] [3 4] [ -> __ignore x + x])]) => "(anonymous command: [ x -> foreach [1 2] [3 4] [ -> __ignore x + x ] ])"
 
 *ToString6
   (word [ [a b] -> rt a fd b ]) => "(anonymous command: [ [a b] -> rt a fd b ])"
 
 *ToString7
   to foo end
-  (word [ -> foo]) => "(anonymous command: [ foo ])"
+  (word [ -> foo]) => "(anonymous command: [ -> foo ])"
 
 CallTask
   globals [ glob1 ]
@@ -138,14 +138,14 @@ command-and-reporter-tasks-close-over-same-procedure-input
 *command-task-stack-trace
   O> run [ -> print __boom] => STACKTRACE boom!\
   error while observer running __BOOM\
-    called by (anonymous command: [ print __boom ])\
+    called by (anonymous command: [ -> print __boom ])\
     called by procedure __EVALUATOR
 
 *command-task-in-command-task-stack-trace
   O> run [run [print __boom]] => STACKTRACE boom!\
   error while observer running __BOOM\
     called by (anonymous command: [ print __boom ])\
-    called by (anonymous command: [ run [print __boom] ])\
+    called by (anonymous command: [ run [ print __boom ] ])\
     called by procedure __EVALUATOR
 
 turtle-executing-command-task

--- a/test/reporters/ReporterLambda.txt
+++ b/test/reporters/ReporterLambda.txt
@@ -225,6 +225,6 @@ AlternateReporterSyntaxesSupported
   one-argument-unbracketed => [3 4 5]
 
 PrintReporterLambda
-  (word [ -> 5 ]) => "(anonymous reporter: [ 5 ])"
+  (word [ -> 5 ]) => "(anonymous reporter: [ -> 5 ])"
   (word [ a -> a ]) => "(anonymous reporter: [ a -> a ])"
   (word [ [a b] -> a + b ]) => "(anonymous reporter: [ [a b] -> a + b ])"


### PR DESCRIPTION
This change adds a field `source: Option[String]` to both the `_commandlambda` and `_reporterlambda` primitives. After parsing, this field will contain the source of the lambda. The source will be normalized using the following rules:

* All newlines and comments are removed from the source
* Anonymous procedure arguments are normalized:
  * Concise anonymous procedures will be shown as concise
  * No-argument, no-arrow anonymous procedures will be displayed without arrows or arguments
  * Single-argument, arrowed anonymous procedures will be displayed with the argument and an arrow
  * Bracketed, arrowed anonymous procedures will display a bracket, the list of arguments, a closing bracket, and then the arrow
* Non-list literals (numbers, colors, strings, booleans) are printed as entered by the user
* List literals are dumped
* All other tokens inside the lambda will be displayed with a single space between them