### PR TITLE
Update behaviorspace.html.mustache

### DIFF
--- a/autogen/docs/behaviorspace.html.mustache
+++ b/autogen/docs/behaviorspace.html.mustache
@@ -623,7 +623,7 @@ java -Dorg.nlogo.is3d=true -Xmx1024m -Dfile.encoding=UTF-8 -cp NetLogo.jar \
     <p>
       The second line must be included exactly as shown. In the first line,
       you may specify a different encoding than <code>UTF-8</code>, such as
-      <code>UTF-8</code>.
+      <code>ISO-8859-1</code>.
     <h3>
       Controlling API
     </h3>


### PR DESCRIPTION
In [the BehaviorSpace documentation](https://github.com/NetLogo/NetLogo/blob/c56cffd5b12cf135efc4c3640b3cc0d5dc2acc3c/autogen/docs/behaviorspace.html.mustache#L625-L626), it said:

> In the first line, you may specify a different encoding than `UTF-8`, such as `UTF-8`. 

I changed the example to say "such as `ISO-8859-1`" instead.

(Spotted by @mariopaolucci.)