### PR TITLE
[Libraries Dialog] Handle bundled extensions correctly

### DIFF
--- a/netlogo-gui/resources/system/bundled-libraries.conf
+++ b/netlogo-gui/resources/system/bundled-libraries.conf
@@ -1,0 +1,64 @@
+{
+    "extensions" : {
+        "arduino" : {
+            "installedVersion" : "3.0.0"
+        },
+        "array" : {
+            "installedVersion" : "1.1.0"
+        },
+        "bitmap" : {
+            "installedVersion" : "1.1.0"
+        },
+        "cf" : {
+            "installedVersion" : "2.0.0"
+        },
+        "csv" : {
+            "installedVersion" : "1.1.0"
+        },
+        "gis" : {
+            "installedVersion" : "1.1.1"
+        },
+        "gogo" : {
+            "installedVersion" : "2.0.0"
+        },
+        "ls" : {
+            "installedVersion" : "2.2.3"
+        },
+        "matrix" : {
+            "installedVersion" : "1.1.0"
+        },
+        "nw" : {
+            "installedVersion" : "3.7.5"
+        },
+        "palette" : {
+            "installedVersion" : "1.1.0"
+        },
+        "profiler" : {
+            "installedVersion" : "1.1.0"
+        },
+        "r" : {
+            "installedVersion" : "1.2.0"
+        },
+        "rnd" : {
+            "installedVersion" : "3.0.0"
+        },
+        "sample" : {
+            "installedVersion" : "1.1.0"
+        },
+        "sample-scala" : {
+            "installedVersion" : "1.1.0"
+        },
+        "sound" : {
+            "installedVersion" : "1.1.0"
+        },
+        "table" : {
+            "installedVersion" : "1.3.0"
+        },
+        "vid" : {
+            "installedVersion" : "1.0.0"
+        },
+        "view2.5d" : {
+            "installedVersion" : "1.1.0"
+        }
+    }
+}

--- a/netlogo-gui/src/main/app/tools/LibrariesTab.scala
+++ b/netlogo-gui/src/main/app/tools/LibrariesTab.scala
@@ -89,9 +89,10 @@ extends JPanel(new BorderLayout) {
         updateSingleOperationStatus("installing", selectedValue.name)
         new Worker("installing", install, selectedValue, multiple = false).execute()
       } else {
-        numOperatedLibs = numSelected
+        val forInstall = selectedValues.filter(_.status != LibraryStatus.UpToDate)
+        numOperatedLibs = forInstall.length
         updateMultipleOperationStatus("installing")
-        selectedValues.map(new Worker("installing", install, _, multiple = true)).foreach(_.execute)
+        forInstall.map(new Worker("installing", install, _, multiple = true)).foreach(_.execute)
       }
     }
     uninstallButton.addActionListener { _ =>
@@ -99,9 +100,9 @@ extends JPanel(new BorderLayout) {
         updateSingleOperationStatus("uninstalling", selectedValue.name)
         new Worker("unintalling", uninstall, selectedValue, multiple = false).execute()
       } else {
-        updateMultipleOperationStatus("uninstalling")
-        val forUninstall = selectedValues.filter(_.status != LibraryStatus.CanInstall)
+        val forUninstall = selectedValues.filter(lib => lib.status != LibraryStatus.CanInstall && !lib.bundled)
         numOperatedLibs = forUninstall.length
+        updateMultipleOperationStatus("uninstalling")
         forUninstall.map(new Worker("uninstalling", uninstall, _, multiple = true)).foreach(_.execute)
       }
     }

--- a/netlogo-gui/src/main/app/tools/LibrariesTab.scala
+++ b/netlogo-gui/src/main/app/tools/LibrariesTab.scala
@@ -132,6 +132,7 @@ extends JPanel(new BorderLayout) {
       installButton.setText(installButtonText)
 
       installButton.setEnabled(actionableLibraries.length > 0)
+      uninstallButton.setEnabled(selectedValues.filter(_.status != LibraryStatus.CanInstall).exists(!_.bundled))
       homepageButton.setEnabled(numSelected == 1)
 
       val installToolTip = if (numSelected == 1) selectedValue.downloadURL.toString else null

--- a/netlogo-gui/src/main/app/tools/LibraryInfo.scala
+++ b/netlogo-gui/src/main/app/tools/LibraryInfo.scala
@@ -12,6 +12,7 @@ case class LibraryInfo(
   version: String,
   homepage: URL,
   downloadURL: URL,
+  bundled: Boolean,
   status: LibraryStatus) {
 
   // We override `equals`, because we don't want to compare URLs directly. Checking equality

--- a/netlogo-gui/src/main/app/tools/LibraryManager.scala
+++ b/netlogo-gui/src/main/app/tools/LibraryManager.scala
@@ -15,6 +15,7 @@ import org.nlogo.swing.ProgressListener
 object LibraryManager {
   private val LibrariesConfBasename = "libraries.conf"
   private val MetadataURL = new URL(s"https://raw.githubusercontent.com/NetLogo/NetLogo-Libraries/${APIVersion.version}/$LibrariesConfBasename")
+  private val BundledLibrariesConfig = ConfigFactory.parseResources("system/bundled-libraries.conf")
   val LibrariesConf = FileIO.perUserFile(LibrariesConfBasename)
   val InstalledLibrariesConf = FileIO.perUserFile("installed-libraries.conf")
 
@@ -57,7 +58,9 @@ class LibraryManager(categories: Map[String, LibrariesCategoryInstaller], progre
     if (configFile.exists) {
       try {
         val config = ConfigFactory.parseFile(configFile)
-        val installedLibsConf = ConfigFactory.parseFile(new File(InstalledLibrariesConf))
+        val installedLibsConf =
+          ConfigFactory.parseFile(new File(InstalledLibrariesConf))
+            .withFallback(BundledLibrariesConfig)
         categoryNames.foreach(c => updateList(config, installedLibsConf, c, mutableListModels(c)))
       } catch {
         case ex: ConfigException =>

--- a/netlogo-gui/src/main/app/tools/LibraryManager.scala
+++ b/netlogo-gui/src/main/app/tools/LibraryManager.scala
@@ -23,10 +23,10 @@ object LibraryManager {
     val config = ConfigFactory.parseFile(new File(InstalledLibrariesConf))
     val updatedConfig =
       if (uninstall)
-        config.withoutPath(s"$category.${lib.codeName}")
+        config.withoutPath(s"""$category."${lib.codeName}"""")
       else
         config.withValue(
-          s"$category.${lib.codeName}.installedVersion", ConfigValueFactory.fromAnyRef(lib.version))
+          s"""$category."${lib.codeName}".installedVersion""", ConfigValueFactory.fromAnyRef(lib.version))
     val options = ConfigRenderOptions.defaults.setOriginComments(false)
     FileIO.writeFile(LibraryManager.InstalledLibrariesConf, updatedConfig.root.render(options), false)
   }
@@ -90,7 +90,7 @@ class LibraryManager(categories: Map[String, LibrariesCategoryInstaller], progre
       val homepage    = new URL(c.getString("homepage"))
       val downloadURL = new URL(c.getString("downloadURL"))
 
-      val installedVersionPath = s"$category.$codeName.installedVersion"
+      val installedVersionPath = s"""$category."$codeName".installedVersion"""
       val status =
         if (!installedLibsConf.hasPath(installedVersionPath))
           LibraryStatus.CanInstall

--- a/netlogo-gui/src/main/app/tools/LibraryManager.scala
+++ b/netlogo-gui/src/main/app/tools/LibraryManager.scala
@@ -91,6 +91,7 @@ class LibraryManager(categories: Map[String, LibrariesCategoryInstaller], progre
       val downloadURL = new URL(c.getString("downloadURL"))
 
       val installedVersionPath = s"""$category."$codeName".installedVersion"""
+      val bundled = BundledLibrariesConfig.hasPath(installedVersionPath)
       val status =
         if (!installedLibsConf.hasPath(installedVersionPath))
           LibraryStatus.CanInstall
@@ -100,7 +101,7 @@ class LibraryManager(categories: Map[String, LibrariesCategoryInstaller], progre
           LibraryStatus.CanUpdate
 
       listModel.addElement(
-        LibraryInfo(name, codeName, shortDesc, longDesc, version, homepage, downloadURL, status))
+        LibraryInfo(name, codeName, shortDesc, longDesc, version, homepage, downloadURL, bundled, status))
     }
   }
 }


### PR DESCRIPTION
I didn't implemented it exactly as I've written in https://github.com/NetLogo/NetLogo-Libraries/issues/3#issuecomment-406624443. Instead of copying the bundled resource, we use it as a Config and merge it with installed-libraries.conf (which can override values). See the [commit message](https://github.com/NetLogo/NetLogo/commit/bc7ae2970dfda11c619626010c59bdd3dea71341).

@TheBizzle, please review.