### PR TITLE
Prevent plot & pen case sensitivity

### DIFF
--- a/netlogo-core/src/main/api/CompilerServices.scala
+++ b/netlogo-core/src/main/api/CompilerServices.scala
@@ -8,8 +8,6 @@ trait CompilerServices extends LiteralParser {
   def dialect: Dialect
   def isConstant(s: String): Boolean
   @throws(classOf[CompilerException])
-  def readFromString(s: String): AnyRef
-  @throws(classOf[CompilerException])
   def readNumberFromString(source: String): java.lang.Double
   @throws(classOf[CompilerException])
   def checkReporterSyntax(source: String)

--- a/netlogo-core/src/main/fileformat/ChainConverter.scala
+++ b/netlogo-core/src/main/fileformat/ChainConverter.scala
@@ -1,0 +1,15 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.fileformat
+
+import java.nio.file.Path
+
+import org.nlogo.core.Model
+
+class ChainConverter(converters: Seq[ModelConversion]) extends ModelConversion {
+  def apply(model: Model, modelPath: Path): ConversionResult = {
+    converters.foldLeft[ConversionResult](SuccessfulConversion(model, model)) {
+      case (result, converter) => result.mergeResult(converter(result.model, modelPath))
+    }
+  }
+}

--- a/netlogo-core/src/main/fileformat/PlotConverter.scala
+++ b/netlogo-core/src/main/fileformat/PlotConverter.scala
@@ -1,0 +1,129 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.fileformat
+
+import java.nio.file.Path
+
+import org.nlogo.core.{ CompilationEnvironment, Dialect, ExtensionManager,
+  LiteralParser, Model, Plot, Pen, SourceRewriter }
+import org.nlogo.api.AutoConvertable
+
+object PlotConverter {
+  def allPlotNames(model: Model): Seq[String] =
+    model.plots.flatMap(_.display).filterNot(_.isEmpty)
+
+  def allPenNames(model: Model): Seq[String] =
+    model.plots.flatMap(_.pens).collect {
+      case pen: Pen => pen
+    }.map(_.display)
+
+  private def determineRenames(names: Seq[String]): Seq[(String, String)] = {
+    names.groupBy(_.toUpperCase)
+      .toSeq
+      .map {
+        case (upper, originals) => upper -> originals.distinct
+      }
+      .flatMap {
+        case (upper, originals) if originals.length > 1 =>
+          // Put lower-case names before uppercase names
+          val sortedOriginals = originals.sorted.reverse
+          sortedOriginals.zipWithIndex.map {
+            case (original, index) if index == 0 => (original, original)
+            case (original, index) => (original, s"${original}_${index}")
+          }
+        case _ => Seq.empty[(String, String)]
+      }
+  }
+
+  private def clarifyProcedureBody(renamePairs: Seq[(String, String)]): String = {
+    val nameMap = renamePairs.map(p => s"""["${p._1}" "${p._2}"]""").mkString("[", " ", "]")
+    s"""|  let name-map ${nameMap}
+        |  let replacement filter [ rename -> first rename = name] name-map
+        |  let reported-name name
+        |  if not empty? replacement [
+        |    set reported-name item 1 replacement
+        |  ]
+        |  report reported-name""".stripMargin
+  }
+
+  private def buildConversionSet(
+    description: String,
+    reporterName: String,
+    renames: Seq[(String, String)],
+    conversionTarget: String
+  ): Seq[ConversionSet] = {
+    if (renames.nonEmpty) {
+      val codeTabTransformation: SourceRewriter => String =
+        _.addReporterProcedure(reporterName, Seq("name"), clarifyProcedureBody(renames))
+      val sharedTransformations = Seq[SourceRewriter => String](
+        _.replaceToken(conversionTarget, s"$conversionTarget $reporterName"))
+      Seq(ConversionSet(description,
+        codeTabTransformation +: sharedTransformations,
+        sharedTransformations,
+        Seq(conversionTarget)))
+    } else
+      Seq.empty[ConversionSet]
+  }
+
+  def plotCodeConversions(model: Model): Seq[ConversionSet] = {
+    val plotConversions =
+      buildConversionSet("Make plots case-insensitive",
+        "_clarify-duplicate-plot-name",
+        determineRenames(allPlotNames(model)),
+        "set-current-plot")
+
+    val penConversions =
+      buildConversionSet("Make pens case-insensitive",
+        "_clarify-duplicate-plot-pen-name",
+        determineRenames(allPenNames(model)),
+        "set-current-plot-pen")
+
+    plotConversions ++ penConversions
+  }
+
+}
+
+class PlotConverter(
+  extensionManager:      ExtensionManager,
+  compilationEnv:        CompilationEnvironment,
+  literalParser:         LiteralParser,
+  baseDialect:           Dialect,
+  components:            Seq[AutoConvertable]) extends
+  ModelConverter(
+    extensionManager,
+    compilationEnv,
+    literalParser,
+    baseDialect,
+    components,
+    PlotConverter.plotCodeConversions _) {
+      import PlotConverter._
+
+      override def apply(model: Model, modelPath: Path): ConversionResult = {
+        val plotRenames = determineRenames(allPlotNames(model))
+        val penRenames = determineRenames(allPenNames(model))
+        if (plotRenames.isEmpty && penRenames.isEmpty) {
+          super.apply(model, modelPath)
+        } else {
+          val conversion = super.apply(model, modelPath)
+          conversion.updateModel(convertPlotAndPenNames(conversion.model, plotRenames.toMap, penRenames.toMap))
+        }
+      }
+
+      private def convertPlotAndPenNames(
+        model:       Model,
+        plotRenames: Map[String, String],
+        penRenames:  Map[String, String]): Model = {
+          val updatedWidgets = model.widgets.map {
+            case p: Plot =>
+              val newDisplay = p.display.map(currentName => plotRenames.getOrElse(currentName, currentName))
+              val newPens = p.pens.map {
+                pen =>
+                  val newPenName = penRenames.getOrElse(pen.display, pen.display)
+                  pen.copy(display = newPenName)
+              }
+              p.copy(display = newDisplay, pens = newPens)
+            case w => w
+          }
+          model.copy(widgets = updatedWidgets)
+    }
+}

--- a/netlogo-core/src/main/fileformat/package.scala
+++ b/netlogo-core/src/main/fileformat/package.scala
@@ -28,11 +28,15 @@ package object fileformat {
     extensionManager:       ExtensionManager,
     compilationEnvironment: CompilationEnvironment,
     literalParser:          LiteralParser,
-    conversionSections:     Seq[AutoConvertable])(
-      dialect:                Dialect): ModelConversion = {
-        ModelConverter(extensionManager, compilationEnvironment,
-          literalParser, dialect, conversionSections)
-      }
+    conversionSections:     Seq[AutoConvertable])
+  (dialect:               Dialect): ModelConversion = {
+    new ChainConverter(
+      Seq(
+        ModelConverter(extensionManager, compilationEnvironment, literalParser, dialect, conversionSections),
+        new PlotConverter(extensionManager, compilationEnvironment, literalParser, dialect, conversionSections)
+      )
+    )
+  }
 
   // basicLoader only loads the core of the model, and does no autoconversion, but has no external dependencies
   def basicLoader: ConfigurableModelLoader =

--- a/netlogo-core/src/test/fileformat/ConversionHelper.scala
+++ b/netlogo-core/src/test/fileformat/ConversionHelper.scala
@@ -19,10 +19,11 @@ trait ConversionHelper {
   val literalParser =
     Femto.scalaSingleton[LiteralParser]("org.nlogo.parse.CompilerUtilities")
 
-  def converter(conversions: Model => Seq[ConversionSet] = (_ => Seq())) = {
-    def literalParser = Femto.scalaSingleton[LiteralParser]("org.nlogo.parse.CompilerUtilities")
+  def converter(conversions: Model => Seq[ConversionSet] = (_ => Seq())) =
     new ModelConverter(VidExtensionManager, FooCompilationEnvironment, literalParser, NetLogoLegacyDialect, defaultAutoConvertables, conversions)
-  }
+
+  def plotConverter =
+    new PlotConverter(VidExtensionManager, FooCompilationEnvironment, literalParser, NetLogoLegacyDialect, defaultAutoConvertables)
 
   def tryConvert(model: Model, conversions: ConversionSet*): ConversionResult =
     converter(_ => conversions)(model, modelPath)

--- a/netlogo-core/src/test/fileformat/ModelConverterTests.scala
+++ b/netlogo-core/src/test/fileformat/ModelConverterTests.scala
@@ -11,256 +11,308 @@ import org.scalatest.FunSuite
 
 class ModelConverterTests extends FunSuite with ConversionHelper {
   if (canTestConversions) {
-  test("if the model is empty, returns the model") {
-    val model = Model()
-    assertResult(model)(convert(model))
-  }
-
-  test("if a code tab contains the affected prims, runs the code tab rewrites on the code tab") {
-    val model = Model(code = "to bar fd 1 end")
-    val convertedModel = convert(model, conversion(codeTabConversions = Seq(_.addGlobal("foo")), targets = Seq("fd")))
-    assertResult("globals [foo]\nto bar fd 1 end")(convertedModel.code)
-  }
-
-  test("if the model doesn't contain any targets, returns the model") {
-    val model = Model(code = "to foo fd 1 bk 1 end")
-    assertResult(model)(convert(model, conversion(codeTabConversions = Seq(_.addGlobal("foo")), targets = Seq("left", "right"))))
-  }
-
-  test("if the model code doesn't compile when passed in, returns a failure") {
-    val model = Model(code = "to foo fd 1")
-    tryConvert(model, conversion(name = "add global foo", codeTabConversions = Seq(_.addGlobal("foo")), targets = Seq("fd"))) match {
-      case ErroredConversion(m, e) =>
-        assertResult(model)(m)
-        assert(e.conversionDescription === "add global foo")
-        assert(e.componentDescription === "code tab")
-        assert(e.errors.head.isInstanceOf[CompilerException])
-      case other => fail(s"Expected failure, got $other")
+    test("if the model is empty, returns the model") {
+      val model = Model()
+      assertResult(model)(convert(model))
     }
-  }
 
-  test("if a model component doesn't compile, returns a component failure") {
-    val model = Model(widgets = Seq(View(), Button(Some("fd 1 foobar"), 0, 0, 0, 0)))
-    tryConvert(model, conversion(name = "fd to back", otherCodeConversions = Seq(_.replaceCommand("fd" -> "bk {0}")), targets = Seq("fd"))) match {
-      case ConversionWithErrors(_, m, e) =>
-        assert(e.head.componentDescription === "NetLogo interface")
-        assert(e.head.conversionDescription === "fd to back")
-        assert(e.head.errors.head.isInstanceOf[CompilerException])
-      case other => fail(s"Expected failure, got $other")
+    test("if a code tab contains the affected prims, runs the code tab rewrites on the code tab") {
+      val model = Model(code = "to bar fd 1 end")
+      val convertedModel = convert(model, conversion(codeTabConversions = Seq(_.addGlobal("foo")), targets = Seq("fd")))
+      assertResult("globals [foo]\nto bar fd 1 end")(convertedModel.code)
     }
-  }
 
-  test("applies multiple conversions when supplied") {
-    val model = Model(code = "to foo fd 1 bk 1 end")
-    assert(convert(model,
-      conversion(codeTabConversions = Seq(_.replaceCommand("fd" -> "rt 90")), targets = Seq("fd")),
-      conversion(codeTabConversions = Seq(_.replaceCommand("bk" -> "lt 90")), targets = Seq("bk"))).code ==
-        "to foo rt 90 lt 90 end")
-  }
+    test("if the model doesn't contain any targets, returns the model") {
+      val model = Model(code = "to foo fd 1 bk 1 end")
+      assertResult(model)(convert(model, conversion(codeTabConversions = Seq(_.addGlobal("foo")), targets = Seq("left", "right"))))
+    }
 
-  test("if a button contains the affected prims, runs the code tab rewrites on the code tab") {
-    val model = Model(widgets = Seq(View(), Button(Some("fd 1"), 0, 0, 0, 0)))
-    assertResult("globals [foo]")(convert(model, conversion(codeTabConversions = Seq(_.addGlobal("foo")), targets = Seq("fd"))).code)
-  }
-
-  test("if a slider contains the affected prims, runs the code tab rewrites on the code tab") {
-    val model = Model(widgets = Seq(View(), Slider(variable = Some("bar"), max = "e 10")))
-    assertResult("globals [foo]")(convert(model, conversion(codeTabConversions = Seq(_.addGlobal("foo")), targets = Seq("e"))).code)
-  }
-
-  test("if a monitor contains the affected prims, runs the code tab rewrites on the code tab") {
-    val model = Model(widgets = Seq(View(), Monitor(source = Some("e 10"), 0, 0, 0, 0, None, 1)))
-    assertResult("globals [foo]")(convert(model, conversion(codeTabConversions = Seq(_.addGlobal("foo")),targets =  Seq("e"))).code)
-  }
-
-  test("if a plot contains the affected prims, runs the code tab rewrites on the code tab") {
-    val model = Model(widgets = Seq(View(), Plot(display = None, setupCode = "plot e 10")))
-    assertResult("globals [foo]")(convert(model, conversion(codeTabConversions = Seq(_.addGlobal("foo")),targets =  Seq("e"))).code)
-  }
-
-  test("if a plot pen contains the affected prims, runs the code tab rewrites on the code tab") {
-    val model = Model(widgets = Seq(View(), Plot(display = None, pens = List(Pen(display = "", setupCode = "plot e 10")))))
-    assertResult("globals [foo]")(convert(model, conversion(codeTabConversions = Seq(_.addGlobal("foo")), targets = Seq("e"))).code)
-  }
-
-  test("if a widget contains the affected prims, runs the source rewrites on the widget") {
-    val model = Model(widgets = Seq(View(), Button(Some("fd 1"), 0, 0, 0, 0)))
-    assertResult("bk 1")(convert(model, conversion(otherCodeConversions = Seq((_.replaceCommand("fd" -> "bk 1"))), targets = Seq("fd"))).widgets(1).asInstanceOf[Button].source.get)
-  }
-
-  test("if the model has a widgets which don't compile, converts all compiling widgets") {
-    val model = Model(widgets = Seq(View(), Button(Some("fd 1"), 0, 0, 0, 0), Button(Some("qux"), 0, 0, 0, 0)))
-    assertResult("bk 1")(convert(model, conversion(otherCodeConversions = Seq((_.replaceCommand("fd" -> "bk 1"))), targets = Seq("fd"))).widgets(1).asInstanceOf[Button].source.get)
-  }
-
-  test("converts widgets which reference code tab code") {
-    val model = Model(code = "to qux rt 30 end", widgets = Seq(View(), Button(Some("fd 1"), 0, 0, 0, 0), Button(Some("qux fd 2"), 0, 0, 0, 0)))
-    assertResult("bk 1")(convert(model, conversion(otherCodeConversions = Seq(_.replaceCommand("fd" -> "bk 1")), targets = Seq("fd"))).widgets(1).asInstanceOf[Button].source.get)
-    assertResult("qux bk 1")(convert(model, conversion(otherCodeConversions = Seq((_.replaceCommand("fd" -> "bk 1"))), targets = Seq("fd"))).widgets(2).asInstanceOf[Button].source.get)
-  }
-
-  test("converts code tab when referencing interface values") {
-    val model = Model(code = "to foo if on? [ fd 1 ] end", widgets = Seq(View(), Switch(Some("on?"))))
-    assertResult("to foo if on? [ bk 1 ] end")(convert(model, conversion(codeTabConversions = Seq(_.replaceCommand("fd" -> "bk 1")), targets = Seq("fd"))).code)
-  }
-
-  test("if the model has a widgets which don't compile, continues to convert the code tab") {
-    val model = Model(code = "to baz fd 1 end", widgets = Seq(View(), Button(Some("bar"), 0, 0, 0, 0)))
-    assertResult("globals [foo]\nto baz fd 1 end")(convert(model, conversion(codeTabConversions = Seq(_.addGlobal("foo")), targets = Seq("fd"))).code)
-  }
-
-  test("handles the conversion of movie prims") {
-    val originalSource =
-      """|to start
-    |  movie-start user-new-file
-    |end
-    |to go
-    |  if movie-status != "" [
-    |    movie-grab-view
-    |  ]
-    |end
-    |to finish
-    |  movie-close
-    |end
-    |to abort
-    |  movie-cancel
-    |end""".stripMargin
-    val convertedSource =
-      """|extensions [vid]
-    |globals [_recording-save-file-name]
-    |to start
-    |  set _recording-save-file-name user-new-file
-    |  vid:start-recorder
-    |end
-    |to go
-    |  if vid:recorder-status != "" [
-    |    vid:record-view
-    |  ]
-    |end
-    |to finish
-    |  vid:save-recording _recording-save-file-name
-    |end
-    |to abort
-    |  vid:reset-recorder
-    |end""".stripMargin
-    val model = Model(code = originalSource)
-    val changes = Seq[SourceRewriter => String](
-      _.addGlobal("_recording-save-file-name"),
-      _.addExtension("vid"),
-      _.replaceCommand("movie-grab-view" -> "vid:record-view"),
-      _.replaceCommand("movie-grab-interface" -> "vid:record-interface"),
-      _.replaceCommand("movie-cancel" -> "vid:reset-recorder"),
-      _.replaceCommand("movie-close" -> "vid:save-recording _recording-save-file-name"),
-      _.addCommand("movie-start" -> "set _recording-save-file-name {0}"),
-      _.replaceCommand("movie-start" -> "vid:start-recorder"),
-      _.replaceReporter("movie-status" -> "vid:recorder-status"))
-    val targets = Seq("movie-start", "movie-cancel", "movie-close", "movie-grab-view", "movie-grab-interface", "movie-status")
-    val converted = convert(model, conversion(codeTabConversions = changes, targets = targets))
-    assertResult(convertedSource)(converted.code)
-  }
-
-  test("doesn't try to convert movie prims if they're all commented out") {
-    val originalSource =
-      """|to maybe-error
-    |  ; movie-cancel; movie stuff
-    |  ; movie-start "kinomodel2.mov"
-    |  ; movie-set-frame-rate 10
-    |  ; repeat 365 * 3
-    |  ; [  go
-    |  ;   movie-grab-view
-    |  ; ]
-    |end""".stripMargin
-    val conversionSet = AutoConversionList.conversions
-      .filter(t => t._1 == "NetLogo 6.0-RC1" || t._1 == "NetLogo 6.0-M9")
-      .map(_._2)
-      assertResult(originalSource)(convert(Model(code = originalSource), conversionSet: _*).code)
-  }
-
-  test("converts movie prims in the presence of tasks") {
-    val originalSource =
-      """|to start
-    |  movie-start user-new-file
-    |end
-    |to test-task
-    |  (run (task [show ?1]) 3)
-    |end""".stripMargin
-    val convertedSource =
-      """|extensions [vid]
-    |globals [_recording-save-file-name]
-    |to start
-    |  set _recording-save-file-name user-new-file
-    |  vid:start-recorder
-    |end
-    |to test-task
-    |  (run ([ ?1 -> show ?1 ]) 3)
-    |end""".stripMargin
-    val conversionSet = AutoConversionList.conversions
-      .filter(t => t._1 == "NetLogo 6.0-RC1" || t._1 == "NetLogo 6.0-M9")
-      .map(_._2)
-      assertResult(convertedSource)(convert(Model(code = originalSource), conversionSet: _*).code)
-  }
-  test("lambda-izes") {
-    val conversionSet= AutoConversionList.conversions.filter(_._1 == "NetLogo 6.0-RC1").map(_._2).head
-    val model = Model(code = """|to foo run task [ clear-all ] foreach [] [ tick ] end to bar __ignore sort-by [?1 > ?2] [1 2 3] end
-      |to baz show is-reporter-task? 1 show is-command-task? task tick end""".stripMargin)
-    val converted = convert(model, conversionSet)
-    val expectedResult = """|to foo run [ [] ->  clear-all ] foreach [] [ tick ] end to bar __ignore sort-by [ [?1 ?2] -> ?1 > ?2 ] [1 2 3] end
-    |to baz show is-anonymous-reporter? 1 show is-anonymous-command? [ [] -> tick ] end""".stripMargin
-    assertResult(expectedResult)(converted.code)
-  }
-
-  test("handles models with trailing comments properly") {
-    val originalSource =
-      """|to abort
-    |  movie-cancel
-    |end
-    |; comment at end""".stripMargin
-    val expectedSource =
-      """|to abort
-    |  vid:reset-recorder
-    |end
-    |; comment at end""".stripMargin
-
-    val model = Model(code = originalSource)
-    val changes = Seq[SourceRewriter => String](_.replaceCommand("movie-cancel" -> "vid:reset-recorder"))
-    val targets = Seq("movie-cancel")
-    val converted = convert(model, conversion(codeTabConversions = changes, targets = targets))
-    assertResult(expectedSource)(converted.code)
-  }
-
-  test("handles models with includes properly") {
-    writeNls("foo.nls", "to bar bk 1 end")
-    val originalSource =
-      """|__includes [ "foo.nls" ]
-    |to foo
-    |  bar
-    |  fd 1
-    |end""".stripMargin
-    val expectedSource =
-      """|__includes [ "foo.nls" ]
-    |to foo
-    |  bar
-    |  rt 90
-    |end""".stripMargin
-    val model = Model(code = originalSource)
-    val converted = convert(model, conversion(codeTabConversions = Seq(_.replaceCommand("fd" -> "rt 90")), targets = Seq("fd")))
-    assertResult(expectedSource)(converted.code)
-  }
-
-  test("won't convert a model with an un-locatable included file") {
-    val originalSource =
-      """|__includes [ "bar.nls" ]
-    |to foo
-    |  bar
-    |  fd 1
-    |end""".stripMargin
-    val model = Model(code = originalSource)
-    val conversions = Seq[SourceRewriter => String](_.replaceCommand("fd" -> "rt 90"))
-    tryConvert(model,
-      conversion(codeTabConversions = conversions, targets = Seq("fd"))) match {
-        case ErroredConversion(_, error) => assert(error.errors.exists(_.getMessage.contains("bar.nls")))
-        case _ => fail("converted model with unidentified includes")
+    test("if the model code doesn't compile when passed in, returns a failure") {
+      val model = Model(code = "to foo fd 1")
+      tryConvert(model, conversion(name = "add global foo", codeTabConversions = Seq(_.addGlobal("foo")), targets = Seq("fd"))) match {
+        case ErroredConversion(m, e) =>
+          assertResult(model)(m)
+          assert(e.conversionDescription === "add global foo")
+          assert(e.componentDescription === "code tab")
+          assert(e.errors.head.isInstanceOf[CompilerException])
+        case other => fail(s"Expected failure, got $other")
       }
-  }
+    }
+
+    test("if a model component doesn't compile, returns a component failure") {
+      val model = Model(widgets = Seq(View(), Button(Some("fd 1 foobar"), 0, 0, 0, 0)))
+      tryConvert(model, conversion(name = "fd to back", otherCodeConversions = Seq(_.replaceCommand("fd" -> "bk {0}")), targets = Seq("fd"))) match {
+        case ConversionWithErrors(_, m, e) =>
+          assert(e.head.componentDescription === "NetLogo interface")
+          assert(e.head.conversionDescription === "fd to back")
+          assert(e.head.errors.head.isInstanceOf[CompilerException])
+        case other => fail(s"Expected failure, got $other")
+      }
+    }
+
+    test("applies multiple conversions when supplied") {
+      val model = Model(code = "to foo fd 1 bk 1 end")
+      assert(convert(model,
+        conversion(codeTabConversions = Seq(_.replaceCommand("fd" -> "rt 90")), targets = Seq("fd")),
+        conversion(codeTabConversions = Seq(_.replaceCommand("bk" -> "lt 90")), targets = Seq("bk"))).code ==
+          "to foo rt 90 lt 90 end")
+    }
+
+    test("if a button contains the affected prims, runs the code tab rewrites on the code tab") {
+      val model = Model(widgets = Seq(View(), Button(Some("fd 1"), 0, 0, 0, 0)))
+      assertResult("globals [foo]")(convert(model, conversion(codeTabConversions = Seq(_.addGlobal("foo")), targets = Seq("fd"))).code)
+    }
+
+    test("if a slider contains the affected prims, runs the code tab rewrites on the code tab") {
+      val model = Model(widgets = Seq(View(), Slider(variable = Some("bar"), max = "e 10")))
+      assertResult("globals [foo]")(convert(model, conversion(codeTabConversions = Seq(_.addGlobal("foo")), targets = Seq("e"))).code)
+    }
+
+    test("if a monitor contains the affected prims, runs the code tab rewrites on the code tab") {
+      val model = Model(widgets = Seq(View(), Monitor(source = Some("e 10"), 0, 0, 0, 0, None, 1)))
+      assertResult("globals [foo]")(convert(model, conversion(codeTabConversions = Seq(_.addGlobal("foo")),targets =  Seq("e"))).code)
+    }
+
+    test("if a plot contains the affected prims, runs the code tab rewrites on the code tab") {
+      val model = Model(widgets = Seq(View(), Plot(display = None, setupCode = "plot e 10")))
+      assertResult("globals [foo]")(convert(model, conversion(codeTabConversions = Seq(_.addGlobal("foo")),targets =  Seq("e"))).code)
+    }
+
+    test("if a plot pen contains the affected prims, runs the code tab rewrites on the code tab") {
+      val model = Model(widgets = Seq(View(), Plot(display = None, pens = List(Pen(display = "", setupCode = "plot e 10")))))
+      assertResult("globals [foo]")(convert(model, conversion(codeTabConversions = Seq(_.addGlobal("foo")), targets = Seq("e"))).code)
+    }
+
+    test("if a widget contains the affected prims, runs the source rewrites on the widget") {
+      val model = Model(widgets = Seq(View(), Button(Some("fd 1"), 0, 0, 0, 0)))
+      assertResult("bk 1")(convert(model, conversion(otherCodeConversions = Seq((_.replaceCommand("fd" -> "bk 1"))), targets = Seq("fd"))).widgets(1).asInstanceOf[Button].source.get)
+    }
+
+    test("if the model has a widgets which don't compile, converts all compiling widgets") {
+      val model = Model(widgets = Seq(View(), Button(Some("fd 1"), 0, 0, 0, 0), Button(Some("qux"), 0, 0, 0, 0)))
+      assertResult("bk 1")(convert(model, conversion(otherCodeConversions = Seq((_.replaceCommand("fd" -> "bk 1"))), targets = Seq("fd"))).widgets(1).asInstanceOf[Button].source.get)
+    }
+
+    test("converts widgets which reference code tab code") {
+      val model = Model(code = "to qux rt 30 end", widgets = Seq(View(), Button(Some("fd 1"), 0, 0, 0, 0), Button(Some("qux fd 2"), 0, 0, 0, 0)))
+      assertResult("bk 1")(convert(model, conversion(otherCodeConversions = Seq(_.replaceCommand("fd" -> "bk 1")), targets = Seq("fd"))).widgets(1).asInstanceOf[Button].source.get)
+      assertResult("qux bk 1")(convert(model, conversion(otherCodeConversions = Seq((_.replaceCommand("fd" -> "bk 1"))), targets = Seq("fd"))).widgets(2).asInstanceOf[Button].source.get)
+    }
+
+    test("converts code tab when referencing interface values") {
+      val model = Model(code = "to foo if on? [ fd 1 ] end", widgets = Seq(View(), Switch(Some("on?"))))
+      assertResult("to foo if on? [ bk 1 ] end")(convert(model, conversion(codeTabConversions = Seq(_.replaceCommand("fd" -> "bk 1")), targets = Seq("fd"))).code)
+    }
+
+    test("if the model has a widgets which don't compile, continues to convert the code tab") {
+      val model = Model(code = "to baz fd 1 end", widgets = Seq(View(), Button(Some("bar"), 0, 0, 0, 0)))
+      assertResult("globals [foo]\nto baz fd 1 end")(convert(model, conversion(codeTabConversions = Seq(_.addGlobal("foo")), targets = Seq("fd"))).code)
+    }
+
+    test("handles the conversion of movie prims") {
+      val originalSource =
+        """|to start
+      |  movie-start user-new-file
+      |end
+      |to go
+      |  if movie-status != "" [
+      |    movie-grab-view
+      |  ]
+      |end
+      |to finish
+      |  movie-close
+      |end
+      |to abort
+      |  movie-cancel
+      |end""".stripMargin
+      val convertedSource =
+        """|extensions [vid]
+      |globals [_recording-save-file-name]
+      |to start
+      |  set _recording-save-file-name user-new-file
+      |  vid:start-recorder
+      |end
+      |to go
+      |  if vid:recorder-status != "" [
+      |    vid:record-view
+      |  ]
+      |end
+      |to finish
+      |  vid:save-recording _recording-save-file-name
+      |end
+      |to abort
+      |  vid:reset-recorder
+      |end""".stripMargin
+      val model = Model(code = originalSource)
+      val changes = Seq[SourceRewriter => String](
+        _.addGlobal("_recording-save-file-name"),
+        _.addExtension("vid"),
+        _.replaceCommand("movie-grab-view" -> "vid:record-view"),
+        _.replaceCommand("movie-grab-interface" -> "vid:record-interface"),
+        _.replaceCommand("movie-cancel" -> "vid:reset-recorder"),
+        _.replaceCommand("movie-close" -> "vid:save-recording _recording-save-file-name"),
+        _.addCommand("movie-start" -> "set _recording-save-file-name {0}"),
+        _.replaceCommand("movie-start" -> "vid:start-recorder"),
+        _.replaceReporter("movie-status" -> "vid:recorder-status"))
+      val targets = Seq("movie-start", "movie-cancel", "movie-close", "movie-grab-view", "movie-grab-interface", "movie-status")
+      val converted = convert(model, conversion(codeTabConversions = changes, targets = targets))
+      assertResult(convertedSource)(converted.code)
+    }
+
+    test("doesn't try to convert movie prims if they're all commented out") {
+      val originalSource =
+        """|to maybe-error
+      |  ; movie-cancel; movie stuff
+      |  ; movie-start "kinomodel2.mov"
+      |  ; movie-set-frame-rate 10
+      |  ; repeat 365 * 3
+      |  ; [  go
+      |  ;   movie-grab-view
+      |  ; ]
+      |end""".stripMargin
+      val conversionSet = AutoConversionList.conversions
+        .filter(t => t._1 == "NetLogo 6.0-RC1" || t._1 == "NetLogo 6.0-M9")
+        .map(_._2)
+        assertResult(originalSource)(convert(Model(code = originalSource), conversionSet: _*).code)
+    }
+
+    test("converts movie prims in the presence of tasks") {
+      val originalSource =
+        """|to start
+      |  movie-start user-new-file
+      |end
+      |to test-task
+      |  (run (task [show ?1]) 3)
+      |end""".stripMargin
+      val convertedSource =
+        """|extensions [vid]
+      |globals [_recording-save-file-name]
+      |to start
+      |  set _recording-save-file-name user-new-file
+      |  vid:start-recorder
+      |end
+      |to test-task
+      |  (run ([ ?1 -> show ?1 ]) 3)
+      |end""".stripMargin
+      val conversionSet = AutoConversionList.conversions
+        .filter(t => t._1 == "NetLogo 6.0-RC1" || t._1 == "NetLogo 6.0-M9")
+        .map(_._2)
+        assertResult(convertedSource)(convert(Model(code = originalSource), conversionSet: _*).code)
+    }
+    test("lambda-izes") {
+      val conversionSet= AutoConversionList.conversions.filter(_._1 == "NetLogo 6.0-RC1").map(_._2).head
+      val model = Model(code = """|to foo run task [ clear-all ] foreach [] [ tick ] end to bar __ignore sort-by [?1 > ?2] [1 2 3] end
+        |to baz show is-reporter-task? 1 show is-command-task? task tick end""".stripMargin)
+      val converted = convert(model, conversionSet)
+      val expectedResult = """|to foo run [ [] ->  clear-all ] foreach [] [ tick ] end to bar __ignore sort-by [ [?1 ?2] -> ?1 > ?2 ] [1 2 3] end
+      |to baz show is-anonymous-reporter? 1 show is-anonymous-command? [ [] -> tick ] end""".stripMargin
+      assertResult(expectedResult)(converted.code)
+    }
+
+    test("handles models with trailing comments properly") {
+      val originalSource =
+        """|to abort
+      |  movie-cancel
+      |end
+      |; comment at end""".stripMargin
+      val expectedSource =
+        """|to abort
+      |  vid:reset-recorder
+      |end
+      |; comment at end""".stripMargin
+
+      val model = Model(code = originalSource)
+      val changes = Seq[SourceRewriter => String](_.replaceCommand("movie-cancel" -> "vid:reset-recorder"))
+      val targets = Seq("movie-cancel")
+      val converted = convert(model, conversion(codeTabConversions = changes, targets = targets))
+      assertResult(expectedSource)(converted.code)
+    }
+
+    test("handles models with includes properly") {
+      writeNls("foo.nls", "to bar bk 1 end")
+      val originalSource =
+        """|__includes [ "foo.nls" ]
+      |to foo
+      |  bar
+      |  fd 1
+      |end""".stripMargin
+      val expectedSource =
+        """|__includes [ "foo.nls" ]
+      |to foo
+      |  bar
+      |  rt 90
+      |end""".stripMargin
+      val model = Model(code = originalSource)
+      val converted = convert(model, conversion(codeTabConversions = Seq(_.replaceCommand("fd" -> "rt 90")), targets = Seq("fd")))
+      assertResult(expectedSource)(converted.code)
+    }
+
+    test("won't convert a model with an un-locatable included file") {
+      val originalSource =
+        """|__includes [ "bar.nls" ]
+      |to foo
+      |  bar
+      |  fd 1
+      |end""".stripMargin
+      val model = Model(code = originalSource)
+      val conversions = Seq[SourceRewriter => String](_.replaceCommand("fd" -> "rt 90"))
+      tryConvert(model,
+        conversion(codeTabConversions = conversions, targets = Seq("fd"))) match {
+          case ErroredConversion(_, error) => assert(error.errors.exists(_.getMessage.contains("bar.nls")))
+          case _ => fail("converted model with unidentified includes")
+        }
+    }
+
+    test("conditionally converts plot and plot pen names") {
+      val originalSource =
+        """|to foo
+           |  set-current-plot "dup"
+           |  set-current-plot-pen "duppen"
+           |end""".stripMargin
+      val originalPlotOne = Plot(Some("dup"),
+        updateCode = "set-current-plot-pen \"DUPPEN\"",
+        pens = List(Pen("duppen"), Pen("DUPPEN")))
+      val originalPlotTwo = Plot(Some("DUP"))
+      val originalModel = Model(code = originalSource, widgets = List(View(), originalPlotOne, originalPlotTwo))
+      val clarifyBody =
+           """|  let name-map [["dup" "dup"] ["DUP" "DUP_1"]]
+              |  let replacement filter [ rename -> first rename = name] name-map
+              |  let reported-name name
+              |  if not empty? replacement [
+              |    set reported-name item 1 replacement
+              |  ]
+              |  report reported-name""".stripMargin
+      val clarifyPenBody =
+        """|  let name-map [["duppen" "duppen"] ["DUPPEN" "DUPPEN_1"]]
+           |  let replacement filter [ rename -> first rename = name] name-map
+           |  let reported-name name
+           |  if not empty? replacement [
+           |    set reported-name item 1 replacement
+           |  ]
+           |  report reported-name""".stripMargin
+
+      val expectedSource =
+       s"""|to foo
+           |  set-current-plot _clarify-duplicate-plot-name "dup"
+           |  set-current-plot-pen _clarify-duplicate-plot-pen-name "duppen"
+           |end
+           |
+           |to-report _clarify-duplicate-plot-name [ name ]
+           |${clarifyBody}
+           |end
+           |
+           |to-report _clarify-duplicate-plot-pen-name [ name ]
+           |${clarifyPenBody}
+           |end""".stripMargin
+      val expectedPlotOne = Plot(Some("dup"),
+        updateCode = "set-current-plot-pen _clarify-duplicate-plot-pen-name \"DUPPEN\"",
+        pens = List(Pen("duppen"), Pen("DUPPEN_1")))
+      val expectedPlotTwo = Plot(Some("DUP_1"))
+      val expectedModel = Model(code = expectedSource, widgets = List(View(), expectedPlotOne, expectedPlotTwo))
+      // Using ModelConverter only gets us halfway there, since we will also need to change the widgets
+      val result = plotConverter(originalModel, modelPath).model
+      assertResult(expectedModel.code)(result.code)
+      assertResult(expectedModel.widgets.collect { case p: Plot => p })(result.widgets.collect { case p: Plot => p })
+    }
   }
 }

--- a/netlogo-gui/project/autogen/i18n/GUI_Strings_en.txt
+++ b/netlogo-gui/project/autogen/i18n/GUI_Strings_en.txt
@@ -282,6 +282,10 @@ dialog.interface.saving.task = Saving…
 
 # widget editors
 
+edit.general.invalidSettings = Invalid Settings
+edit.general.invalidValue = Invalid value for {0}
+edit.general.invalidValues = The following values are invalid: {0}
+
 edit.button.agents = Agent(s)
 edit.button.forever = Forever
 edit.button.disable = Disable until ticks start
@@ -300,6 +304,7 @@ edit.plot.autoScale = Auto scale?
 edit.plot.showLegend = Show legend?
 edit.plot.setupCode = Plot setup commands
 edit.plot.updateCode = Plot update commands
+edit.plot.name.duplicate = There is already a plot with the name {0}
 edit.plot.pen.plotPens = Plot pens
 edit.plot.pen.color = Color
 edit.plot.pen.name = Pen name
@@ -314,6 +319,7 @@ edit.plot.pen.interval = Interval
 edit.plot.pen.showInLegend = Show in legend
 edit.plot.pen.setupCommands = Pen setup commands
 edit.plot.pen.updateCommands = Pen update commands
+edit.plot.pen.duplicateNames = Pens list contains duplicate names: {0}.
 edit.plot.error.runtimeError = Runtime Error:
 edit.plot.copyimage = Copy Image
 edit.plot.clearplot = Clear

--- a/netlogo-gui/src/main/api/Editable.scala
+++ b/netlogo-gui/src/main/api/Editable.scala
@@ -12,6 +12,8 @@ trait Editable {
   def error(key: Object, e: Exception): Unit
   // could be null
   def error(key: Object): Exception
+  def invalidSettings: Seq[(String, String)] =
+    Seq.empty[(String, String)]
 
   // it's kind of lame to put this here but it'll require a bunch of changes all over the properties
   // package otherwise it seems not worth the effort ev 6/10/08

--- a/netlogo-gui/src/main/app/Adapters.scala
+++ b/netlogo-gui/src/main/app/Adapters.scala
@@ -47,7 +47,8 @@ object Adapters {
       val allAutoConvertables =
         fileformat.defaultAutoConvertables ++ container.getComponents(classOf[AutoConvertable]).asScala
 
-      fileformat.converter(workspace.getExtensionManager, workspace.getCompilationEnvironment, workspace, allAutoConvertables)(container.getComponent(classOf[Dialect]))
+      fileformat.converter(workspace.getExtensionManager, workspace.getCompilationEnvironment, workspace, allAutoConvertables)(
+        container.getComponent(classOf[Dialect]))
     }
   }
 }

--- a/netlogo-gui/src/main/app/interfacetab/WidgetPanel.scala
+++ b/netlogo-gui/src/main/app/interfacetab/WidgetPanel.scala
@@ -573,6 +573,9 @@ class WidgetPanel(val workspace: GUIWorkspace)
       case w: WidgetWrapper => w.widget.model
     }.distinct.toSeq
 
+  override def allWidgets: Seq[CoreWidget] =
+    getWidgetsForSaving
+
   override def removeAllWidgets(): Unit = {
     val comps = getComponents
     setVisible(false)

--- a/netlogo-gui/src/main/properties/EditPanel.scala
+++ b/netlogo-gui/src/main/properties/EditPanel.scala
@@ -131,7 +131,7 @@ class EditPanel(val target: Editable, val compiler: CompilerServices, colorizer:
       // the error to pop up twice. - JC 4/9/10
       val value = editor.get
       if(!value.isDefined && !editor.handlesOwnErrors)
-        org.nlogo.swing.OptionDialog.showMessage(frame,
+        org.nlogo.swing.OptionDialog.showMessage(this,
           "Invalid Entry", "Invalid value for " + editor.accessor.displayName,
           Array(I18N.gui.get("common.buttons.ok")))
       value.isDefined

--- a/netlogo-gui/src/main/properties/EditPanel.scala
+++ b/netlogo-gui/src/main/properties/EditPanel.scala
@@ -2,15 +2,20 @@
 
 package org.nlogo.properties
 
-import org.nlogo.core.{ CompilerException, I18N, LogoList, Nobody }
-import org.nlogo.editor.Colorizer
-import org.nlogo.window.WidgetWrapperInterface
-import javax.swing.{JPanel, JLabel}
 import java.awt.{Component, Insets, GridBagConstraints, Dimension, GridBagLayout, BorderLayout}
-import org.nlogo.api.{ CompilerServices, Editable, Property}
-import scala.reflect.ClassTag
-// This is the contents of an EditDialog, except for the buttons at the bottom (OK/Apply/Cancel).
 
+import javax.swing.{JPanel, JLabel}
+
+import org.nlogo.core.{ CompilerException, I18N, LogoList, Nobody }
+import org.nlogo.api.{ CompilerServices, Editable, Property}
+import org.nlogo.editor.Colorizer
+import org.nlogo.swing.OptionDialog
+import org.nlogo.window.WidgetWrapperInterface
+
+import scala.reflect.ClassTag
+import scala.collection.JavaConverters._
+
+// This is the contents of an EditDialog, except for the buttons at the bottom (OK/Apply/Cancel).
 class EditPanel(val target: Editable, val compiler: CompilerServices, colorizer: Colorizer)
   extends JPanel {
 
@@ -122,6 +127,7 @@ class EditPanel(val target: Editable, val compiler: CompilerServices, colorizer:
       wrapper.widgetChanged()
     }
   }
+
   def valid() = {
     def valid(editor: PropertyEditor[_]) = {
       // plot editor handles its errors when you press the ok button.
@@ -131,24 +137,61 @@ class EditPanel(val target: Editable, val compiler: CompilerServices, colorizer:
       // the error to pop up twice. - JC 4/9/10
       val value = editor.get
       if(!value.isDefined && !editor.handlesOwnErrors)
-        org.nlogo.swing.OptionDialog.showMessage(this,
-          "Invalid Entry", "Invalid value for " + editor.accessor.displayName,
+        OptionDialog.showMessage(this,
+          I18N.gui.get("edit.general.invalidSettings"),
+          I18N.gui.getN("edit.general.invalidValue", editor.accessor.displayName),
           Array(I18N.gui.get("common.buttons.ok")))
       value.isDefined
     }
-    propertyEditors.forall(valid)
+    propertyEditors.forall(valid) && targetValid()
   }
+
   def apply() {
-    propertyEditors.foreach(_.apply)
+    applyProperties()
     changed()
   }
+
   def revert() {
+    revertProperties()
+    for(wrapper <- wrapperOption)
+      wrapper.setSize(originalSize)
+  }
+
+  private def applyProperties(): Unit = {
+    propertyEditors.foreach(_.apply)
+  }
+
+  private def revertProperties(): Unit = {
     for(editor <- propertyEditors) {
       editor.revert()
       editor.refresh()
     }
-    for(wrapper <- wrapperOption)
-      wrapper.setSize(originalSize)
+  }
+
+  private def targetValid(): Boolean = {
+    propertyEditors.foreach(_.apply)
+    val isValid = target.invalidSettings.isEmpty
+    if (! isValid) {
+      val allInvalidations =
+        target.invalidSettings.map {
+          case (name, error) =>
+            val displayName =
+              target.propertySet
+                .asScala
+                .filter(_.accessString == name)
+                .map(_.name)
+                .headOption
+                .getOrElse(name)
+                s"${displayName}: ${error}"
+        }.mkString("\n", "\n", "")
+      val invalidMessage = I18N.gui.getN("edit.general.invalidValues", allInvalidations)
+      OptionDialog.showMessage(this,
+        I18N.gui.get("edit.general.invalidSettings"),
+        invalidMessage,
+        Array(I18N.gui.get("common.buttons.ok")))
+      revertProperties()
+    }
+    isValid
   }
 
   ////

--- a/netlogo-gui/src/main/properties/PlotPensEditor.scala
+++ b/netlogo-gui/src/main/properties/PlotPensEditor.scala
@@ -2,7 +2,7 @@
 
 package org.nlogo.properties
 
-import java.awt.{ BorderLayout, Color, Dimension, Font, GridBagConstraints } 
+import java.awt.{ BorderLayout, Color, Dimension, Font, GridBagConstraints }
 import javax.swing._
 import javax.swing.BorderFactory._
 import javax.swing.border.{ EtchedBorder, TitledBorder }
@@ -83,7 +83,6 @@ class PlotPensEditor(accessor: PropertyAccessor[List[PlotPen]], colorizer: Color
   import PlotPensEditor._
   private implicit val i18nPrefix = I18N.Prefix("edit.plot.pen")
 
-
   val plot = accessor.target.asInstanceOf[PlotWidget].plot
   val plotManager = accessor.target.asInstanceOf[PlotWidget].plotManager
   val table = new PlotPensTable()
@@ -114,13 +113,13 @@ class PlotPensEditor(accessor: PropertyAccessor[List[PlotPen]], colorizer: Color
   override def get: Option[List[PlotPen]] = {
     if(table.isEditing) table.getCellEditor.stopCellEditing
     val names = table.model.pens.map(_.name)
-    // for https://trac.assembla.com/nlogo/ticket/1174
-    // i'm deciding that we can have many pens with no names, if we choose.
-    // maybe we don't need this duplicate pen name restriction at all,
-    // but for now I'll leave it. It would seem weird to have two pens named "turtles"
-    // but also weird to allow for one pen to have no name, but only one.
-    if((names.toSet - "").size  < (names.toList.filterNot(_ == "")).size){
-      org.nlogo.swing.OptionDialog.showMessage(frame, "Invalid Entry", "Pens list contains duplicate names.",
+    // It was an intentional decision made Q2 2011 to allow multiple pens with
+    // a blank name. - RG 2/21/2018
+    val groupedNames = (names.groupBy(_.toUpperCase) - "").toSeq
+    val duplicateNames = groupedNames.filter(_._2.length > 1)
+    if (duplicateNames.nonEmpty) {
+      org.nlogo.swing.OptionDialog.showMessage(this, "Invalid Entry",
+        I18N.gui.getN("edit.plot.pen.duplicateNames", duplicateNames.map(_._1.toUpperCase).mkString(", ")),
         Array(I18N.gui.get("common.buttons.ok")))
       None
     } else Some(table.getPlotPens)

--- a/netlogo-gui/src/main/swing/OptionDialog.scala
+++ b/netlogo-gui/src/main/swing/OptionDialog.scala
@@ -31,7 +31,7 @@ object OptionDialog {
   }
 
   def showCustom(owner: Component, title: String, message: AnyRef, options: Array[_ <: Object]): Int =
-    JOptionPane.showOptionDialog(Hierarchy.getFrame(owner), message, title,
+    JOptionPane.showOptionDialog(owner, message, title,
       JOptionPane.DEFAULT_OPTION, JOptionPane.QUESTION_MESSAGE, null,
       options.asInstanceOf[Array[Object]], options(0))
 

--- a/netlogo-gui/src/main/window/AbstractPlotWidget.scala
+++ b/netlogo-gui/src/main/window/AbstractPlotWidget.scala
@@ -309,7 +309,17 @@ abstract class AbstractPlotWidget(val plot:Plot, val plotManager: PlotManagerInt
     case "setupCode" => plotManager.getPlotSetupError(plot)
     case "updateCode" => plotManager.getPlotUpdateError(plot)
   }).orNull
+
   def error(key: Object, e: Exception) { throw new UnsupportedOperationException }
+
+  override def invalidSettings: Seq[(String, String)] = {
+    val hasDuplicatedName =
+      findWidgetContainer.allWidgets.collect {
+        case p: CorePlot if p.display.map(_.toUpperCase).getOrElse("") == plotName.toUpperCase => p
+      }.length > 1
+    if (hasDuplicatedName) Seq("plotName" -> I18N.gui.getN("edit.plot.name.duplicate", plotName.toUpperCase))
+    else                   Seq.empty[(String, String)]
+  }
 
   override def editFinished: Boolean = {
     super.editFinished

--- a/netlogo-gui/src/main/window/InterfacePanelLite.scala
+++ b/netlogo-gui/src/main/window/InterfacePanelLite.scala
@@ -221,6 +221,9 @@ class InterfacePanelLite(val viewWidget: ViewWidgetInterface, compiler: Compiler
     "Button"   -> (() => new ButtonWidget(random.mainRNG)),
     "Output"   -> (() => new OutputWidget()))
 
+  override def allWidgets: Seq[CoreWidget] =
+    widgets.map(_._2).map(_.model).toSeq.distinct
+
   def loadWidget(coreWidget: CoreWidget): Widget = {
     try {
       val x = coreWidget.left

--- a/netlogo-gui/src/main/window/WidgetContainer.scala
+++ b/netlogo-gui/src/main/window/WidgetContainer.scala
@@ -27,4 +27,6 @@ trait WidgetContainer {
   def isZoomed: Boolean
 
   def loadWidget(coreWidget: CoreWidget): Widget
+
+  def allWidgets: Seq[CoreWidget]
 }

--- a/parser-core/src/main/core/CompilerUtilitiesInterface.scala
+++ b/parser-core/src/main/core/CompilerUtilitiesInterface.scala
@@ -4,11 +4,6 @@ package org.nlogo.core
 
 import FrontEndInterface.ProceduresMap
 
-trait LiteralParser {
-  def readFromString(s: String): AnyRef
-  def readNumberFromString(source: String): AnyRef
-}
-
 trait CompilerUtilitiesInterface extends LiteralParser {
   def readFromString(source: String): AnyRef
 

--- a/parser-core/src/main/core/LiteralParser.scala
+++ b/parser-core/src/main/core/LiteralParser.scala
@@ -1,0 +1,10 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.core
+
+trait LiteralParser {
+  @throws(classOf[CompilerException])
+  def readFromString(s: String): AnyRef
+  def readNumberFromString(source: String): AnyRef
+}
+

--- a/parser-core/src/main/core/SourceRewriter.scala
+++ b/parser-core/src/main/core/SourceRewriter.scala
@@ -5,6 +5,7 @@ package org.nlogo.core
 trait SourceRewriter {
   def addGlobal(global: String): String
   def addExtension(extension: String): String
+  def addReporterProcedure(name: String, args: Seq[String], body: String): String
   def remove(commandName: String): String
   def replaceToken(originalToken: String, replaceToken:String): String
   def addCommand(sourceAndNewCommand: (String, String)): String

--- a/parser-jvm/src/test/parse/AstRewriterTests.scala
+++ b/parser-jvm/src/test/parse/AstRewriterTests.scala
@@ -159,6 +159,15 @@ class AstRewriterTests extends FunSuite {
     assertResult("globals [foo qux baz] to bar end")(addGlobal("GLOBALS [foo qux] to bar end", "baz"))
   }
 
+  test("adds reporter procedure") {
+    assertResult("globals [foo]\n\nto-report foo\nreport 3\nend")(
+      addReporterProcedure("globals [foo]", "foo", "report 3"))
+    assertResult("globals [foo]\nto-report a report 5 end\n\nto-report foo\nreport 3\nend")(
+      addReporterProcedure("globals [foo]\nto-report a report 5 end", "foo", "report 3"))
+    assertResult("globals [foo]\n\nto-report foo [ a ]\nreport a\nend")(
+      addReporterProcedure("globals [foo]", "foo", "report a", Seq("a")))
+  }
+
   val tokenizer: TokenizerInterface =
     Femto.scalaSingleton[TokenizerInterface]("org.nlogo.lex.Tokenizer")
 
@@ -183,6 +192,11 @@ class AstRewriterTests extends FunSuite {
 
   def addGlobal(source: String, global: String): String = {
     val added = rewriter(source).addGlobal(global)
+    added.trim
+  }
+
+  def addReporterProcedure(source: String, name: String, body: String, args: Seq[String] = Seq()): String = {
+    val added = rewriter(source).addReporterProcedure(name, args, body)
     added.trim
   }
 


### PR DESCRIPTION
This both prevents the UI from creating plots and pens with the same-name-modulo-case AND converts existing models to ensure they have no plots or pens with the same-name-modulo-case.

Conversion is accomplished with the following technique:

* If duplicate names are found, they are sorted in reverse-string order (lowercase-first), then a number is appended to each name except for the first one. So `"abc" "aBC" "ABC"` become `"abc" "aBC_1", "ABC_2"`.
* The widgets are altered by renaming plots and pens as appropriate according to the renaming scheme. Plot and pen names are processed separately, so having a plot named "abc" and a pen named "ABC" won't convert either of those names.
* If any code in the model (including widget code) uses `set-current-plot` or `set-current-plot-pen`, two changes are made:
  1. As needed, procedures `_clarify-duplicate-{plot,plot-pen}` are added which disambiguate case-sensitive (old) names to case-insensitive (new) names. (see example code on L267 of ModelConverterTests).
  2. Code in the code tab and any widgets is altered from using `set-current-plot` to using `set-current-plot _clarify-duplicate-plot <original argument>`

I plan to do a bit more code-tidying, but would appreciate any feedback on both the general approach taken as well as on the renaming-and-conversion scheme that people (@TheBizzle, perhaps?) have to offer.