### PR TITLE
Fix IllegalArgumentException when removing/changing interface variable

### DIFF
--- a/netlogo-core/src/main/agent/AgentManagement.scala
+++ b/netlogo-core/src/main/agent/AgentManagement.scala
@@ -35,8 +35,8 @@ trait AgentManagement
 
   def patchesOwnNameAt(index: Int): String = program.patchesOwn(index)
   def patchesOwnIndexOf(name: String): Int = program.patchesOwn.indexOf(name)
-  def observerOwnsNameAt(index: Int): String = program.globals(index)
-  def observerOwnsIndexOf(name: String): Int = program.globals.indexOf(name)
+  def observerOwnsNameAt(index: Int): String = observer.variableName(index)
+  def observerOwnsIndexOf(name: String): Int = observer.variableIndex(name)
 
   protected var breedsOwnCache: JHashMap[String, Integer] = new JHashMap[String, Integer]()
 

--- a/netlogo-core/src/main/agent/Observer.scala
+++ b/netlogo-core/src/main/agent/Observer.scala
@@ -17,8 +17,9 @@ with api.Observer with OrientatableObserver with Constraints {
 
   private var varNames: Array[String] = new Array[String](0)
 
-  override def variableName(vn: Int) =
-    world.observerOwnsNameAt(vn)
+  override def variableName(vn: Int) = varNames(vn)
+
+  def variableIndex(name: String): Int = varNames.indexOf(name)
 
   @throws(classOf[api.AgentException])
   override def setVariable(vn: Int, value: AnyRef) {
@@ -26,8 +27,6 @@ with api.Observer with OrientatableObserver with Constraints {
     variables(vn) = value
     world.notifyWatchers(this, vn, value)
   }
-
-  def variableIndex(name: String): Int = varNames.indexOf(name)
 
   override def realloc(oldProgram: Program, newProgram: Program): Agent = {
     val forRecompile = oldProgram != null


### PR DESCRIPTION
Fixes exception caused by discrepancy between program-specified globals and allocated observer variables. 