### PR TITLE
Optimizations to improve Termites, GridWalk benchmarks (fix #1529)

### DIFF
--- a/bin/benches.scala
+++ b/bin/benches.scala
@@ -12,15 +12,21 @@ val home = System.getenv("HOME")
 
 val classpath =
   Seq("netlogo-gui/target/classes",
+      "parser-jvm/target/classes",
       "shared/target/classes",
       "netlogo-gui/resources",
-      home + "/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.1.jar",
-      home + "/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12/bundles/scala-parser-combinators_2.12-1.0.4.jar",
+      home + ".ivy2/cache/org.typelevel/cats-core_2.12/jars/cats-core_2.12-1.0.0-MF.jar",
+      home + "/.ivy2/local/org.nlogo/xml-lib_2.12/0.0.1/jars/xml-lib_2.12.jar",
+      home + "/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.2.jar",
+      home + "/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12/bundles/scala-parser-combinators_2.12-1.0.5.jar",
+      home + "/.ivy2/cache/org.scala-lang.modules/scala-xml_2.12/bundles/scala-xml_2.12-1.0.6.jar",
+      home + "/.ivy2/cache/org.typelevel/cats-core_2.12/jars/cats-core_2.12-1.0.0-MF.jar",
       home + "/.ivy2/cache/org.ow2.asm/asm-all/jars/asm-all-5.0.4.jar",
       home + "/.ivy2/cache/log4j/log4j/jars/log4j-1.2.16.jar",
       home + "/.ivy2/cache/commons-codec/commons-codec/jars/commons-codec-1.10.jar",
       home + "/.ivy2/cache/org.parboiled/parboiled_2.12/jars/parboiled_2.12-2.1.3.jar",
       home + "/.ivy2/cache/org.picocontainer/picocontainer/jars/picocontainer-2.13.6.jar")
+
     .mkString(":")
 Process("java -classpath " + classpath + " org.nlogo.headless.Main --fullversion")
   .lineStream.foreach(println)

--- a/netlogo-core/src/main/agent/Observer.scala
+++ b/netlogo-core/src/main/agent/Observer.scala
@@ -48,9 +48,9 @@ with api.Observer with OrientatableObserver with Constraints {
 
   def targetAgent: api.Agent =
     perspective match {
+      case Perspective.Observe          => null
       case a: AgentFollowingPerspective => a.targetAgent
       case Perspective.Watch(a)         => a
-      case _                            => null
     }
 
   def followDistance: Int =

--- a/netlogo-core/src/main/agent/TieManager.scala
+++ b/netlogo-core/src/main/agent/TieManager.scala
@@ -19,10 +19,11 @@ class TieManager(links: TreeAgentSet, linkManager: LinkManager, protractor: Prot
   }
 
   def setTieMode(link: Link, mode: String): Unit = {
-    if (link.isTied && mode == Link.MODE_NONE)
+    if (link.isTied && mode == Link.MODE_NONE) {
       tieCount -= 1
-    else if (mode != Link.MODE_NONE)
+    } else if (mode != Link.MODE_NONE) {
       tieCount += 1
+    }
   }
 
   protected def tiedTurtles(root: Turtle, seenTurtles: Set[Turtle]): Seq[Turtle] = {

--- a/netlogo-core/src/main/agent/Turtle.java
+++ b/netlogo-core/src/main/agent/Turtle.java
@@ -55,9 +55,9 @@ public strictfp abstract class Turtle
   public int LAST_PREDEFINED_VAR = VAR_PENMODE;
   public int NUMBER_PREDEFINED_VARS = LAST_PREDEFINED_VAR + 1;
 
-  public static final String PEN_UP = "up";
-  public static final String PEN_DOWN = "down";
-  public static final String PEN_ERASE = "erase";
+  public static final String PEN_UP = "up".intern();
+  public static final String PEN_DOWN = "down".intern();
+  public static final String PEN_ERASE = "erase".intern();
 
 
   void initvars(Double xcor, Double ycor, AgentSet breed) {
@@ -680,7 +680,7 @@ public strictfp abstract class Turtle
       throws AgentException {
     // if the pen is not even down we don't care
     // what the shortest path is so just return.
-    if (!penMode().equals(PEN_DOWN)) {
+    if (penMode() != PEN_DOWN) {
       return y;
     }
 
@@ -717,7 +717,7 @@ public strictfp abstract class Turtle
 
   public double shortestPathX(double x)
       throws AgentException {
-    if (!penMode().equals(PEN_DOWN)) {
+    if (penMode() != PEN_DOWN) {
       return x;
     }
 
@@ -881,9 +881,12 @@ public strictfp abstract class Turtle
     xandycorHelper(xcor, ycor, seenTurtles, isJump);
   }
 
+  private final scala.collection.immutable.Set<Turtle> setOfSelf =
+    Agent$.MODULE$.turtleSet(this);
+
   public void xandycorHelper(double xcor, double ycor, boolean isJump)
     throws AgentException {
-    xandycorHelper(xcor, ycor, Agent$.MODULE$.turtleSet(this), isJump);
+    xandycorHelper(xcor, ycor, setOfSelf, isJump);
   }
 
   public void xandycorHelper(double xcor, double ycor, scala.collection.immutable.Set<Turtle> seenTurtles, boolean isJump)
@@ -1095,7 +1098,7 @@ public strictfp abstract class Turtle
   }
 
   public void penMode(String penMode) {
-    _variables[VAR_PENMODE] = penMode;
+    _variables[VAR_PENMODE] = penMode.intern();
   }
 
   @Override

--- a/netlogo-core/src/main/agent/Turtle2D.java
+++ b/netlogo-core/src/main/agent/Turtle2D.java
@@ -66,7 +66,7 @@ public strictfp class Turtle2D
       }
     }
 
-    if (!penMode().equals(PEN_UP)) {
+    if (penMode() != PEN_UP) {
       try {
         Patch ignore = getPatchAtHeadingAndDistance(0, distance);
         drawLine(xcor, ycor, distance);
@@ -92,7 +92,7 @@ public strictfp class Turtle2D
   }
 
   void drawLine(double xcor, double ycor, double distance) {
-    if (!penMode().equals(PEN_UP)) {
+    if (penMode() != PEN_UP) {
       Object color = variables()[VAR_COLOR];
       double size = penSize();
       String mode = penMode();
@@ -108,7 +108,7 @@ public strictfp class Turtle2D
   }
 
   void drawLine(double x0, double y0, double x1, double y1) {
-    if (!penMode().equals(PEN_UP)) {
+    if (penMode() != PEN_UP) {
       Object color = variables()[VAR_COLOR];
       double size = penSize();
       String mode = penMode();


### PR DESCRIPTION
Haven't run all the benchmarks, but the results of running Termites and GridWalk show performance as good or better than 6.0.1/6.0.2.

Giving a brief explanation of the optimizations, in decreasing order of impact:

* `intern()` the pen mode strings. This was responsible for a huge performance gain on GridWalk, primarily by making [this check](https://github.com/NetLogo/NetLogo/compare/hexy...wip-fix-603-perf-regressions#diff-e44dd5e0b96bd9fd2b33db4c98d47d26R95) much faster.
* Creating a single set with a turtle at the time the turtle is initialized. This provides a decent speed boost by eliminating on-the-fly `Set` creation, which is actually somewhat expensive.
* Changing the check order of `targetAgent`. Much of the time, no agents are being observed, so it's faster to check that case before moving on to others. This resulted in minor savings.