### PR TITLE
NetLogo errors when opening a model with an empty-line in the snapToGrid section

### DIFF
--- a/netlogo-core/src/main/fileformat/NLogoModelSettings.scala
+++ b/netlogo-core/src/main/fileformat/NLogoModelSettings.scala
@@ -23,7 +23,7 @@ trait ModelSettingsComponent[A <: ModelFormat[Array[String], A]] extends Compone
   override def deserialize(s: Array[String]) = {(m: Model) =>
     Try {
       val foundValue =
-        ModelSettings(s.headOption.map(_.toInt != 0).getOrElse(false))
+        ModelSettings(s.headOption.flatMap(s => Try(s.toInt).toOption).map(_ != 0).getOrElse(false))
       m.withOptionalSection(componentName, Some(foundValue), ModelSettings(false))
     }
   }

--- a/netlogo-core/src/test/fileformat/NLogoFormatTests.scala
+++ b/netlogo-core/src/test/fileformat/NLogoFormatTests.scala
@@ -8,7 +8,7 @@ import java.util.Arrays
 
 import org.scalatest.FunSuite
 
-import org.nlogo.api.{ ComponentSerialization, ConfigurableModelLoader, ModelLoader, Version }
+import org.nlogo.api.{ ComponentSerialization, ConfigurableModelLoader, ModelLoader, ModelSettings, Version }
 import org.nlogo.core.{ DummyCompilationEnvironment, DummyExtensionManager, Model, Shape, Widget },
   Shape.{ LinkShape, VectorShape }
 
@@ -196,4 +196,19 @@ class LinkShapesComponentTest extends NLogoFormatTest[Seq[LinkShape]] {
   testDeserializes("empty link shapes to default shapes", Array[String](), Model.defaultLinkShapes)
   val defaultShape = Model.defaultLinkShapes.find(_.name == "default").get
   testRoundTripsObjectForm("default-only link shape list", Seq(defaultShape))
+}
+
+class ModelSettingsComponentTest extends NLogoFormatTest[ModelSettings] {
+  def subject = NLogoModelSettings
+  def modelComponent(model: Model): ModelSettings =
+    model.optionalSectionValue(NLogoModelSettings.componentName).get
+  def attachComponent(settings: ModelSettings): Model =
+    Model().withOptionalSection(NLogoModelSettings.componentName, Some(settings), ModelSettings(false))
+
+  testDeserializes("empty section to snap-to-grid = false", Array[String](), ModelSettings(false))
+  testDeserializes("blank section to snap-to-grid = false", Array[String](""), ModelSettings(false))
+  testDeserializes("0 to snap-to-grid = false", Array[String]("0"), ModelSettings(false))
+  testDeserializes("1 to snap-to-grid = true", Array[String]("1"), ModelSettings(true))
+  testRoundTripsObjectForm("snap-to-grid", ModelSettings(true))
+  testRoundTripsObjectForm("non-snap-to-grid", ModelSettings(false))
 }


### PR DESCRIPTION
Should assume "false"

This was apparently a "save as nlogo" from a NLW page generated based on "Connected Chemistry 1 Bike Tire". It's possible that there is a NetLogo Web bug involved here as well.