### PR TITLE
Make lambda arrow checking take into account depth

### DIFF
--- a/parser-core/src/test/parse/ArrowLambdaScoperTests.scala
+++ b/parser-core/src/test/parse/ArrowLambdaScoperTests.scala
@@ -68,7 +68,7 @@ class ArrowLambdaScoperTests extends FunSuite {
   }
 
   test("a block with an arrow in the argument list errors") {
-    intercept[CompilerException] { scope(Seq(`[`, `[`, `->`, `]`, `]`)) }
+    intercept[CompilerException] { scope(Seq(`[`, `[`, `->`, `]`, `->`, `]`)) }
   }
 
   test("a block with multiple arguments without brackets errors") {

--- a/parser-core/src/test/parse/TestLiteralParser.scala
+++ b/parser-core/src/test/parse/TestLiteralParser.scala
@@ -86,6 +86,9 @@ class TestLiteralParser extends FunSuite {
   test("parseLiteralList2b") { assertResult("[[1] [2] [3]]")(dumpObject(toLiteralList("[[1] [2] [3]]"))) }
   test("parseLiteralList3") { assertResult("[[1 2 3]]")(dumpObject(toLiteralList("[[1 2 3]]"))) }
   test("parseLiteralList4") { assertResult("[1 hi true]")(dumpObject(toLiteralList("[1 \"hi\" true]"))) }
+  test("list literal: no lambdas") {
+    testError("[[->]]", "Expected a literal value.")
+  }
 
   test("agent and agentset literals surrounded by brackets") {
     val result = toLiteral("{agent-parseable}")
@@ -104,4 +107,5 @@ class TestLiteralParser extends FunSuite {
     val result = toLiteral(input)
     assertResult("PARSEDEXTENSIONOBJECT")(result)
   }
+
 }


### PR DESCRIPTION
Fixes this:

`ifelse-value true [ [ -> true ] ] [ [ -> false ] ]`

This was reported by @nicolaspayette.