### PR TITLE
Added condition for mixed NetLogo files

### DIFF
--- a/netlogo-core/src/main/api/ModelLoader.scala
+++ b/netlogo-core/src/main/api/ModelLoader.scala
@@ -50,7 +50,7 @@ object ModelLoader {
 trait ModelLoader {
   def formats: Seq[FormatterPair[_, _]]
 
-  protected def uriFormat(uri: URI): Option[FormatterPair[_, _]] =
+  def uriFormat(uri: URI): Option[FormatterPair[_, _]] =
     ModelLoader.getURIExtension(uri)
       .flatMap(extension => formats.find(_.name == extension))
 

--- a/netlogo-core/src/main/fileformat/NLogoFormat.scala
+++ b/netlogo-core/src/main/fileformat/NLogoFormat.scala
@@ -149,8 +149,10 @@ trait AbstractNLogoFormat[A <: ModelFormat[Array[String], A]] extends ModelForma
     def validationErrors(m: Model): Option[String] = None
     override def deserialize(s: Array[String]) = {(m: Model) =>
       val versionString = s.mkString.trim
-      if(versionString.startsWith("NetLogo 3D") && Version.is3D(versionString) && !is3DFormat)
-        Success(m.copy(version = versionString.replace("3D ","")))
+      if(!versionString.startsWith("NetLogo 3D") && versionString.startsWith("NetLogo") && is3DFormat)
+        Success(m.copy(version = versionString))
+      else if(versionString.startsWith("NetLogo 3D") && Version.is3D(versionString) && !is3DFormat)
+        Success(m.copy(version = versionString))
       else if (versionString.startsWith("NetLogo") && Version.is3D(versionString) == is3DFormat)
         Success(m.copy(version = versionString))
       else {

--- a/netlogo-core/src/main/fileformat/NLogoFormat.scala
+++ b/netlogo-core/src/main/fileformat/NLogoFormat.scala
@@ -79,6 +79,10 @@ trait AbstractNLogoFormat[A <: ModelFormat[Array[String], A]] extends ModelForma
         val sectionLines = sections.getOrElse(name, Array[String]())
         if (sectionLines.isEmpty)
           "\n"
+        else if (name == "org.nlogo.modelsection.version"){
+          if(!is3DFormat) sectionLines.map(_.replace("3D ", "")).mkString("\n", "\n", "\n")
+          else sectionLines.mkString("\n", "\n", "\n")
+        }
         else if (sectionLines.head.isEmpty || sectionLines.head.startsWith("\n") || name == "org.nlogo.modelsection.code")
           sectionLines.mkString("", "\n", "\n")
         else
@@ -145,8 +149,9 @@ trait AbstractNLogoFormat[A <: ModelFormat[Array[String], A]] extends ModelForma
     def validationErrors(m: Model): Option[String] = None
     override def deserialize(s: Array[String]) = {(m: Model) =>
       val versionString = s.mkString.trim
-      if (versionString.startsWith("NetLogo") &&
-        Version.is3D(versionString) == is3DFormat)
+      if(versionString.startsWith("NetLogo 3D") && Version.is3D(versionString) && !is3DFormat)
+        Success(m.copy(version = versionString.replace("3D ","")))
+      else if (versionString.startsWith("NetLogo") && Version.is3D(versionString) == is3DFormat)
         Success(m.copy(version = versionString))
       else {
         val errorString =

--- a/netlogo-core/src/test/fileformat/ModelSectionTest.scala
+++ b/netlogo-core/src/test/fileformat/ModelSectionTest.scala
@@ -51,6 +51,15 @@ trait ModelSectionTest[A, B <: ModelFormat[A, B], C] extends FunSuite {
     }
   }
 
+  def testOnDeserializationAndWrongArity(
+    description: String, serializedVersion: A, error: String): Unit = {
+    test(s"errors when deserializing $description") {
+      val s = subject
+      val m = s.deserialize(serializedVersion)(new Model())
+      assert(!m.isFailure)
+    }
+  }
+
   def testErrorsOnDeserialization(description: String, serializedVersion: A, error: String): Unit = {
     test(s"errors when deserializing $description") {
       val s = subject

--- a/netlogo-core/src/test/fileformat/NLogoFormatTests.scala
+++ b/netlogo-core/src/test/fileformat/NLogoFormatTests.scala
@@ -111,6 +111,42 @@ class NLogoFormatConversionTest extends FunSuite with ConversionHelper {
       assert(rereadModel.code.contains("extensions [vid]"))
     }
 
+    test("carries out conversions between files") {
+      val sectionsMap = collection.immutable.Map("org.nlogo.modelsection.version" -> Array[String]("NetLogo 3D 6.0.4"))
+      val nlogoformatTwod = new NLogoFormat
+      val nlogoformatThreed = new NLogoThreeDFormat
+      val expectedTwodResult =
+        """@#$#@#$#@
+          |@#$#@#$#@
+          |@#$#@#$#@
+          |@#$#@#$#@
+          |NetLogo 6.0.4
+          |@#$#@#$#@
+          |@#$#@#$#@
+          |@#$#@#$#@
+          |@#$#@#$#@
+          |@#$#@#$#@
+          |@#$#@#$#@
+          |@#$#@#$#@""".trim.stripMargin
+      val expectedThreedResult = 
+        """@#$#@#$#@
+          |@#$#@#$#@
+          |@#$#@#$#@
+          |@#$#@#$#@
+          |NetLogo 3D 6.0.4
+          |@#$#@#$#@
+          |@#$#@#$#@
+          |@#$#@#$#@
+          |@#$#@#$#@
+          |@#$#@#$#@
+          |@#$#@#$#@
+          |@#$#@#$#@""".trim.stripMargin
+
+      assert(nlogoformatTwod.sectionsToSource(sectionsMap).get.trim == expectedTwodResult)
+      assert(nlogoformatThreed.sectionsToSource(sectionsMap).get.trim != expectedTwodResult)
+      assert(nlogoformatThreed.sectionsToSource(sectionsMap).get.trim == expectedThreedResult)
+    }
+
     test("returns a failure for a model needing conversion which doesn't compile") {
       val m = Model(code = "to foo hsb")
       val conversions = AutoConversionList.conversions.map(_._2)
@@ -156,7 +192,8 @@ class VersionComponentTest extends NLogoFormatTest[String] {
   val correctArityFormat = Version.version.replaceAll(" 3D", "")
   val wrongArityVersion = Version.version.replaceAll("NetLogo", "NetLogo 3D")
 
-  testErrorsOnDeserialization("wrong arity", Array[String](wrongArityVersion), wrongArityVersion)
+  testOnDeserializationAndWrongArity(
+    "wrong arity", Array[String](wrongArityVersion), wrongArityVersion)
   testErrorsOnDeserialization("empty version section to empty version", Array[String](), "")
   // up to the other components to error if they detect a problem
   testDeserializes("unknown version", Array[String]("NetLogo 4D 8.9"), "NetLogo 4D 8.9")

--- a/netlogo-gui/project/autogen/i18n/GUI_Strings_en.txt
+++ b/netlogo-gui/project/autogen/i18n/GUI_Strings_en.txt
@@ -227,6 +227,12 @@ file.open.warn.intwod.openthreed = You are attempting to open a model \
   that was created in a 3D version of NetLogo.  \
   (This is {0}; the model was created in {1}.) \
   NetLogo can try to open the model, but it may or may not work.
+file.open.warn.intwod.opentwodconflict = You are attempting to open a 2D model \
+  with a 3D section header in {0}.  \
+  NetLogo can try to open the model, but it may or may not work.
+file.open.warn.inthreed.openthreedconflict = You are attempting to open a 3D model \
+  with a 2D section header in {0}.  \
+  NetLogo can try to open the model, but it may or may not work.
 file.open.warn.inthreed.opentwod = You are attempting to open \
   a 2D model in {0}. You might need to make changes before it will work in 3D.
 file.open.warn.autoconversion.model.title = Error Converting Model

--- a/netlogo-gui/src/main/window/FileController.scala
+++ b/netlogo-gui/src/main/window/FileController.scala
@@ -103,10 +103,13 @@ class FileController(owner: Component, modelTracker: ModelTracker) extends OpenM
 
   def shouldOpenModelOfDifferingArity(arity: Int, version: String): Boolean = {
     try {
-      if (arity == 2)
-        checkWithUserBeforeOpening3DModelin2D(version)
-      else
-        checkWithUserBeforeOpening2DModelin3D()
+      arity match {
+        case 2 if version.contains("3D") => checkWithUserBeforeOpening2DModelWith3DSection()
+        case 2 => checkWithUserBeforeOpening2DModelin3D()
+        case 3 if !version.contains("3D") => checkWithUserBeforeOpening3DModelWith2DSection()
+        case 3 => checkWithUserBeforeOpening3DModelin2D(version)
+        case _ => throw new UserCancelException
+      }
       true
     } catch {
       case ex: UserCancelException => false
@@ -149,6 +152,22 @@ class FileController(owner: Component, modelTracker: ModelTracker) extends OpenM
   @throws(classOf[UserCancelException])
   def checkWithUserBeforeOpening2DModelin3D(): Unit = {
     val message = I18N.gui.getN("file.open.warn.inthreed.opentwod", Version.version)
+    if (OptionDialog.showMessage(owner, "NetLogo", message, continueAndCancelOptions) != 0) {
+      throw new UserCancelException()
+    }
+  }
+
+  @throws(classOf[UserCancelException])
+  def checkWithUserBeforeOpening3DModelWith2DSection(): Unit = {
+    val message = I18N.gui.getN("file.open.warn.inthreed.openthreedconflict", Version.version)
+    if (OptionDialog.showMessage(owner, "NetLogo", message, continueAndCancelOptions) != 0) {
+      throw new UserCancelException()
+    }
+  }
+
+  @throws(classOf[UserCancelException])
+  def checkWithUserBeforeOpening2DModelWith3DSection(): Unit = {
+    val message = I18N.gui.getN("file.open.warn.intwod.opentwodconflict", Version.version)
     if (OptionDialog.showMessage(owner, "NetLogo", message, continueAndCancelOptions) != 0) {
       throw new UserCancelException()
     }

--- a/netlogo-gui/src/main/workspace/OpenModel.scala
+++ b/netlogo-gui/src/main/workspace/OpenModel.scala
@@ -46,12 +46,13 @@ trait OpenModel[OpenParameter] {
         controller.invalidModel(uri)
         None
       } else {
+        val nlogoFormat = loader.uriFormat(uri).get.name
         readModel(loader, openParam) match {
           case Success(model) =>
             if (! model.version.startsWith("NetLogo")) {
               controller.invalidModelVersion(uri, model.version)
               None
-            } else if (shouldCancelOpeningModel(model, controller, currentVersion))
+            } else if (shouldCancelOpeningModel(model, controller, currentVersion, nlogoFormat))
               None
             else
               modelConverter(model, Paths.get(uri)) match {
@@ -66,9 +67,9 @@ trait OpenModel[OpenParameter] {
       }
   }
 
-  private def shouldCancelOpeningModel(model: Model, controller: Controller, currentVersion: Version): Boolean = {
-    val modelArity = if (Version.is3D(model.version)) 3 else 2
-    val modelArityDiffers = Version.is3D(model.version) != currentVersion.is3D
+  private def shouldCancelOpeningModel(model: Model, controller: Controller, currentVersion: Version, format: String): Boolean = {
+    val modelArity = if (format.contains("3d")) 3 else 2
+    val modelArityDiffers = Version.is3D(model.version) != currentVersion.is3D || Version.is3D(model.version) != format.contains("3d") || currentVersion.is3D != format.contains("3d")
     if (modelArityDiffers)
       ! controller.shouldOpenModelOfDifferingArity(modelArity, model.version)
     else if (! currentVersion.knownVersion(model.version))

--- a/netlogo-gui/src/test/workspace/OpenModelTests.scala
+++ b/netlogo-gui/src/test/workspace/OpenModelTests.scala
@@ -57,7 +57,7 @@ class OpenModelTests extends FunSuite {
     override def modelChanges = _.copy(version = "NetLogo 3D 6.0")
     userContinuesOpen()
     assert(openedModel.isDefined)
-    assert(controller.notifiedModelArity == 3)
+    assert(controller.notifiedModelArity == 2)
     assert(controller.notifiedModelVersion == "NetLogo 3D 6.0")
     assert(! controller.notifiedVersionUnknown)
   } }
@@ -66,7 +66,7 @@ class OpenModelTests extends FunSuite {
     override def modelChanges = _.copy(version = "NetLogo 3D 6.0")
     userCancelsOpen()
     assert(openedModel.isEmpty)
-    assert(controller.notifiedModelArity   == 3)
+    assert(controller.notifiedModelArity   == 2)
     assert(controller.notifiedModelVersion == "NetLogo 3D 6.0")
   } }
 


### PR DESCRIPTION
This fix adds another condition for opening files with NetLogo. The additional condition
checks if the NetLogo version and source file are 3D while the file extension is 2D. If the
version match up in this case, NetLogo 3D will happily open a .nlogo file with a mislabeled
NetLogo section ("NetLogo 3D").