### PR TITLE
Disconnected flows and buggy behavior in System Dynamics Modeler

### DIFF
--- a/netlogo-gui/src/main/sdm/gui/AggregateDrawing.java
+++ b/netlogo-gui/src/main/sdm/gui/AggregateDrawing.java
@@ -17,12 +17,13 @@ public strictfp class AggregateDrawing
   }
 
   public void synchronizeModel() {
+    model.elements().clear();
     FigureEnumeration figs = figures();
     while (figs.hasNextFigure()) {
       Figure fig = figs.nextFigure();
       if (fig instanceof ModelElementFigure &&
           ((ModelElementFigure) fig).getModelElement() != null) {
-        getModel().addElement(((ModelElementFigure) fig).getModelElement());
+        model.addElement(((ModelElementFigure) fig).getModelElement());
           }
     }
   }

--- a/netlogo-gui/src/main/sdm/gui/AggregateModelEditor.scala
+++ b/netlogo-gui/src/main/sdm/gui/AggregateModelEditor.scala
@@ -158,6 +158,7 @@ class AggregateModelEditor(
    * Translates the model into NetLogo code.
    */
   def toNetLogoCode: String = {
+    drawing.synchronizeModel()
     new Translator(drawing.getModel, compiler).source
   }
 

--- a/netlogo-gui/src/main/sdm/gui/NLogoGuiSDMFormat.scala
+++ b/netlogo-gui/src/main/sdm/gui/NLogoGuiSDMFormat.scala
@@ -33,6 +33,7 @@ class NLogoGuiSDMFormat extends ComponentSerialization[Array[String], NLogoForma
   }
 
   private def drawingStrings(drawing: AggregateDrawing): Array[String] = {
+    drawing.synchronizeModel()
     if (drawing.getModel.elements.isEmpty)
       Array()
     else {


### PR DESCRIPTION
Greetings, several students in my class have reported strange behaviors while using the System Dynamics Modeler using NetLogo 6.0.2 (although similar problems were observed last year on version 5.3.1 as well).

During the course of creating a SD model, some of the flows seem to "disconnect" from the attached stocks and are not computed in the simulation. If the user re-attaches the flows to the stocks, they are _still_ not considered in the simulation. The flows must be deleted and re-created to fix the problem.

I have attached two sample files here exhibiting the behavior and one file with expected results. While I can verify the problems with these files, I cannot reproduce the steps to break a SD model in this way which leads me to believe it is a bug in the GUI related to redefining flow variables as a model takes shape.

[examples.zip](https://github.com/NetLogo/NetLogo/files/1476971/examples.zip)