### PR TITLE
Fix: #1679 Added AllLocalPenNames to reduce the scope of allPenName

### DIFF
--- a/netlogo-core/src/main/fileformat/PlotConverter.scala
+++ b/netlogo-core/src/main/fileformat/PlotConverter.scala
@@ -18,7 +18,7 @@ object PlotConverter {
       .filterNot(_._1.isEmpty)
   }
 
-  private[fileformat] def mapRenameDecision(groupedNames: Seq[(String, Seq[String])]):  Seq[(String, String)] = {
+  private[fileformat] def generateRenameMappings(groupedNames: Seq[(String, Seq[String])]):  Seq[(String, String)] = {
     groupedNames
       .map {
         case (upper, originals) => upper -> originals
@@ -43,22 +43,37 @@ object PlotConverter {
       }
   }
 
-  private[fileformat] def determineMapRenames(names: Seq[(String, Seq[String])]): Seq[(String, Seq[(String, String)])] = {
+  private[fileformat] def determinePenSubstitutions(names: Seq[(String, Seq[String])]): Seq[(String, Seq[(String, String)])] = {
     names.map(plotAndPens =>
-        (plotAndPens._1, mapRenameDecision(plotAndPens._2.groupBy(_.toUpperCase).toSeq))).filterNot(_._2.isEmpty)
+        (plotAndPens._1, generateRenameMappings(plotAndPens._2.groupBy(_.toUpperCase).toSeq))).filterNot(_._2.isEmpty)
   }
 
-  private[fileformat] def determineRenames(names: Seq[String]): Seq[(String, String)] = {
-    mapRenameDecision(names.groupBy(_.toUpperCase).toSeq)
+  private[fileformat] def determinePlotSubstitutions(names: Seq[String]): Seq[(String, String)] = {
+    generateRenameMappings(names.groupBy(_.toUpperCase).toSeq)
   }
 
-  private def clarifyProcedureBody(renamePairs: Seq[(String, String)]): String = {
+  private def modifyPlotNameKeys(groupedPlotAndPens: Seq[(String, Seq[(String, String)])], nameMappings: Seq[(String, String)]): Seq[(String, Seq[(String, String)])] =
+    groupedPlotAndPens
+      .map(element => (nameMappings.toMap.getOrElse(element._1, element._1), element._2))
+
+  private def clarifyPlotProcedureBody(renamePairs: Seq[(String, String)]): String = {
     val nameMap = renamePairs.map(p => s"""["${p._1}" "${p._2}"]""").mkString("[", " ", "]")
     s"""|  let name-map ${nameMap}
-        |  let replacement filter [ rename -> first rename = name] name-map
+        |  let replacement filter [ rename -> first rename = name ] name-map
         |  let reported-name name
         |  if not empty? replacement [
-        |    set reported-name item 1 replacement
+        |    set reported-name item 1 (item 0 replacement)
+        |  ]
+        |  report reported-name""".stripMargin
+  }
+
+  private def clarifyPensProcedureBody(renamePensPairs: Seq[(String, Seq[(String, String)])]): String = {
+    val penNameMapping = renamePensPairs.flatMap(renamePair => renamePair._2.map(p => s"""[ "${renamePair._1}" "${p._1}" "${p._2}" ]""")).mkString("[", " ", "]")
+    s"""|  let name-map ${penNameMapping}
+        |  let replacement filter [ rename -> first rename = plot-name and item 1 rename = name ] name-map
+        |  let reported-name name
+        |  if not empty? replacement [
+        |    set reported-name item 2 (item 0 replacement)
         |  ]
         |  report reported-name""".stripMargin
   }
@@ -71,7 +86,26 @@ object PlotConverter {
   ): Seq[ConversionSet] = {
     if (renames.nonEmpty) {
       val codeTabTransformation: SourceRewriter => String =
-        _.addReporterProcedure(reporterName, Seq("name"), clarifyProcedureBody(renames))
+        _.addReporterProcedure(reporterName, Seq("name"), clarifyPlotProcedureBody(renames))
+      val sharedTransformations = Seq[SourceRewriter => String](
+        _.replaceToken(conversionTarget, s"$conversionTarget $reporterName"))
+      Seq(ConversionSet(description,
+        codeTabTransformation +: sharedTransformations,
+        sharedTransformations,
+        Seq(conversionTarget)))
+    } else
+      Seq.empty[ConversionSet]
+  }
+
+  private def buildPensConversionSet(
+    description: String,
+    reporterName: String,
+    renames: Seq[(String, Seq[(String, String)])],
+    conversionTarget: String
+  ): Seq[ConversionSet] = {
+    if (renames.nonEmpty) {
+      val codeTabTransformation: SourceRewriter => String =
+        _.addReporterProcedure(reporterName, Seq("name"), clarifyPensProcedureBody(renames))
       val sharedTransformations = Seq[SourceRewriter => String](
         _.replaceToken(conversionTarget, s"$conversionTarget $reporterName"))
       Seq(ConversionSet(description,
@@ -83,16 +117,17 @@ object PlotConverter {
   }
 
   def plotCodeConversions(model: Model): Seq[ConversionSet] = {
+    val plotSubstitutions = determinePlotSubstitutions(allPlotNames(model))
     val plotConversions =
       buildConversionSet("Make plots case-insensitive",
         "_clarify-duplicate-plot-name",
-        determineRenames(allPlotNames(model)),
+        plotSubstitutions,
         "set-current-plot")
 
     val penConversions =
-      buildConversionSet("Make pens case-insensitive",
+      buildPensConversionSet("Make pens case-insensitive",
         "_clarify-duplicate-plot-pen-name",
-        determineMapRenames(allKeyedPenNames(model)).map(_._2).flatten.distinct,
+        modifyPlotNameKeys(determinePenSubstitutions(allKeyedPenNames(model)), plotSubstitutions),
         "set-current-plot-pen")
 
     plotConversions ++ penConversions
@@ -115,10 +150,10 @@ class PlotConverter(
       import PlotConverter._
 
       override def apply(model: Model, modelPath: Path): ConversionResult = {
-        val plotRenames = determineRenames(allPlotNames(model))
-        val penRenames: Seq[(String, Seq[(String,String)])] = determineMapRenames(allKeyedPenNames(model))
+        val plotRenames = determinePlotSubstitutions(allPlotNames(model))
+        val penRenames: Seq[(String, Seq[(String,String)])] = determinePenSubstitutions(allKeyedPenNames(model))
         (plotRenames, penRenames) match {
-          case (Seq(), Seq()) => super.apply(model,modelPath)
+          case (Seq(), Seq()) => super.apply(model, modelPath)
           case _ => { val conversion = super.apply(model, modelPath)
             val convertPandPN: Model = convertPlotAndPenNames(conversion.model, plotRenames.toMap, penRenames.toMap)
             conversion.updateModel(convertPandPN)
@@ -126,26 +161,23 @@ class PlotConverter(
         }
       }
 
-   private def convertPlotAndPenNames( // you need to create a pipeline
-        model:       Model,               // Seq[Seq[String]] -> Seq[(String, String)] -> Complete
-        plotRenames: Map[String, String], // Apply each set of changes to its corresponding list
-        penRenames:  Map[String, Seq[(String, String)]]): Model = { // I need penRenames with list of list
-                                                     // List[Map[String,String]], possibly
-                                                     // this would need to be generated as we go
-       val updatedWidgets = model.widgets.map{
-         case p: Plot => {
-           val newDisplay = p.display.map(currentName => plotRenames.getOrElse(currentName, currentName))
-           val localRenames = penRenames.getOrElse((p.display.getOrElse("")), Seq()).toMap
-           val newPens = p.pens.map {
-             pen =>
-             val newPenName = localRenames.getOrElse(pen.display, pen.display)
-             pen.copy(display = newPenName)
-
-           }
-           p.copy(display = newDisplay, pens = newPens)
-         }
-         case w => w
-       }
-       model.copy(widgets = updatedWidgets)
-    }
+   private def convertPlotAndPenNames(
+      model:       Model,
+      plotRenames: Map[String, String],
+      penRenames:  Map[String, Seq[(String, String)]]): Model = {
+      val updatedWidgets = model.widgets.map{
+        case p: Plot => {
+          val newDisplay = p.display.map(currentName => plotRenames.getOrElse(currentName, currentName))
+          val localRenames = penRenames.getOrElse((p.display.getOrElse("")), Seq()).toMap
+          val newPens = p.pens.map {
+            pen =>
+              val newPenName = localRenames.getOrElse(pen.display, pen.display)
+              pen.copy(display = newPenName)
+          }
+          p.copy(display = newDisplay, pens = newPens)
+        }
+        case w => w
+      }
+     model.copy(widgets = updatedWidgets)
+   }
 }

--- a/netlogo-core/src/test/fileformat/PlotConverterTest.scala
+++ b/netlogo-core/src/test/fileformat/PlotConverterTest.scala
@@ -1,0 +1,163 @@
+package org.nlogo.fileformat
+
+import org.nlogo.core.{ Model }
+import org.nlogo.core.{ Pen, Plot, View }
+import org.scalatest.{ FunSuite, DiagrammedAssertions }
+
+class PlotConverterTests extends FunSuite with ConversionHelper with DiagrammedAssertions {
+
+  /*************
+   * Plot Name *
+   *************/
+
+  test("if the plot names are not initialized"){
+    val model = Model(widgets = Seq( View()
+                                   , Plot(display = None, pens = List(Pen(display = "dep", setupCode = "plot e 10")))
+                                   , Plot(display = None, pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
+                                   , Plot(display = None, pens = List(Pen(display = "Dep", setupCode = "plot e 10")))))
+
+    val result = PlotConverter.allPlotNames(model)
+    assertResult(List())(result)
+  }
+
+  test("if the plot names are initialized"){
+    val model = Model(widgets = Seq( View()
+                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "dep", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Test"), pens = List(Pen(display = "Dep", setupCode = "plot e 10")))))
+
+    val result = PlotConverter.allPlotNames(model)
+    assertResult(List("MegaLazer", "Teser", "Test"))(result)
+  }
+
+   /*********************
+   * All Key Pens Names *
+   **********************/
+
+  test("if the plot pen names are renamed from a list with no similarities"){
+    val model = Model(widgets = Seq( View()
+                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "dep", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Test"), pens = List(Pen(display = "Dep", setupCode = "plot e 10")))))
+
+    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    assertResult(Seq())(result)
+  }
+
+  test("if the plot pen names are similar and require rename of a similar type"){
+    val model = Model(widgets = Seq( View()
+                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "dep", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Test"), pens = List(Pen(display = "Dep", setupCode = "plot e 10"),
+                                                                              Pen(display = "DEP", setupCode = "plot e 10")))))
+
+    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    assertResult(Seq(("Test",Seq(("Dep","Dep"), ("DEP","DEP_1")))))(result)
+  }
+
+  test("if the global plot pen names are renamed from a list with similarities and a duplicate pen name"){
+    val model = Model(widgets = Seq( View()
+                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Test"), pens = List(Pen(display = "Dep", setupCode = "plot e 10"),
+                                                                              Pen(display = "DEP", setupCode = "plot e 10")))))
+
+    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    assertResult(Seq(("Test", Seq(("Dep","Dep"), ("DEP","DEP_1")))))(result)
+  }
+
+  test("if all plots have duplicate pen name"){
+    val model = Model(widgets = Seq( View()
+                  , Plot(display = Some("Tesser"), pens = List(Pen(display = "DEP", setupCode = "plot e 10"),
+                                                               Pen(display = "DEp", setupCode = "plot e 10")))
+                  , Plot(display = Some("Teser"), pens = List(Pen(display = "DEP", setupCode = "plot e 10"),
+                                                               Pen(display = "DEp", setupCode = "plot e 10")))
+                  , Plot(display = Some("Test"), pens = List(Pen(display = "DEP", setupCode = "plot e 10"),
+                                                             Pen(display = "DEp", setupCode = "plot e 10")))))
+
+    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    assertResult(List(("Tesser", Seq(("DEp","DEp"), ("DEP","DEP_1"))), ("Teser", Seq(("DEp","DEp"), ("DEP","DEP_1"))), ("Test", Seq(("DEp","DEp"), ("DEP","DEP_1")))))(result)
+  }
+
+  test("if all plots have duplicate pen name with one field"){
+    val model = Model(widgets = Seq( View()
+                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Test"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))))
+
+    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    assertResult(Seq())(result)
+  }
+
+  test("if only one plot doesn't have duplicate (same capitalization) pen name"){
+    val model = Model(widgets = Seq( View()
+                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Test"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))))
+
+    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    assertResult(Seq())(result)
+  }
+
+  test("if there are duplicate capitalization with names, but in different plots, the converter should be empty"){
+    val model = Model(widgets = Seq( View()
+                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Test"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))))
+
+    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    assertResult(Seq())(result)
+  }
+
+  test("if only two plots contain the same names and necessary renames"){
+    val model = Model(widgets = Seq( View()
+                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DEP", setupCode = "plot e 10"), Pen(display = "DeP", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Tesuer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10"), Pen(display = "DEp", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Test"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))))
+
+    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    assertResult(Seq(("Teser", Seq(("DeP", "DeP"), ("DEP", "DEP_1")))
+                    ,("Tesuer", Seq(("DEp", "DEp"), ("DEP", "DEP_1")))))(result)
+  }
+
+  test("Should rename SPORKS to SPORKS_1 in the first plot and SPORKS in the other plot should not be renamed"){
+    val model = Model(widgets = Seq( View()
+                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "SPORKS", setupCode = "plot e 10"), Pen(display = "sPORKS", setupCode = "plot e 10")))
+                                   , Plot(display = Some("Tseser"), pens = List(Pen(display = "SPORKS", setupCode = "plot e 10"), Pen(display = "SPORKS_1", setupCode = "plot e 10")))))
+
+    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    assertResult(Seq(("MegaLazer", Seq(("sPORKS", "sPORKS"), ("SPORKS", "SPORKS_1")))))(result)
+  }
+
+  test("Should rename SPORKS to SPORKS_1 in the first plot and SPORKS in the other plot should be renamed to SPORKS_3 thanks to possible duplicates"){
+    val model = Model(widgets = Seq( View()
+                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "SPORKS", setupCode = "plot e 10"), Pen(display = "sPORKS", setupCode = "plot e 10")))
+      , Plot(display = Some("Tseser"), pens = List( Pen(display = "sPORKS", setupCode = "plot e 10")
+                                                  , Pen(display = "SPORKS", setupCode = "plot e 10")
+                                                  , Pen(display = "SPORKS_2", setupCode = "plot e 10"), Pen(display = "SPORKS_1", setupCode = "plot e 10")))))
+
+    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    assertResult(Seq(("MegaLazer", Seq(("sPORKS", "sPORKS"), ("SPORKS", "SPORKS_1")))
+                    ,("Tseser",    Seq(("sPORKS", "sPORKS"), ("SPORKS", "SPORKS_3"))) ))(result)
+  }
+
+  test("Should rename SPORKS to SPORKS_2 in the first plot and SPORKS in the other plot should be renamed to SPORKS_4 thanks to possible duplicates"){
+    val model = Model(widgets = Seq( View()
+      , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "SPORKS", setupCode = "plot e 10")
+                                                     , Pen(display = "sPORKS_1", setupCode = "plot e 10")
+                                                     , Pen(display = "sPORKS", setupCode = "plot e 10")))
+      , Plot(display = Some("Tseser"), pens = List( Pen(display = "sPORKS", setupCode = "plot e 10")
+                                                  , Pen(display = "SPORKS", setupCode = "plot e 10")
+                                                  , Pen(display = "SPORKS_2", setupCode = "plot e 10")
+                                                  , Pen(display = "SPORKS_3", setupCode = "plot e 10")
+                                                  , Pen(display = "SPORKS_5", setupCode = "plot e 10")
+                                                  , Pen(display = "SPORKS_1", setupCode = "plot e 10")))))
+
+    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    assertResult(Seq(("MegaLazer", Seq(("sPORKS", "sPORKS"), ("SPORKS", "SPORKS_2")))
+                    ,("Tseser",    Seq(("sPORKS", "sPORKS"), ("SPORKS", "SPORKS_4"))) ))(result)
+  }
+}

--- a/netlogo-core/src/test/fileformat/PlotConverterTest.scala
+++ b/netlogo-core/src/test/fileformat/PlotConverterTest.scala
@@ -11,23 +11,23 @@ class PlotConverterTests extends FunSuite with ConversionHelper with DiagrammedA
    *************/
 
   test("if the plot names are not initialized"){
-    val model = Model(widgets = Seq( View()
-                                   , Plot(display = None, pens = List(Pen(display = "dep", setupCode = "plot e 10")))
-                                   , Plot(display = None, pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
-                                   , Plot(display = None, pens = List(Pen(display = "Dep", setupCode = "plot e 10")))))
+    val model = Model(widgets = Seq(View()
+                                   ,Plot(display = None, pens = List(Pen(display = "dep", setupCode = "plot e 10")))
+                                   ,Plot(display = None, pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
+                                   ,Plot(display = None, pens = List(Pen(display = "Dep", setupCode = "plot e 10")))))
 
     val result = PlotConverter.allPlotNames(model)
     assertResult(List())(result)
   }
 
   test("if the plot names are initialized"){
-    val model = Model(widgets = Seq( View()
-                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "dep", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Test"), pens = List(Pen(display = "Dep", setupCode = "plot e 10")))))
+    val model = Model(widgets = Seq(View()
+                                   ,Plot(display = Some("MegaLazer"), pens = List(Pen(display = "dep", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("TeserMaze"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("TestMazer"), pens = List(Pen(display = "Dep", setupCode = "plot e 10")))))
 
     val result = PlotConverter.allPlotNames(model)
-    assertResult(List("MegaLazer", "Teser", "Test"))(result)
+    assertResult(List("MegaLazer", "TeserMaze", "TestMazer"))(result)
   }
 
    /*********************
@@ -35,111 +35,111 @@ class PlotConverterTests extends FunSuite with ConversionHelper with DiagrammedA
    **********************/
 
   test("if the plot pen names are renamed from a list with no similarities"){
-    val model = Model(widgets = Seq( View()
-                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "dep", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Test"), pens = List(Pen(display = "Dep", setupCode = "plot e 10")))))
+    val model = Model(widgets = Seq(View()
+                                   ,Plot(display = Some("MegaLazer"), pens = List(Pen(display = "dep", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("TeserMaze"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("TestMazer"), pens = List(Pen(display = "Dep", setupCode = "plot e 10")))))
 
-    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    val result = PlotConverter.determinePenSubstitutions(PlotConverter.allKeyedPenNames(model))
     assertResult(Seq())(result)
   }
 
   test("if the plot pen names are similar and require rename of a similar type"){
-    val model = Model(widgets = Seq( View()
-                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "dep", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Test"), pens = List(Pen(display = "Dep", setupCode = "plot e 10"),
-                                                                              Pen(display = "DEP", setupCode = "plot e 10")))))
+    val model = Model(widgets = Seq(View()
+                                   ,Plot(display = Some("MegaLazer"), pens = List(Pen(display = "dep", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("TeserMaze"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("TestMazer"), pens = List(Pen(display = "Dep", setupCode = "plot e 10")
+                                                                                 ,Pen(display = "DEP", setupCode = "plot e 10")))))
 
-    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
-    assertResult(Seq(("Test",Seq(("Dep","Dep"), ("DEP","DEP_1")))))(result)
+    val result = PlotConverter.determinePenSubstitutions(PlotConverter.allKeyedPenNames(model))
+    assertResult(Seq(("TestMazer", Seq(("Dep","Dep"), ("DEP","DEP_1")))))(result)
   }
 
   test("if the global plot pen names are renamed from a list with similarities and a duplicate pen name"){
-    val model = Model(widgets = Seq( View()
-                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Test"), pens = List(Pen(display = "Dep", setupCode = "plot e 10"),
-                                                                              Pen(display = "DEP", setupCode = "plot e 10")))))
+    val model = Model(widgets = Seq(View()
+                                   ,Plot(display = Some("MegaLazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("TeserMaze"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("TestMazer"), pens = List(Pen(display = "Dep", setupCode = "plot e 10")
+                                                                                 ,Pen(display = "DEP", setupCode = "plot e 10")))))
 
-    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
-    assertResult(Seq(("Test", Seq(("Dep","Dep"), ("DEP","DEP_1")))))(result)
+    val result = PlotConverter.determinePenSubstitutions(PlotConverter.allKeyedPenNames(model))
+    assertResult(Seq(("TestMazer", Seq(("Dep","Dep"), ("DEP","DEP_1")))))(result)
   }
 
   test("if all plots have duplicate pen name"){
     val model = Model(widgets = Seq( View()
-                  , Plot(display = Some("Tesser"), pens = List(Pen(display = "DEP", setupCode = "plot e 10"),
-                                                               Pen(display = "DEp", setupCode = "plot e 10")))
-                  , Plot(display = Some("Teser"), pens = List(Pen(display = "DEP", setupCode = "plot e 10"),
-                                                               Pen(display = "DEp", setupCode = "plot e 10")))
-                  , Plot(display = Some("Test"), pens = List(Pen(display = "DEP", setupCode = "plot e 10"),
-                                                             Pen(display = "DEp", setupCode = "plot e 10")))))
+                  , Plot(display = Some("Tesser"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")
+                                                              ,Pen(display = "DEp", setupCode = "plot e 10")))
+                  , Plot(display = Some("Teser"),  pens = List(Pen(display = "DEP", setupCode = "plot e 10")
+                                                              ,Pen(display = "DEp", setupCode = "plot e 10")))
+                  , Plot(display = Some("Test"),   pens = List(Pen(display = "DEP", setupCode = "plot e 10")
+                                                              ,Pen(display = "DEp", setupCode = "plot e 10")))))
 
-    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    val result = PlotConverter.determinePenSubstitutions(PlotConverter.allKeyedPenNames(model))
     assertResult(List(("Tesser", Seq(("DEp","DEp"), ("DEP","DEP_1"))), ("Teser", Seq(("DEp","DEp"), ("DEP","DEP_1"))), ("Test", Seq(("DEp","DEp"), ("DEP","DEP_1")))))(result)
   }
 
   test("if all plots have duplicate pen name with one field"){
-    val model = Model(widgets = Seq( View()
-                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Test"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))))
+    val model = Model(widgets = Seq(View()
+                                   ,Plot(display = Some("MegaLazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("TeserMaze"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("TestMazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))))
 
-    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    val result = PlotConverter.determinePenSubstitutions(PlotConverter.allKeyedPenNames(model))
     assertResult(Seq())(result)
   }
 
   test("if only one plot doesn't have duplicate (same capitalization) pen name"){
-    val model = Model(widgets = Seq( View()
-                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Test"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))))
+    val model = Model(widgets = Seq(View()
+                                   ,Plot(display = Some("MegaLazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("TeserMaze"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("TestMazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))))
 
-    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    val result = PlotConverter.determinePenSubstitutions(PlotConverter.allKeyedPenNames(model))
     assertResult(Seq())(result)
   }
 
   test("if there are duplicate capitalization with names, but in different plots, the converter should be empty"){
-    val model = Model(widgets = Seq( View()
-                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Test"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))))
+    val model = Model(widgets = Seq(View()
+                                   ,Plot(display = Some("MegaLazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("TeserMaze"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("TeserMaz"), pens = List(Pen(display = "DeP", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("TestMazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))))
 
-    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    val result = PlotConverter.determinePenSubstitutions(PlotConverter.allKeyedPenNames(model))
     assertResult(Seq())(result)
   }
 
   test("if only two plots contain the same names and necessary renames"){
-    val model = Model(widgets = Seq( View()
-                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Teser"), pens = List(Pen(display = "DEP", setupCode = "plot e 10"), Pen(display = "DeP", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Tesuer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10"), Pen(display = "DEp", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Test"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))))
+    val model = Model(widgets = Seq(View()
+                                   ,Plot(display = Some("MegaLazer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("Teser"),  pens = List(Pen(display = "DEP", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("Teseer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10"), Pen(display = "DeP", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("Tesuer"), pens = List(Pen(display = "DEP", setupCode = "plot e 10"), Pen(display = "DEp", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("Test"),   pens = List(Pen(display = "DEP", setupCode = "plot e 10")))))
 
-    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
-    assertResult(Seq(("Teser", Seq(("DeP", "DeP"), ("DEP", "DEP_1")))
+    val result = PlotConverter.determinePenSubstitutions(PlotConverter.allKeyedPenNames(model))
+    assertResult(Seq(("Teseer", Seq(("DeP", "DeP"), ("DEP", "DEP_1")))
                     ,("Tesuer", Seq(("DEp", "DEp"), ("DEP", "DEP_1")))))(result)
   }
 
   test("Should rename SPORKS to SPORKS_1 in the first plot and SPORKS in the other plot should not be renamed"){
-    val model = Model(widgets = Seq( View()
-                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "SPORKS", setupCode = "plot e 10"), Pen(display = "sPORKS", setupCode = "plot e 10")))
-                                   , Plot(display = Some("Tseser"), pens = List(Pen(display = "SPORKS", setupCode = "plot e 10"), Pen(display = "SPORKS_1", setupCode = "plot e 10")))))
+    val model = Model(widgets = Seq(View()
+                                   ,Plot(display = Some("MegaLazer"), pens = List(Pen(display = "SPORKS", setupCode = "plot e 10"), Pen(display = "sPORKS", setupCode = "plot e 10")))
+                                   ,Plot(display = Some("TseserMaz"), pens = List(Pen(display = "SPORKS", setupCode = "plot e 10"), Pen(display = "SPORKS_1", setupCode = "plot e 10")))))
 
-    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    val result = PlotConverter.determinePenSubstitutions(PlotConverter.allKeyedPenNames(model))
     assertResult(Seq(("MegaLazer", Seq(("sPORKS", "sPORKS"), ("SPORKS", "SPORKS_1")))))(result)
   }
 
   test("Should rename SPORKS to SPORKS_1 in the first plot and SPORKS in the other plot should be renamed to SPORKS_3 thanks to possible duplicates"){
-    val model = Model(widgets = Seq( View()
-                                   , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "SPORKS", setupCode = "plot e 10"), Pen(display = "sPORKS", setupCode = "plot e 10")))
-      , Plot(display = Some("Tseser"), pens = List( Pen(display = "sPORKS", setupCode = "plot e 10")
-                                                  , Pen(display = "SPORKS", setupCode = "plot e 10")
-                                                  , Pen(display = "SPORKS_2", setupCode = "plot e 10"), Pen(display = "SPORKS_1", setupCode = "plot e 10")))))
+    val model = Model(widgets = Seq(View()
+                                   ,Plot(display = Some("MegaLazer"), pens = List(Pen(display = "SPORKS", setupCode = "plot e 10"), Pen(display = "sPORKS", setupCode = "plot e 10")))
+      , Plot(display = Some("Tseser"), pens = List(Pen(display = "sPORKS", setupCode = "plot e 10")
+                                                  ,Pen(display = "SPORKS", setupCode = "plot e 10")
+                                                  ,Pen(display = "SPORKS_2", setupCode = "plot e 10"), Pen(display = "SPORKS_1", setupCode = "plot e 10")))))
 
-    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    val result = PlotConverter.determinePenSubstitutions(PlotConverter.allKeyedPenNames(model))
     assertResult(Seq(("MegaLazer", Seq(("sPORKS", "sPORKS"), ("SPORKS", "SPORKS_1")))
                     ,("Tseser",    Seq(("sPORKS", "sPORKS"), ("SPORKS", "SPORKS_3"))) ))(result)
   }
@@ -147,17 +147,17 @@ class PlotConverterTests extends FunSuite with ConversionHelper with DiagrammedA
   test("Should rename SPORKS to SPORKS_2 in the first plot and SPORKS in the other plot should be renamed to SPORKS_4 thanks to possible duplicates"){
     val model = Model(widgets = Seq( View()
       , Plot(display = Some("MegaLazer"), pens = List(Pen(display = "SPORKS", setupCode = "plot e 10")
-                                                     , Pen(display = "sPORKS_1", setupCode = "plot e 10")
-                                                     , Pen(display = "sPORKS", setupCode = "plot e 10")))
-      , Plot(display = Some("Tseser"), pens = List( Pen(display = "sPORKS", setupCode = "plot e 10")
-                                                  , Pen(display = "SPORKS", setupCode = "plot e 10")
-                                                  , Pen(display = "SPORKS_2", setupCode = "plot e 10")
-                                                  , Pen(display = "SPORKS_3", setupCode = "plot e 10")
-                                                  , Pen(display = "SPORKS_5", setupCode = "plot e 10")
-                                                  , Pen(display = "SPORKS_1", setupCode = "plot e 10")))))
+                                                     ,Pen(display = "sPORKS_1", setupCode = "plot e 10")
+                                                     ,Pen(display = "sPORKS", setupCode = "plot e 10")))
+      , Plot(display = Some("TseserMaz"), pens = List(Pen(display = "sPORKS", setupCode = "plot e 10")
+                                                  ,Pen(display = "SPORKS", setupCode = "plot e 10")
+                                                  ,Pen(display = "SPORKS_2", setupCode = "plot e 10")
+                                                  ,Pen(display = "SPORKS_3", setupCode = "plot e 10")
+                                                  ,Pen(display = "SPORKS_5", setupCode = "plot e 10")
+                                                  ,Pen(display = "SPORKS_1", setupCode = "plot e 10")))))
 
-    val result = PlotConverter.determineMapRenames(PlotConverter.allKeyedPenNames(model))
+    val result = PlotConverter.determinePenSubstitutions(PlotConverter.allKeyedPenNames(model))
     assertResult(Seq(("MegaLazer", Seq(("sPORKS", "sPORKS"), ("SPORKS", "SPORKS_2")))
-                    ,("Tseser",    Seq(("sPORKS", "sPORKS"), ("SPORKS", "SPORKS_4"))) ))(result)
+                    ,("TseserMaz", Seq(("sPORKS", "sPORKS"), ("SPORKS", "SPORKS_4")))))(result)
   }
 }


### PR DESCRIPTION
AllLocalPenNames limits which names are renamed through grouping names to their plot and checking each group instead of the whole list.