### PR TITLE
Make `histogram` set plot x range and pen mode

### DIFF
--- a/netlogo-gui/src/main/prim/plot/primitives.scala
+++ b/netlogo-gui/src/main/prim/plot/primitives.scala
@@ -2,12 +2,12 @@
 
 package org.nlogo.prim.plot
 
-import org.nlogo.api.{ CommandRunnable}
-import org.nlogo.core.{ Color, Syntax }
-import org.nlogo.core.{ I18N, LogoList }
-import org.nlogo.nvm.{ Command, Context, Instruction, Reporter }
+import org.nlogo.api.CommandRunnable
+import org.nlogo.core.{Color, Syntax}
+import org.nlogo.core.{I18N, LogoList}
+import org.nlogo.nvm.{Command, Context, Instruction, Reporter}
 import org.nlogo.nvm.RuntimePrimitiveException
-import org.nlogo.plot.PlotManager
+import org.nlogo.plot.{PlotManager, PlotPen}
 
 //
 // base classes
@@ -179,15 +179,15 @@ class _histogram extends PlotCommand {
   override def perform(context: Context) {
     val list = argEvalList(context, 0)
     val pen = currentPen(context)
+    pen.mode = PlotPen.BAR_MODE
     pen.plotListenerReset(false)
     if(pen.interval <= 0)
       throw new RuntimePrimitiveException(context, this,
         "You cannot histogram with a plot-pen-interval of " + Dump.number(pen.interval) + ".")
     val plot = currentPlot(context)
-    plot.beginHistogram(pen)
-    for(d <- list.scalaIterator.collect{case d: java.lang.Double => d.doubleValue})
-      plot.nextHistogramValue(d)
-    plot.endHistogram(pen)
+    plot.makeHistogram(pen, list.collect{
+      case d: java.lang.Double => d.doubleValue
+    })
     plot.makeDirty()
     context.ip = next
   }


### PR DESCRIPTION
Fixes #1274 

This is not ready for merge yet. Things that are not addressed:

- Tests are not updated
- With this solution, users cannot use a fixed x range but expanding y range with histogram. The best solution to that problem would be to have independent x and y auto scaling options, but that requires a file format change, so may not happen for a bit

An alternative to this would be to add this as a new simple histogram primitive (say, `histogram-all` as suggested in #1274), but having such non-orthogonal primitives is unfortunate.

Mostly, I'm opening this PR so people can experiment with behavior. 