### PR TITLE
ArrayIndexOutOfBoundsException when opening a model with compilation error

### DIFF
--- a/autogen/events/events.txt
+++ b/autogen/events/events.txt
@@ -48,7 +48,7 @@ window.RemoveJob - org.nlogo.api.JobOwner owner
 window.ResizeView - int width - int height
 window.RuntimeError - org.nlogo.api.JobOwner jobOwner - org.nlogo.api.SourceOwner sourceOwner - int pos - int length
 window.TickStateChange - boolean tickCounterInitialized
-window.WidgetAdded - Widget widget
+window.WidgetAdded - Object widget
 window.WidgetEdited - Widget widget
 window.WidgetForegrounded - Widget widget
 window.WidgetRemoved - Widget widget

--- a/netlogo-gui/src/main/window/CompilerManager.scala
+++ b/netlogo-gui/src/main/window/CompilerManager.scala
@@ -59,6 +59,8 @@ class CompilerManager(val workspace: AbstractWorkspace,
 
   def handle(e: LoadEndEvent): Unit = {
     isLoading = false
+    world.program(Program.fromDialect(workspace.dialect).copy(interfaceGlobals = getGlobalVariableNames))
+    world.realloc()
     compileAll()
     world.clearAll()
   }
@@ -284,5 +286,5 @@ class CompilerManager(val workspace: AbstractWorkspace,
   }
 
   private def getGlobalVariableNames: Seq[String] =
-    globalWidgets.map(_.name).toSeq
+    globalWidgets.map(_.name.toUpperCase).toSeq
 }


### PR DESCRIPTION
To reproduce in 6.0.2-RC1:

- Create a slider named `x`, accept all defaults
- In the code tab, write something that doesn't compile, e.g.:
  ```
  to go
    print y
  end
  ```
  If you try to compile this, you'll rightfully get "Nothing named Y as been defined."
- Save your model under any name.
- Reopen-it. You get:
```

java.lang.ArrayIndexOutOfBoundsException: 0
 at org.nlogo.agent.Constraints.setConstraint(Constraints.scala:15)
 at org.nlogo.agent.Constraints.setConstraint$(Constraints.scala:14)
 at org.nlogo.agent.Observer.setConstraint(Observer.scala:9)
 at org.nlogo.window.GUIWorkspace.handle(GUIWorkspace.java:909)
 at org.nlogo.window.Events$AddSliderConstraintEvent.beHandledBy(Events.java:127)
 at org.nlogo.window.Event.doRaise(Event.java:198)
 at org.nlogo.window.Event.raise(Event.java:122)
 at org.nlogo.window.SliderWidget.updateConstraints(SliderWidget.scala:187)
 at org.nlogo.window.CompilerManager.$anonfun$updateInterfaceGlobalConstraints$1(CompilerManager.scala:238)
 at org.nlogo.window.CompilerManager.$anonfun$updateInterfaceGlobalConstraints$1$adapted(CompilerManager.scala:238)
 at scala.collection.mutable.HashSet.foreach(HashSet.scala:78)
 at org.nlogo.window.CompilerManager.updateInterfaceGlobalConstraints(CompilerManager.scala:238)
 at org.nlogo.window.CompilerManager.compileAll(CompilerManager.scala:181)
 at org.nlogo.window.CompilerManager.handle(CompilerManager.scala:62)
 at org.nlogo.window.Events$LoadEndEvent.beHandledBy(Events.java:462)
 at org.nlogo.window.Event.doRaise(Event.java:198)
 at org.nlogo.window.Event.raise(Event.java:122)
 at org.nlogo.window.ReconfigureWorkspaceUI$Loader.$anonfun$loadHelper$2(ReconfigureWorkspaceUI.scala:37)
 at org.nlogo.window.ReconfigureWorkspaceUI$Loader.$anonfun$loadHelper$2$adapted(ReconfigureWorkspaceUI.scala:37)
 at scala.collection.immutable.List.foreach(List.scala:389)
 at org.nlogo.window.ReconfigureWorkspaceUI$Loader.loadHelper(ReconfigureWorkspaceUI.scala:37)
 at org.nlogo.window.ReconfigureWorkspaceUI$.apply(ReconfigureWorkspaceUI.scala:19)
 at org.nlogo.app.FileManager.org$nlogo$app$FileManager$$runLoad(FileManager.scala:305)
 at org.nlogo.app.FileManager$$anon$3.run(FileManager.scala:366)
 at org.nlogo.swing.ModalProgressTask$.$anonfun$onUIThread$1(ModalProgressTask.scala:26)
 at org.nlogo.swing.ModalProgressTask$.$anonfun$onUIThread$1$adapted(ModalProgressTask.scala:24)
 at org.nlogo.swing.ModalProgressTask$.$anonfun$display$1(ModalProgressTask.scala:18)
 at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
 at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:756)
 at java.awt.EventQueue.access$500(EventQueue.java:97)
 at java.awt.EventQueue$3.run(EventQueue.java:709)
 at java.awt.EventQueue$3.run(EventQueue.java:703)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
 at java.awt.EventQueue.dispatchEvent(EventQueue.java:726)
 at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:109)
 at java.awt.WaitDispatchSupport$2.run(WaitDispatchSupport.java:184)
 at java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:229)
 at java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:227)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.awt.WaitDispatchSupport.enter(WaitDispatchSupport.java:227)
 at java.awt.Dialog.show(Dialog.java:1084)
 at java.awt.Component.show(Component.java:1671)
 at java.awt.Component.setVisible(Component.java:1623)
 at java.awt.Window.setVisible(Window.java:1014)
 at java.awt.Dialog.setVisible(Dialog.java:1005)
 at org.nlogo.swing.ModalProgressTask$.display(ModalProgressTask.scala:20)
 at org.nlogo.swing.ModalProgressTask$.onUIThread(ModalProgressTask.scala:24)
 at org.nlogo.app.FileManager.openFromModel(FileManager.scala:370)
 at org.nlogo.app.FileManager.$anonfun$openFromURI$1(FileManager.scala:283)
 at org.nlogo.app.FileManager.$anonfun$openFromURI$1$adapted(FileManager.scala:283)
 at scala.Option.foreach(Option.scala:257)
 at org.nlogo.app.FileManager.openFromURI(FileManager.scala:283)
 at org.nlogo.app.FileManager.openFromPath(FileManager.scala:279)
 at org.nlogo.app.OpenRecentFileAction.open(RecentFilesMenu.scala:67)
 at org.nlogo.app.OpenRecentFileAction.actionPerformed(RecentFilesMenu.scala:61)
 at javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:2022)
 at javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2348)
 at javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:402)
 at javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:259)
 at javax.swing.AbstractButton.doClick(AbstractButton.java:376)
 at javax.swing.plaf.basic.BasicMenuItemUI.doClick(BasicMenuItemUI.java:833)
 at javax.swing.plaf.basic.BasicMenuItemUI$Handler.mouseReleased(BasicMenuItemUI.java:877)
 at java.awt.Component.processMouseEvent(Component.java:6533)
 at javax.swing.JComponent.processMouseEvent(JComponent.java:3324)
 at java.awt.Component.processEvent(Component.java:6298)
 at java.awt.Container.processEvent(Container.java:2236)
 at java.awt.Component.dispatchEventImpl(Component.java:4889)
 at java.awt.Container.dispatchEventImpl(Container.java:2294)
 at java.awt.Component.dispatchEvent(Component.java:4711)
 at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4888)
 at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4525)
 at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4466)
 at java.awt.Container.dispatchEventImpl(Container.java:2280)
 at java.awt.Window.dispatchEventImpl(Window.java:2746)
 at java.awt.Component.dispatchEvent(Component.java:4711)
 at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
 at java.awt.EventQueue.access$500(EventQueue.java:97)
 at java.awt.EventQueue$3.run(EventQueue.java:709)
 at java.awt.EventQueue$3.run(EventQueue.java:703)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:90)
 at java.awt.EventQueue$4.run(EventQueue.java:731)
 at java.awt.EventQueue$4.run(EventQueue.java:729)
 at java.security.AccessController.doPrivileged(Native Method)
 at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
 at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
 at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
 at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
 at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
 at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
 at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)

NetLogo 6.0.2-RC1
main: org.nlogo.app.AppFrame
thread: AWT-EventQueue-0
Java HotSpot(TM) 64-Bit Server VM 1.8.0_131 (Oracle Corporation; 1.8.0_131-b11)
operating system: Linux 4.4.0-83-generic (amd64 processor)
Scala version 2.12.2
JOGL: (3D View not initialized)
OpenGL Graphics: (3D View not initialized)
model: Untitled

12:55:33.140 AddSliderConstraintEvent (org.nlogo.app.interfacetab.InterfacePanel$$anon$1 (org.nlogo.window.SliderWidget)) AWT-EventQueue-0
12:55:33.139 SwitchedTabsEvent (org.nlogo.app.Tabs) AWT-EventQueue-0
12:55:33.136 CompiledEvent (org.nlogo.window.CompilerManager) AWT-EventQueue-0
12:55:33.131 RemoveAllJobsEvent (org.nlogo.window.CompilerManager) AWT-EventQueue-0
12:55:33.125 LoadEndEvent (org.nlogo.window.ReconfigureWorkspaceUI$Loader (java.lang.Object)) AWT-EventQueue-0
12:55:33.124 WidgetAddedEvent (org.nlogo.app.interfacetab.InterfacePanel$$anon$1 (org.nlogo.window.SliderWidget)) AWT-EventQueue-0
12:55:33.123 InterfaceGlobalEvent (org.nlogo.app.interfacetab.InterfacePanel$$anon$1 (org.nlogo.window.SliderWidget)) AWT-EventQueue-0
12:55:33.123 ResizeViewEvent (org.nlogo.window.ViewWidget) AWT-EventQueue-0
12:55:33.122 ResizeViewEvent (org.nlogo.window.ViewWidget) AWT-EventQueue-0
12:55:33.122 LoadWidgetsEvent (org.nlogo.window.ReconfigureWorkspaceUI$Loader (java.lang.Object)) AWT-EventQueue-0
```
