### PR TITLE
Slider no longer reverts to 0

### DIFF
--- a/netlogo-gui/src/main/window/CompilerManager.scala
+++ b/netlogo-gui/src/main/window/CompilerManager.scala
@@ -171,12 +171,12 @@ class CompilerManager(val workspace: AbstractWorkspace,
     // this method again. - ST 7/7/06
     if (!isLoading) {
       val proceed = compileProcedures()
-      if (proceed) {
-        world.realloc()
-        world.rememberOldProgram()
-        setGlobalVariables() // also updates constraints
-        compileWidgets()
-      } else {
+      world.realloc()            // reallocates widgets
+      world.rememberOldProgram() // updates world dialect, which is
+                                 // important for 3D to 2D and vice versa
+      setGlobalVariables() // updates constraints
+      compileWidgets()     // update the widget once the compile is done
+      if (!proceed) {
         // even if compilation of the procedure tab fails, we still want to mark our
         // constraints as out of date, so that any existing dynamic constraints are
         // thrown away since they're compiled against the old program -- CLB

--- a/netlogo-gui/src/main/window/CompilerManager.scala
+++ b/netlogo-gui/src/main/window/CompilerManager.scala
@@ -171,12 +171,16 @@ class CompilerManager(val workspace: AbstractWorkspace,
     // this method again. - ST 7/7/06
     if (!isLoading) {
       val proceed = compileProcedures()
-      world.realloc()            // reallocates widgets
-      world.rememberOldProgram() // updates world dialect, which is
-                                 // important for 3D to 2D and vice versa
-      setGlobalVariables() // updates constraints
-      compileWidgets()     // update the widget once the compile is done
-      if (!proceed) {
+      world.realloc()
+      world.rememberOldProgram()
+      setGlobalVariables()
+      compileWidgets()
+      // After every, failing or passing, compilation process, NetLogo needs to remember
+      // the state of all the widgets in the interface tab when loading for the first time.
+      // This is normally done by reallocating the widgets, updating the dialog
+      // (in the case of 2D <-> 3D), updating the constraints, and compiling the widgets
+      // source code. -- CBR 12/07/2018
+      if(!proceed){
         // even if compilation of the procedure tab fails, we still want to mark our
         // constraints as out of date, so that any existing dynamic constraints are
         // thrown away since they're compiled against the old program -- CLB


### PR DESCRIPTION
The slider should no longer revert back to 0 after opening a model when saved with a compile error.
A testsuite was added to keep tabs on the series of events that caused the issue in the first place.