### PR TITLE
Command center should retain focus as much as possible when on interface tab

### DIFF
--- a/netlogo-gui/project/autogen/i18n/GUI_Strings_en.txt
+++ b/netlogo-gui/project/autogen/i18n/GUI_Strings_en.txt
@@ -103,6 +103,7 @@ menu.tools.linkMonitor = Link Monitor
 menu.tools.closeAllAgentMonitors = Close All Agent Monitors
 menu.tools.closeDeadAgentMonitors = Close Monitors for Dead Agents
 menu.tools.hideCommandCenter = Hide Command Center
+menu.tools.jumpToCommandCenter = Jump to Command Center
 menu.tools.showCommandCenter = Show Command Center
 menu.tools.3DView = 3D View
 menu.tools.3DView.switch = Switch to 3D View

--- a/netlogo-gui/src/main/app/interfacetab/CommandCenter.scala
+++ b/netlogo-gui/src/main/app/interfacetab/CommandCenter.scala
@@ -116,6 +116,9 @@ class CommandCenter(workspace: AbstractWorkspace) extends JPanel
 
   def repaintPrompt() { prompt.repaint() }
   override def requestFocus() { getDefaultComponentForFocus().requestFocus() }
+  override def requestFocusInWindow(): Boolean = {
+    getDefaultComponentForFocus().requestFocusInWindow()
+  }
   def getDefaultComponentForFocus(): Component = commandLine.textField
 
   private def doPopup(e: MouseEvent) {


### PR DESCRIPTION
In 5.3.1 (and, I assume, earlier versions) the command center input prompt would almost always have focus when on the interface tab. In particular, every time you switch to the interface tab, the command center acquires focus. The exceptions (I've found) to this are:

- The command center output area will acquire focus when clicked.
- The widget area will acquire focus if and only if a button with an action key is present.
- Modal windows, of course

In 6.0.1, the command center input prompt will only acquire focus when explicitly clicked; it is not focused by default when you switch to the interface tab. Furthermore, clicking on pretty much anything removes focus.

This has been reproduced both on Mac and Linux.