### PR TITLE
Properly set plot legend's openness in Headless

### DIFF
--- a/netlogo-headless/src/main/plot/PlotLoader.scala
+++ b/netlogo-headless/src/main/plot/PlotLoader.scala
@@ -16,6 +16,7 @@ object PlotLoader {
         autoPlotOn = parsedPlot.autoPlotOn)
     plot.setupCode = parsedPlot.setupCode
     plot.updateCode = parsedPlot.updateCode
+    plot.legendIsOpen = parsedPlot.legendOn
 
     def loadPens(parsedPens: Seq[ParsedPen]) {
       plot.pens = Nil

--- a/netlogo-headless/src/test/headless/lang/misc/TestPlotModels.scala
+++ b/netlogo-headless/src/test/headless/lang/misc/TestPlotModels.scala
@@ -256,6 +256,18 @@ class TestPlotModels extends FixtureSuite {
     testReporter("n-values 10 [random 10]", "[8 9 8 4 2 4 5 4 7 9]")
   }
 
+  test("legend is correctly off") { implicit fixture =>
+    import fixture._
+    open(Model("", widgets = List( View(), Plot(display = Some(""), updateCode = "", pens = List()))))
+    assertResult(false)(workspace.plotManager.currentPlot.get.legendIsOpen)
+  }
+
+  test("legend is correctly on") { implicit fixture =>
+    import fixture._
+    open(Model("", widgets = List( View(), Plot(display = Some(""), updateCode = "", pens = List(), legendOn = true))))
+    assertResult(true)(workspace.plotManager.currentPlot.get.legendIsOpen)
+  }
+
   def testCompileError(model: Model)(f: Throwable => Unit)(implicit fixture: Fixture) = {
     val ex = intercept[Throwable] {
       fixture.workspace.openModel(model)


### PR DESCRIPTION
The fact that this variable wasn't getting set was leading to Headless generating `export-world`s with incorrect data about the plots' legends.