### PR TITLE
Missing I18N key

### DIFF
--- a/netlogo-gui/project/autogen/i18n/GUI_Strings_en.txt
+++ b/netlogo-gui/project/autogen/i18n/GUI_Strings_en.txt
@@ -35,6 +35,7 @@ menu.file.open = Open
 menu.file.modelsLibrary = Models Library
 menu.file.uploadMc = Upload To Modeling Commons
 menu.file.save = Save
+menu.file.save.error = Error while saving file: {0}
 menu.file.saveAs = Save As
 menu.file.saveAll = Save All
 menu.file.saveAsNetLogoWeb = Save As NetLogo Web…


### PR DESCRIPTION
A user encountered the following error while trying to save a file to a network drive:

```
java.lang.IllegalArgumentException: internal error, bad translation key: menu.file.save.error for GUI_Strings
at org.nlogo.core.I18N$BundleKind.$anonfun$getN$2(I18N.scala:79)
at scala.Option.getOrElse(Option.scala:121)
at org.nlogo.core.I18N$BundleKind.$anonfun$getN$1(I18N.scala:79)
at scala.Option.getOrElse(Option.scala:121)
at org.nlogo.core.I18N$BundleKind.getN(I18N.scala:74)
at org.nlogo.app.FileManager.$anonfun$saveModel$1(FileManager.scala:352)
at org.nlogo.app.FileManager.$anonfun$saveModel$1$adapted(FileManager.scala:340)
at scala.Option.foreach(Option.scala:257)
at org.nlogo.app.FileManager.saveModel(FileManager.scala:340)
at org.nlogo.app.FileManager$$anon$1.action(FileManager.scala:415)
at org.nlogo.app.common.ExceptionCatchingAction.actionPerformed(Actions.scala:117)
at javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:2022)
at javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2348)
at javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:402)
at javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:259)
at javax.swing.AbstractButton.doClick(AbstractButton.java:376)
at javax.swing.plaf.basic.BasicMenuItemUI.doClick(BasicMenuItemUI.java:833)
at javax.swing.plaf.basic.BasicMenuItemUI$Handler.mouseReleased(BasicMenuItemUI.java:877)
at java.awt.Component.processMouseEvent(Component.java:6533)
at javax.swing.JComponent.processMouseEvent(JComponent.java:3324)
at java.awt.Component.processEvent(Component.java:6298)
at java.awt.Container.processEvent(Container.java:2236)
at java.awt.Component.dispatchEventImpl(Component.java:4889)
at java.awt.Container.dispatchEventImpl(Container.java:2294)
at java.awt.Component.dispatchEvent(Component.java:4711)
at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4888)
at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4525)
at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4466)
at java.awt.Container.dispatchEventImpl(Container.java:2280)
at java.awt.Window.dispatchEventImpl(Window.java:2746)
at java.awt.Component.dispatchEvent(Component.java:4711)
at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
at java.awt.EventQueue.access$500(EventQueue.java:97)
at java.awt.EventQueue$3.run(EventQueue.java:709)
at java.awt.EventQueue$3.run(EventQueue.java:703)
at java.security.AccessController.doPrivileged(Native Method)
at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:90)
at java.awt.EventQueue$4.run(EventQueue.java:731)
at java.awt.EventQueue$4.run(EventQueue.java:729)
at java.security.AccessController.doPrivileged(Native Method)
at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
```

This was probably caused by an IOException, which we may not be able to fix, but we should have an I18N key defined for this.