### PR TITLE
`carefully` with empty body throws `NoSuchElementException`

### DIFF
--- a/netlogo-core/src/main/compile/middle/SourceTagger.scala
+++ b/netlogo-core/src/main/compile/middle/SourceTagger.scala
@@ -66,12 +66,12 @@ private class SourceTagger(existingSources: Map[String, String], compilationEnvi
 
   override def visitCommandBlock(blk: CommandBlock): Unit = {
     super.visitCommandBlock(blk)
-    internalSources = internalSources.dropRight(1) :+ ("[ " + internalSources.last + " ]")
+    internalSources = internalSources.dropRight(1) :+ ("[ " + internalSources.lastOption.getOrElse("") + " ]")
   }
 
   override def visitReporterBlock(blk: ReporterBlock): Unit = {
     super.visitReporterBlock(blk)
-    internalSources = internalSources.dropRight(1) :+ ("[ " + internalSources.last + " ]")
+    internalSources = internalSources.dropRight(1) :+ ("[ " + internalSources.lastOption.getOrElse("") + " ]")
   }
 
   private def addInstructionPositions(i: Instruction, start: Int, end: Int): Unit = {

--- a/test/commands/Errors.txt
+++ b/test/commands/Errors.txt
@@ -17,7 +17,6 @@ CarefullyStackInteraction1
   O> carefully [ __ignore __boom ] [ repeat 2 [ set glob1 fput error-message glob1] ]
   length glob1 => 2
   item 0 glob1 = item 1 glob1 => true
-
 CarefullyStackInteraction2
   globals [ glob1 ]
   O> set glob1 []
@@ -71,3 +70,6 @@ CarefullyWithLambda2
   to-report errant-runresult report runresult "not-a-reporter" end
   to-report runresult-carefully [ lambda ] let r 0 carefully [ set r runresult lambda ] [ set r error-message ] report r end
   guarded-runresult-error => "Nothing named NOT-A-REPORTER has been defined."
+
+CarefullyEmpty
+  O> carefully [] []


### PR DESCRIPTION
To reproduce, run `carefully [] []` in the command line:

Stack:

```
java.util.NoSuchElementException
 at scala.collection.LinearSeqOptimized.last(LinearSeqOptimized.scala:146)
 at scala.collection.LinearSeqOptimized.last$(LinearSeqOptimized.scala:145)
 at scala.collection.immutable.List.last(List.scala:86)
 at org.nlogo.compile.middle.SourceTagger.visitCommandBlock(SourceTagger.scala:58)
 at org.nlogo.compile.api.CommandBlock.accept(AstNode.scala:125)
 at org.nlogo.compile.api.DefaultAstVisitor.$anonfun$visitStatement$1(AstVisitor.scala:31)
 at org.nlogo.compile.api.DefaultAstVisitor.$anonfun$visitStatement$1$adapted(AstVisitor.scala:31)
 at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:59)
 at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:52)
 at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:48)
 at org.nlogo.compile.api.DefaultAstVisitor.visitStatement(AstVisitor.scala:31)
 at org.nlogo.compile.middle.SourceTagger.super$visitStatement(SourceTagger.scala:28)
 at org.nlogo.compile.middle.SourceTagger.$anonfun$visitStatement$1(SourceTagger.scala:28)
 at org.nlogo.compile.middle.SourceTagger.captureInternalSources(SourceTagger.scala:21)
 at org.nlogo.compile.middle.SourceTagger.visitStatement(SourceTagger.scala:28)
 at org.nlogo.compile.api.Statement.accept(AstNode.scala:98)
 at org.nlogo.compile.api.DefaultAstVisitor.$anonfun$visitStatements$1(AstVisitor.scala:32)
 at org.nlogo.compile.api.DefaultAstVisitor.$anonfun$visitStatements$1$adapted(AstVisitor.scala:32)
 at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:59)
 at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:52)
 at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:48)
 at org.nlogo.compile.api.DefaultAstVisitor.visitStatements(AstVisitor.scala:32)
 at org.nlogo.compile.api.Statements.accept(AstNode.scala:74)
 at org.nlogo.compile.api.DefaultAstVisitor.visitProcedureDefinition(AstVisitor.scala:27)
 at org.nlogo.compile.api.ProcedureDefinition.accept(AstNode.scala:50)
 at org.nlogo.compile.middle.MiddleEnd$.$anonfun$middleEnd$3(MiddleEnd.scala:39)
 at org.nlogo.compile.middle.MiddleEnd$.$anonfun$middleEnd$3$adapted(MiddleEnd.scala:38)
 at scala.collection.immutable.List.foreach(List.scala:378)
 at org.nlogo.compile.middle.MiddleEnd$.middleEnd(MiddleEnd.scala:38)
 at org.nlogo.compile.CompilerMain$.compile(CompilerMain.scala:51)
 at org.nlogo.compile.Compiler.compileMoreCode(Compiler.scala:80)
 at org.nlogo.compile.Compiler.compileMoreCode(Compiler.scala:93)
 at org.nlogo.window.CompilerManager.handle(CompilerManager.scala:80)
 at org.nlogo.window.Events$CompileMoreSourceEvent.beHandledBy(Events.java:201)
 at org.nlogo.window.Event.doRaise(Event.java:198)
 at org.nlogo.window.Event.raise(Event.java:122)
 at org.nlogo.window.JobWidget.source(JobWidget.scala:123)
 at org.nlogo.app.common.CommandLine.executeCurrentBuffer(CommandLine.scala:156)
 at org.nlogo.app.common.CommandLine.keyPressed(CommandLine.scala:117)
 at java.awt.Component.processKeyEvent(Component.java:6491)
 at javax.swing.JComponent.processKeyEvent(JComponent.java:2832)
 at java.awt.Component.processEvent(Component.java:6310)
 at java.awt.Container.processEvent(Container.java:2236)
 at java.awt.Component.dispatchEventImpl(Component.java:4889)
 at java.awt.Container.dispatchEventImpl(Container.java:2294)
 at java.awt.Component.dispatchEvent(Component.java:4711)
 at java.awt.KeyboardFocusManager.redispatchEvent(KeyboardFocusManager.java:1954)
 at java.awt.DefaultKeyboardFocusManager.dispatchKeyEvent(DefaultKeyboardFocusManager.java:806)
 at java.awt.DefaultKeyboardFocusManager.preDispatchKeyEvent(DefaultKeyboardFocusManager.java:1074)
 at java.awt.DefaultKeyboardFocusManager.typeAheadAssertions(DefaultKeyboardFocusManager.java:945)
 at java.awt.DefaultKeyboardFocusManager.dispatchEvent(DefaultKeyboardFocusManager.java:771)
 at java.awt.Component.dispatchEventImpl(Component.java:4760)
 at java.awt.Container.dispatchEventImpl(Container.java:2294)
 at java.awt.Window.dispatchEventImpl(Window.java:2746)
 at java.awt.Component.dispatchEvent(Component.java:4711)
 at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
 at java.awt.EventQueue.access$500(EventQueue.java:97)
 at java.awt.EventQueue$3.run(EventQueue.java:709)
 at java.awt.EventQueue$3.run(EventQueue.java:703)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:90)
 at java.awt.EventQueue$4.run(EventQueue.java:731)
 at java.awt.EventQueue$4.run(EventQueue.java:729)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
 at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
 at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
 at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
 at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
```

Reproduced in 6.0.1 and on HEAD.