### PR TITLE
Some nested tasks are not properly converted to anonymous procedures

### DIFF
--- a/parser-jvm/src/test/parse/AstRewriterTests.scala
+++ b/parser-jvm/src/test/parse/AstRewriterTests.scala
@@ -141,6 +141,8 @@ class AstRewriterTests extends FunSuite {
   testLambda("foreach [1 2 3] [ -> show 4 ]", "foreach [1 2 3] [ -> show 4 ]")
   testLambda("__ignore runresult [2 < (3 + pi)]", "__ignore runresult [2 < (3 + pi)]")
   testLambda("show filter [ ?1 -> ?1 < 3 ] [1 3 2]", "show filter [? < 3] [1 3 2]")
+  testLambda("""let i map [ -> [ [] -> show "abc" ] ] [1 2 3]""",
+    """let i map [task [show "abc"]] [1 2 3]""")
 
   test("add extension") {
     assertResult("extensions [foo]")(addExtension("", "foo"))


### PR DESCRIPTION
For example:

```NetLogo
  let i map [task [show "abc"]] [1 2 3]
```

Converts to:

```NetLogo
  let i map [[ [] -> show "abc" ]] [1 2 3]
```

Given that 6.0 has been out for three months and we haven't heard feedback on this, it's possible that this is mostly a non-issue.