### PR TITLE
Current-line editor highlight is too close to "error" color

### DIFF
--- a/netlogo-gui/resources/system/netlogo-editor-style.xml
+++ b/netlogo-gui/resources/system/netlogo-editor-style.xml
@@ -14,7 +14,7 @@
    <background color="ffffff"/>
    <caret color="444444"/>
    <selection fg="default" useFG="false" bg="c8c8ff"/>
-   <currentLineHighlight color="ffffaa" fade="false"/>
+   <currentLineHighlight color="ffffcc" fade="false"/>
    <marginLine fg="b0b4b9"/>
    <markAllHighlight color="ffc800"/>
    <markOccurrencesHighlight color="d4d4d4" border="false"/>


### PR DESCRIPTION
Should be switched back to same color as in 5.3.1