### PR TITLE
Fix HubNet NullPointerException

### DIFF
--- a/netlogo-gui/src/main/hubnet/client/ClientApp.scala
+++ b/netlogo-gui/src/main/hubnet/client/ClientApp.scala
@@ -119,7 +119,9 @@ class ClientApp extends JFrame("HubNet") with ErrorHandler with ClientAppInterfa
     }
   }
 
-  def completeLogin() { setVisible(true) }
+  def completeLogin() {
+    setVisible(true)
+  }
 
   private def login(userid: String, hostip: String, port: Int) {
     var exs: Option[String] = None
@@ -145,13 +147,11 @@ class ClientApp extends JFrame("HubNet") with ErrorHandler with ClientAppInterfa
   def handleDisconnect(activityName: String, connected: Boolean, reason:String) {
     EventQueue.mustBeEventDispatchThread()
     if (isLocal) this.dispose()
-    else {
-      if (connected) {
-        OptionDialog.showMessage(this, "", "You have been disconnected from " + activityName + ".", Array("ok"))
-        dispose()
-        doLogin()
-        ()
-      }
+    else if (connected) {
+      OptionDialog.showMessage(this, "", "You have been disconnected from " + activityName + ".", Array("ok"))
+      dispose()
+      doLogin()
+      ()
     }
   }
 

--- a/netlogo-gui/src/main/hubnet/client/RoboClientPanel.scala
+++ b/netlogo-gui/src/main/hubnet/client/RoboClientPanel.scala
@@ -82,7 +82,7 @@ private class RoboClientPanel(editorFactory:org.nlogo.window.EditorFactory,
         // need to check if we are still connected since we could
         // have shutdown while we were waiting to be called.
         // --mag 8/26/03
-        if (connected && value.isDefined) sendDataAndWait(new ActivityCommand(name, value.get.asInstanceOf[AnyRef]))
+        if (connected.get && value.isDefined) sendDataAndWait(new ActivityCommand(name, value.get.asInstanceOf[AnyRef]))
       })
     }
   }

--- a/netlogo-gui/src/main/hubnet/server/ConnectionManager.scala
+++ b/netlogo-gui/src/main/hubnet/server/ConnectionManager.scala
@@ -358,7 +358,7 @@ class ConnectionManager(val connection: ConnectionInterface,
   }
 
   /// view stuff
-  def sendOverrideList (client:String, agentKind: AgentKind,
+  def sendOverrideList(client:String, agentKind: AgentKind,
                                  varName: String, overrides:Map[java.lang.Long, AnyRef]) = {
     sendUserMessage(client, new OverrideMessage(new SendOverride(agentKind, varName, overrides), false))
   }

--- a/netlogo-gui/src/test/headless/TestImportExport.scala
+++ b/netlogo-gui/src/test/headless/TestImportExport.scala
@@ -544,19 +544,20 @@ with BeforeAndAfterEach with OneInstancePerTest with SlowTest {
     roundTripHelper(setup="set t \"" + x + "\"", model="globals [t]")
   }
 
-  test("CurrentPlotPenAfterImport", SlowTest.Tag) {
+  if (! Version.is3D)
+    test("CurrentPlotPenAfterImport", SlowTest.Tag) {
 
-    workspace.open("test/import/current-plot-pen.nlogo")
-    testCommand("reset-ticks")
-    assertResult(workspace.plotManager.currentPlot.get.currentPenByName)("pen1")
+      workspace.open("test/import/current-plot-pen.nlogo")
+      testCommand("reset-ticks")
+      assertResult(workspace.plotManager.currentPlot.get.currentPenByName)("pen1")
 
-    val filename = getUniqueFilename()
-    testCommand(s"""export-world "$filename"""")
-    testCommand(s"""import-world "$filename"""")
-    assertResult(workspace.plotManager.currentPlot.get.currentPenByName)("pen1")
-    delete(filename)
+      val filename = getUniqueFilename()
+      testCommand(s"""export-world "../../$filename"""")
+      testCommand(s"""import-world "../../$filename"""")
+      assertResult(workspace.plotManager.currentPlot.get.currentPenByName)("pen1")
+      delete(filename)
 
-  }
+    }
 
   /// 3D tests
 

--- a/netlogo-gui/src/tools/org/nlogo/hubnet/HubNetLoginFuzzing.scala
+++ b/netlogo-gui/src/tools/org/nlogo/hubnet/HubNetLoginFuzzing.scala
@@ -1,0 +1,210 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.hubnet
+
+import java.net.Socket
+import java.nio.file.{ Files, Path, Paths }
+import java.io.{ ObjectOutputStream}
+import java.util.concurrent.Executors
+
+import org.nlogo.api.Version
+import org.nlogo.util.ClassLoaderObjectInputStream
+import protocol.{ ActivityCommand, EnterMessage, ExitMessage, HandshakeFromClient, HandshakeFromServer }
+
+import scala.util.Random
+
+object HubNetLoginFuzzing extends App {
+  sealed trait Action
+  case class SendAction(send: Send) extends Action
+  case object WaitOneMessage extends Action
+
+  sealed trait Send
+  case class SendVersion(version: String) extends Send
+  case class SendHandshake(clientId: String) extends Send
+  case object SendEnter extends Send
+  case object SendExit extends Send
+  case class SendActivityMessage(tag: String, value: AnyRef) extends Send
+
+  trait Output {
+    def write(s: String): Unit
+  }
+  case class FileOutput(path: Path) extends Output {
+    def write(s: String): Unit =
+      Files.write(path, s.getBytes("UTF-8"))
+  }
+  object StdOutput extends Output {
+    def write(s: String): Unit =
+      println(s)
+  }
+
+  lazy val threadPool = Executors.newFixedThreadPool(4)
+
+  val actionCount =
+    if (args.length >= 1) args(0).toInt else 100
+
+  val groupedArgs: Seq[Seq[String]] =
+    if (args.length < 3) Seq()
+    else args.tail.grouped(2).map(_.toSeq).toSeq
+
+  val output =
+    groupedArgs
+      .find(_.head == "--output")
+      .map(p => new FileOutput(Paths.get(p(1))))
+      .getOrElse(StdOutput)
+
+  val seed =
+    groupedArgs
+      .find(_.head == "--seed")
+      .map(_(1).toInt)
+      .getOrElse(0)
+
+  val random = new Random(seed)
+
+  val actions: Iterable[ActionRunnable] =
+    Iterator
+      .continually(makeActions(random))
+      .map(makeActionRunnables _)
+      .take(actionCount)
+      .toSeq
+
+  actions.foreach(threadPool.submit _)
+
+  threadPool.shutdown()
+
+  while (! threadPool.isTerminated()) { }
+
+  output.write(actions.map(_.result).mkString("\n"))
+
+  lazy val messagePool: Seq[(Random => Send)] =
+    Seq(
+    { (r) => SendVersion(Version.version) },
+    { (r) => SendHandshake(randString(r)) },
+    { (r) => SendHandshake(null) },
+    { (r) => SendEnter },
+    { (r) => SendActivityMessage("Choice", Double.box(3)) },
+    { (r) => SendExit })
+
+  def makeActions(rand: Random): Seq[Action] = {
+    (0 to rand.nextInt(9))
+      .map(_ => messagePool(rand.nextInt(messagePool.length)))
+      .flatMap { messageMaker =>
+          val madeMessage = messageMaker(rand)
+          madeMessage match {
+            case _: SendActivityMessage | SendExit | SendEnter => Seq(SendAction(madeMessage))
+            case _ => Seq(SendAction(madeMessage), WaitOneMessage)
+          }
+      }
+  }
+
+  private def randString(rand: Random): String = {
+    (1 to 5).map(_ => rand.nextPrintableChar()).mkString("")
+  }
+
+  def makeActionRunnables(actions: Seq[Action]): ActionRunnable =
+    new ActionRunnable(actions)
+
+  class ActionRunnable(actions: Seq[Action]) extends Runnable {
+    sealed trait Event
+    case class PendingSend(send: Send) extends Event
+    case class Sent(send: Send) extends Event
+    case class Received(any: AnyRef) extends Event {
+      override def toString = any match {
+        case hs: HandshakeFromServer => "Received(HandshakeFromServer(" + hs.activityName + "...))"
+        case _ => "Received(" + any.toString + ")"
+      }
+    }
+    case class ExceptionRaised(e: Exception) extends Event
+    case object Timeout extends Event
+    case object SocketClosed extends Event
+
+    var events: List[AnyRef] = Nil
+    var remainingActions = actions
+
+    def makeConnection(): Option[(Socket, ObjectOutputStream, ClassLoaderObjectInputStream)] = {
+      var socket: Socket = null
+      var out: ObjectOutputStream = null
+      var in: ClassLoaderObjectInputStream = null
+
+      try {
+        while (socket == null || out == null || in == null) {
+          socket = new Socket("127.0.0.1", 9173) { setSoTimeout(250) }
+          while (! socket.isConnected()) {}
+
+          while (socket != null && out == null) {
+            try {
+              out = new ObjectOutputStream(socket.getOutputStream)
+            } catch {
+              case _: java.net.SocketException =>
+                socket = null
+                System.err.println("output stream opening exception...")
+            }
+          }
+          while (socket != null && in == null) {
+            try {
+              in = ClassLoaderObjectInputStream(Thread.currentThread.getContextClassLoader, socket.getInputStream)
+            } catch {
+              case _: java.net.SocketException =>
+                socket = null
+                System.err.println("input stream opening exception...")
+            }
+          }
+        }
+        Some((socket, out, in))
+      } catch {
+        case e: Exception =>
+          ExceptionRaised(e) :: events
+          None
+      }
+    }
+
+    override def run() {
+      makeConnection().foreach {
+        case (socket, out, in) =>
+          try {
+            while (remainingActions.nonEmpty && ! socket.isClosed()) {
+              remainingActions.head match {
+                case SendAction(send: Send) =>
+                  events = PendingSend(send) :: events
+                  send match {
+                    case SendVersion(v) =>
+                      out.writeObject(v); out.flush()
+                    case SendHandshake(clientId) =>
+                      out.writeObject(HandshakeFromClient(clientId, "COMPUTER")); out.flush()
+                    case SendEnter =>
+                      out.writeObject(EnterMessage); out.flush()
+                    case SendActivityMessage(tag, value) =>
+                      out.writeObject(ActivityCommand(tag, value)); out.flush()
+                    case SendExit =>
+                      out.writeObject(ExitMessage("DONE!")); out.flush()
+                  }
+                  events = Sent(send) :: events.tail
+                    case WaitOneMessage =>
+                      try {
+                        val obj = in.readObject()
+                        events = Received(obj) :: events
+                      } catch {
+                        case to: java.net.SocketTimeoutException =>
+                          events = Timeout :: events
+                      }
+              }
+              remainingActions = remainingActions.tail
+            }
+            if (socket.isClosed()) {
+              events = SocketClosed :: events
+            }
+          } catch {
+            case e: Exception =>
+              events = ExceptionRaised(e) :: events
+          } finally {
+            if (socket != null) {
+              socket.close()
+            }
+          }
+      }
+    }
+
+    def result: String = {
+      s"${actions.mkString(",")} => ${events.reverse.mkString(",")}".trim
+    }
+  }
+}


### PR DESCRIPTION
Fixes the infamous #92 . 

The main fix here was to the server, but I spent a substantial amount of time investigating the "double login" bug that afflicted the client and often seemed to lead to this bug. The behavior to create this was to have a client login, kick that client, and have them login again. Their first login would fail, their second would succeed. This odd client behavior correlated strongly with the `NullPointerException` and was a reflection of the client being out-of-state.

A basic sketch of several of the issues contributing to this problem:

* Client were being added to the server's client map when they had a `clientId` of `null` (`EnterMessage` sent or received out-of-order).
* Client enter, activity, and exit messages were processed by the server regardless of whether the client had sent a handshake.
* Calls to `disconnect` would fail for clients which had not completed a client handshake, since they were routed through the connection manager, which looked up clients based on client id.
* Client disconnections for clients with `clientId = null` would generate a hubnet exit message with a `null` `hubnet-message-source`.
* If a client sent multiple handshakes, all of them were processed as enter messages. This lead to the following problems:
  * "ghost" clients appearing in the HubNet control center
  * The HubNet server retained `ServerSideConnection`s after they had been closed because it had them in the client map under two distinct `clientId`s
* The double login bug was fixed by making the `connected` variable (which is accessed at roughly the same time by both the UI thread and the `AbstractConnection` read thread) atomic so as to prevent repeated calls to `ClientApp.handleDisconnect` with `connected == true`. When called with `connected == true`, `ClientApp.handleDisconnect` performed *two* logins.

As is often the case when changing HubNet code, I feel there is a decent chance I have introduced two or three new bugs (although these will likely be rarer and less severe than #92). I am taking the time to write this up in hopes that when those bugs manifest, they can be fixed in such a way that the bug fixed here does not re-emerge.