### PR TITLE
Make DoubleRange use ulp instead of custom thing

### DIFF
--- a/netlogo-core/src/main/api/DoubleRange.scala
+++ b/netlogo-core/src/main/api/DoubleRange.scala
@@ -1,28 +1,21 @@
 package org.nlogo.api
 
-import java.lang.{Double => JDouble, StrictMath}
-
 case class DoubleRange(start: Double, stop: Double, step: Double = 1.0, inclusive: Boolean = false)
   extends IndexedSeq[Double] {
   if (step == 0) throw new IllegalArgumentException("`step` must be nonzero")
 
-  // Calculate the scale of precision of the number of the quotient that
-  // determines the number of elements in the sequence. Error can occur in the
-  // last bit of this number. Note, we may want to extend this to the last two
-  // bits due to accumulated error from multiple operations.
-  val exponentPrecision = doubleScale((stop - start) / step)
-  // So we get a number that essentially has a one at that bit...
-  val epsilon = StrictMath.pow(2, -52) * StrictMath.pow(2, exponentPrecision)
-
-  override val length = {
-    val l = if (inclusive)
-    // We want, for instance, 9.999999999999998 to become 10 instead of 9
-    // from the floor, so we add the epsilon here.
-      StrictMath.floor((stop - start) / step + epsilon + 1)
-    else
-    // We want, for instance, 10.000000000000002 to become 10 instead of 11
-    // from the ceil, so we subtract the epsilon here.
-      StrictMath.ceil((stop - start) / step - epsilon)
+  override val length: Int = {
+    val l = if (inclusive) {
+      // We want, for instance, 9.999999999999998 to become 10 instead of 9
+      // from the floor, so we add the ulp here.
+      val num = (stop - start) / step + 1
+      StrictMath.floor(num + StrictMath.ulp(num))
+    } else {
+      // We want, for instance, 10.000000000000002 to become 10 instead of 11
+      // from the ceil, so we subtract the ulp here.
+      val num = (stop - start) / step
+      StrictMath.ceil(num - StrictMath.ulp(num))
+    }
 
     if (l > Integer.MAX_VALUE)
       throw new IllegalArgumentException("Range results in too many elements.")
@@ -37,26 +30,4 @@ case class DoubleRange(start: Double, stop: Double, step: Double = 1.0, inclusiv
 
   override def tail = DoubleRange(start + step, stop, step, inclusive)
   override def init = DoubleRange(start, stop - step, step, inclusive)
-
-  /**
-    * Quantifies the scale of the given double. Usually this is the exponent
-    * portion of the double bit representation, corrected for its zero offset.
-    * 0 is given a scale of 1023, however, so that it's always considered less
-    * specific, so to speak, than any other number.
-    */
-  private def doubleScale(x: Double): Long = {
-    if (x == 0)
-      1023
-    else {
-      val bits = JDouble.doubleToRawLongBits(x)
-      // Cut off the significand, which is the last 52 bits
-      val rightShifted = bits >>> 52
-      // This leaves us with 12 bits, where the first one is the sign and the
-      // last 11 are the exponent + 1023
-      // So, we use an 11 bit mask to drop the sign.
-      val mask = (1L << 11) - 1L
-      // And then subtract 1023 to correct for the zero offset (0 is -1023)
-      (rightShifted & mask) - 1023
-    }
-  }
 }


### PR DESCRIPTION
This is primarily a very minor code improvement, though there are likely some very extreme corner cases out there that this will fix.

Had I known `ulp` existed I would have used `ulp` originally.

This only changes how we calculate how many numbers are in the list, not the numbers themselves. The number of numbers in the list are extensively tested, so this should be pretty safe. Furthermore, theoretically, this should be floating point equivalent to the code before, it's just that we were calculating the `ulp` ourselves before (or something close to it). Regardless, the fact that this didn't break any tests is still kind of blowing my mind.