### PR TITLE
Editor should stick to end-of-line when navigating whitespace lines

### DIFF
--- a/netlogo-gui/src/main/api/EditorAreaInterface.scala
+++ b/netlogo-gui/src/main/api/EditorAreaInterface.scala
@@ -18,6 +18,6 @@ trait EditorAreaInterface {
   def replaceSelection(text: String)
   def replace(start: Int, len: Int, str: String): Unit
   def remove(start: Int, len: Int)
-  def beginCompoundEdit(): Unit = {}
-  def endCompoundEdit(): Unit = {}
+  def beginCompoundEdit(): Unit
+  def endCompoundEdit(): Unit
 }

--- a/netlogo-gui/src/main/app/codetab/CodeTab.scala
+++ b/netlogo-gui/src/main/app/codetab/CodeTab.scala
@@ -8,15 +8,25 @@ import java.awt.print.PageFormat
 import java.io.IOException
 import java.net.MalformedURLException
 import javax.swing.{ AbstractAction, Action, ImageIcon, JPanel }
+import javax.swing.text.JTextComponent
 
 import org.nlogo.agent.Observer
+import org.nlogo.api.EditorAreaInterface
 import org.nlogo.app.common.{ CodeToHtml, EditorFactory, Events => AppEvents, FindDialog, MenuTab, TabsInterface }
 import org.nlogo.core.{ AgentKind, I18N }
-import org.nlogo.editor.DumbIndenter
+import org.nlogo.editor.{ DumbIndenter, EditorAreaWrapper }
 import org.nlogo.ide.FocusedOnlyAction
 import org.nlogo.swing.{ Printable => NlogoPrintable, PrinterManager, ToolBar, ToolBarActionButton, UserAction, WrappedAction }
 import org.nlogo.window.{ EditorAreaErrorLabel, Events => WindowEvents, ProceduresInterface, Zoomable }
 import org.nlogo.workspace.AbstractWorkspace
+
+object CodeTab {
+  class CodeTabEditorAreaWrapper(val textComponent: JTextComponent)
+  extends EditorAreaWrapper
+  with EditorAreaInterface
+}
+
+import CodeTab.CodeTabEditorAreaWrapper
 
 abstract class CodeTab(val workspace: AbstractWorkspace, tabs: TabsInterface) extends JPanel
 with ProceduresInterface
@@ -172,7 +182,7 @@ with MenuTab {
     printer.printText(g, pageFormat, pageIndex, text.getText)
 
   def setIndenter(isSmart: Boolean): Unit = {
-    if(isSmart) text.setIndenter(new SmartIndenter(new EditorAreaWrapper(text), workspace))
+    if(isSmart) text.setIndenter(new SmartIndenter(new CodeTabEditorAreaWrapper(text), workspace))
     else text.setIndenter(new DumbIndenter(text))
   }
 

--- a/netlogo-gui/src/main/app/codetab/SmartIndenter.scala
+++ b/netlogo-gui/src/main/app/codetab/SmartIndenter.scala
@@ -70,7 +70,6 @@ extends Indenter {
     val line = code.offsetToLine(code.getSelectionEnd)
     val start = code.lineToStartOffset(line)
     val end = code.lineToEndOffset(line)
-    // end - 1 because the editor includes newlines as part of the text given in a line
     val indentations = lineIndentation(start, end - 1)
     if (indentations.nonEmpty) {
       executeIndentations(indentations, Some(originalCaretPosition))

--- a/netlogo-gui/src/main/editor/AdvancedEditorArea.scala
+++ b/netlogo-gui/src/main/editor/AdvancedEditorArea.scala
@@ -3,7 +3,7 @@
 package org.nlogo.editor
 
 import javax.swing.{ Action, JMenu, JPopupMenu }
-import javax.swing.text.EditorKit
+import javax.swing.text.{ EditorKit, NavigationFilter }
 
 import org.fife.ui.rtextarea.RTextArea
 import org.fife.ui.rsyntaxtextarea.{ RSyntaxTextArea, Theme }
@@ -25,6 +25,11 @@ class AdvancedEditorArea(val configuration: EditorConfiguration)
 
   def enableBracketMatcher(enable: Boolean): Unit = {
     setBracketMatchingEnabled(enable)
+  }
+
+  override def setNavigationFilter(filter: NavigationFilter): Unit = {
+    if (filter == null) super.setNavigationFilter(null)
+    else                super.setNavigationFilter(new StickyLineEndNavigationFilter(filter))
   }
 
   override def getActions(): Array[Action] = {

--- a/netlogo-gui/src/main/editor/EditorAreaWrapper.scala
+++ b/netlogo-gui/src/main/editor/EditorAreaWrapper.scala
@@ -1,45 +1,44 @@
 // (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
 
-package org.nlogo.app.codetab
+package org.nlogo.editor
 
-import org.nlogo.api.EditorAreaInterface
-import org.nlogo.editor.AdvancedEditorArea
 import javax.swing.JTextArea
 import javax.swing.text.{ AbstractDocument, JTextComponent }
 
 // wraps an EditorArea to satisfy EditorAreaInterface, for the benefit of SmartIndenter
 
-class EditorAreaWrapper(text: JTextComponent) extends EditorAreaInterface {
+trait EditorAreaWrapper {
+  def textComponent: JTextComponent
   def getLineOfText(lineNum: Int) = {
     val lineStart = lineToStartOffset(lineNum)
     val lineEnd = lineToEndOffset(lineNum)
     getText(lineStart, lineEnd - lineStart)
   }
-  def getCaretPosition: Int = text.getCaretPosition
-  def setCaretPosition(pos: Int) = text.setCaretPosition(pos)
-  def getText(start: Int, len: Int) = text.getDocument.getText(start, len)
-  def getSelectionStart = text.getSelectionStart
-  def getSelectionEnd = text.getSelectionEnd
-  def setSelectionStart(pos: Int) { text.setSelectionStart(pos) }
-  def setSelectionEnd(pos: Int) { text.setSelectionEnd(pos) }
+  def getCaretPosition: Int = textComponent.getCaretPosition
+  def setCaretPosition(pos: Int) = textComponent.setCaretPosition(pos)
+  def getText(start: Int, len: Int) = textComponent.getDocument.getText(start, len)
+  def getSelectionStart = textComponent.getSelectionStart
+  def getSelectionEnd = textComponent.getSelectionEnd
+  def setSelectionStart(pos: Int) { textComponent.setSelectionStart(pos) }
+  def setSelectionEnd(pos: Int) { textComponent.setSelectionEnd(pos) }
   def offsetToLine(offset: Int) =
-    text.getDocument.getDefaultRootElement.getElementIndex(offset)
+    textComponent.getDocument.getDefaultRootElement.getElementIndex(offset)
   def lineToStartOffset(line: Int) =
-    text.getDocument.getDefaultRootElement.getElement(line).getStartOffset
+    textComponent.getDocument.getDefaultRootElement.getElement(line).getStartOffset
   def lineToEndOffset(line: Int) = {
-    text.getDocument.getDefaultRootElement.getElement(line).getEndOffset
+    textComponent.getDocument.getDefaultRootElement.getElement(line).getEndOffset
   }
   def insertString(pos: Int, spaces: String) {
-    text.getDocument.insertString(pos, spaces, null)
+    textComponent.getDocument.insertString(pos, spaces, null)
   }
-  def replaceSelection(s: String) { text.replaceSelection(s) }
+  def replaceSelection(s: String) { textComponent.replaceSelection(s) }
   def replace(start: Int, len: Int, str: String): Unit = {
     try {
-      text match {
+      textComponent match {
         case textArea: JTextArea =>
           textArea.replaceRange(str, start, start + len)
         case _ =>
-          text.getDocument match {
+          textComponent.getDocument match {
             case abstractDoc: AbstractDocument =>
               abstractDoc.replace(start, len, str, null)
             case doc =>
@@ -58,23 +57,23 @@ class EditorAreaWrapper(text: JTextComponent) extends EditorAreaInterface {
   }
   def remove(start: Int, len: Int) {
     try {
-      text.getDocument.remove(start, len)
+      textComponent.getDocument.remove(start, len)
     } catch {
       case ex: javax.swing.text.BadLocationException =>
         println("errored removing: " + start + ", " + len)
         throw ex
     }
   }
-  override def beginCompoundEdit(): Unit = {
-    text match {
+  def beginCompoundEdit(): Unit = {
+    textComponent match {
       case a: AdvancedEditorArea => a.beginCompoundEdit()
-      case _ => super.beginCompoundEdit()
+      case _ =>
     }
   }
-  override def endCompoundEdit(): Unit = {
-    text match {
+  def endCompoundEdit(): Unit = {
+    textComponent match {
       case a: AdvancedEditorArea => a.endCompoundEdit()
-      case _ => super.endCompoundEdit()
+      case _ =>
     }
   }
 }

--- a/netlogo-gui/src/main/editor/StickyLineEndNavigationFilter.scala
+++ b/netlogo-gui/src/main/editor/StickyLineEndNavigationFilter.scala
@@ -21,13 +21,8 @@ object StickyLineEndNavigationFilter {
         }
         offsetValidIndex = Some(lineEndOffset)
         lineEndOffset
-      } else if (offsetValidIndex.contains(fromPos)) {
-        val offset = savedOffset.get
-        val targetLineStart = ea.lineToStartOffset(targetLineNum)
-        val targetLineEnd = ea.lineToEndOffset(targetLineNum)
-        offsetValidIndex = None
-        (targetLineStart + offset) min (targetLineEnd - 1)
       } else {
+        offsetValidIndex = None
         endPos
       }
     }

--- a/netlogo-gui/src/main/editor/StickyLineEndNavigationFilter.scala
+++ b/netlogo-gui/src/main/editor/StickyLineEndNavigationFilter.scala
@@ -1,0 +1,61 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.editor
+
+import javax.swing.SwingConstants
+import javax.swing.text.{ JTextComponent, NavigationFilter, Position }
+
+object StickyLineEndNavigationFilter {
+  class Logic {
+    var savedOffset = Option.empty[Int]
+    var offsetValidIndex = Option.empty[Int]
+
+    def move(ea: EditorAreaWrapper, fromPos: Int, endPos: Int): Int = {
+      val targetLineNum = ea.offsetToLine(endPos)
+      val targetLine = ea.getLineOfText(targetLineNum)
+      if (targetLine.trim.isEmpty) {
+        val sourceLineNum = ea.offsetToLine(fromPos)
+        val lineEndOffset = ea.lineToEndOffset(targetLineNum) - 1
+        if (ea.getLineOfText(sourceLineNum).trim.nonEmpty) {
+          savedOffset = Some(fromPos - ea.lineToStartOffset(sourceLineNum))
+        }
+        offsetValidIndex = Some(lineEndOffset)
+        lineEndOffset
+      } else if (offsetValidIndex.contains(fromPos)) {
+        val offset = savedOffset.get
+        val targetLineStart = ea.lineToStartOffset(targetLineNum)
+        val targetLineEnd = ea.lineToEndOffset(targetLineNum)
+        offsetValidIndex = None
+        (targetLineStart + offset) min (targetLineEnd - 1)
+      } else {
+        endPos
+      }
+    }
+  }
+}
+
+import StickyLineEndNavigationFilter.Logic
+
+class StickyLineEndNavigationFilter(delegate: NavigationFilter) extends NavigationFilter {
+  val logic = new Logic()
+
+  override def getNextVisualPositionFrom(
+    text: JTextComponent,
+    pos: Int,
+    bias: Position.Bias,
+    direction: Int,
+    biasRet: Array[Position.Bias]): Int = {
+      val delegateNVPF = delegate.getNextVisualPositionFrom(text, pos, bias, direction, biasRet)
+      if (direction == SwingConstants.EAST || direction == SwingConstants.WEST)
+        delegateNVPF
+      else
+        logic.move(new EditorAreaWrapper { val textComponent: JTextComponent = text }, pos, delegateNVPF)
+  }
+  override def moveDot(fb: NavigationFilter.FilterBypass, dot: Int, bias: Position.Bias): Unit = {
+    delegate.moveDot(fb, dot, bias)
+  }
+  override def setDot(fb: NavigationFilter.FilterBypass, dot: Int, bias: Position.Bias): Unit = {
+    delegate.setDot(fb, dot, bias)
+  }
+
+}

--- a/netlogo-gui/src/test/app/codetab/SmartIndenterTests.scala
+++ b/netlogo-gui/src/test/app/codetab/SmartIndenterTests.scala
@@ -3,87 +3,17 @@
 package org.nlogo.app.codetab
 
 import org.nlogo.api.{ EditorAreaInterface, NetLogoLegacyDialect, NetLogoThreeDDialect, Version }
+import org.nlogo.api.FileIO.fileToString
 import org.nlogo.nvm.{ PresentationCompilerInterface, DefaultCompilerServices }
 import org.nlogo.core.Femto
-import org.nlogo.api.FileIO.fileToString
+import org.nlogo.editor.DummyEditorArea
 import org.scalatest.FunSuite
 
 import scala.util.matching.Regex
 
-object SmartIndenterTests {
-  class Scaffold(var text: String) extends EditorAreaInterface {
-    private var _caretPosition: Int = 0
-    private var selectionStart = 0
-    private var selectionEnd = 0
-    private var _linesText = text
-    private var _lines = text.split("\\n")
-
-    def getCaretPosition = _caretPosition
-    def setCaretPosition(pos: Int) = {
-      _caretPosition = pos
-    }
-    def getSelectionStart = selectionStart
-    def setSelectionStart(pos: Int): Unit = {
-      selectionStart = pos
-    }
-    def getSelectionEnd = selectionEnd
-    def setSelectionEnd(pos: Int): Unit = {
-      selectionEnd = pos
-    }
-    selectAll()
-    def lines: Array[String] = {
-      if (_linesText eq text) {
-        _lines
-      } else {
-        _linesText = text
-        _lines = _linesText.split("\\n")
-        _lines
-      }
-    }
-
-    def selectAll() { selectionStart = 0; selectionEnd = text.size }
-
-    def offsetToLine(offset: Int): Int = lines.indices.find(lineToEndOffset(_) > offset)
-            .getOrElse(lines.size - 1)
-
-    def lineToStartOffset(line: Int) = lines.take(line).map(_.length + 1).sum
-
-    def lineToEndOffset(line: Int) = lineToStartOffset(line) + lines(line).length
-
-    def getLineOfText(lineNum: Int) = {
-      val start = lineToStartOffset(lineNum)
-      getText(start, lineToEndOffset(lineNum) - start)
-    }
-
-    def getText(start: Int, len: Int) = text.substring(start, start + len)
-
-    def insertString(pos: Int, str: String) { text = text.substring(0, pos) + str + text.substring(pos, text.length) }
-
-    def replaceSelection(str: String) {
-      text = text.take(selectionStart) + str + text.drop(selectionEnd)
-      val originalStart = selectionStart
-      _caretPosition = selectionStart + str.length
-      selectionStart = originalStart + str.length
-      selectionEnd   = originalStart + str.length
-    }
-
-    def remove(start: Int, len: Int) { text = text.substring(0, start) + text.substring(start + len, text.length) }
-
-    def replace(start: Int, len: Int, str: String): Unit = {
-      text = text.substring(0, start) + str + text.substring(start + len, text.length)
-      _caretPosition = start + str.length
-    }
-
-    def replace(start: Int, len: Int, str: String, newCaretPosition: Int): Unit = {
-      text = text.substring(0, start) + str + text.substring(start + len, text.length)
-      _caretPosition = newCaretPosition
-    }
-  }
-}
-
-import SmartIndenterTests.Scaffold
-
 class SmartIndenterTests extends FunSuite {
+  class DummyEditor(text: String) extends DummyEditorArea(text) with EditorAreaInterface
+
   val path = "test/indent.txt" // where the actual test cases live
 
   // read tests from file
@@ -119,26 +49,26 @@ class SmartIndenterTests extends FunSuite {
     Femto.get[PresentationCompilerInterface]("org.nlogo.compile.Compiler", if (Version.is3D) NetLogoLegacyDialect else NetLogoThreeDDialect))
 
   test("handleCloseBracket adds closing bracket") {
-    val code = new Scaffold("")
+    val code = new DummyEditor("")
     new SmartIndenter(code, compiler).handleCloseBracket()
-    assert("]" == code.text)
+    assert("]" == code.presentationText)
   }
 
   test("handleCloseBracket correctly indents line") {
-    val code = new Scaffold("[\n  abc\n  ")
+    val code = new DummyEditor("[\n  abc\n  ")
     code.setSelectionStart(10)
     code.setSelectionEnd(10)
     code.setCaretPosition(10)
     new SmartIndenter(code, compiler).handleCloseBracket()
-    assert("[\n  abc\n]" == code.text)
+    assert("[\n  abc\n]" == code.presentationText)
   }
 
   // call FunSuite's test method for each test read
   for(Array(name, in, out) <- data) {
     test("indent all lines in " + name) {
-      val code = new Scaffold(in)
+      val code = new DummyEditor(in)
       new SmartIndenter(code, compiler).handleTab()
-      assert(out === code.text)
+      assert(out === code.presentationText)
     }
 
     test("indent a single line in " + name) {
@@ -146,7 +76,7 @@ class SmartIndenterTests extends FunSuite {
       for {
         lineNumber <- (0 until lineCount)
       } {
-        val code = new Scaffold(in)
+        val code = new DummyEditor(in)
         val indenter = new SmartIndenter(code, compiler)
         code.setSelectionStart(code.lineToStartOffset(lineNumber))
         code.setSelectionEnd(code.lineToEndOffset(lineNumber) - 1)
@@ -161,13 +91,13 @@ class SmartIndenterTests extends FunSuite {
       }
     }
 
-    test("handleEnter does not mangle next line " + name) {
+    test("indents lines when handleEnter replaces a selection including their start " + name) {
       val newline = new Regex("\\n")
       for {
         (newLine, i) <- (newline.findAllMatchIn(in).toSeq.zipWithIndex)
       } {
         if (i < out.lines.length) {
-          val code = new Scaffold(in)
+          val code = new DummyEditor(in)
           val indenter = new SmartIndenter(code, compiler)
           code.setSelectionStart(newLine.start)
           code.setSelectionEnd(newLine.end)
@@ -181,12 +111,12 @@ class SmartIndenterTests extends FunSuite {
       for {
         (char, index) <- in.zipWithIndex if ! char.isWhitespace
       } {
-        val code = new Scaffold(in)
+        val code = new DummyEditor(in)
         code.setCaretPosition(index)
         new SmartIndenter(code, compiler).handleTab()
-        val startOffset = code.getCaretPosition.min(code.text.size - 1).max(0)
+        val startOffset = code.getCaretPosition.min(code.presentationText.size - 1).max(0)
         val newChar = code.getText(startOffset, 1)
-        assert(char == newChar.head, s"When caret started at: $index (${code.text.slice(index, 3)}), ended at: ${code.getCaretPosition}")
+        assert(char == newChar.head, s"When caret started at: $index (${code.presentationText.slice(index, 3)}), ended at: ${code.getCaretPosition}")
       }
     }
 
@@ -194,14 +124,14 @@ class SmartIndenterTests extends FunSuite {
       for {
         (char, index) <- in.zipWithIndex if ! char.isWhitespace
       } {
-        val code = new Scaffold(in)
+        val code = new DummyEditor(in)
         code.setSelectionStart(index)
         code.setSelectionEnd(index)
         code.setCaretPosition(index)
         new SmartIndenter(code, compiler).handleEnter()
-        val startOffset = code.getCaretPosition.min(code.text.size - 1).max(0)
+        val startOffset = code.getCaretPosition.min(code.presentationText.size - 1).max(0)
         val newChar = code.getText(startOffset, 1)
-        assert(char == newChar.head, s"When caret started at: $index (${code.text.slice(index, 3)}), ended at: ${code.getCaretPosition}")
+        assert(char == newChar.head, s"When caret started at: $index (${code.presentationText.slice(index, 3)}), ended at: ${code.getCaretPosition}")
       }
     }
   }

--- a/netlogo-gui/src/test/editor/DummyEditorArea.scala
+++ b/netlogo-gui/src/test/editor/DummyEditorArea.scala
@@ -1,0 +1,104 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.editor
+
+import org.scalatest.FunSuite
+
+class DummyEditorArea(_text: String) extends EditorAreaWrapper {
+  def textComponent = null
+  var text = _text + "\n"
+  private var _caretPosition: Int = 0
+  private var selectionStart = 0
+  private var selectionEnd = 0
+  private var _linesText = text
+  private var _lines = text.split("\\n")
+
+  override def getCaretPosition = _caretPosition
+  override def setCaretPosition(pos: Int) = {
+    _caretPosition = pos
+  }
+  override def getSelectionStart = selectionStart
+  override def setSelectionStart(pos: Int): Unit = {
+    selectionStart = pos
+  }
+  override def getSelectionEnd = selectionEnd
+  override def setSelectionEnd(pos: Int): Unit = {
+    selectionEnd = pos
+  }
+  selectAll()
+  def lines: Array[String] = {
+    if (_linesText eq text) {
+      _lines
+    } else {
+      text = if (text.lastOption.contains('\n')) text else text + "\n"
+      _linesText = text
+      _lines = _linesText.split("\\n")
+      _lines
+    }
+  }
+  // drop the newline we are obligated to have at the end of the last bit of text
+  def presentationText = text.dropRight(1)
+
+  def selectAll() { selectionStart = 0; selectionEnd = text.size }
+
+  override def offsetToLine(offset: Int): Int =
+    lines.indices.find(lineToEndOffset(_) > offset)
+      .getOrElse(lines.size - 1)
+
+  override def lineToStartOffset(line: Int) = lines.take(line).map(_.length + 1).sum
+
+  override def lineToEndOffset(line: Int) = lineToStartOffset(line) + lines(line).length + (if (lines.length > 1) 1 else 0)
+
+  override def getLineOfText(lineNum: Int) = {
+    val start = lineToStartOffset(lineNum)
+    getText(start, (lineToEndOffset(lineNum) - 1) - start) + "\n"
+  }
+
+  override def getText(start: Int, len: Int) = text.substring(start, start + len)
+
+  override def insertString(pos: Int, str: String) { text = text.substring(0, pos) + str + text.substring(pos, text.length) }
+
+  override def replaceSelection(str: String) {
+    text = text.take(selectionStart) + str + text.drop(selectionEnd)
+    val originalStart = selectionStart
+    _caretPosition = selectionStart + str.length
+    selectionStart = originalStart + str.length
+    selectionEnd   = originalStart + str.length
+  }
+
+  override def remove(start: Int, len: Int) { text = text.substring(0, start) + text.substring(start + len, text.length) }
+
+  override def replace(start: Int, len: Int, str: String): Unit = {
+    text = text.substring(0, start) + str + text.substring(start + len, text.length)
+    _caretPosition = start + str.length
+  }
+
+  def replace(start: Int, len: Int, str: String, newCaretPosition: Int): Unit = {
+    text = text.substring(0, start) + str + text.substring(start + len, text.length)
+    _caretPosition = newCaretPosition
+  }
+}
+
+class DummyEditorAreaTests extends FunSuite {
+
+  // NOTE: These values were obtained empirically on Java 8u141
+  // Please remeasure before adjusting
+  test("behaves the same way that EditorAreaWrapper does") {
+    val text = "abc\n   \nd\nhij"
+    val ea = new DummyEditorArea(text)
+    val lineData =
+      Seq(
+        ((0, 4),   "abc\n"),
+        ((4, 8),   "   \n"),
+        ((8, 10),  "d\n"),
+        ((10, 14), "hij\n"))
+
+    lineData.zipWithIndex.foreach {
+      case (((start, end), text), lineNum) =>
+        assertResult(start, "expected start offset to match")(ea.lineToStartOffset(lineNum))
+        assertResult(end,   "expected end offset to match")(ea.lineToEndOffset(lineNum))
+        assertResult(text,  "expected getLineOfText to match")(ea.getLineOfText(lineNum))
+        assertResult(text,  "expected getText to match")(ea.getText(start, end - start))
+    }
+  }
+}

--- a/netlogo-gui/src/test/editor/StickyLineEndNavigationFilterTests.scala
+++ b/netlogo-gui/src/test/editor/StickyLineEndNavigationFilterTests.scala
@@ -21,10 +21,10 @@ class StickyLineEndNavigationFilterTests extends FunSuite {
     assertResult(7)(logic.move(ea, 0, 5))
   } }
 
-  test("moving from a full line to a whitespace-only line, back to a full line preserves line offset") { new Helper {
+  test("moving off of a whitespace-only line, uses standard line offset") { new Helper {
     text = "abc\n   \ndef"
     logic.move(ea, 0, 5)
-    assertResult(8)(logic.move(ea, 7, 11))
+    assertResult(8)(logic.move(ea, 7, 8))
   } }
 
   test("ignores line offset when moving from a different position than the prior one") { new Helper {
@@ -33,16 +33,10 @@ class StickyLineEndNavigationFilterTests extends FunSuite {
     assertResult(10)(logic.move(ea, 6, 10))
   } }
 
-  test("offset preservation does not go past the end of a non-empty line") { new Helper {
-    text = "abc\n   \nd\nhij"
-    assertResult(7)(logic.move(ea, 2, 6))
-    assertResult(9)(logic.move(ea, 7, 9))
-  } }
-
   test("offset preservation continues across multiple blank lines") { new Helper {
     text = "abc\n   \n   \ndef"
     assertResult(7)(logic.move(ea, 2, 6))
     assertResult(11)(logic.move(ea, 7, 11))
-    assertResult(14)(logic.move(ea, 11, 15))
+    assertResult(14)(logic.move(ea, 11, 14))
   } }
 }

--- a/netlogo-gui/src/test/editor/StickyLineEndNavigationFilterTests.scala
+++ b/netlogo-gui/src/test/editor/StickyLineEndNavigationFilterTests.scala
@@ -1,0 +1,48 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.editor
+
+import org.scalatest.FunSuite
+
+class StickyLineEndNavigationFilterTests extends FunSuite {
+  trait Helper {
+    var text: String = ""
+    lazy val ea = new DummyEditorArea(text)
+    val logic = new StickyLineEndNavigationFilter.Logic()
+  }
+
+  test("moving between full lines switches as normal") { new Helper {
+    text = "abc\ndef"
+    assertResult(5)(logic.move(ea, 0, 5))
+  } }
+
+  test("moving from a full line to an whitespace-only line moves to the end of that line") { new Helper {
+    text = "abc\n   "
+    assertResult(7)(logic.move(ea, 0, 5))
+  } }
+
+  test("moving from a full line to a whitespace-only line, back to a full line preserves line offset") { new Helper {
+    text = "abc\n   \ndef"
+    logic.move(ea, 0, 5)
+    assertResult(8)(logic.move(ea, 7, 11))
+  } }
+
+  test("ignores line offset when moving from a different position than the prior one") { new Helper {
+    text = "abc\n   \ndef"
+    assertResult(7)(logic.move(ea, 0, 5))
+    assertResult(10)(logic.move(ea, 6, 10))
+  } }
+
+  test("offset preservation does not go past the end of a non-empty line") { new Helper {
+    text = "abc\n   \nd\nhij"
+    assertResult(7)(logic.move(ea, 2, 6))
+    assertResult(9)(logic.move(ea, 7, 9))
+  } }
+
+  test("offset preservation continues across multiple blank lines") { new Helper {
+    text = "abc\n   \n   \ndef"
+    assertResult(7)(logic.move(ea, 2, 6))
+    assertResult(11)(logic.move(ea, 7, 11))
+    assertResult(14)(logic.move(ea, 11, 15))
+  } }
+}


### PR DESCRIPTION
Instead of staying on the current column, when navigating to the a blank line, the editor should move to the rightmost column.

If a user enters a block, then closes that block, then navigates backward, they end up 1 space from the end of the line instead of at the very end of the line.