### PR TITLE
stack trace fails to appear (under specific, obscure circumstances)

### DIFF
--- a/netlogo-core/src/main/nvm/Context.java
+++ b/netlogo-core/src/main/nvm/Context.java
@@ -297,7 +297,7 @@ public final strictfp class Context implements org.nlogo.api.Context {
       if (context == null) {
         context = this;
       }
-      activation.code[ip].workspace
+      instruction.workspace
           .runtimeError(job.owner, context, instruction, ex);
     } catch (RuntimeException ex2) {
       // well we tried to report the original exception to the user,

--- a/parser-core/src/main/parse/SourceTagger.scala
+++ b/parser-core/src/main/parse/SourceTagger.scala
@@ -3,7 +3,7 @@
 package org.nlogo.parse
 
 import
-  org.nlogo.core.{ prim, Dump, LogoList },
+  org.nlogo.core.{ prim, Application, CommandBlock, Dump, LogoList },
     prim.{ _commandlambda, _const, _lambdavariable, _reporterlambda, Lambda }
 
 import
@@ -43,12 +43,12 @@ class LambdaWhitespace(startNode: ReporterApp) extends FormattingWhitespace {
   def get(path: AstPath, placement: WhiteSpace.Placement): Option[String] = None
   def backMargin(path: AstPath): String =
     path.components.lastOption match {
-      case Some(AstPath.CmdBlk(_)) =>
+      case Some(AstPath.CmdBlk(b)) =>
         path.`../`.traverse(startNode) match {
           case Some(ReporterApp(c: _commandlambda, _, _)) => " "
-          case _ => " ]"
+          case other => " ]"
         }
-      case _ => " "
+      case other => " "
     }
   def content(path: AstPath): String =
     path.traverse(startNode) match {
@@ -64,9 +64,14 @@ class LambdaWhitespace(startNode: ReporterApp) extends FormattingWhitespace {
     path.components.lastOption match {
       case Some(AstPath.Stmt(_)) => " "
       case Some(AstPath.RepArg(_)) => " "
-      case Some(AstPath.CmdBlk(_)) =>
+      case Some(AstPath.CmdBlk(i)) =>
         path.`../`.traverse(startNode) match {
           case Some(ReporterApp(c: _commandlambda, _, _)) => ""
+          case Some(app: Application) =>
+            app.args(i) match {
+              case blk: CommandBlock if blk.synthetic => ""
+              case _ => " ["
+            }
           case other => " ["
         }
       case _ => ""

--- a/parser-core/src/test/parse/AnonymousProcedureSourceTests.scala
+++ b/parser-core/src/test/parse/AnonymousProcedureSourceTests.scala
@@ -55,6 +55,9 @@ class AnonymousProcedureSourceTests extends FunSuite with Inside with BaseParser
   test("anonymous command with newlines") {
     assertStringifies(expression("[ -> \nfd 1]"), "[ -> fd 1 ]")
   }
+  test("anonymous command with optional command block") {
+    assertStringifies(expression("[ -> crt 1 ]"), "[ -> crt 1 ]")
+  }
   test("concise anonymous command") {
     assertStringifies(
       expression("fd", expIndex = 1, preamble = "to __test foreach [] "),

--- a/test/commands/StackTraces.txt
+++ b/test/commands/StackTraces.txt
@@ -139,3 +139,87 @@
   O> show sum [ n ] of turtles => STACKTRACE math operation produced a number too large for NetLogo\
   error while observer running SUM\
     called by procedure __EVALUATOR
+
+*StackTraceCommand
+  to foo error "boom" end
+  O> foo => STACKTRACE boom\
+  error while observer running ERROR\
+    called by procedure FOO\
+    called by procedure __EVALUATOR
+
+*StackTraceCallCommand
+  to foo bar end
+  to bar error "boom" end
+  O> foo => STACKTRACE boom\
+  error while observer running ERROR\
+    called by procedure BAR\
+    called by procedure FOO\
+    called by procedure __EVALUATOR
+
+*StackTraceForeach
+  to foo foreach [ 0 ] [ error "boom" ] end
+  O> foo => STACKTRACE boom\
+  error while observer running ERROR\
+    called by (anonymous command: [ error "boom" ])\
+    called by procedure FOO\
+    called by procedure __EVALUATOR
+
+*StackTraceRepeat
+  to foo repeat 1 [ error "boom" ] end
+  O> foo => STACKTRACE boom\
+  error while observer running ERROR\
+    called by procedure FOO\
+    called by procedure __EVALUATOR
+
+*StackTraceAsk
+  to foo crt 1 ask turtles [ error "boom" ] end
+  O> foo => STACKTRACE boom\
+  error while turtle 0 running ERROR\
+    called by procedure FOO\
+    called by procedure __EVALUATOR
+
+*StackTraceForeachRepeat
+  to foo foreach [ 0 ] [ repeat 1 [ error "boom" ] ] end
+  O> foo => STACKTRACE boom\
+  error while observer running ERROR\
+    called by (anonymous command: [ repeat 1 [ error "boom" ] ])\
+    called by procedure FOO\
+    called by procedure __EVALUATOR
+
+*StackTraceForeachAsk
+  to foo crt 1 foreach [ 0 ] [ ask turtles [ error "boom" ] ] end
+  O> foo => STACKTRACE boom\
+  error while turtle 0 running ERROR\
+    called by (anonymous command: [ ask turtles [ error "boom" ] ])\
+    called by procedure FOO\
+    called by procedure __EVALUATOR
+
+*StackTraceForeachRepeatAsk
+  to foo foreach [ 0 ] [ repeat 1 [ crt 1 ask turtles [ error "boom" ] ] ] end
+  O> random-seed 0
+  O> foo => STACKTRACE boom\
+  error while turtle 0 running ERROR\
+    called by (anonymous command: [ repeat 1 [ crt 1 ask turtles [ error "boom" ] ] ])\
+    called by procedure FOO\
+    called by procedure __EVALUATOR
+
+*StackTracesCallForeachRepeat
+  to foo ca crt 1 bar end
+  to bar foreach [0] [ repeat 1 [ crt 1 ask turtles [ error "boom" ] ] ] end
+  O> random-seed 0
+  O> foo => STACKTRACE boom\
+  error while turtle 1 running ERROR\
+    called by (anonymous command: [ repeat 1 [ crt 1 ask turtles [ error "boom" ] ] ])\
+    called by procedure BAR\
+    called by procedure FOO\
+    called by procedure __EVALUATOR
+
+*StackTracesCall
+  to foo ca crt 1 bar end
+  to bar error "boom" end
+  O> foo => STACKTRACE boom\
+  error while observer running ERROR\
+    called by procedure BAR\
+    called by procedure FOO\
+    called by procedure __EVALUATOR
+


### PR DESCRIPTION
``` text
to foo
  ca
  crt 1
  test
end

to test
  foreach [0] [
    repeat 1 [
      create-turtles 1
      ask turtles [ error "boom" ]
    ]
  ]
end
```

after running `foo`, there is no stack trace in the Runtime Error dialog beyond the "boom" message

it seems unlikely the above code can be the minimal code to reproduce this, but at least at the moment I can't find anything shorter/simpler that still makes it happen

turning the bytecode generator off makes no difference.
