### PR TITLE
Improve behaviorspace command-line documentation

### DIFF
--- a/autogen/docs/behaviorspace.html.mustache
+++ b/autogen/docs/behaviorspace.html.mustache
@@ -394,8 +394,11 @@ windows.-->
       How to use it
     </h4>
     <p>
-      Run Java with the org.nlogo.headless.Main class. The Main.main()
-      method supports these arguments:
+      Run NetLogo using the included command line script.
+      This is found in the root directory of your NetLogo installation and is named
+      <code>netlogo-headless.sh</code> on Mac and Linux and
+      <code>netlogo-headless.bat</code> on Windows.
+      The netlogo-headless script supports the following arguments:
     <ul>
       <li>
         <code>--model &lt;path&gt;</code>: pathname of model to open (required)
@@ -434,6 +437,11 @@ windows.-->
       specify either <code>--table</code> or <code>--spreadsheet</code>, or both.
       If you specify any of the world dimensions, you must specify all
       four.
+    <p>
+      <b>Note:</b> The remainder of this guide uses <code>netlogo-headless.sh</code>
+      to refer to the NetLogo Headless launch script. If you are using Windows, please
+      substitute <code>netlogo-headless.bat</code> for <code>netlogo-headless.sh</code>
+      in each example.
     <h4>
       Examples
     </h4>
@@ -442,36 +450,31 @@ windows.-->
       the GUI, so it is saved as part of the model. To run an experiment
       setup saved in a model, here is an example command line:
     <pre>
-java -Xmx1024m -Dfile.encoding=UTF-8 -cp NetLogo.jar \
-  org.nlogo.headless.Main \
+netlogo-headless.sh \
   --model Fire.nlogo \
   --experiment experiment1 \
   --table -
 </pre>
     <p>
-      (For this to work, <code>NetLogo.jar</code> must be present along with
-      the <code>lib</code> subdirectory containing necessary libraries. Both
-      <code>NetLogo.jar</code> and <code>lib</code> are included with NetLogo.)
+      For this to work, Java (version 1.8 or later) must be available.
+      You can make Java available to headless in either of two ways
+      <ol>
+        <li>Set the <code>JAVA_HOME</code> environment variable to the path to the Java installation.
+          This is the directory of the Java installation which contains a "bin" directory.</li>
+        <li>Add the directory containing the Java executable to the <code>PATH</code> environment variable</li>
+      </ol>
+      If <code>JAVA_HOME</code> is defined, netlogo-headless will run
+      NetLogo using the Java that it points to, ignoring the version of Java
+      available on the path.
     <p>
       After the named experiment has run, the results are sent to standard
       output in table format, as CSV. (&quot;-&quot; is how you specify
       standard output instead of output to a file.)
     <p>
-      When running the headless.Main class as an application, it forces the
+      When running netlogo headless, it forces the
       system property <code>java.awt.headless</code> to be true. This tells
       Java to run in headless mode, allowing NetLogo to run on machines
       when a graphical display is not available.
-    <p>
-      Note the use of <code>-Xmx</code> to specify a maximum heap size of one
-      gigabyte. If you don't specify a maximum heap size, you will get
-      your VM's default size, which may be unusably small. (One
-      gigabyte is an arbitrary size which should be more than large enough
-      for most models; you can specify a different limit if you want.)
-    <p>
-      Note the use of <code>-Dfile.encoding=UTF-8</code>. This forces all file
-      I/O to use UTF-8 encoding. Doing so ensures that NetLogo can load all
-      models consistently, and that file-* primitives work consistently on
-      all platforms, including models containing Unicode characters.
     <p>
       The required <code>--model</code> argument is used to specify the model
       file you want to open.
@@ -483,8 +486,7 @@ java -Xmx1024m -Dfile.encoding=UTF-8 -cp NetLogo.jar \
       Here's another example that shows some additional, optional
       arguments:
     <pre>
-java -Xmx1024m -Dfile.encoding=UTF-8 -cp NetLogo.jar \
-  org.nlogo.headless.Main \
+netloog-headless.sh \
   --model Fire.nlogo \
   --experiment experiment2 \
   --max-pxcor 100 \
@@ -500,15 +502,14 @@ java -Xmx1024m -Dfile.encoding=UTF-8 -cp NetLogo.jar \
       are specified by the experiment setup, then there is no need to
       specify them on the command line.)
     <p>
-      Since neither --table nor --spreadsheet is specified, no results will
+      Since neither <code>--table</code> nor <code>--spreadsheet</code> is specified, no results will
       be generated. This is useful if the experiment setup generates all
       the output you need by some other means, such as exporting world
       files or writing to a text file.
     <p>
       Yet another example:
     <pre>
-java -Xmx1024m -Dfile.encoding=UTF-8 -cp NetLogo.jar \
-  org.nlogo.headless.Main \
+netlogo-headless.sh \
   --model Fire.nlogo \
   --experiment experiment2 \
   --table table-output.csv \
@@ -535,8 +536,7 @@ java -Xmx1024m -Dfile.encoding=UTF-8 -cp NetLogo.jar \
       Here is one final example that shows how to run an experiment setup
       which is stored in a separate XML file, instead of in the model file:
     <pre>
-java -Xmx1024m -Dfile.encoding=UTF-8 -cp NetLogo.jar \
-  org.nlogo.headless.Main \
+netlogo-headless.sh \
   --model Fire.nlogo \
   --setup-file fire-setups.xml \
   --experiment experiment3
@@ -546,13 +546,12 @@ java -Xmx1024m -Dfile.encoding=UTF-8 -cp NetLogo.jar \
       necessary to use the <code>--experiment</code> argument to specify the
       name of the setup to use.
     <p>
-      In order to run any of these experiments in 3D add
-      <code>-Dorg.nlogo.is3d=true</code> to any of these startup commands, for
-      example:
+      In order to run a NetLogo 3D experiment, run headless with the
+      <code>--3D</code> argument, for example:
     <pre>
-java -Dorg.nlogo.is3d=true -Xmx1024m -Dfile.encoding=UTF-8 -cp NetLogo.jar \
-  org.nlogo.headless.Main \
-  --model Fire3D.nlogo \
+netlogo-headless.sh \
+  --3D \
+  --model "Mousetraps 3D.nlogo3d" \
   --experiment experiment1 \
   --table -
 </pre>
@@ -624,6 +623,25 @@ java -Dorg.nlogo.is3d=true -Xmx1024m -Dfile.encoding=UTF-8 -cp NetLogo.jar \
       The second line must be included exactly as shown. In the first line,
       you may specify a different encoding than <code>UTF-8</code>, such as
       <code>ISO-8859-1</code>.
+    <h3>
+      Adjusting JVM Parameters
+    </h3>
+    <p>
+      Opening the NetLogo Headless launcher script will show the options used
+      to launch java when running NetLogo Headless. You can adjust various JVM
+      parameters in this script. You may also pass in Java properties
+      starting with <code>-D</code> to the launcher.
+    <p>
+      Note the use of <code>-Xmx</code> to specify a maximum heap size of one
+      gigabyte. If you don't specify a maximum heap size, you will get
+      your VM's default size, which may be unusably small. (One
+      gigabyte is an arbitrary size which should be more than large enough
+      for most models; you can specify a different limit if you want.)
+    <p>
+      Note the use of <code>-Dfile.encoding=UTF-8</code>. This forces all file
+      I/O to use UTF-8 encoding. Doing so ensures that NetLogo can load all
+      models consistently, and that file-* primitives work consistently on
+      all platforms, including models containing Unicode characters.
     <h3>
       Controlling API
     </h3>

--- a/dist/configuration/shared/macosx/netlogo-headless.sh.mustache
+++ b/dist/configuration/shared/macosx/netlogo-headless.sh.mustache
@@ -39,4 +39,4 @@ CLASSPATH=`echo $CLASSPATH | sed 's/://'`
 # -classpath ....         specify jars
 # org.nlogo.headless.Main specify we want headless, not GUI
 # "${ARGS[0]}"            pass along any additional arguments
-java "${JVM_OPTS[@]}" -Dnetlogo.extensions.dir="${BASE_DIR}/app/extensions" -classpath "$CLASSPATH" org.nlogo.headless.Main "${ARGS[@]}"
+java "${JVM_OPTS[@]}" -Dnetlogo.extensions.dir="${BASE_DIR}/extensions" -classpath "$CLASSPATH" org.nlogo.headless.Main "${ARGS[@]}"

--- a/dist/configuration/shared/windows/netlogo-headless.bat.mustache
+++ b/dist/configuration/shared/windows/netlogo-headless.bat.mustache
@@ -1,0 +1,46 @@
+@echo off
+
+setlocal ENABLEDELAYEDEXPANSION
+
+set BASE_DIR=%~dp0
+
+if defined JAVA_HOME (
+  set "JAVA=%JAVA_HOME%\bin\java.exe"
+) ELSE (
+  ECHO JAVA_HOME not defined, using java on PATH.
+  ECHO If you encounter errors, set JAVA_HOME or update your PATH to include java.exe.
+  set "JAVA=java.exe"
+)
+
+REM -Xmx1024m                     use up to 1GB RAM (edit to increase)
+REM -Dfile.encoding=UTF-8         ensure Unicode characters in model files are compatible cross-platform
+REM -Dnetlogo.extensions.dir=...  tell netlogo where to find extensions
+
+SET "JVM_OPTS=-Xmx1024m -Dfile.encoding=UTF-8 -Dnetlogo.extensions.dir=^"%BASE_DIR%app\extensions^""
+
+set ARGS=
+
+REM Process the arguments, some of which should be passed as java parameters
+REM All other arguments will be passed to NetLogo as given to this script.
+
+FOR %%a IN (%*) DO (
+  SET "ARG=%%a"
+  IF "!ARG!" == "--3D" (
+    SET "JVM_OPTS=!JVM_OPTS! -Dorg.nlogo.is3d=true"
+  ) ELSE (
+    IF "!ARG:~0,2!" == "-D" (
+      SET "JVM_OPTS=!JVM_OPTS! !ARG!"
+	  ) ELSE (
+      SET "ARGS=!ARGS! !ARG!"
+	  )
+  )
+)
+
+REM the NetLogo jar specifies other dependencies within its included classpath
+
+SET "ABSOLUTE_CLASSPATH=%BASE_DIR%{{{netlogoJar}}}"
+
+REM -classpath ....               specify jars
+REM org.nlogo.headless.Main       specify we want headless, not GUI
+
+"%JAVA%" %JVM_OPTS% -classpath "%ABSOLUTE_CLASSPATH%" org.nlogo.headless.Main %ARGS%

--- a/project/AggregateLinuxBuild.scala
+++ b/project/AggregateLinuxBuild.scala
@@ -75,8 +75,6 @@ object PackageLinuxAggregate {
         FileActions.copyAny(f, aggregateLinuxDir / f.getName)
       }
 
-      val variablesAndJarClasspath =
-
       // configure each sub application
       subApplications.foreach { app =>
         configureSubApplication(aggregateLinuxDir, app, commonConfig, variables)

--- a/project/AggregateMacBuild.scala
+++ b/project/AggregateMacBuild.scala
@@ -145,6 +145,17 @@ object PackageMacAggregate {
       configureSubApplication(aggregateMacDir / (appName + ".app"), app, commonConfig, variables ++ appSpecificConfig(app))
     }
 
+    val headlessClasspath =
+      ("classpathJars" ->
+        commonConfig.classpath
+          .map(jar => "Java/" + jar.getName)
+          .sorted
+          .mkString(File.pathSeparator))
+    val targetFile = aggregateMacDir / "netlogo-headless.sh"
+    Mustache(commonConfig.configRoot / "shared" / "macosx" / "netlogo-headless.sh.mustache",
+      targetFile, variables + headlessClasspath)
+
+    targetFile.setExecutable(true)
     // build and sign
     (aggregateMacDir / "JRE" / "Contents" / "Home" / "jre" / "lib" / "jspawnhelper").setExecutable(true)
 

--- a/project/AggregateWindowsBuild.scala
+++ b/project/AggregateWindowsBuild.scala
@@ -189,6 +189,19 @@ object PackageWinAggregate {
       configureSubApplication(aggregateWinDir, app, commonConfig, variables, aggregateTarget)
     }
 
+    val headlessClasspath =
+      ("netlogoJar" ->
+        commonConfig.classpath
+          .filter(_.getName.startsWith("netlogo"))
+          .map(jar => "app\\" + jar.getName)
+          .take(1)
+          .mkString(""))
+
+    val targetFile = aggregateWinDir / "netlogo-headless.bat"
+    Mustache(commonConfig.configRoot / "shared" / "windows" / "netlogo-headless.bat.mustache",
+      targetFile, variables + headlessClasspath)
+    targetFile.setExecutable(true)
+
     val uuidArchiveFileName =
       variables("version").replaceAllLiterally("-", "").replaceAllLiterally(".", "") + ".properties"
     val uuidArchiveFile = commonConfig.configRoot / "aggregate" / "win" /  "archive" / uuidArchiveFileName


### PR DESCRIPTION
https://ccl.northwestern.edu/netlogo/docs/behaviorspace.html#advanced

A user notes that the jar is no longer at NetLogo.jar, it's at app/NetLogo.jar (on Windows and Linux, it's actually in a different location entirely on Mac OS X.

On Linux, we distribute a headless.sh script. It's probably worth distributing a similar script for other platforms so we can unburden users of the responsibility of locating the appropriate jars and configuring everything on their own.