### PR TITLE
HTML5-compliant dictionary

### DIFF
--- a/autogen/docs/dictionary.html.mustache
+++ b/autogen/docs/dictionary.html.mustache
@@ -1,14 +1,18 @@
-<!DOCTYPE html>
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
 <title>
   NetLogo {{version}} User Manual: NetLogo Dictionary
 </title>
 <link rel="stylesheet" href="netlogo.css" type="text/css">
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<style type="text/css">
+<style>
 p  { margin-left: 1.5em ; }
 h3 { font-size: 115% ; }
 h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
 </style>
+</head>
+<body>
 <h1>
   NetLogo Dictionary
 </h1>
@@ -76,6 +80,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       primitive might still be used by patches or the observer, and vice
       versa. To see which agents (turtles, patches, links, observer) can
       actually run a primitive, consult its dictionary entry.
+    </p>
       <!-- ======================================== -->
     <h3 id="turtlegroup">
       Turtle-related
@@ -155,6 +160,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#untie">untie</a>
       <a href="#uphill">uphill</a>
       <a href="#uphill">uphill4</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="patchgroup">
       Patch-related
@@ -194,6 +200,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#stop-inspecting">stop-inspecting</a>
       <a href="#subject">subject</a>
       <a href="#turtles-here">turtles-here</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="linkgroup">
       Link-related
@@ -260,6 +267,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#tie">tie</a>
       <a href="#undirected-link-breed">undirected-link-breed</a>
       <a href="#untie">untie</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="agentsetgroup">
       <a>Agentset</a>
@@ -309,6 +317,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#with">with</a>
       <a href="#with-max">with-max</a>
       <a href="#with-min">with-min</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="colorgroup">
       Color
@@ -328,6 +337,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#scale-color">scale-color</a>
       <a href="#shade-of">shade-of?</a>
       <a href="#wrap-color">wrap-color</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="controlgroup">
       Control flow and logic
@@ -363,6 +373,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#with-local-randomness">with-local-randomness</a>
       <a href="#without-interruption">without-interruption</a>
       <a href="#xor">xor</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="anonproceduresgroup">
       Anonymous Procedures
@@ -379,6 +390,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#run">run</a>
       <a href="#run">runresult</a>
       <a href="#sort-by">sort-by</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="worldgroup">
       World
@@ -409,6 +421,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#ticks">ticks</a>
       <a href="#world-dim">world-width</a>
       <a href="#world-dim">world-height</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="perspectivegroup">
       Perspective
@@ -422,6 +435,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#subject">subject</a>
       <a href="#watch">watch</a>
       <a href="#watch-me">watch-me</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="hubnetgroup">
       <a>HubNet</a>
@@ -450,6 +464,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#hubnet-send-message">hubnet-send-message</a>
       <a href="#hubnet-send-override">hubnet-send-override</a>
       <a href="#hubnet-send-watch">hubnet-send-watch</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="iogroup">
       Input/output
@@ -491,6 +506,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#user-one-of">user-one-of</a>
       <a href="#user-yes-or-no">user-yes-or-no?</a>
       <a href="#write">write</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="fileiogroup">
       File
@@ -513,6 +529,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#user-directory">user-directory</a>
       <a href="#user-file">user-file</a>
       <a href="#user-new-file">user-new-file</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="listsgroup">
       List
@@ -557,6 +574,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#sort-on">sort-on</a>
       <a href="#subliststring">sublist</a>
       <a href="#up-to-n-of">up-to-n-of</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="stringgroup">
       String
@@ -581,6 +599,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#reverse">reverse</a>
       <a href="#subliststring">substring</a>
       <a href="#word">word</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="mathematicalgroup">
       Mathematical
@@ -625,6 +644,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#sum">sum</a>
       <a href="#tan">tan</a>
       <a href="#variance">variance</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="plottinggroup">
       Plotting
@@ -661,6 +681,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#set-plot--range">set-plot-y-range</a>
       <a href="#setup-plots">setup-plots</a>
       <a href="#update-plots">update-plots</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="behaviorspacegroup">
       BehaviorSpace
@@ -668,6 +689,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
     <p>
       <a href="#behaviorspace-experiment-name">behaviorspace-experiment-name</a>
       <a href="#behaviorspace-run-number">behaviorspace-run-number</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="systemgroup">
       System
@@ -675,6 +697,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
     <p>
       <a href="#netlogo-version">netlogo-version</a>
       <a href="#netlogo-web">netlogo-web?</a>
+    </p>
       <!-- ======================================== -->
        <!-- ======================================== -->
        <!-- ======================================== -->
@@ -699,6 +722,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#who">who</a>
       <a href="#xcor">xcor</a>
       <a href="#ycor">ycor</a>
+      </p>
       <!-- ======================================== -->
       <h3 id="patch-variables">
         <a>Patches</a>
@@ -709,6 +733,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#plabel-color">plabel-color</a>
       <a href="#pcor">pxcor</a>
       <a href="#pcor">pycor</a>
+      </p>
       <!-- ======================================== -->
       <h3 id="link-variables">
         <a>Links</a>
@@ -724,12 +749,14 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#shape">shape</a>
       <a href="#thickness">thickness</a>
       <a href="#tie-mode">tie-mode</a>
+      </p>
       <!-- ======================================== -->
       <h3 id="other-variables">
         <a>Other</a>
       </h3>
       <p>
       <a href="#arrow">-&gt;</a>
+      </p>
       <!-- ======================================== -->
       <!-- ======================================== -->
       <!-- ======================================== -->
@@ -750,75 +777,78 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#to-report">to-report</a>
       <a href="#turtles-own">turtles-own</a>
       <a href="#undirected-link-breed">undirected-link-breed</a>
+    </p>
       <!-- ======================================== -->
        <!-- ======================================== -->
        <!-- ======================================== -->
     <h2 id="Constants">
       <a>Constants</a>
     </h2><!-- ======================================== -->
-    <div>
-      <div class="dict_entry" id="mathconstants" data-constants="e pi">
-        <h3>
-          Mathematical Constants
-        </h3>
-        <p>
-        <b id="num-e"><a>e</a></b> = 2.718281828459045
-        <br>
-        <b id="pi"><a>pi</a></b> = 3.141592653589793
-      </div><!-- ======================================== -->
-      <div class="dict_entry" id="boolconstants" data-constants="false true">
-        <h3>
-          <a>Boolean Constants</a>
-        </h3>
-        <p id="false true">
-        <b><a>false</a></b>
-        <br>
-        <b><a>true</a></b>
-      </div><!-- ======================================== -->
-      <div class="dict_entry" id="colorconstants" data-constants="black gray white red orange brown yellow green lime turquoise cyan sky blue violet magenta pink">
-        <h3>
-          <a>Color Constants</a>
-        </h3>
-        <p>
-        <b>black</b> = 0
-        <br>
-        <b>gray</b> = 5
-        <br>
-        <b>white</b> = 9.9
-        <br>
-        <b>red</b> = 15
-        <br>
-        <b>orange</b> = 25
-        <br>
-        <b>brown</b> = 35
-        <br>
-        <b>yellow</b> = 45
-        <br>
-        <b>green</b> = 55
-        <br>
-        <b>lime</b> = 65
-        <br>
-        <b>turquoise</b> = 75
-        <br>
-        <b>cyan</b> = 85
-        <br>
-        <b>sky</b> = 95
-        <br>
-        <b>blue</b> = 105
-        <br>
-        <b>violet</b> = 115
-        <br>
-        <b>magenta</b> = 125
-        <br>
-        <b>pink</b> = 135
-        <p>
-        See the <a href="programming.html#colors">Colors</a> section of the
-        Programming Guide for more details.
-      </div><!-- ======================================== -->
-      <!-- ======================================== -->
-      <!-- ======================================== -->
-      <!-- ======================================== -->
-    </div>
+		<div class="dict_entry" id="mathconstants" data-constants="e pi">
+			<h3>
+				Mathematical Constants
+			</h3>
+			<p>
+			<b id="num-e"><a>e</a></b> = 2.718281828459045
+			<br>
+			<b id="pi"><a>pi</a></b> = 3.141592653589793
+			</p>
+		</div><!-- ======================================== -->
+		<div class="dict_entry" id="boolconstants" data-constants="false true">
+			<h3>
+				<a>Boolean Constants</a>
+			</h3>
+			<p id="false_true">
+			<b><a>false</a></b>
+			<br>
+			<b><a>true</a></b>
+			</p>
+		</div><!-- ======================================== -->
+		<div class="dict_entry" id="colorconstants" data-constants="black gray white red orange brown yellow green lime turquoise cyan sky blue violet magenta pink">
+			<h3>
+				<a>Color Constants</a>
+			</h3>
+			<p>
+			<b>black</b> = 0
+			<br>
+			<b>gray</b> = 5
+			<br>
+			<b>white</b> = 9.9
+			<br>
+			<b>red</b> = 15
+			<br>
+			<b>orange</b> = 25
+			<br>
+			<b>brown</b> = 35
+			<br>
+			<b>yellow</b> = 45
+			<br>
+			<b>green</b> = 55
+			<br>
+			<b>lime</b> = 65
+			<br>
+			<b>turquoise</b> = 75
+			<br>
+			<b>cyan</b> = 85
+			<br>
+			<b>sky</b> = 95
+			<br>
+			<b>blue</b> = 105
+			<br>
+			<b>violet</b> = 115
+			<br>
+			<b>magenta</b> = 125
+			<br>
+			<b>pink</b> = 135
+			</p>
+			<p>
+			See the <a href="programming.html#colors">Colors</a> section of the
+			Programming Guide for more details.
+			</p>
+		</div><!-- ======================================== -->
+		<!-- ======================================== -->
+		<!-- ======================================== -->
+		<!-- ======================================== -->
     <h2 id="A">
       <a>A</a>
     </h2><!-- ======================================== -->
@@ -832,6 +862,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       </h4>
       <p>
         Reports the absolute value of <i>number</i>.
+      </p>
       <pre>
 show abs -7
 =&gt; 7
@@ -850,6 +881,7 @@ show abs 5
         Reports the arc cosine (inverse cosine) of the given number. The
         input must be in the range -1 to 1. The result is in degrees, and
         lies in the range 0 to 180.
+      </p>
       </div>
     <div class="dict_entry" id="all">
       <h3>
@@ -862,17 +894,20 @@ show abs 5
         Reports true if all of the agents in the agentset report true for
         the given reporter. Otherwise reports false as soon as a
         counterexample is found.
+      </p>
       <p>
         If the agentset is empty, reports true.
       <p>
         The reporter must report a boolean value for every agent (either
         true or false), otherwise an error occurs.
+      </p>
       <pre>
 if all? turtles [color = red]
   [ show &quot;every turtle is red!&quot; ]
 </pre>
       <p>
         See also <a href="#any">any?</a>.
+      </p>
       </div>
     <div class="dict_entry" id="and">
       <h3>
@@ -884,9 +919,11 @@ if all? turtles [color = red]
       <p>
         Reports true if both <i>condition1</i> and <i>condition2</i> are
         true.
+      </p>
       <p>
         Note that if <i>condition1</i> is false, then <i>condition2</i>
         will not be run (since it can't affect the result).
+      </p>
       <pre>
 if (pxcor &gt; 0) and (pycor &gt; 0)
   [ set pcolor blue ]  ;; the upper-right quadrant of
@@ -902,9 +939,11 @@ if (pxcor &gt; 0) and (pycor &gt; 0)
       </h4>
       <p>
         Reports true if the given agentset is non-empty, false otherwise.
+      </p>
       <p>
         Equivalent to &quot;count <i>agentset</i> &gt; 0&quot;, but more
         efficient (and arguably more readable).
+      </p>
       <pre>
 if any? turtles with [color = red]
   [ show &quot;at least one turtle is red!&quot; ]
@@ -913,8 +952,10 @@ if any? turtles with [color = red]
         Note: nobody is not an agentset. You only get nobody back in
         situations where you were expecting a single agent, not a whole
         agentset. If any? gets nobody as input, an error results.
+      </p>
       <p>
         See also <a href="#all">all?</a>, <a href="#nobody">nobody</a>.
+      </p>
       </div>
     <div class="dict_entry" id="approximate-hsb">
       <h3>
@@ -927,12 +968,15 @@ if any? turtles with [color = red]
         Reports a number in the range 0 to 140, not including 140 itself,
         that represents the given color, specified in the HSB spectrum, in
         NetLogo's color space.
+      </p>
       <p>
         The first value (hue) should be in the range of 0 to 360, the second
         and third (saturation and brightness) in the range between 0 and 100.
+      </p>
       <p>
         The color reported may be only an approximation, since the NetLogo
         color space does not include all possible colors.
+      </p>
       <pre>
 show approximate-hsb 0 0 0
 =&gt; 0  ;; (black)
@@ -941,6 +985,7 @@ show approximate-hsb 180 57.143 76.863
 </pre>
       <p>
         See also <a href="#extract-hsb">extract-hsb</a>, <a href="#approximate-rgb">approximate-rgb</a>, <a href="#extract-rgb">extract-rgb</a>.
+      </p>
       </div>
     <div class="dict_entry" id="approximate-rgb">
       <h3>
@@ -953,13 +998,16 @@ show approximate-hsb 180 57.143 76.863
         Reports a number in the range 0 to 140, not including 140 itself,
         that represents the given color, specified in the RGB spectrum, in
         NetLogo's color space.
+      </p>
       <p>
         All three inputs should be in the range 0 to 255.
+      </p>
       <p>
         The color reported may be only an approximation, since the NetLogo
         color space does not include all possible colors. (See <a href="#approximate-hsb">approximate-hsb</a> for a description of what
         parts of the HSB color space NetLogo colors cover; this is
         difficult to characterize in RGB terms.)
+      </p>
       <pre>
 show approximate-rgb 0 0 0
 =&gt; 0  ;; black
@@ -968,6 +1016,7 @@ show approximate-rgb 0 255 255
 </pre>
       <p>
         See also <a href="#extract-rgb">extract-rgb</a>, <a href="#approximate-hsb">approximate-hsb</a>, and <a href="#extract-hsb">extract-hsb</a>.
+      </p>
       </div>
     <div class="dict_entry" id="Symbols">
       <h3>
@@ -989,18 +1038,22 @@ show approximate-rgb 0 255 255
         operators&quot; (going between the two inputs, as in standard
         mathematical use). NetLogo correctly supports order of operations
         for infix operators.
+      </p>
       <p>
         The operators work as follows: + is addition, * is multiplication,
         - is subtraction, / is division, ^ is exponentiation, &lt; is less
         than, &gt; is greater than, = is equal to, != is not equal to,
         &lt;= is less than or equal, &gt;= is greater than or equal.
+      </p>
       <p>
         Note that the subtraction operator (-) always takes two inputs
         unless you put parentheses around it, in which case it can take one
         input. For example, to take the negative of x, write (- x), with
         the parentheses.
+      </p>
       <p>
         All of the comparison operators also work on strings.
+      </p>
       <p>
         All of the comparison operators work on agents. Turtles are
         compared by who number. Patches are compared top to bottom left to
@@ -1011,13 +1064,16 @@ show approximate-rgb 0 255 255
         breeds of links unbreeded links will come before breeded links of
         the same end points and breeded links will be sorted in the order
         they are declared in the Code tab.
+      </p>
       <p>
         Agentsets can be tested for equality or inequality. Two agentsets
         are equal if they are the same type (turtle or patch) and contain
         the same agents.
+      </p>
       <p>
         If you are not sure how NetLogo will interpret your code, you
         should add parentheses.
+      </p>
       <pre>
 show 5 * 6 + 6 / 3
 =&gt; 32
@@ -1030,6 +1086,7 @@ show 5 * (6 + 6) / 3
         For instance, the array, matrix, and table objects returned by their
         respective extensions may be compared for equality / inequality.
         Extension objects may not be tested using &lt;, &gt;, &lt;=, or &gt;=.
+      </p>
     </div>
     <div class="dict_entry" id="asin">
       <h3>
@@ -1042,6 +1099,7 @@ show 5 * (6 + 6) / 3
         Reports the arc sine (inverse sine) of the given number. The input
         must be in the range -1 to 1. The result is in degrees, and lies in
         the range -90 to 90.
+      </p>
       </div>
     <div class="dict_entry" id="ask">
       <h3>
@@ -1057,6 +1115,7 @@ show 5 * (6 + 6) / 3
         used with an agentset each agent will take its turn in a random
         order.  See <a href="programming.html#agentsets">Agentsets</a>
         for more information.
+      </p>
       <pre>
 ask turtles [ fd 1 ]
   ;; all turtles move forward one step
@@ -1071,9 +1130,11 @@ ask turtle 4 [ rt 90 ]
         or all patches ask all patches, which is a common mistake to make
         if you're not careful about which agents will run the code you
         are writing.
+      </p>
       <p>
         Note: Only the agents that are in the agentset <i>at the time the
         ask begins</i> run the commands.
+      </p>
       </div>
     <div class="dict_entry" id="ask-concurrent">
       <h3>
@@ -1085,16 +1146,20 @@ ask turtle 4 [ rt 90 ]
       <p>
         This primitive exists only for backwards compatibility. We
         don't recommend using it new models.
+      </p>
       <p>
         The agents in the given agentset run the given commands, using a
         turn-taking mechanism to produce simulated concurrency. See the
         <a href="programming.html#ask-concurrent">Ask-Concurrent</a>
         section of the Programming Guide for details on how this works.
+      </p>
       <p>
         Note: Only the agents that are in the agentset <i>at the time the
         ask begins</i> run the commands.
+      </p>
       <p>
         See also <a href="#without-interruption">without-interruption</a>.
+      </p>
       </div>
     <div class="dict_entry" id="at-points">
       <h3>
@@ -1108,14 +1173,17 @@ ask turtle 4 [ rt 90 ]
         agents on the patches at the given coordinates (relative to this
         agent). The coordinates are specified as a list of two-item lists,
         where the two items are the x and y offsets.
+      </p>
       <p>
         If the caller is the observer, then the points are measured
         relative to the origin, in other words, the points are taken as
         absolute patch coordinates.
+      </p>
       <p>
         If the caller is a turtle, the points are measured relative to the
         turtle's exact location, and not from the center of the patch
         under the turtle.
+      </p>
       <pre>
 ask turtles at-points [[2 4] [1 2] [10 15]]
   [ fd 1 ]  ;; only the turtles on the patches at the
@@ -1133,6 +1201,7 @@ ask turtles at-points [[2 4] [1 2] [10 15]]
       <p>
         Converts x and y offsets to a turtle heading in degrees (from 0 to
         360).
+      </p>
       <p>
         Note that this version of atan is designed to conform to the
         geometry of the NetLogo world, where a heading of 0 is straight up,
@@ -1140,9 +1209,11 @@ ask turtles at-points [[2 4] [1 2] [10 15]]
         (Normally in geometry an angle of 0 is right, 90 is up, and so on,
         counterclockwise around the circle, and atan would be defined
         accordingly.)
+      </p>
       <p>
         When y is 0: if x is positive, it reports 90; if x is negative, it
         reports 270; if x is zero, you get an error.
+      </p>
       <pre>
 show atan 1 -1
 =&gt; 135
@@ -1154,10 +1225,12 @@ crt 1 [ set heading 30  fd 1  print atan xcor ycor ]
       <p>
         In the final example, note that the result of <code>atan</code> equals
         the turtle's heading.
+      </p>
       <p>
         If you ever need to convert a turtle heading (obtained with atan or
         otherwise) to a normal mathematical angle, the following should be
         helpful:
+      </p>
       <pre>
 to-report heading-to-angle [ h ]
   report (90 - h) mod 360
@@ -1174,6 +1247,7 @@ end
       <p>
         Reports true if auto-plotting is on for the current plot, false
         otherwise.
+      </p>
       </div>
     <div class="dict_entry" id="auto-plot-status">
       <h3>
@@ -1191,6 +1265,7 @@ end
         exceeds these boundaries. It is useful when wanting to show all
         plotted values in the current plot, regardless of the current plot
         ranges.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="B">
@@ -1209,17 +1284,21 @@ end
       <p>
         The turtle moves backward by <i>number</i> steps. (If <i>number</i>
         is negative, the turtle moves forward.)
+      </p>
       <p>
         Turtles using this primitive can move a maximum of one unit per
         time increment. So <code>bk 0.5</code> and <code>bk 1</code> both take one
         unit of time, but <code>bk 3</code> takes three.
+      </p>
       <p>
         If the turtle cannot move backward <i>number</i> steps because it
         is not permitted by the current topology the turtle will complete
         as many steps of 1 as it can and stop.
+      </p>
       <p>
         See also <a href="#forward">forward</a>, <a href="#jump">jump</a>,
         <a href="#can-move">can-move?</a>.
+      </p>
       </div>
     <div class="dict_entry" id="base-colors">
       <h3>
@@ -1230,6 +1309,7 @@ end
       </h4>
       <p>
         Reports a list of the 14 basic NetLogo hues.
+      </p>
       <pre>
 print base-colors
 =&gt; [5 15 25 35 45 55 65 75 85 95 105 115 125 135]
@@ -1250,8 +1330,10 @@ ask turtles [ set color one-of remove gray base-colors ]
         Emits a beep. Note that the beep sounds immediately, so several
         beep commands in close succession may produce only one audible
         sound.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 beep                       ;; emits one beep
 repeat 3 [ beep ]          ;; emits 3 beeps at once,
@@ -1261,6 +1343,7 @@ repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
 </pre>
       <p>
         When running headless, this command has no effect.
+      </p>
       </div>
     <div class="dict_entry" id="behaviorspace-experiment-name">
       <h3>
@@ -1271,8 +1354,10 @@ repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
       </h4>
       <p>
         Reports the current experiment name in the current experiment.
+      </p>
       <p>
         If no BehaviorSpace experiment is running, reports &quot;&quot;.
+      </p>
       </div>
     <div class="dict_entry" id="behaviorspace-run-number">
       <h3>
@@ -1284,8 +1369,10 @@ repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
       <p>
         Reports the current run number in the current BehaviorSpace
         experiment, starting at 1.
+      </p>
       <p>
         If no BehaviorSpace experiment is running, reports 0.
+      </p>
       </div>
     <div class="dict_entry" id="both-ends">
       <h3>
@@ -1297,6 +1384,7 @@ repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
       </h4>
       <p>
         Reports the agentset of the 2 nodes connected by this link.
+      </p>
       <pre>
 crt 2
 ask turtle 0 [ create-link-with turtle 1 ]
@@ -1319,14 +1407,18 @@ ask link 0 1 [
         (For turtles or links that do not have any particular breed, this
         is the <a href="#turtles">turtles</a> agentset of all turtles or
         the <a href="#links">links</a> agentset of all links respectively.)
+      </p>
       <p>
         You can set this variable to change a turtle or link's breed.
         (When a turtle changes breeds, its shape is reset to the default
         shape for that breed. See <a href="#set-default-shape">set-default-shape</a>.)
+      </p>
       <p>
         See also <a href="#breed">breed</a>, <a href="#directed-link-breed">directed-link-breed</a>, <a href="#undirected-link-breed">undirected-link-breed</a>
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 breed [cats cat]
 breed [dogs dog]
@@ -1354,8 +1446,10 @@ if breed = roads [ set color gray ]
         any procedure definitions. It defines a breed. The first input
         defines the name of the agentset associated with the breed. The
         second input defines the name of a single member of the breed.
+      </p>
       <p>
         Any turtle of the given breed:
+      </p>
       <ul>
         <li>is part of the agentset named by the breed name
         <li>has its breed built-in variable set to that agentset
@@ -1363,6 +1457,7 @@ if breed = roads [ set color gray ]
       <p>
         Most often, the agentset is used in conjunction with ask to give
         commands to only the turtles of a particular breed.
+      </p>
       <pre>
 breed [mice mouse]
 breed [frogs frog]
@@ -1385,6 +1480,7 @@ show turtle 51
 </pre>
       <p>
         See also <a href="#globals">globals</a>, <a href="#patches-own">patches-own</a>, <a href="#turtles-own">turtles-own</a>, <a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>, <a href="#create-turtles">create-<i>&lt;breeds&gt;</i></a>, <a href="#turtles-at"><i>&lt;breeds&gt;</i>-at</a>, <a href="#turtles-here"><i>&lt;breeds&gt;</i>-here</a>.
+      </p>
       </div>
     <div class="dict_entry" id="but-first-and-last">
       <h3>
@@ -1405,9 +1501,11 @@ show turtle 51
         When used on a list, but-first reports all of the list items of
         <i>list</i> except the first, and but-last reports all of the list
         items of <i>list</i> except the last.
+      </p>
       <p>
         On strings, but-first and but-last report a shorter string omitting
         the first or last character of the original string.
+      </p>
       <pre>
 ;; mylist is [2 4 6 5 8 12]
 set mylist but-first mylist
@@ -1437,8 +1535,10 @@ show but-last &quot;string&quot;
         Reports true if this turtle can move <i>distance</i> in the
         direction it is facing without violating the topology; reports
         false otherwise.
+      </p>
       <p>
         It is equivalent to:
+      </p>
       <pre>
 patch-ahead <i>distance</i> != nobody
 </pre>
@@ -1455,9 +1555,11 @@ patch-ahead <i>distance</i> != nobody
         <i>commands1</i>, NetLogo won't stop and alert the user that an
         error occurred. It will suppress the error and run <i>commands2</i>
         instead.
+      </p>
       <p>
         The error-message reporter can be used in <i>commands2</i> to find
         out what error was suppressed in <i>commands1</i>. See <a href="#error-message">error-message</a>.
+      </p>
       <pre>
 carefully [ print one-of [1 2 3] ] [ print error-message ]
 =&gt; 3
@@ -1475,6 +1577,7 @@ observer&gt; carefully [ print one-of [] ] [ print error-message ]
       <p>
         Reports the smallest integer greater than or equal to
         <i>number</i>.
+      </p>
       <pre>
 show ceiling 4.5
 =&gt; 5
@@ -1484,6 +1587,7 @@ show ceiling -4.5
       <p>
         See also <a href="#floor">floor</a>, <a href="#round">round</a>,
         <a href="#precision">precision</a>.
+      </p>
       </div>
     </div>
     <div class="dict_entry" id="clear-all">
@@ -1499,6 +1603,7 @@ show ceiling -4.5
         Combines the effects of clear-globals, clear-ticks,
         clear-turtles, clear-patches, clear-drawing, clear-all-plots, and
         clear-output.
+      </p>
       </div>
     <div class="dict_entry" id="clear-all-plots">
       <h3>
@@ -1510,6 +1615,7 @@ show ceiling -4.5
       </h4>
       <p>
         Clears every plot in the model. See <a href="#clear-plot">clear-plot</a> for more information.
+      </p>
       </div>
     <div class="dict_entry" id="clear-drawing">
       <h3>
@@ -1522,6 +1628,7 @@ show ceiling -4.5
       </h4>
       <p>
         Clears all lines and stamps drawn by turtles.
+      </p>
       </div>
     <div class="dict_entry" id="clear-globals">
       <h3>
@@ -1533,6 +1640,7 @@ show ceiling -4.5
       </h4>
       <p>
         Sets all code-defined global variables (i.e., those defined inside of <code>globals [ ... ]</code>) to 0.  Global variables defined by widgets are not affected by this primitive.
+      </p>
       </div>
     <div class="dict_entry" id="clear-links">
       <h3>
@@ -1544,8 +1652,10 @@ show ceiling -4.5
       </h4>
       <p>
         Kills all links.
+      </p>
       <p>
         See also <a href="#die">die</a>.
+      </p>
       </div>
     <div class="dict_entry" id="clear-output">
       <h3>
@@ -1558,6 +1668,7 @@ show ceiling -4.5
       <p>
         Clears all text from the model's output area, if it has one.
         Otherwise does nothing.
+      </p>
       </div>
     <div class="dict_entry" id="clear-patches">
       <h3>
@@ -1571,6 +1682,7 @@ show ceiling -4.5
       <p>
         Clears the patches by resetting all patch variables to their
         default initial values, including setting their color to black.
+      </p>
       </div>
     <div class="dict_entry" id="clear-plot">
       <h3>
@@ -1589,6 +1701,7 @@ show ceiling -4.5
         deleting all temporary pens, that is to say if there are no
         permanent plot pens, a default plot pen will be created with the
         following initial settings:
+      </p>
       <ul>
         <li>Pen: down
         <li>Color: black
@@ -1598,6 +1711,7 @@ show ceiling -4.5
         </ul>
       <p>
         See also <a href="#clear-all-plots">clear-all-plots</a>.
+      </p>
       </div>
     <div class="dict_entry" id="clear-ticks">
       <h3>
@@ -1609,14 +1723,17 @@ show ceiling -4.5
       </h4>
       <p>
         Clears the tick counter.
+      </p>
       <p>
         Does not set the counter to zero. After this command runs, the tick
         counter has no value. Attempting to access or update it is an error
         until <a href="#reset-ticks">reset-ticks</a> is called. This is
         useful if you want to set the model to a "pre-setup" state with some
         forever buttons disabled.
+      </p>
       <p>
         See also <a href="#reset-ticks">reset-ticks</a>.
+      </p>
       </div>
     <div class="dict_entry" id="clear-turtles">
       <h3>
@@ -1629,11 +1746,14 @@ show ceiling -4.5
       </h4>
       <p>
         Kills all turtles.
+      </p>
       <p>
         Also resets the who numbering, so the next turtle created will be
         turtle 0.
+      </p>
       <p>
         See also <a href="#die">die</a>.
+      </p>
       </div>
     <div class="dict_entry" id="color">
       <h3>
@@ -1650,8 +1770,10 @@ show ceiling -4.5
         color (a single number), or an RGB color (a list of 3 numbers). See
         details in the <a href="programming.html#colors">Colors section</a>
         of the Programming Guide.
+      </p>
       <p>
         See also <a href="#pcolor">pcolor</a>.
+      </p>
       </div>
     <div class="dict_entry" id="cos">
       <h3>
@@ -1663,6 +1785,7 @@ show ceiling -4.5
       <p>
         Reports the cosine of the given angle. Assumes the angle is given
         in degrees.
+      </p>
       <pre>
 show cos 180
 =&gt; -1
@@ -1677,6 +1800,7 @@ show cos 180
       </h4>
       <p>
         Reports the number of agents in the given agentset.
+      </p>
       <pre>
 show count turtles
 ;; prints the total number of turtles
@@ -1700,14 +1824,17 @@ show count patches with [pcolor = red]
         Creates <i>number</i> new turtles. New turtles start at position
         (0, 0), are created with the 14 primary colors, and have headings
         from 0 to 360, evenly spaced.
+      </p>
       <p>
         If the create-ordered-<i>&lt;breeds&gt;</i> form is used, the new
         turtles are created as members of the given breed.
+      </p>
       <p>
         If <i>commands</i> are supplied, the new turtles immediately run
         them. This is useful for giving the new turtles a different color,
         heading, or whatever. (The new turtles are created all at once then
         run one at a time, in random order.)
+      </p>
       <pre>
 cro 100 [ fd 10 ]  ;; makes an evenly spaced circle
 </pre>
@@ -1756,28 +1883,34 @@ cro 100 [ fd 10 ]  ;; makes an evenly spaced circle
       </h4>
       <p>
         Used for creating breeded and unbreeded links between turtles.
+      </p>
       <p>
         <code>create-link-with</code> creates an undirected link between the caller and
         <i>agent</i>. <code>create-link-to</code> creates a directed link from the
         caller to <i>agent</i>. <code>create-link-from</code> creates a directed link
         from <i>agent</i> to the caller.
+      </p>
       <p>
         When the plural form of the breed name is used, an <i>agentset</i>
         is expected instead of an agent and links are created between the
         caller and all agents in the agentset.
+      </p>
       <p>
         The optional command block is the set of commands each newly formed
         link runs. (The links are created all at once then run one at a
         time, in random order.)
+      </p>
       <p>
         A node cannot be linked to itself. Also, you cannot have more than
         one undirected link of the same breed between the same two nodes,
         nor can you have more than one directed link of the same breed
         going in the same direction between two nodes.
+      </p>
       <p>
         If you try to create a link where one (of the same breed) already
         exists, nothing happens. If you try to create a link from a turtle
         to itself you get a runtime error.
+      </p>
       <pre>
 to setup
   clear-all
@@ -1827,14 +1960,17 @@ end
         Creates <i>number</i> new turtles at the origin. New turtles have
         random integer headings and the color is randomly selected from the
         14 primary colors.
+      </p>
       <p>
         If the create-<i>&lt;breeds&gt;</i> form is used, the new turtles
         are created as members of the given breed.
+      </p>
       <p>
         If <i>commands</i> are supplied, the new turtles immediately run
         them. This is useful for giving the new turtles a different color,
         heading, or whatever. (The new turtles are created all at once then
         run one at a time, in random order.)
+      </p>
       <pre>
 crt 100 [ fd 10 ]     ;; makes a randomly spaced circle
 </pre>
@@ -1849,6 +1985,7 @@ end
 </pre>
       <p>
         See also <a href="#hatch">hatch</a>, <a href="#sprout">sprout</a>.
+      </p>
       </div>
     <div class="dict_entry" id="create-temporary-plot-pen">
       <h3>
@@ -1860,17 +1997,21 @@ end
       <p>
         A new temporary plot pen with the given name is created in the
         current plot and set to be the current pen.
+      </p>
       <p>
         Few models will want to use this primitive, because all temporary
         pens disappear when clear-plot or clear-all-plots are called. The
         normal way to make a pen is to make a permanent pen in the
         plot's Edit dialog.
+      </p>
       <p>
         If a pen with that name already exists in the current plot, no
         new pen is created, and the existing pen is set to the current
         pen.
+      </p>
       <p>
         The new temporary plot pen has the following initial settings:
+      </p>
       <ul>
         <li>Pen: down
         <li>Color: black
@@ -1879,9 +2020,9 @@ end
         </ul>
       <p>
         See: <a href="#clear-plot">clear-plot</a>, <a href="#clear-all-plots">clear-all-plots</a>, and <a href="#set-current-plot-pen">set-current-plot-pen</a>.
+      </p>
         <!-- ======================================== -->
       </div>
-    </div>
     <h2 id="D">
       <a>D</a>
     </h2><!-- ======================================== -->
@@ -1900,6 +2041,7 @@ end
         clock is milliseconds. (Whether you get resolution that high in
         practice may vary from system to system, depending on the
         capabilities of the underlying Java Virtual Machine.)
+      </p>
       <pre>
 show date-and-time
 =&gt; &quot;01:19:36.685 PM 19-Sep-2002&quot;
@@ -1915,6 +2057,7 @@ show date-and-time
       </h4>
       <p>
         The turtle or link dies.
+      </p>
       <pre>
 if xcor &gt; 20 [ die ]
 ;; all turtles with xcor greater than 20 die
@@ -1923,6 +2066,7 @@ ask links with [color = blue] [ die ]
 </pre>
       <p>
         A dead agent ceases to exist. The effects of this include:
+      </p>
       <ul>
         <li>The agent will not execute any further code. So if you write
         <code>ask turtles [ die print &quot;last words?&quot; ]</code>, no last
@@ -1941,6 +2085,7 @@ ask links with [color = blue] [ die ]
         </ul>
       <p>
         See also: <a href="#clear-turtles">clear-turtles</a> <a href="#clear-links">clear-links</a>
+      </p>
       </div>
     <div class="dict_entry" id="diffuse">
       <h3>
@@ -1958,10 +2103,12 @@ ask links with [color = blue] [ die ]
         conserved across the world. (If a patch has fewer than eight
         neighbors, each neighbor still gets an eighth share; the patch
         keeps any leftover shares.)
+      </p>
       <p>
         Note that this is an observer command only, even though you might
         expect it to be a patch command. (The reason is that it acts on all
         the patches at once -- patch commands act on individual patches.)
+      </p>
       <pre>
 diffuse chemical 0.5
 ;; each patch diffuses 50% of its variable
@@ -1981,6 +2128,7 @@ diffuse chemical 0.5
       <p>
         Like diffuse, but only diffuses to the four neighboring patches (to
         the north, south, east, and west), not to the diagonal neighbors.
+      </p>
       <pre>
 diffuse4 chemical 0.5
 ;; each patch diffuses 50% of its variable
@@ -2005,8 +2153,10 @@ diffuse4 chemical 0.5
         link breed. The second input defines the name of a single member of
         the breed. Directed links can be created using <a href="#create-link">create-link(s)-to</a>, and <a href="#create-link">create-link(s)-from</a>, but not
         <code>create-link(s)-with</code>
+      </p>
       <p>
         Any link of the given link breed:
+      </p>
       <ul>
         <li>is part of the agentset named by the link breed name
         <li>has its built-in variable <code>breed</code> set to that agentset
@@ -2015,6 +2165,7 @@ diffuse4 chemical 0.5
       <p>
         Most often, the agentset is used in conjunction with ask to give
         commands to only the links of a particular breed.
+      </p>
       <pre>
 directed-link-breed [streets street]
 directed-link-breed [highways highway]
@@ -2034,6 +2185,7 @@ ask turtle 0 [ show one-of my-out-links ]
 </pre>
       <p>
         See also <a href="#breed">breed</a>, <a href="#undirected-link-breed">undirected-link-breed</a>
+      </p>
       </div>
     <div class="dict_entry" id="display">
       <h3>
@@ -2046,9 +2198,11 @@ ask turtle 0 [ show one-of my-out-links ]
         Causes the view to be updated immediately. (Exception: if the user
         is using the speed slider to fast-forward the model, then the
         update may be skipped.)
+      </p>
       <p>
         Also undoes the effect of the no-display command, so that if view
         updates were suspended by that command, they will resume.
+      </p>
       <pre>
 no-display
 ask turtles [ jump 10 set color blue set size 5 ]
@@ -2063,6 +2217,7 @@ display
         updates, so that fewer total updates take place, so that models run
         faster. This command lets you force a view update, so whatever
         changes have taken place in the world are visible to the user.
+      </p>
       <pre>
 ask turtles [ set color red ]
 display
@@ -2073,8 +2228,10 @@ ask turtles [ set color blue]
       <p>
         Note that display and no-display operate independently of the
         switch in the view control strip that freezes the view.
+      </p>
       <p>
         See also <a href="#no-display">no-display</a>.
+      </p>
       </div>
     <div class="dict_entry" id="distance">
       <h3>
@@ -2086,11 +2243,13 @@ ask turtles [ set color blue]
       </h4>
       <p>
         Reports the distance from this agent to the given turtle or patch.
+      </p>
       <p>
         The distance to or a from a patch is measured from the center of
         the patch. Turtles and patches use the wrapped distance (around the
         edges of the world) if wrapping is allowed by the topology and the
         wrapped distance is shorter.
+      </p>
       <pre>
 ask turtles [ show max-one-of turtles [distance myself] ]
 ;; each turtle prints the turtle farthest from itself
@@ -2107,11 +2266,13 @@ ask turtles [ show max-one-of turtles [distance myself] ]
       <p>
         Reports the distance from this agent to the point (<i>x</i>,
         <i>y</i>).
+      </p>
       <p>
         The distance from a patch is measured from the center of the patch.
         Turtles and patches use the wrapped distance (around the edges of
         the world) if wrapping is allowed by the topology and the wrapped
         distance is shorter.
+      </p>
       <pre>
 if (distancexy 0 0) &gt; 10
   [ set color green ]
@@ -2135,12 +2296,15 @@ if (distancexy 0 0) &gt; 10
         than the current patch, the turtle stays put. If there are multiple
         patches with the same lowest value, the turtle picks one randomly.
         Non-numeric values are ignored.
+      </p>
       <p>
         downhill considers the eight neighboring patches; downhill4 only
         considers the four neighbors.
+      </p>
       <p>
         Equivalent to the following code (assumes variable values are
         numeric):
+      </p>
       <pre>
 move-to patch-here  ;; go to patch center
 let p min-one-of neighbors [<i>patch-variable</i>]  ;; or neighbors4
@@ -2152,8 +2316,10 @@ if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
       <p>
         Note that the turtle always ends up on a patch center and has a
         heading that is a multiple of 45 (downhill) or 90 (downhill4).
+      </p>
       <p>
         See also <a href="#uphill">uphill</a>, <a href="#uphill">uphill4</a>.
+      </p>
       </div>
     <div class="dict_entry" id="dxy">
       <h3>
@@ -2169,16 +2335,19 @@ if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
         Reports the x-increment or y-increment (the amount by which the
         turtle's xcor or ycor would change) if the turtle were to take
         one step forward in its current heading.
+      </p>
       <p>
         Note: dx is simply the sine of the turtle's heading, and dy is
         simply the cosine. (If this is the reverse of what you expected,
         it's because in NetLogo a heading of 0 is north and 90 is east,
         which is the reverse of how angles are usually defined in
         geometry.)
+      </p>
       <p>
         Note: In earlier versions of NetLogo, these primitives were used in
         many situations where the new <code>patch-ahead</code> primitive is now
-        more appropriate. <!-- ======================================== -->
+        more appropriate.
+      </p> <!-- ======================================== -->
       </div>
     </div>
     <h2 id="E">
@@ -2195,9 +2364,11 @@ if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
       </h4>
       <p>
         Reports true if the given list or string is empty, false otherwise.
+      </p>
       <p>
         Note: the empty list is written <code>[]</code>. The empty string is
         written <code>&quot;&quot;</code>.
+      </p>
       </div>
     <div class="dict_entry" id="end">
       <h3>
@@ -2208,6 +2379,7 @@ if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
       </h4>
       <p>
         Used to conclude a procedure. See <a href="#to">to</a> and <a href="#to-report">to-report</a>.
+      </p>
       </div>
     <div class="dict_entry" id="end1">
       <h3>
@@ -2222,6 +2394,7 @@ if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
         (turtle) of a link. For directed links this will always be the
         source for undirected links it will always be the turtle with the
         lower who number. You cannot set end1.
+      </p>
       <pre>
 crt 2
 ask turtle 0
@@ -2243,6 +2416,7 @@ ask links
         (turtle) of a link. For directed links this will always be the
         destination for undirected links it will always be the turtle with
         the higher who number. You cannot set end2.
+      </p>
       <pre>
 crt 2
 ask turtle 1
@@ -2260,11 +2434,14 @@ ask links
       </h4>
       <p>
         Causes a runtime error to occur.
+      </p>
       <p>
         The given value is converted to a string (if it isn't one
         already) and used as the error message.
+      </p>
       <p>
         See also <a href="#error-message">error-message</a>, <a href="#carefully">carefully</a>.
+      </p>
       </div>
     <div class="dict_entry" id="error-message">
       <h3>
@@ -2276,11 +2453,14 @@ ask links
       <p>
         Reports a string describing the error that was suppressed by
         carefully.
+      </p>
       <p>
         This reporter can only be used in the second block of a carefully
         command.
+      </p>
       <p>
         See also <a href="#error">error</a>, <a href="#carefully">carefully</a>.
+      </p>
       </div>
     <div class="dict_entry" id="every">
       <h3>
@@ -2293,11 +2473,13 @@ ask links
         Runs the given commands only if it's been more than
         <i>number</i> seconds since the last time this agent ran them in
         this context. Otherwise, the commands are skipped.
+      </p>
       <p>
         By itself, every doesn't make commands run over and over again.
         You need to use every inside a loop, or inside a forever button, if
         you want the commands run over and over again. every only limits
         how often the commands run.
+      </p>
       <p>
         Above, &quot;in this context&quot; means during the same ask (or
         button press or command typed in the Command Center). So it
@@ -2305,6 +2487,7 @@ ask links
         ]</code>, because when the ask finishes the turtles will all discard
         their timers for the &quot;every&quot;. The correct usage is shown
         below.
+      </p>
       <pre>
 every 0.5 [ ask turtles [ fd 1 ] ]
 ;; twice a second the turtles will move forward 1
@@ -2313,6 +2496,7 @@ every 2 [ set index index + 1 ]
 </pre>
       <p>
         See also <a href="#wait">wait</a>.
+      </p>
       </div>
     <div class="dict_entry" id="exp">
       <h3>
@@ -2323,8 +2507,10 @@ every 2 [ set index index + 1 ]
       </h4>
       <p>
         Reports the value of e raised to the <i>number</i> power.
+      </p>
       <p>
         Note: This is the same as e ^ <i>number</i>.
+      </p>
       </div>
     <div class="dict_entry" id="export-cmds">
       <h3>
@@ -2348,16 +2534,20 @@ every 2 [ set index index + 1 ]
         external file given by the string <i>filename</i>. The file is
         saved in PNG (Portable Network Graphics) format, so it is
         recommended to supply a filename ending in &quot;.png&quot;.
+      </p>
       <p>
         export-interface is similar, but for the whole interface tab.
+      </p>
       <p>
         Note that export-view still works when running NetLogo in headless
         mode, but export-interface doesn't.
+      </p>
       <p>
         export-output writes the contents of the model's output area to
         an external file given by the string <i>filename</i>. (If the model
         does not have a separate output area, the output portion of the
         Command Center is used.)
+      </p>
       <p>
         export-plot writes the x and y values of all points plotted by all
         the plot pens in the plot given by the string <i>plotname</i> to an
@@ -2366,10 +2556,12 @@ every 2 [ set index index + 1 ]
         than 0, the upper-left corner point of the bar will be exported. If
         the y value is less than 0, then the lower-left corner point of the
         bar will be exported.
+      </p>
       <p>
         export-all-plots writes every plot in the current model to an
         external file given by the string <i>filename</i>. Each plot is
         identical in format to the output of export-plot.
+      </p>
       <p>
         export-world writes the values of all variables, both built-in and
         user-defined, including all observer, turtle, and patch variables,
@@ -2378,19 +2570,23 @@ every 2 [ set index index + 1 ]
         to an external file given by the string <i>filename</i>. (The
         result file can be read back into NetLogo with the <a href="#import-world">import-world</a> primitive.) export-world does not
         save the state of open files.
+      </p>
       <p>
         export-plot, export-all-plots and export-world save files in in
         plain-text, &quot;comma-separated values&quot; (<code>.csv</code>)
         format. CSV files can be read by most popular spreadsheet and
         database programs as well as any text editor.
+      </p>
       <p>
         If you wish to export to a file in a location other than the
         model's location, you should include the full path to the file
         you wish to export. (Use the forward-slash &quot;/&quot; as the
         folder separator.)
+      </p>
       <p>
         Note that the functionality of these primitives is also available
         directly from NetLogo's File menu.
+      </p>
       <pre>
 export-world &quot;fire.csv&quot;
 ;; exports the state of the model to the file fire.csv
@@ -2406,6 +2602,7 @@ export-all-plots &quot;c:/My Documents/plots.csv&quot;
       <p>
         If the file already exists, it is overwritten. To avoid this you
         may wish to use some method of generating fresh names. Examples:
+      </p>
       <pre>
 export-world user-new-file
 export-world (word &quot;results &quot; date-and-time &quot;.csv&quot;) ;; Colon characters in the time cause errors on Windows
@@ -2423,6 +2620,7 @@ export-world (word &quot;results &quot; random-float 1.0 &quot;.csv&quot;)
         Allows the model to use primitives from the extensions with the
         given names. See the <a href="extensions.html">Extensions guide</a>
         for more information.
+      </p>
       </div>
     <div class="dict_entry" id="extract-hsb">
       <h3>
@@ -2435,11 +2633,13 @@ export-world (word &quot;results &quot; random-float 1.0 &quot;.csv&quot;)
         Reports a list of three values, the first (hue) in the range of
         0 to 360, the second and third (brightness and saturation) in
         the range of 0 to 100.
+      </p>
       <p>
         The given <i>color</i> can either be a NetLogo color in the
         range 0 to 140, not including 140 itself, or an RGB list of
         three values in the range 0 to 255 representing the levels
         of red, green, and blue.
+      </p>
       <pre>
 show extract-hsb cyan
 =&gt; [180 57.143 76.863]
@@ -2450,6 +2650,7 @@ show extract-hsb [255 0 0]
 </pre>
       <p>
         See also <a href="#approximate-hsb">approximate-hsb</a>, <a href="#approximate-rgb">approximate-rgb</a>, <a href="#extract-rgb">extract-rgb</a>.
+      </p>
       </div>
     <div class="dict_entry" id="extract-rgb">
       <h3>
@@ -2463,6 +2664,7 @@ show extract-hsb [255 0 0]
         the levels of red, green, and blue, respectively, of the given
         NetLogo <i>color</i> in the range 0 to 140, not including 140
         itself.
+      </p>
       <pre>
 show extract-rgb red
 =&gt; [215 50 41]
@@ -2471,6 +2673,7 @@ show extract-rgb cyan
 </pre>
       <p>
         See also <a href="#approximate-rgb">approximate-rgb</a>, <a href="#approximate-hsb">approximate-hsb</a>, <a href="#extract-hsb">extract-hsb</a>.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="F">
@@ -2487,13 +2690,16 @@ show extract-rgb cyan
       </h4>
       <p>
         Set the caller's heading towards <i>agent</i>.
+      </p>
       <p>
         If wrapping is allowed by the topology and the wrapped distance
         (around the edges of the world) is shorter, face will use the
         wrapped path.
+      </p>
       <p>
         If the caller and the agent are at the exact same position, the
         caller's heading won't change.
+      </p>
       </div>
     <div class="dict_entry" id="facexy">
       <h3>
@@ -2505,6 +2711,7 @@ show extract-rgb cyan
       </h4>
       <p>
         Set the caller's heading towards the point (x,y).
+      </p>
       <p>
         If wrapping is allowed by the topology and the wrapped distance
         (around the edges of the world) is shorter and wrapping is allowed,
@@ -2512,6 +2719,7 @@ show extract-rgb cyan
       <p>
         If the caller is on the point (x,y), the caller's heading
         won't change.
+      </p>
       </div>
     <div class="dict_entry" id="file-at-end">
       <h3>
@@ -2523,6 +2731,7 @@ show extract-rgb cyan
       <p>
         Reports true when there are no more characters left to read in from
         the current file (that was opened previously with <a href="#file-open">file-open</a>). Otherwise, reports false.
+      </p>
       <pre>
 file-open &quot;my-file.txt&quot;
 print file-at-end?
@@ -2534,6 +2743,7 @@ print file-at-end?
 </pre>
       <p>
         See also <a href="#file-open">file-open</a>, <a href="#file-close-all">file-close-all</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-close">
       <h3>
@@ -2544,13 +2754,17 @@ print file-at-end?
       </h4>
       <p>
         Closes a file that has been opened previously with <a href="#file-open">file-open</a>.
+      </p>
       <p>
         Note that this and file-close-all are the only ways to restart to
         the beginning of an opened file or to switch between file modes.
+      </p>
       <p>
         If no file is open, does nothing.
+      </p>
       <p>
         See also <a href="#file-close-all">file-close-all</a>, <a href="#file-open">file-open</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-close-all">
       <h3>
@@ -2562,8 +2776,10 @@ print file-at-end?
       <p>
         Closes all files (if any) that have been opened previously with
         <a href="#file-open">file-open</a>.
+      </p>
       <p>
         See also <a href="#file-close">file-close</a>, <a href="#file-open">file-open</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-delete">
       <h3>
@@ -2574,15 +2790,18 @@ print file-at-end?
       </h4>
       <p>
         Deletes the file specified as <i>string</i>
+      </p>
       <p>
         <i>string</i> must be an existing file with writable permission by
         the user. Also, the file cannot be open. Use the command <a href="#file-close">file-close</a> to close an opened file before
         deletion.
+      </p>
       <p>
         Note that the string can either be a file name or an absolute file
         path. If it is a file name, it looks in whatever the current
         directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It is defaulted
         to the model's directory.
+      </p>
       </div>
     <div class="dict_entry" id="file-exists">
       <h3>
@@ -2594,11 +2813,13 @@ print file-at-end?
       <p>
         Reports true if <i>string</i> is the name of an existing file on
         the system. Otherwise it reports false.
+      </p>
       <p>
         Note that the string can either be a file name or an absolute file
         path. If it is a file name, it looks in whatever the current
         directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It defaults to
         to the model's directory.
+      </p>
       </div>
     <div class="dict_entry" id="file-flush">
       <h3>
@@ -2612,11 +2833,13 @@ print file-at-end?
         or other output commands, the values may not be immediately written
         to disk. This improves the performance of the file output commands.
         Closing a file ensures that all output is written to disk.
+      </p>
       <p>
         Sometimes you need to ensure that data is written to disk without
         closing the file. For example, you could be using a file to
         communicate with another program on your machine and want the other
         program to be able to see the output immediately.
+      </p>
       </div>
     <div class="dict_entry" id="file-open">
       <h3>
@@ -2630,14 +2853,17 @@ print file-at-end?
         and open the file. You may then use the reporters <a href="#file-read">file-read</a>, <a href="#file-read-line">file-read-line</a>, and <a href="#file-read-characters">file-read-characters</a> to read in from
         the file, or <a href="#file-write">file-write</a>, <a href="#file-print">file-print</a>, <a href="#file-type">file-type</a>,
         or <a href="#file-show">file-show</a> to write out to the file.
+      </p>
       <p>
         Note that you can only open a file for reading or writing but not
         both. The next file i/o primitive you use after this command
         dictates which mode the file is opened in. To switch modes, you
         need to close the file using <a href="#file-close">file-close</a>.
+      </p>
       <p>
         Also, the file must already exist if opening a file in reading
         mode.
+      </p>
       <p>
         When opening a file in writing mode, all new data will be appended
         to the end of the original file. If there is no original file, a
@@ -2647,11 +2873,13 @@ print file-at-end?
         <a href="#file-delete">file-delete</a> to delete it first, perhaps
         inside a <a href="#carefully">carefully</a> if you're not sure
         whether it already exists.)
+      </p>
       <p>
         Note that the string can either be a file name or an absolute file
         path. If it is a file name, it looks in whatever the current
         directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It is defaulted
         to the model's directory.
+      </p>
       <pre>
 file-open &quot;my-file-in.txt&quot;
 print file-read-line
@@ -2664,8 +2892,10 @@ file-print &quot;Hello World&quot; ;; File is in writing mode
         Opening a file does not close previously opened files. You can use
         <code>file-open</code> to switch back and forth between multiple open
         files.
+      </p>
       <p>
         See also <a href="#file-close">file-close</a> See also <a href="#file-close-all">file-close-all</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-print">
       <h3>
@@ -2677,15 +2907,19 @@ file-print &quot;Hello World&quot; ;; File is in writing mode
       <p>
         Prints <i>value</i> to an opened file, followed by a carriage
         return.
+      </p>
       <p>
         This agent is <i>not</i> printed before the value, unlike <a href="#file-show">file-show</a>.
+      </p>
       <p>
         Note that this command is the file i/o equivalent of <a href="#print">print</a>, and <a href="#file-open">file-open</a> needs to
         be called before this command can be used.
+      </p>
       <p>
       See also <a href="#file-show">file-show</a>, <a href="#file-type">file-type</a>,
       <a href="#file-write">file-write</a>,
       and <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-read">
       <h3>
@@ -2699,17 +2933,21 @@ file-print &quot;Hello World&quot; ;; File is in writing mode
         and interpret it as if it had been typed in the Command Center. It
         reports the resulting value. The result may be a number, list,
         string, boolean, or the special value nobody.
+      </p>
       <p>
         Whitespace separates the constants. Each call to file-read will
         skip past both leading and trailing whitespace.
+      </p>
       <p>
         Note that strings need to have quotes around them. Use the command
         <a href="#file-write">file-write</a> to have quotes included.
+      </p>
       <p>
         Also note that the <a href="#file-open">file-open</a> command must
         be called before this reporter can be used, and there must be data
         remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
         of the file.
+      </p>
       <pre>
 file-open &quot;my-file.data&quot;
 print file-read + 5
@@ -2721,6 +2959,7 @@ print length file-read
 </pre>
       <p>
         See also <a href="#file-open">file-open</a> and <a href="#file-write">file-write</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-read-characters">
       <h3>
@@ -2733,14 +2972,17 @@ print length file-read
         Reports the given <i>number</i> of characters from an opened file
         as a string. If there are fewer than that many characters left, it
         will report all of the remaining characters.
+      </p>
       <p>
         Note that it will return every character including newlines and
         spaces.
+      </p>
       <p>
         Also note that the <a href="#file-open">file-open</a> command must
         be called before this reporter can be used, and there must be data
         remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
         of the file.
+      </p>
       <pre>
 file-open &quot;my-file.txt&quot;
 print file-read-characters 5
@@ -2749,6 +2991,7 @@ print file-read-characters 5
 </pre>
       <p>
         See also <a href="#file-open">file-open</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-read-line">
       <h3>
@@ -2762,11 +3005,13 @@ print file-read-characters 5
         determines the end of the file by a carriage return, an end of file
         character or both in a row. It does not return the line terminator
         characters.
+      </p>
       <p>
         Also note that the <a href="#file-open">file-open</a> command must
         be called before this reporter can be used, and there must be data
         remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
         of the file.
+      </p>
       <pre>
 file-open &quot;my-file.txt&quot;
 print file-read-line
@@ -2774,6 +3019,7 @@ print file-read-line
 </pre>
       <p>
         See also <a href="#file-open">file-open</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-show">
       <h3>
@@ -2788,13 +3034,16 @@ print file-read-line
         to help you keep track of what agents are producing which lines of
         output.) Also, all strings have their quotes included similar to
         <a href="#file-write">file-write</a>.
+      </p>
       <p>
         Note that this command is the file i/o equivalent of <a href="#show">show</a>, and <a href="#file-open">file-open</a> needs to
         be called before this command can be used.
+      </p>
       <p>
         See also <a href="#file-print">file-print</a>, <a href="#file-type">file-type</a>,
         <a href="#file-write">file-write</a>,
         and <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-type">
       <h3>
@@ -2808,14 +3057,18 @@ print file-read-line
         carriage return (unlike <a href="#file-print">file-print</a> and
         <a href="#file-show">file-show</a>). The lack of a carriage return
         allows you to print several values on the same line.
+      </p>
       <p>
         This agent is <i>not</i> printed before the value. unlike <a href="#file-show">file-show</a>.
+      </p>
       <p>
         Note that this command is the file i/o equivalent of <a href="#type">type</a>, and <a href="#file-open">file-open</a> needs to
         be called before this command can be used.
+      </p>
       <p>
         See also <a href="#file-print">file-print</a>, <a href="#file-show">file-show</a>, <a href="#file-write">file-write</a>, and
         <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-write">
       <h3>
@@ -2828,14 +3081,17 @@ print file-read-line
         This command will output <i>value</i>, which can be a number,
         string, list, boolean, or nobody to an opened file, <i>not</i>
         followed by a carriage return (unlike <a href="#file-print">file-print</a> and <a href="#file-show">file-show</a>).
+      </p>
       <p>
         This agent is <i>not</i> printed before the value, unlike <a href="#file-show">file-show</a>. Its output also includes quotes around
         strings and is prepended with a space. It will output the value in
         such a manner that <a href="#file-read">file-read</a> will be able
         to interpret it.
+      </p>
       <p>
         Note that this command is the file i/o equivalent of <a href="#write">write</a>, and <a href="#file-open">file-open</a> needs to
         be called before this command can be used.
+      </p>
       <pre>
 file-open &quot;locations.txt&quot;
 ask turtles
@@ -2845,6 +3101,7 @@ ask turtles
         See also <a href="#file-print">file-print</a>, <a href="#file-show">file-show</a>,
         <a href="#file-type">file-type</a>,
         and <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="filter">
       <h3>
@@ -2858,6 +3115,7 @@ ask turtles
         the reporter reports true -- in other words, the items satisfying the
         given condition. <i>reporter</i> may be an anonymous reporter or the
         name of a reporter.
+      </p>
       <pre>
 show filter is-number? [1 &quot;2&quot; 3]
 =&gt; [1 3]
@@ -2869,6 +3127,7 @@ show filter [ s -&gt; first s != &quot;t&quot; ] [&quot;hi&quot; &quot;there&quo
       <p>
         See also <a href="#map">map</a>, <a href="#reduce">reduce</a>,
         <a href="#arrow">-> (anonymous procedure)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="first">
       <h3>
@@ -2880,9 +3139,11 @@ show filter [ s -&gt; first s != &quot;t&quot; ] [&quot;hi&quot; &quot;there&quo
       </h4>
       <p>
         On a list, reports the first (0th) item in the list.
+      </p>
       <p>
         On a string, reports a one-character string containing only the
         first character of the original string.
+      </p>
       </div>
     <div class="dict_entry" id="floor">
       <h3>
@@ -2893,6 +3154,7 @@ show filter [ s -&gt; first s != &quot;t&quot; ] [&quot;hi&quot; &quot;there&quo
       </h4>
       <p>
         Reports the largest integer less than or equal to <i>number</i>.
+      </p>
       <pre>
 show floor 4.5
 =&gt; 4
@@ -2901,6 +3163,7 @@ show floor -4.5
 </pre>
       <p>
         See also <a href="#ceiling">ceiling</a>, <a href="#round">round</a>, <a href="#precision">precision</a>.
+      </p>
       </div>
     <div class="dict_entry" id="follow">
       <h3>
@@ -2913,14 +3176,17 @@ show floor -4.5
       <p>
         Similar to ride, but, in the 3D view, the observer&apos;s vantage
         point is behind and above <i>turtle</i>.
+      </p>
       <p>
         The observer may only watch or follow a single subject.
         Calling <code>follow</code> will alter the highlight created by
         prior calls to <code>watch</code> and <code>watch-me</code>, highlighting
         the followed turtle instead.
+      </p>
       <p>
         See also <a href="#follow-me">follow-me</a>, <a href="#ride">ride</a>,
         <a href="#reset-perspective">reset-perspective</a>, <a href="#watch">watch</a>, <a href="#subject">subject</a>.
+      </p>
       </div>
     <div class="dict_entry" id="follow-me">
       <h3>
@@ -2932,13 +3198,16 @@ show floor -4.5
       </h4>
       <p>
         Asks the observer to follow this turtle.
+      </p>
       <p>
         The observer may only watch or follow a single subject.
         Calling <code>follow-me</code> will remove the highlight created by
         prior calls to <code>watch</code> and <code>watch-me</code>, highlighting
         this turtle instead.
+      </p>
       <p>
         See also <a href="#follow">follow</a>.
+      </p>
       </div>
     <div class="dict_entry" id="foreach">
       <h3>
@@ -2952,6 +3221,7 @@ show floor -4.5
         With a single list, runs the command for each item of <i>list</i>.
         <i>command</i> may be the name of a command, or an anonymous command
         created with <a href="#arrow">-&gt;</a>.
+      </p>
       <pre>
 foreach [1.1 2.2 2.6] show
 =&gt; 1.1
@@ -2967,8 +3237,10 @@ foreach [1.1 2.2 2.6] [ x -&gt; show (word x &quot; -&gt; &quot; round x) ]
         from each list.
         So, they are run once for the first items, once for
         the second items, and so on. All the lists must be the same length.
+      </p>
       <p>
         Some examples make this clearer:
+      </p>
       <pre>
 (foreach [1 2 3] [2 4 6]
    [ [a b] -&gt; show word &quot;the sum is: &quot; (a + b) ])
@@ -2982,6 +3254,7 @@ foreach [1.1 2.2 2.6] [ x -&gt; show (word x &quot; -&gt; &quot; round x) ]
 </pre>
       <p>
         See also <a href="#map">map</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="forward">
       <h3>
@@ -2995,16 +3268,20 @@ foreach [1.1 2.2 2.6] [ x -&gt; show (word x &quot; -&gt; &quot; round x) ]
       <p>
         The turtle moves forward by <i>number</i> steps, one step at a
         time. (If <i>number</i> is negative, the turtle moves backward.)
+      </p>
       <p>
         <code>fd 10</code> is equivalent to <code>repeat 10 [ jump 1 ]</code>.
         <code>fd 10.5</code> is equivalent to <code>repeat 10 [ jump 1 ] jump
         0.5</code>.
+      </p>
       <p>
         If the turtle cannot move forward <i>number</i> steps because it is
         not permitted by the current topology the turtle will complete as
         many steps of 1 as it can, then stop.
+      </p>
       <p>
         See also <a href="#jump">jump</a>, <a href="#can-move">can-move?</a>.
+      </p>
       </div>
     <div class="dict_entry" id="fput">
       <h3>
@@ -3016,6 +3293,7 @@ foreach [1.1 2.2 2.6] [ x -&gt; show (word x &quot; -&gt; &quot; round x) ]
       <p>
         Adds <i>item</i> to the beginning of a list and reports the new
         list.
+      </p>
       <pre>
 ;; suppose mylist is [5 7 10]
 set mylist fput 2 mylist
@@ -3041,9 +3319,11 @@ set mylist fput 2 mylist
         new global variables. Global variables are &quot;global&quot;
         because they are accessible by all agents and can be used anywhere
         in a model.
+      </p>
       <p>
         Most often, globals is used to define variables or constants that
         need to be used in many parts of the program.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="H">
@@ -3065,15 +3345,18 @@ set mylist fput 2 mylist
         parent. (Exceptions: each new turtle will have a new <code>who</code>
         number, and it may be of a different breed than its parent if the
         <code>hatch-<i>&lt;breeds&gt;</i></code> form is used.)
+      </p>
       <p>
         The new turtles then run <i>commands</i>. You can use the commands
         to give the new turtles different colors, headings, locations, or
         whatever. (The new turtles are created all at once, then run one at
         a time, in random order.)
+      </p>
       <p>
         If the hatch-<i>&lt;breeds&gt;</i> form is used, the new turtles
         are created as members of the given breed. Otherwise, the new
         turtles are the same breed as their parent.
+      </p>
       <pre>
 hatch 1 [ lt 45 fd 1 ]
 ;; this turtle creates one new turtle,
@@ -3084,6 +3367,7 @@ hatch-sheep 1 [ set color black ]
 </pre>
       <p>
         See also <a href="#create-turtles">create-turtles</a>, <a href="#sprout">sprout</a>.
+      </p>
       </div>
     <div class="dict_entry" id="heading">
       <h3>
@@ -3098,11 +3382,14 @@ hatch-sheep 1 [ set color black ]
         turtle is facing. This is a number greater than or equal to 0 and
         less than 360. 0 is north, 90 is east, and so on. You can set this
         variable to make a turtle turn.
+      </p>
       <p>
         See also <a href="#right">right</a>, <a href="#left">left</a>,
         <a href="#dxy">dx</a>, <a href="#dxy">dy</a>.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 set heading 45      ;; turtle is now facing northeast
 set heading heading + 10 ;; same effect as &quot;rt 10&quot;
@@ -3121,11 +3408,14 @@ set heading heading + 10 ;; same effect as &quot;rt 10&quot;
         (true or false) value indicating whether the turtle or link is
         currently hidden (i.e., invisible). You can set this variable to
         make a turtle or link disappear or reappear.
+      </p>
       <p>
         See also <a href="#hide-turtle">hide-turtle</a>, <a href="#show-turtle">show-turtle</a>, <a href="#hide-link">hide-link</a>,
         <a href="#show-link">show-link</a>
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 set hidden? not hidden?
 ;; if turtle was showing, it hides, and if it was hiding,
@@ -3142,11 +3432,14 @@ set hidden? not hidden?
       </h4>
       <p>
         The link makes itself invisible.
+      </p>
       <p>
         Note: This command is equivalent to setting the link variable
         &quot;hidden?&quot; to true.
+      </p>
       <p>
         See also <a href="#show-turtle">show-link</a>.
+      </p>
       </div>
     <div class="dict_entry" id="hide-turtle">
       <h3>
@@ -3159,11 +3452,14 @@ set hidden? not hidden?
       </h4>
       <p>
         The turtle makes itself invisible.
+      </p>
       <p>
         Note: This command is equivalent to setting the turtle variable
         &quot;hidden?&quot; to true.
+      </p>
       <p>
         See also <a href="#show-turtle">show-turtle</a>.
+      </p>
       </div>
     <div class="dict_entry" id="histogram">
       <h3>
@@ -3174,15 +3470,19 @@ set hidden? not hidden?
       </h4>
       <p>
         Histograms the values in the given list
+      </p>
       <p>
         Draws a histogram showing the frequency distribution of the values
         in the list. The heights of the bars in the histogram represent the
         numbers of values in each subrange.
+      </p>
       <p>
         Before the histogram is drawn, first any previous points drawn by
         the current plot pen are removed.
+      </p>
       <p>
         Any non-numeric values in the list are ignored.
+      </p>
       <p>
         The histogram is drawn on the current plot using the current plot
         pen and pen color. Auto scaling does not affect a histogram's
@@ -3190,13 +3490,16 @@ set hidden? not hidden?
         range, and the pen interval can then be set (either directly with
         set-plot-pen-interval, or indirectly via set-histogram-num-bars) to
         control how many bars that range is split up into.
+      </p>
       <p>
         Be sure that if you want the histogram drawn with bars that the
         current pen is in bar mode (mode 1).
+      </p>
       <p>
         For histogramming purposes the plot's X range is not considered
         to include the maximum X value. Values equal to the maximum X will
         fall outside of the histogram's range.
+      </p>
       <pre>
 histogram [color] of turtles
 ;; draws a histogram showing how many turtles there are
@@ -3214,6 +3517,7 @@ histogram [color] of turtles
       <p>
         This turtle moves to the origin (0,0). Equivalent to <code>setxy 0
         0</code>.
+      </p>
       </div>
     <div class="dict_entry" id="hsb">
       <h3>
@@ -3227,8 +3531,10 @@ histogram [color] of turtles
         color. Hue, saturation, and brightness are integers in the range
         0-360, 0-100, 0-100 respectively. The RGB list contains three
         integers in the range of 0-255.
+      </p>
       <p>
         See also <a href="#rgb">rgb</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-broadcast">
       <h3>
@@ -3240,9 +3546,11 @@ histogram [color] of turtles
       <p>
         This broadcasts <i>value</i> from NetLogo to the interface element
         with the name <i>tag-name</i> on the clients.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details and instructions.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-broadcast-clear-output">
       <h3>
@@ -3253,8 +3561,10 @@ histogram [color] of turtles
       </h4>
       <p>
         This clears all messages printed to the text area on every client.
+      </p>
       <p>
         See also: <a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>, <a href="#hubnet-send-clear-output">hubnet-send-clear-output</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-broadcast-message">
       <h3>
@@ -3267,8 +3577,10 @@ histogram [color] of turtles
         This prints the value in the text area on each client. This is the
         same functionality as the &quot;Broadcast Message&quot; button in
         the HubNet Control Center.
+      </p>
       <p>
         See also: <a href="#hubnet-send-message">hubnet-send-message</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-clear-override">
       <h3>
@@ -3285,8 +3597,10 @@ histogram [color] of turtles
         specified variable for the specified agent or agentset.
         <code>hubnet-clear-overrides</code> removes all overrides from the
         specified client.
+      </p>
       <p>
         See also: <a href="#hubnet-send-override">hubnet-send-override</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-clients-list">
       <h3>
@@ -3298,6 +3612,7 @@ histogram [color] of turtles
       <p>
         Reports a list containing the names of all the clients currently
         connected to the HubNet server.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-enter-message">
       <h3>
@@ -3310,9 +3625,11 @@ histogram [color] of turtles
         Reports true if a new client just entered the simulation. Reports
         false otherwise. <a href="#hubnet-message-source">hubnet-message-source</a> will contain the
         user name of the client that just logged on.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details and instructions.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-exit-message">
       <h3>
@@ -3325,9 +3642,11 @@ histogram [color] of turtles
         Reports true if a client just exited the simulation. Reports false
         otherwise. <a href="#hubnet-message-source">hubnet-message-source</a> will contain the
         user name of the client that just logged off.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details and instructions.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-fetch-message">
       <h3>
@@ -3340,9 +3659,11 @@ histogram [color] of turtles
         If there is any new data sent by the clients, this retrieves the
         next piece of data, so that it can be accessed by <a href="#hubnet-message">hubnet-message</a>, <a href="#hubnet-message-source">hubnet-message-source</a>, and <a href="#hubnet-message-tag">hubnet-message-tag</a>. This will cause an
         error if there is no new data from the clients.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-kick-client">
       <h3>
@@ -3355,6 +3676,7 @@ histogram [color] of turtles
         Kicks the client with the given client-name. This is equivalent to
         clicking the client name in the HubNet Control Center and pressing
         the Kick button.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-kick-all-clients">
       <h3>
@@ -3367,6 +3689,7 @@ histogram [color] of turtles
         Kicks out all currently connected HubNet clients. This is
         equivalent to selecting all clients in the HubNet Control Center
         and pressing the Kick button.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-message">
       <h3>
@@ -3377,9 +3700,11 @@ histogram [color] of turtles
       </h4>
       <p>
         Reports the message retrieved by <a href="#hubnet-fetch-message">hubnet-fetch-message</a>.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-message-source">
       <h3>
@@ -3391,9 +3716,11 @@ histogram [color] of turtles
       <p>
         Reports the name of the client that sent the message retrieved by
         <a href="#hubnet-fetch-message">hubnet-fetch-message</a>.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-message-tag">
       <h3>
@@ -3407,9 +3734,11 @@ histogram [color] of turtles
         by <a href="#hubnet-fetch-message">hubnet-fetch-message</a>. The
         tag will be one of the Display Names of the interface elements in
         the client interface.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-message-waiting">
       <h3>
@@ -3421,9 +3750,11 @@ histogram [color] of turtles
       <p>
         This looks for a new message sent by the clients. It reports true
         if there is one, and false if there is not.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-reset">
       <h3>
@@ -3435,9 +3766,11 @@ histogram [color] of turtles
       <p>
         Starts up the HubNet system. HubNet must be started to use any of
         the other hubnet primitives.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-reset-perspective">
       <h3>
@@ -3449,9 +3782,11 @@ histogram [color] of turtles
       <p>
         Clears watch or follow sent directly to the client. The view
         perspective will revert to the server perspective.
+      </p>
       <p>
         See also: <a href="#hubnet-send-watch">hubnet-send-watch</a>
         <a href="#hubnet-send-follow">hubnet-send-follow</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-send">
       <h3>
@@ -3467,16 +3802,20 @@ histogram [color] of turtles
         For a <i>string</i>, this sends <i>value</i> from NetLogo to the
         tag <i>tag-name</i> on the client that has <i>string</i> for its
         user name.
+      </p>
       <p>
         For a <i>list-of-strings</i>, this sends <i>value</i> from NetLogo
         to the tag <i>tag-name</i> on all the clients that have a user name
         that is in the <i>list-of-strings</i>.
+      </p>
       <p>
         Sending a message to a non-existent client, using
         <code>hubnet-send</code>, generates a <code>hubnet-exit-message</code>.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-send-clear-output">
       <h3>
@@ -3492,9 +3831,11 @@ histogram [color] of turtles
         This clears all messages printed to the text area on the given
         client or clients (specified in the <i>string</i> or
         <i>list-of-strings</i>.
+      </p>
       <p>
         See also: <a href="#hubnet-send-message">hubnet-send-message</a>,
         <a href="#hubnet-broadcast-clear-output">hubnet-broadcast-clear-output</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-send-follow">
       <h3>
@@ -3507,14 +3848,17 @@ histogram [color] of turtles
         Tells the client associated with <i>client-name</i> to follow
         <i>agent</i> showing a <i>radius</i> sized Moore neighborhood
         around the agent.
+      </p>
       <p>
         A client may only watch or follow a single subject.
         Calling <code>hubnet-send-follow</code> will alter the highlight created by
         prior calls to <code>hubnet-send-watch</code>, highlighting
         the followed agent instead.
+      </p>
       <p>
         See also: <a href="#hubnet-send-watch">hubnet-send-watch</a>,
         <a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-send-message">
       <h3>
@@ -3526,8 +3870,10 @@ histogram [color] of turtles
       <p>
         This prints <code>value</code> in the text area on the client specified
         by <code>string</code>.
+      </p>
       <p>
         See also: <a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-send-override">
       <h3>
@@ -3545,6 +3891,7 @@ histogram [color] of turtles
         built-in variables that affect the appearance of the agent may be
         selected. For example, you can override the color variable of a
         turtle:
+      </p>
       <pre>
 ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
 </pre>
@@ -3554,8 +3901,10 @@ ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
         the turtles are blue. This code makes the turtle associated with
         each client appear red in his or her own view but not on anyone
         else's or on the server.
+      </p>
       <p>
         See also: <a href="#hubnet-clear-override">hubnet-clear-overrides</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-send-watch">
       <h3>
@@ -3567,13 +3916,16 @@ ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
       <p>
         Tells the client associated with <i>client-name</i> to watch
         <i>agent</i>.
+      </p>
       <p>
         A client may only watch or follow a single subject.
         Calling <code>hubnet-send-watch</code> will undo perspective changes caused
         by prior calls to <code>hubnet-send-follow</code>.
+      </p>
       <p>
         See also: <a href="#hubnet-send-follow">hubnet-send-follow</a>,
         <a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
+      </p>
       </div>
     </div> <!-- ======================================== -->
     <h2 id="I">
@@ -3589,11 +3941,14 @@ ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
       </h4>
       <p>
         Reporter must report a boolean (true or false) value.
+      </p>
       <p>
         If <i>condition</i> reports true, runs <i>commands</i>.
+      </p>
       <p>
         The reporter may report a different value for different agents, so
         some agents may run <i>commands</i> and others don't.
+      </p>
       <pre>
 if xcor &gt; 0[ set color blue ]
 ;; turtles in the right half of the world
@@ -3601,6 +3956,7 @@ if xcor &gt; 0[ set color blue ]
 </pre>
       <p>
         See also <a href="#ifelse">ifelse</a>, <a href="#ifelse-value">ifelse-value</a>.
+      </p>
       </div>
     <div class="dict_entry" id="ifelse">
       <h3>
@@ -3612,12 +3968,15 @@ if xcor &gt; 0[ set color blue ]
       </h4>
       <p>
         The <i>reporter</i>s must report boolean (true or false) values.
+      </p>
       <p>
         For the first <i>reporter</i> that reports true, runs the <i>commands</i> that follow.
+      </p>
       <p>
         If no <i>reporter</i> reports true, runs <i>elsecommands</i> or does nothing if
         <i>elsecommands</i> is not given.  When using only one <i>reporter</i>
         you do not need to surround the entire <i>ifelse</i> primitive and its blocks in parentheses.
+      </p>
         <pre>
   ask patches
     [ ifelse pxcor &gt; 0
@@ -3629,7 +3988,8 @@ if xcor &gt; 0[ set color blue ]
       <p>
         The reporters may report a different value for different agents, so
         some agents may run different command blocks.  When using more than one <i>reporter</i> you
-        must surround the whole <i>ifelse<i> primitive and its blocks in parentheses.
+        must surround the whole <i>ifelse</i> primitive and its blocks in parentheses.
+      </p>
       <pre>
         ask patches [
           let choice random 4
@@ -3655,6 +4015,7 @@ if xcor &gt; 0[ set color blue ]
       </pre>
       <p>
         See also <a href="#if">if</a>, <a href="#ifelse-value">ifelse-value</a>.
+      </p>
       </div>
     <div class="dict_entry" id="ifelse-value">
       <h3>
@@ -3666,18 +4027,22 @@ if xcor &gt; 0[ set color blue ]
       </h4>
       <p>
         The <i>tfreporter</i>s must report boolean (true or false) values.
+      </p>
       <p>
         For the first <i>tfreporter</i> that reports true, runs the
-        <i>reporter</i> that follows and reports that result.  When using only one <i>tfreporter1<i>
+        <i>reporter</i> that follows and reports that result.  When using only one <i>tfreporter1</i>
         you do not need to surround the entire <i>ifelse-value</i> primitive and its blocks in parentheses.
+      </p>
       <p>
         If all <i>tfreporter</i>s report false, the result is the value of
         <i>elsereporter</i>.  You may leave out the <i>elsereporter</i>, but
         if all <i>tfreporter</i>s report false then a runtime error will occur.
+      </p>
       <p>
         This can be used when a conditional is needed in the context of a
         reporter, where commands (such as <a href="#ifelse">ifelse</a>) are
         not allowed.
+      </p>
       <pre>
 ask patches [
   set pcolor ifelse-value (pxcor &gt; 0) [blue] [red]
@@ -3692,7 +4057,8 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
 </pre>
       <p>
         When using more than one <i>tfreporter</i> you
-        must surround the whole <i>ifelse-value<i> primitive and its blocks in parentheses.
+        must surround the whole <i>ifelse-value</i> primitive and its blocks in parentheses.
+      </p>
       <pre>
         ask patches [
           let choice random 4
@@ -3702,8 +4068,10 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
             choice = 2 [ green ]
                        [ yellow ])
         ]
+      </pre>
       <p>
         A runtime error can occur if there is no <i>elsereporter</i>.
+      </p>
       <pre>
         ask patches [
           let x = 2
@@ -3715,6 +4083,7 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
       </pre>
       <p>
         See also <a href="#if">if</a>, <a href="#ifelse">ifelse</a>.
+      </p>
       </div>
     <div class="dict_entry" id="import-drawing">
       <h3>
@@ -3729,15 +4098,18 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
         world, while retaining the original aspect ratio of the image. The
         image is centered in the drawing. The old drawing is not cleared
         first.
+      </p>
       <p>
         Agents cannot sense the drawing, so they cannot interact with or
         process images imported by import-drawing. If you need agents to
         sense an image, use <a href="#import-pcolors">import-pcolors</a> or
         <a href="#import-pcolors-rgb">import-pcolors-rgb</a>.
+      </p>
       <p>
         The following image file formats are supported: BMP, JPG, GIF, and
         PNG. If the image format supports transparency (alpha), that
         information will be imported as well.
+      </p>
       </div>
     <div class="dict_entry" id="import-pcolors">
       <h3>
@@ -3756,16 +4128,19 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
         possible colors. (See the Color section of the Programming Guide.)
         import-pcolors may be slow for some images, particularly when you
         have many patches and a large image with many different colors.
+      </p>
       <p>
         Since import-pcolors sets the pcolor of patches, agents can sense
         the image. This is useful if agents need to analyze, process, or
         otherwise interact with the image. If you want to simply display a
         static backdrop, without color distortion, see <a href="#import-drawing">import-drawing</a>.
+      </p>
       <p>
         The following image file formats are supported: BMP, JPG, GIF, and
         PNG. If the image format supports transparency (alpha), then all
         fully transparent pixels will be ignored. (Partially transparent
         pixels will be treated as opaque.)
+      </p>
       </div>
     <div class="dict_entry" id="import-pcolors-rgb">
       <h3>
@@ -3782,11 +4157,13 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
         centered in the patch grid. Unlike <a href="#import-pcolors">import-pcolors</a> the exact colors in the
         original image are retained. The pcolor variable of all the patches
         will be an RGB list rather than an (approximated) NetLogo color.
+      </p>
       <p>
         The following image file formats are supported: BMP, JPG, GIF, and
         PNG. If the image format supports transparency (alpha), then all
         fully transparent pixels will be ignored. (Partially transparent
         pixels will be treated as opaque.)
+      </p>
       </div>
     <div class="dict_entry" id="import-world">
       <h3>
@@ -3802,12 +4179,15 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
         from an external file named by the given string. The file should be
         in the format used by the <a href="#export-cmds">export-world</a>
         primitive.
+      </p>
       <p>
         Note that the functionality of this primitive is also directly
         available from NetLogo's File menu.
+      </p>
       <p>
         When using import-world, to avoid errors, perform these steps in
         the following order:
+      </p>
       <ol>
         <li>Open the model from which you created the export file.
         <li>Press the Setup button, to get the model in a state from which
@@ -3823,6 +4203,7 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
         model's location, you may include the full path to the file you
         wish to import. See <a href="#export-cmds">export-world</a> for an
         example.
+      </p>
       </div>
     <div class="dict_entry" id="in-cone">
       <h3>
@@ -3839,12 +4220,15 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
         may range from 0 to 360 and is centered around the turtle's
         current heading. (If the angle is 360, then in-cone is equivalent
         to in-radius.)
+      </p>
       <p>
         in-cone reports an agentset that includes only those agents from
         the original agentset that fall in the cone. (This can include the
         agent itself.)
+      </p>
       <p>
         The distance to a patch is measured from the center of the patch.
+      </p>
       <pre>
 ask turtles
   [ ask patches in-cone 3 60
@@ -3868,6 +4252,7 @@ ask turtles
         to the caller or an undirected link connecting <i>turtle</i> to the
         caller. You can think of this as "is there a link I can use to get from
         <i>turtle</i> to the caller?"
+      </p>
       <pre>
 crt 2
 ask turtle 0 [
@@ -3896,6 +4281,7 @@ ask turtle 1 [
         from them to the caller as well as all turtles that have an undirected
         link connecting them with the caller. You can think of this as "all the
         turtles that can get to the caller using a link."
+      </p>
       <pre>
 crt 4
 ask turtle 0 [ create-links-to other turtles ]
@@ -3918,6 +4304,7 @@ ask turtle 1 [ ask in-link-neighbors [ set color blue ] ] ;; turtle 0 turns blue
         reports nobody. If more than one such link exists, reports a
         random one. You can think of this as "give me a link that I can use
         to travel from <i>turtle</i> to the caller."
+      </p>
       <pre>
 crt 2
 ask turtle 0 [ create-link-to turtle 1 ]
@@ -3926,6 +4313,7 @@ ask turtle 0 [ show in-link-from turtle 1 ] ;; shows nobody
 </pre>
       <p>
         See also: <a href="#out-link-to">out-link-to</a> <a href="#link-with">link-with</a>
+      </p>
       </div>
     <div class="dict_entry" id="includes">
       <h3>
@@ -3939,13 +4327,16 @@ ask turtle 0 [ show in-link-from turtle 1 ] ;; shows nobody
         suffix) to be included in this model. Included files may contain
         breed, variable, and procedure definitions. <code>__includes</code> can
         only be used once per file.
+      </p>
       <p>
         The file names must be strings, for example:
+      </p>
       <pre>
 __includes [ &quot;utils.nls&quot; ]
       </pre>
       <p>
         Or, for multiple files:
+      </p>
       <pre>
 __includes [ &quot;utils1.nls&quot; &quot;utils2.nls&quot; ]
       </pre>
@@ -3962,9 +4353,11 @@ __includes [ &quot;utils1.nls&quot; &quot;utils2.nls&quot; ]
         Reports an agentset that includes only those agents from the
         original agentset whose distance from the caller is less than or
         equal to <i>number</i>. (This can include the agent itself.)
+      </p>
       <p>
         The distance to or a from a patch is measured from the center of
         the patch.
+      </p>
       <pre>
 ask turtles
   [ ask patches in-radius 3
@@ -3985,9 +4378,11 @@ ask turtles
         On a list, inserts an item in that list. <i>index</i> is the index
         where the item will be inserted. The first item has an index of 0.
         (The 6th item in a list would have an index of 5.)
+      </p>
       <p>
         Likewise for a string, but all characters in a multiple-character <i>string2</i>
         are inserted at <i>index</i>.
+      </p>
       <pre>
 show insert-item 2 [2 7 4 5] 15
 =&gt; [2 7 15 4 5]
@@ -4006,6 +4401,7 @@ show insert-item 2 &quot;cat&quot; &quot;re&quot;
       </h4>
       <p>
         Opens an agent monitor for the given agent (turtle or patch).
+      </p>
       <pre>
 inspect patch 2 4
 ;; an agent monitor opens for that patch
@@ -4015,6 +4411,7 @@ inspect one-of sheep
 </pre>
       <p>
         See <a href="#stop-inspecting">stop-inspecting</a> and <a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>
+      </p>
     </div>
     <div class="dict_entry" id="int">
       <h3>
@@ -4026,6 +4423,7 @@ inspect one-of sheep
       <p>
         Reports the integer part of number -- any fractional part is
         discarded.
+      </p>
       <pre>
 show int 4.7
 =&gt; 4
@@ -4074,6 +4472,7 @@ show int -3.5
       </h4>
       <p>
         Reports true if <i>value</i> is of the given type, false otherwise.
+      </p>
       </div>
     <div class="dict_entry" id="item">
       <h3>
@@ -4086,12 +4485,15 @@ show int -3.5
       <p>
         On lists, reports the value of the item in the given list with the
         given index.
+      </p>
       <p>
         On strings, reports the character in the given string at the given
         index.
+      </p>
       <p>
         Note that the indices begin from 0, not 1. (The first item is item
         0, the second item is item 1, and so on.)
+      </p>
       <pre>
 ;; suppose mylist is [2 4 6 8 10]
 show item 2 mylist
@@ -4116,17 +4518,19 @@ show item 3 &quot;my-shoe&quot;
       <p>
         The turtle moves forward by <i>number</i> units all at once (rather
         than one step at a time as with the <code>forward</code> command).
+      </p>
       <p>
         If the turtle cannot jump <i>number</i> units because it is not
         permitted by the current topology the turtle does not move at all.
+      </p>
       <p>
         See also <a href="#forward">forward</a>, <a href="#can-move">can-move?</a>.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="L">
       <a>L</a>
     </h2><!-- ======================================== -->
-    <div>
     <div class="dict_entry" id="label">
       <h3>
         <a>label</a>
@@ -4140,10 +4544,13 @@ show item 3 &quot;my-shoe&quot;
         any type. The turtle or link appears in the view with the given
         value &quot;attached&quot; to it as text. You can set this variable
         to add, change, or remove a turtle or link's label.
+      </p>
       <p>
         See also <a href="#label-color">label-color</a>, <a href="#plabel">plabel</a>, <a href="#plabel-color">plabel-color</a>.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 ask turtles [ set label who ]
 ;; all the turtles now are labeled with their
@@ -4166,11 +4573,14 @@ ask turtles [ set label &quot;&quot; ]
         determines what color the turtle or link's label appears in (if
         it has a label). You can set this variable to change the color of a
         turtle or link's label.
+      </p>
       <p>
         See also <a href="#label">label</a>, <a href="#plabel">plabel</a>,
         <a href="#plabel-color">plabel-color</a>.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 ask turtles [ set label-color red ]
 ;; all the turtles now have red labels
@@ -4186,9 +4596,11 @@ ask turtles [ set label-color red ]
       </h4>
       <p>
         On a list, reports the last item in the list.
+      </p>
       <p>
         On a string, reports a one-character string containing only the
         last character of the original string.
+      </p>
       </div>
     <div class="dict_entry" id="layout-circle">
       <h3>
@@ -4203,13 +4615,16 @@ ask turtles [ set label-color red ]
         center of the world with the given radius. (If the world has an
         even size the center of the circle is rounded down to the nearest
         patch.) The turtles point outwards.
+      </p>
       <p>
         If the first input is an agentset, the turtles are arranged in
         random order.
+      </p>
       <p>
         If the first input is a list, the turtles are arranged clockwise in
         the given order, starting at the top of the circle. (Any
         non-turtles in the list are ignored.)
+      </p>
       <pre>
 ;; in random order
 layout-circle turtles 10
@@ -4230,14 +4645,17 @@ layout-circle sort-by [ [a b] -&gt; [size] of a &lt; [size] of b ] turtles 10
         Arranges the turtles in <i>turtle-set</i> connected by links in
         <i>link-set</i>, in a radial tree layout, centered around the
         <i>root-agent</i> which is moved to the center of the world view.
+      </p>
       <p>
         Only links in the <i>link-set</i> will be used to determine the
         layout. If links connect turtles that are not in <i>turtle-set</i>
         those turtles will remain stationary.
+      </p>
       <p>
         Even if the network does contain cycles, and is not a true tree
         structure, this layout will still work, although the results will
         not always be pretty.
+      </p>
       <pre>
 to make-a-tree
   set-default-shape turtles &quot;circle&quot;
@@ -4270,19 +4688,23 @@ end
         other. Turtles that are connected by links in <i>link-set</i> but
         not included in <i>turtle-set</i> are treated as anchors and are
         not moved.
+      </p>
       <p>
         <i>spring-constant</i> is a measure of the &quot;tautness&quot; of
         the spring. It is the &quot;resistance&quot; to change in their
         length. spring-constant is the force the spring would exert if
         it's length were changed by 1 unit.
+      </p>
       <p>
         spring-length is the &quot;zero-force&quot; length or the natural
         length of the springs. This is the length which all springs try to
         achieve either by pushing out their nodes or pulling them in.
+      </p>
       <p>
         repulsion-constant is a measure of repulsion between the nodes. It
         is the force that 2 nodes at a distance of 1 unit will exert on
         each other.
+      </p>
       <p>
         The repulsion effect tries to get the nodes as far as possible from
         each other, in order to avoid crowding and the spring effect tries
@@ -4290,10 +4712,12 @@ end
         they are connected to. The result is the laying out of the whole
         network in a way which highlights relationships among the nodes and
         at the same time is crowded less and is visually pleasing.
+      </p>
       <p>
         The layout algorithm is based on the Fruchterman-Reingold layout
         algorithm. More information about this algorithm can be obtained
         <a href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.13.8444" target="_blank">here</a>.
+      </p>
       <pre>
 to make-a-triangle
   set-default-shape turtles &quot;circle&quot;
@@ -4322,19 +4746,24 @@ end
         included in <i>turtle-set</i> are placed in a circle layout with
         the given <i>radius</i>. There should be at least 3 agents in this
         agentset.
+      </p>
       <p>
         The turtles in <i>turtle-set</i> are then laid out in the following
         manner: Each turtle is placed at centroid (or barycenter) of the
         polygon formed by its linked neighbors. (The centroid is like a
         2-dimensional average of the coordinates of the neighbors.)
+      </p>
       <p>
         (The purpose of the circle of &quot;anchor agents&quot; is to
         prevent all the turtles from collapsing down to one point.)
+      </p>
       <p>
         After a few iterations of this, the layout will stabilize.
+      </p>
       <p>
         This layout is named after the mathematician William Thomas Tutte,
         who proposed it as a method for graph layout.
+      </p>
       <pre>
 to make-a-tree
   set-default-shape turtles &quot;circle&quot;
@@ -4368,6 +4797,7 @@ end
       <p>
         The turtle turns left by <i>number</i> degrees. (If <i>number</i>
         is negative, it turns right.)
+      </p>
       </div>
     <div class="dict_entry" id="length">
       <h3>
@@ -4380,6 +4810,7 @@ end
       <p>
         Reports the number of items in the given list, or the number of
         characters in the given string.
+      </p>
       </div>
     <div class="dict_entry" id="let">
       <h3>
@@ -4392,10 +4823,13 @@ end
         Creates a new local variable and gives it the given value. A local
         variable is one that exists only within the enclosing block of
         commands.
+      </p>
       <p>
         If you want to change the value afterwards, use <a href="#set">set</a>.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 let prey one-of sheep-here
 if prey != nobody
@@ -4415,6 +4849,7 @@ if prey != nobody
         the turtles. If there is no such link reports <code>nobody</code>. To
         refer to breeded links you must use the singular breed form with
         the endpoints.
+      </p>
       <pre>
 ask link 0 1 [ set color green ]
 ;; unbreeded link connecting turtle 0 and turtle 1 will turn green
@@ -4423,6 +4858,7 @@ ask directed-link 0 1 [ set color red ]
 </pre>
       <p>
         See also <a href="#patch-at">patch-at</a>.
+      </p>
       </div>
     <div class="dict_entry" id="link-heading">
       <h3>
@@ -4436,12 +4872,14 @@ ask directed-link 0 1 [ set color red ]
         Reports the heading in degrees (at least 0, less than 360) from
         <code>end1</code> to <code>end2</code> of the link. Throws a runtime error
         if the endpoints are at the same location.
+      </p>
       <pre>
 ask link 0 1 [ print link-heading ]
 ;; prints [[towards other-end] of end1] of link 0 1
 </pre>
       <p>
         See also <a href="#link-length">link-length</a>
+      </p>
       </div>
     <div class="dict_entry" id="link-length">
       <h3>
@@ -4453,12 +4891,14 @@ ask link 0 1 [ print link-heading ]
       </h4>
       <p>
         Reports the distance between the endpoints of the link.
+      </p>
       <pre>
 ask link 0 1 [ print link-length ]
 ;; prints [[distance other-end] of end1] of link 0 1
 </pre>
       <p>
         See also <a href="#link-heading">link-heading</a>
+      </p>
       </div>
     <div class="dict_entry" id="link-set">
       <h3>
@@ -4472,12 +4912,14 @@ ask link 0 1 [ print link-length ]
         Reports an agentset containing all of the links anywhere in any of
         the inputs. The inputs may be individual links, link agentsets,
         nobody, or lists (or nested lists) containing any of the above.
+      </p>
       <pre>
 link-set self
 link-set [my-links] of nodes with [color = red]
 </pre>
       <p>
         See also <a href="#turtle-set">turtle-set</a>, <a href="#patch-set">patch-set</a>.
+      </p>
       </div>
     <div class="dict_entry" id="link-shapes">
       <h3>
@@ -4489,9 +4931,11 @@ link-set [my-links] of nodes with [color = red]
       <p>
         Reports a list of strings containing all of the link shapes in the
         model.
+      </p>
       <p>
         New shapes can be created, or imported from other models, in the
         <a href="shapes.html">Link Shapes Editor</a>.
+      </p>
       <pre>
 show link-shapes
 =&gt; [&quot;default&quot;]
@@ -4506,6 +4950,7 @@ show link-shapes
       </h4>
       <p>
         Reports the agentset consisting of all links. This is a special agentset that can grow as links are added to the world, see <a href="programming.html#special-agentsets">the programming guide for more info</a>.
+      </p>
       <pre>
 show count links
 ;; prints the number of links
@@ -4524,10 +4969,12 @@ show count links
         <i>&lt;breeds&gt;</i>-own, turtles-own, and patches-own keywords,
         can only be used at the beginning of a program, before any function
         definitions. It defines the variables belonging to each link.
+      </p>
       <p>
         If you specify a breed instead of &quot;links&quot;, only links of
         that breed have the listed variables. (More than one link breed may
         list the same variable.)
+      </p>
       <pre>
 undirected-link-breed [sidewalks sidewalk]
 directed-link-breed [streets street]
@@ -4546,6 +4993,7 @@ streets-own [cars bikes]
         <p>
           Reports a list containing the given items. The items can be of
           any type, produced by any kind of reporter.
+        </p>
         <pre>
 show list (random 10) (random 10)
 =&gt; [4 9]  ;; or similar list
@@ -4565,8 +5013,10 @@ show (list (random 10) 1 2 3 (random 10))
         <p>
           Reports the natural logarithm of <i>number</i>, that is, the
           logarithm to the base e (2.71828...).
+        </p>
         <p>
           See also <a href="#num-e">e</a>, <a href="#log">log</a>.
+        </p>
         </div>
       <div class="dict_entry" id="log">
         <h3>
@@ -4577,12 +5027,14 @@ show (list (random 10) 1 2 3 (random 10))
         </h4>
         <p>
           Reports the logarithm of <i>number</i> in base <i>base</i>.
+        </p>
         <pre>
 show log 64 2
 =&gt; 6
 </pre>
         <p>
           See also <a href="#ln">ln</a>.
+        </p>
         </div>
       <div class="dict_entry" id="loop">
         <h3>
@@ -4595,6 +5047,7 @@ show log 64 2
           Repeats the commands forever, or until the enclosing procedure
           exits through use of the <a href="#stop">stop</a> or
           <a href="#report">report</a> commands.
+        </p>
           <pre>to move-to-world-edge  ;; turtle procedure
   loop [
     if not can-move? 1 [ stop ]
@@ -4603,11 +5056,13 @@ show log 64 2
 end</pre>
         <p>In this example, <code>stop</code> exits not just the loop,
            but the entire procedure.
+        </p>
         <p>
           Note: in many circumstances, it is more appropriate to use
           a forever button to repeat something indefinitely.  See
           <a href="programming.html#buttons">Buttons</a> in the
           Programming Guide.
+        </p>
         </div>
       <div class="dict_entry" id="lput">
         <h3>
@@ -4618,6 +5073,7 @@ end</pre>
         </h4>
         <p>
           Adds <i>value</i> to the end of a list and reports the new list.
+        </p>
         <pre>
 ;; suppose mylist is [2 7 10 &quot;Bob&quot;]
 set mylist lput 42 mylist
@@ -4641,6 +5097,7 @@ set mylist lput 42 mylist
           With a single <i>list</i>, the given reporter is run for each item in
           the list, and a list of the results is collected and reported.
           <i>reporter</i> may be an anonymous reporter or the name of a reporter.
+        </p>
         <pre>
 show map round [1.1 2.2 2.7]
 =&gt; [1 2 3]
@@ -4652,8 +5109,10 @@ show map [ i -&gt; i * i ] [1 2 3]
           items from each list. So, it is run once for the first items,
           once for the second items, and so on. All the lists must be the
           same length.
+        </p>
         <p>
           Some examples make this clearer:
+        </p>
         <pre>
 show (map + [1 2 3] [2 4 6])
 =&gt; [3 6 9]
@@ -4662,6 +5121,7 @@ show (map [ [a b c] -&gt; a + b = c ] [1 2 3] [2 4 6] [3 5 9])
 </pre>
         <p>
         See also <a href="#foreach">foreach</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>.
+        </p>
         </div>
       <div class="dict_entry" id="max">
         <h3>
@@ -4673,6 +5133,7 @@ show (map [ [a b c] -&gt; a + b = c ] [1 2 3] [2 4 6] [3 5 9])
         <p>
           Reports the maximum number value in the list. It ignores other
           types of items.
+        </p>
         <pre>
 show max [xcor] of turtles
 ;; prints the x coordinate of the turtle which is
@@ -4698,6 +5159,7 @@ show max (list a b c)
           with that value then agents with the second highest value are
           found, and so on. At the end, if there is a tie that would make
           the resulting agentset too large, the tie is broken randomly.
+        </p>
         <pre>
 ;; assume the world is 11 x 11
 show max-n-of 5 patches [pxcor]
@@ -4708,6 +5170,7 @@ show max-n-of 5 patches with [pycor = 0] [pxcor]
 </pre>
         <p>
           See also <a href="#max-one-of">max-one-of</a>, <a href="#with-max">with-max</a>.
+        </p>
         </div>
       <div class="dict_entry" id="max-one-of">
         <h3>
@@ -4721,12 +5184,14 @@ show max-n-of 5 patches with [pycor = 0] [pxcor]
           the given reporter. If there is a tie this command reports one
           random agent with the highest value. If you want all such agents,
           use with-max instead.
+        </p>
         <pre>
 show max-one-of patches [count turtles-here]
 <br>;; prints the first patch with the most turtles on it
 </pre>
         <p>
           See also <a href="#max-n-of">max-n-of</a>, <a href="#with-max">with-max</a>.
+        </p>
         </div>
       <div class="dict_entry" id="max-pcor">
         <h3>
@@ -4741,13 +5206,16 @@ show max-one-of patches [count turtles-here]
           These reporters give the maximum x-coordinate and maximum
           y-coordinate, (respectively) for patches, which determines the
           size of the world.
+        </p>
         <p>
           Unlike in older versions of NetLogo the origin does not have to
           be at the center of the world. However, the maximum x- and y-
           coordinates must be greater than or equal to zero.
+        </p>
         <p>
           Note: You can set the size of the world only by editing the view
           -- these are reporters which cannot be set.
+        </p>
         <pre>
 crt 100 [ setxy random-float max-pxcor
                 random-float max-pycor ]
@@ -4756,6 +5224,7 @@ crt 100 [ setxy random-float max-pxcor
 </pre>
         <p>
           See also <a href="#min-pcor">min-pxcor</a>, <a href="#min-pcor">min-pycor</a>, <a href="#world-dim">world-width</a>, and <a href="#world-dim">world-height</a>
+        </p>
         </div>
       <div class="dict_entry" id="mean">
         <h3>
@@ -4768,6 +5237,7 @@ crt 100 [ setxy random-float max-pxcor
           Reports the statistical mean of the numeric items in the given
           list. Errors on non-numeric items. The mean is the average, i.e.,
           the sum of the items divided by the total number of items.
+        </p>
         <pre>
 show mean [xcor] of turtles
 ;; prints the average of all the turtles' x coordinates
@@ -4786,6 +5256,7 @@ show mean [xcor] of turtles
           would be in the middle if all the items were arranged in order.
           (If two items would be in the middle, the median is the average
           of the two.)
+        </p>
         <pre>
 show median [xcor] of turtles
 ;; prints the median of all the turtles' x coordinates
@@ -4803,13 +5274,16 @@ show median [xcor] of turtles
         <p>
           For a list, reports true if the given value appears in the given
           list, otherwise reports false.
+        </p>
         <p>
           For a string, reports true or false depending on whether
           <i>string1</i> appears anywhere inside <i>string2</i> as a
           substring.
+        </p>
         <p>
           For an agentset, reports true if the given agent is appears in
           the given agentset, otherwise reports false.
+        </p>
         <pre>
 show member? 2 [1 2 3]
 =&gt; true
@@ -4824,6 +5298,7 @@ show member? turtle 0 patches
 </pre>
         <p>
           See also <a href="#position">position</a>.
+        </p>
         </div>
       <div class="dict_entry" id="min">
         <h3>
@@ -4835,6 +5310,7 @@ show member? turtle 0 patches
         <p>
           Reports the minimum number value in the list. It ignores other
           types of items.
+        </p>
         <pre>
 show min [xcor] of turtles
 ;; prints the lowest x-coordinate of all the turtles
@@ -4859,6 +5335,7 @@ show min (list a b c)
           that value then the agents with the second lowest value are
           found, and so on. At the end, if there is a tie that would make
           the resulting agentset too large, the tie is broken randomly.
+        </p>
         <pre>
 ;; assume the world is 11 x 11
 show min-n-of 5 patches [pxcor]
@@ -4869,6 +5346,7 @@ show min-n-of 5 patches with [pycor = 0] [pxcor]
 </pre>
         <p>
           See also <a href="#min-one-of">min-one-of</a>, <a href="#with-min">with-min</a>.
+        </p>
         </div>
       <div class="dict_entry" id="min-one-of">
         <h3>
@@ -4882,6 +5360,7 @@ show min-n-of 5 patches with [pycor = 0] [pxcor]
           value for the given reporter. If there is a tie, this command
           reports one random agent that meets the condition. If you want
           all such agents use with-min instead.
+        </p>
         <pre>
 show min-one-of turtles [xcor + ycor]
 ;; reports the first turtle with the smallest sum of
@@ -4889,6 +5368,7 @@ show min-one-of turtles [xcor + ycor]
 </pre>
         <p>
           See also <a href="#with-min">with-min</a>, <a href="#min-n-of">min-n-of</a>.
+        </p>
         </div>
       <div class="dict_entry" id="min-pcor">
         <h3>
@@ -4903,13 +5383,16 @@ show min-one-of turtles [xcor + ycor]
           These reporters give the minimum x-coordinate and minimum
           y-coordinate, (respectively) for patches, which determines the
           size of the world.
+        </p>
         <p>
           Unlike in older versions of NetLogo the origin does not have to
           be at the center of the world. However, the minimum x- and y-
           coordinates must be less than or equal to zero.
+        </p>
         <p>
           Note: You can set the size of the world only by editing the view
           -- these are reporters which cannot be set.
+        </p>
         <pre>
 crt 100 [ setxy random-float min-pxcor
                 random-float min-pycor ]
@@ -4918,6 +5401,7 @@ crt 100 [ setxy random-float min-pxcor
 </pre>
         <p>
           See also <a href="#max-pcor">max-pxcor</a>, <a href="#max-pcor">max-pycor</a>, <a href="#world-dim">world-width</a>, and <a href="#world-dim">world-height</a>
+        </p>
         </div>
       <div class="dict_entry" id="mod">
         <h3>
@@ -4930,12 +5414,14 @@ crt 100 [ setxy random-float min-pxcor
           Reports <i>number1</i> modulo <i>number2</i>: that is, the
           residue of <i>number1</i> (mod <i>number2</i>). mod is is
           equivalent to the following NetLogo code:
+        </p>
         <pre>
 <i>number1</i> - (floor (<i>number1</i> / <i>number2</i>)) * <i>number2</i>
 </pre>
         <p>
           Note that mod is &quot;infix&quot;, that is, it comes between its
           two inputs.
+        </p>
         <pre>
 show 62 mod 5
 =&gt; 2
@@ -4946,6 +5432,7 @@ show -8 mod 3
           See also <a href="#remainder">remainder</a>. mod and remainder
           behave the same for positive numbers, but differently for
           negative numbers.
+        </p>
         </div>
       <div class="dict_entry" id="modes">
         <h3>
@@ -4956,10 +5443,13 @@ show -8 mod 3
         </h4>
         <p>
           Reports a list of the most common item or items in <i>list</i>.
+        </p>
         <p>
           The input list may contain any NetLogo values.
+        </p>
         <p>
           If the input is an empty list, reports an empty list.
+        </p>
         <pre>
 show modes [1 2 2 3 4]
 =&gt; [2]
@@ -4981,9 +5471,11 @@ show modes [pxcor] of turtles
         </h4>
         <p>
           Reports true if the mouse button is down, false otherwise.
+        </p>
         <p>
           Note: If the mouse pointer is outside of the current view ,
           mouse-down? will always report false.
+        </p>
         </div>
       <div class="dict_entry" id="mouse-inside">
         <h3>
@@ -4995,6 +5487,7 @@ show modes [pxcor] of turtles
         <p>
           Reports true if the mouse pointer is inside the current view,
           false otherwise.
+        </p>
         </div>
       <div class="dict_entry" id="mouse-cor">
         <h3>
@@ -5010,9 +5503,11 @@ show modes [pxcor] of turtles
           value is in terms of turtle coordinates, so it might not be an
           integer. If you want patch coordinates, use <code>round
           mouse-xcor</code> and <code>round mouse-ycor</code>.
+        </p>
         <p>
           Note: If the mouse is outside of the 2D view, reports the value
           from the last time it was inside.
+        </p>
         <pre>
 ;; to make the mouse &quot;draw&quot; in red:
 if mouse-down?
@@ -5030,9 +5525,11 @@ if mouse-down?
         <p>
           The turtle sets its x and y coordinates to be the same as the
           given agent's.
+        </p>
         <p>
           (If that agent is a patch, the effect is to move the turtle to
           the center of that patch.)
+        </p>
         <pre>
 move-to turtle 5
 ;; turtle moves to same point as turtle 5
@@ -5045,8 +5542,10 @@ move-to max-one-of turtles [size]
           Note that the turtle's heading is unaltered. You may want to
           use the <a href="#face">face</a> command first to orient the
           turtle in the direction of motion.
+        </p>
         <p>
           See also <a href="#setxy">setxy</a>.
+        </p>
         </div>
       <div class="dict_entry" id="my-links">
         <h3>
@@ -5066,6 +5565,7 @@ move-to max-one-of turtles [size]
           of this primitive, as it works well for either directed or
           undirected networks (since it excludes directed, incoming
           links).
+        </p>
         <pre>
 crt 5
 ask turtle 0
@@ -5098,6 +5598,7 @@ end
           other nodes to the caller as well as all undirected links
           connected to the caller. You can think of this as "all links
           that you can use to travel <i>to</i> this node".
+        </p>
         <pre>
 crt 5
 ask turtle 0
@@ -5126,6 +5627,7 @@ ask turtle 1
           caller to other nodes as well as undirected links connected to the
           caller. You can think of this as "all links you can use to travel
           <i>from</i> this node".
+        </p>
         <pre>
 crt 5
 ask turtle 0
@@ -5152,17 +5654,21 @@ ask turtle 1
           &quot;self&quot; is simple; it means &quot;me&quot;.
           &quot;myself&quot; means &quot;the turtle, patch or link who asked me
           to do what I'm doing right now.&quot;
+        </p>
         <p>
           When an agent has been asked to run some code, using myself in
           that code reports the agent (turtle, patch or link) that did the
           asking.
+        </p>
         <p>
           myself is most often used in conjunction with <code>of</code> to read
           or set variables in the asking agent.
+        </p>
         <p>
           myself can be used within blocks of code not just in the ask
           command, but also hatch, sprout, of, with, all?, with-min,
           with-max, min-one-of, max-one-of, min-n-of, max-n-of.
+        </p>
         <pre>
 ask turtles
   [ ask patches in-radius 3
@@ -5172,8 +5678,10 @@ ask turtles
         <p>
           See the &quot;Myself Example&quot; code example for more
           examples.
+        </p>
         <p>
           See also <a href="#self">self</a>.
+        </p>
         </div><!-- ======================================== -->
       </div>
       <h2 id="N">
@@ -5191,14 +5699,17 @@ ask turtles
         <p>
           From an agentset, reports an agentset of size <i>size</i>
           randomly chosen from the input set, with no repeats.
+        </p>
         <p>
           From a list, reports a list of size <i>size</i> randomly chosen
           from the input set, with no repeats. The items in the result
           appear in the same order that they appeared in the input list.
           (If you want them in random order, use shuffle on the result.)
+        </p>
         <p>
           It is an error for <i>size</i> to be greater than the size of the
           input.
+        </p>
         <pre>
 ask n-of 50 patches [ set pcolor green ]
 ;; 50 randomly chosen patches turn green
@@ -5207,6 +5718,7 @@ ask n-of 50 patches [ set pcolor green ]
           See also <a href="#one-of">one-of</a> and <a href="#up-to-n-of">up-to-n-of</a>,
           a version that does not error with a <i>size</i> greater than
           the size of the input.
+        </p>
         </div>
       <div class="dict_entry" id="n-values">
         <h3>
@@ -5219,9 +5731,11 @@ ask n-of 50 patches [ set pcolor green ]
           Reports a list of length <i>size</i> containing values computed
           by repeatedly running the reporter. <i>reporter</i> may be an anonymous
           reporter or the name of a reporter.
+        </p>
         <p>
           If the reporter accepts inputs, the input will be the number of the
           item currently being computed, starting from zero.
+        </p>
         <pre>
 show n-values 5 [1]
 =&gt; [1 1 1 1 1]
@@ -5234,6 +5748,7 @@ show n-values 5 [ x -&gt; x * x ]
 </pre>
         <p>
         See also <a href="#reduce">reduce</a>, <a href="#filter">filter</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>, <a href="#range">range</a>.
+        </p>
         </div>
       <div class="dict_entry" id="neighbors">
         <h3>
@@ -5248,6 +5763,7 @@ show n-values 5 [ x -&gt; x * x ]
         <p>
           Reports an agentset containing the 8 surrounding patches
           (neighbors) or 4 surrounding patches (neighbors4).
+        </p>
         <pre>
 show sum [count turtles-here] of neighbors
   ;; prints the total number of turtles on the eight
@@ -5272,6 +5788,7 @@ ask neighbors4 [ set pcolor red ]
           Reports the agentset of all turtles found at the other end of
           any links (undirected or directed, incoming or outgoing)
           connected to this turtle.
+        </p>
         <pre>
 crt 3
 ask turtle 0
@@ -5299,6 +5816,7 @@ end
         <p>
           Reports true if there is a link (either directed or undirected,
           incoming or outgoing) between <i>turtle</i> and the caller.
+        </p>
         <pre>
 crt 2
 ask turtle 0
@@ -5322,6 +5840,7 @@ ask turtle 1
       <p>
         Reports a string containing the version number of the NetLogo you
         are running.
+      </p>
       <pre>
 show netlogo-version
 =&gt; &quot;{{version}}&quot;
@@ -5336,6 +5855,7 @@ show netlogo-version
       </h4>
       <p>
         Reports true if the model is running in NetLogo Web.
+      </p>
       </div>
     <div class="dict_entry" id="new-seed">
       <h3>
@@ -5346,17 +5866,21 @@ show netlogo-version
       </h4>
       <p>
         Reports a number suitable for seeding the random number generator.
+      </p>
       <p>
         The numbers reported by new-seed are based on the current date and
         time in milliseconds and lie in the generator's usable range of
         seeds, -2147483648 to 2147483647.
+      </p>
       <p>
         new-seed never reports the same number twice in succession, even
         across parallel BehaviorSpace runs. (This
         is accomplished by waiting a millisecond if the seed for the
         current millisecond was already used.)
+      </p>
       <p>
         See also <a href="#random-seed">random-seed</a>.
+      </p>
       </div>
     <div class="dict_entry" id="no-display">
       <h3>
@@ -5368,21 +5892,26 @@ show netlogo-version
       <p>
         Turns off all updates to the current view until the display command
         is issued. This has two major uses.
+      </p>
       <p>
         One, you can control when the user sees view updates. You might
         want to change lots of things on the view behind the user's
         back, so to speak, then make them visible to the user all at once.
+      </p>
       <p>
         Two, your model will run faster when view updating is off, so if
         you're in a hurry, this command will let you get results
         faster. (Note that normally you don't need to use no-display
         for this, since you can also use the on/off switch in view control
         strip to freeze the view.)
+      </p>
       <p>
         Note that display and no-display operate independently of the
         switch in the view control strip that freezes the view.
+      </p>
       <p>
         See also <a href="#display">display</a>.
+      </p>
       </div>
     <div class="dict_entry" id="nobody">
       <h3>
@@ -5395,11 +5924,13 @@ show netlogo-version
         This is a special value which some primitives such as turtle,
         one-of, max-one-of, etc. report to indicate that no agent was
         found. Also, when a turtle dies, it becomes equal to nobody.
+      </p>
       <p>
         Note: Empty agentsets are not equal to nobody. If you want to test
         for an empty agentset, use <a href="#any">any?</a>. You only get
         nobody back in situations where you were expecting a single agent,
         not a whole agentset.
+      </p>
       <pre>
 set target one-of other turtles-here
 if target != nobody
@@ -5415,6 +5946,7 @@ if target != nobody
       </h4>
       <p>
         Reports an empty link agentset.
+      </p>
     </div>
     <div class="dict_entry" id="no-patches">
       <h3>
@@ -5425,6 +5957,7 @@ if target != nobody
       </h4>
       <p>
         Reports an empty patch agentset.
+      </p>
     </div>
     <div class="dict_entry" id="not">
       <h3>
@@ -5435,6 +5968,7 @@ if target != nobody
       </h4>
       <p>
         Reports true if <i>boolean</i> is false, otherwise reports false.
+      </p>
       <pre>
 if not any? turtles [ crt 10 ]
 </pre>
@@ -5448,6 +5982,7 @@ if not any? turtles [ crt 10 ]
       </h4>
       <p>
         Reports an empty turtle agentset.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="O">
@@ -5465,6 +6000,7 @@ if not any? turtles [ crt 10 ]
       <p>
         For an agent, reports the value of the reporter for that agent
         (turtle or patch).
+      </p>
       <pre>
 show [pxcor] of patch 3 5
 ;; prints 3
@@ -5479,6 +6015,7 @@ show [count turtles in-radius 3] of patch 0 0
       <p>
         For an agentset, reports a list that contains the value of the
         reporter for each agent in the agentset (in random order).
+      </p>
       <pre>
 crt 4
 show sort [who] of turtles
@@ -5498,9 +6035,11 @@ show sort [who * who] of turtles
       <p>
         From an agentset, reports a random agent. If the agentset is empty,
         reports <a href="#nobody">nobody</a>.
+      </p>
       <p>
         From a list, reports a random list item. It is an error for the
         list to be empty.
+      </p>
       <pre>
 ask one-of patches [ set pcolor green ]
 ;; a random patch turns green
@@ -5515,6 +6054,7 @@ show one-of mylist
 </pre>
       <p>
         See also <a href="#n-of">n-of</a>, <a href="#up-to-n-of">up-to-n-of</a>.
+      </p>
       </div>
     <div class="dict_entry" id="or">
       <h3>
@@ -5526,9 +6066,11 @@ show one-of mylist
       <p>
         Reports true if either <i>boolean1</i> or <i>boolean2</i>, or both,
         is true.
+      </p>
       <p>
         Note that if <i>condition1</i> is true, then <i>condition2</i> will
         not be run (since it can't affect the result).
+      </p>
       <pre>
 if (pxcor &gt; 0) or (pycor &gt; 0) [ set pcolor red ]
 ;; patches turn red except in lower-left quadrant
@@ -5545,6 +6087,7 @@ if (pxcor &gt; 0) or (pycor &gt; 0) [ set pcolor red ]
       <p>
         Reports an agentset which is the same as the input agentset but
         omits this agent.
+      </p>
       <pre>
 show count turtles-here
 =&gt; 10
@@ -5563,12 +6106,15 @@ show count other turtles-here
       <p>
         If run by a turtle, reports the turtle at the other end of the
         asking link.
+      </p>
       <p>
         If run by a link, reports the turtle at the end of the link that
         isn't the asking turtle.
+      </p>
       <p>
         These definitions are difficult to understand in the abstract, but
         the following examples should help:
+      </p>
       <pre>
 ask turtle 0 [ create-link-with turtle 1 ]
 ask turtle 0 [ ask link 0 1 [ show other-end ] ] ;; prints turtle 1
@@ -5578,6 +6124,7 @@ ask link 0 1 [ ask turtle 0 [ show other-end ] ] ;; prints turtle 1
       <p>
         As these examples hopefully make plain, the &quot;other&quot; end
         is the end that is neither asking nor being asked.
+      </p>
       </div>
     <div class="dict_entry" id="out-link-neighbor">
       <h3>
@@ -5594,6 +6141,7 @@ ask link 0 1 [ ask turtle 0 [ show other-end ] ] ;; prints turtle 1
         <i>turtle</i> or if there is an undirected link connecting the caller
         with <i>turtle</i>. You can think of this as "can I get from the caller
         to <i>turtle</i> using a link?"
+      </p>
       <pre>
 crt 2
 ask turtle 0 [
@@ -5621,6 +6169,7 @@ ask turtle 1 [
         Reports the agentset of all the turtles that have directed links
         from the caller, or undirected links with the caller. You can think
         of this as "who can I get to from the caller using a link?"
+      </p>
       <pre>
 crt 4
 ask turtle 0
@@ -5652,6 +6201,7 @@ end
         reports nobody. If more than one such link exists, reports a
         random one. You can think of this as "give me a link that I can use
         to travel from the caller to <i>turtle</i>."
+      </p>
       <pre>
 crt 2
 ask turtle 0 [
@@ -5665,6 +6215,7 @@ ask turtle 1
 </pre>
       <p>
         See also: <a href="#in-link-from">in-link-from</a> <a href="#link-with">link-with</a>
+      </p>
       </div>
     <div class="dict_entry" id="output-cmds">
       <h3>
@@ -5685,6 +6236,7 @@ ask turtle 1
         the model's output area, instead of in the Command Center. (If
         the model does not have a separate output area, then the Command
         Center is used.) See also <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="P">
@@ -5702,14 +6254,17 @@ ask turtle 1
         Given the x and y coordinates of a point, reports the patch
         containing that point. (The coordinates are absolute coordinates;
         they are not computed relative to this agent, as with patch-at.)
+      </p>
       <p>
         If x and y are integers, the point is the center of a patch. If x
         or y is not an integer, rounding to the nearest integer is used to
         determine which patch contains the point.
+      </p>
       <p>
         If wrapping is allowed by the topology, the given coordinates will
         be wrapped to be within the world. If wrapping is not allowed and
         the given coordinates are outside the world, reports nobody.
+      </p>
       <pre>
 ask patch 3 -4 [ set pcolor green ]
 ;; patch with pxcor of 3 and pycor of -4 turns green
@@ -5723,6 +6278,7 @@ show patch 18 19
 </pre>
       <p>
         See also <a href="#patch-at">patch-at</a>.
+      </p>
       </div>
     <div class="dict_entry" id="patch-ahead">
       <h3>
@@ -5737,6 +6293,7 @@ show patch 18 19
         &quot;ahead&quot; of this turtle, that is, along the turtle's
         current heading. Reports nobody if the patch does not exist because
         it is outside the world.
+      </p>
       <pre>
 ask patch-ahead 1 [ set pcolor green ]
 ;; turns the patch 1 in front of this turtle
@@ -5745,6 +6302,7 @@ ask patch-ahead 1 [ set pcolor green ]
 </pre>
       <p>
         See also <a href="#patch-at">patch-at</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
+      </p>
       </div>
     <div class="dict_entry" id="patch-at">
       <h3>
@@ -5757,9 +6315,11 @@ ask patch-ahead 1 [ set pcolor green ]
       <p>
         Reports the patch at (dx, dy) from the caller, that is, the patch
         containing the point dx east and dy patches north of this agent.
+      </p>
       <p>
         Reports nobody if there is no such patch because that point is
         beyond a non-wrapping world boundary.
+      </p>
       <pre>
 ask patch-at 1 -1 [ set pcolor green ]
 ;; if caller is a turtle or patch, turns the
@@ -5767,6 +6327,7 @@ ask patch-at 1 -1 [ set pcolor green ]
 </pre>
       <p>
         See also <a href="#patch">patch</a>, <a href="#patch-ahead">patch-ahead</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
+      </p>
       </div>
     <div class="dict_entry" id="patch-at-heading-and-distance">
       <h3>
@@ -5783,12 +6344,14 @@ ask patch-at 1 -1 [ set pcolor green ]
         patch-right-and-ahead, this turtle's current heading is not
         taken into account.) Reports nobody if the patch does not exist
         because it is outside the world.
+      </p>
       <pre>
 ask patch-at-heading-and-distance -90 1 [ set pcolor green ]
 ;; turns the patch 1 to the west of this patch green
 </pre>
       <p>
         See also <a href="#patch">patch</a>, <a href="#patch-at">patch-at</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>.
+      </p>
       </div>
     <div class="dict_entry" id="patch-here">
       <h3>
@@ -5800,9 +6363,11 @@ ask patch-at-heading-and-distance -90 1 [ set pcolor green ]
       </h4>
       <p>
         patch-here reports the patch under the turtle.
+      </p>
       <p>
         Note that this reporter isn't available to a patch because a
         patch can just say &quot;self&quot;.
+      </p>
       </div>
     <div class="dict_entry" id="patch-lr-and-ahead">
       <h3>
@@ -5819,10 +6384,12 @@ ask patch-at-heading-and-distance -90 1 [ set pcolor green ]
         turtle, in the direction turned left or right the given angle (in
         degrees) from the turtle's current heading. Reports nobody if
         the patch does not exist because it is outside the world.
+      </p>
       <p>
         (If you want to find a patch in a given absolute heading, rather
         than one relative to the current turtle's heading, use
         patch-at-heading-and-distance instead.)
+      </p>
       <pre>
 ask patch-right-and-ahead 30 1 [ set pcolor green ]
 ;; this turtle &quot;looks&quot; 30 degrees right of its
@@ -5832,6 +6399,7 @@ ask patch-right-and-ahead 30 1 [ set pcolor green ]
 </pre>
       <p>
         See also <a href="#patch">patch</a>, <a href="#patch-at">patch-at</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
+      </p>
       </div>
     <div class="dict_entry" id="patch-set">
       <h3>
@@ -5846,6 +6414,7 @@ ask patch-right-and-ahead 30 1 [ set pcolor green ]
         of the inputs. The inputs may be individual patches, patch
         agentsets, nobody, or lists (or nested lists) containing any of the
         above.
+      </p>
       <pre>
 patch-set self
 patch-set patch-here
@@ -5858,6 +6427,7 @@ patch-set [neighbors] of turtles
 </pre>
       <p>
         See also <a href="#turtle-set">turtle-set</a>, <a href="#link-set">link-set</a>.
+      </p>
       </div>
     <div class="dict_entry" id="patch-size">
       <h3>
@@ -5869,8 +6439,10 @@ patch-set [neighbors] of turtles
       <p>
         Reports the size of the patches in the view in pixels. The size is
         typically an integer, but may also be a floating point number.
+      </p>
       <p>
         See also <a href="#set-patch-size">set-patch-size</a>.
+      </p>
       </div>
     <div class="dict_entry" id="patches">
       <h3>
@@ -5881,6 +6453,7 @@ patch-set [neighbors] of turtles
       </h4>
       <p>
         Reports the agentset consisting of all patches.
+      </p>
       </div>
     <div class="dict_entry" id="patches-own">
       <h3>
@@ -5894,15 +6467,19 @@ patch-set [neighbors] of turtles
         and turtles-own keywords, can only be used at the beginning of a
         program, before any function definitions. It defines the variables
         that all patches can use.
+      </p>
       <p>
         All patches will then have the given variables and be able to use
         them.
+      </p>
       <p>
         All patch variables can also be directly accessed by any turtle
         standing on the patch.
+      </p>
       <p>
         See also <a href="#globals">globals</a>, <a href="#turtles-own">turtles-own</a>, <a href="#breed">breed</a>,
         <a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>.
+      </p>
       </div>
     <div class="dict_entry" id="pcolor">
       <h3>
@@ -5915,14 +6492,17 @@ patch-set [neighbors] of turtles
       <p>
         This is a built-in patch variable. It holds the color of the patch.
         You can set this variable to make the patch change color.
+      </p>
       <p>
         All patch variables can be directly accessed by any turtle standing
         on the patch. Color can be represented either as a NetLogo color (a
         single number) or an RGB color (a list of 3 numbers). See details
         in the <a href="programming.html#colors">Colors section</a> of the
         Programming Guide.
+      </p>
       <p>
         See also <a href="#color">color</a>.
+      </p>
       </div>
     <div class="dict_entry" id="pen-switch-status">
       <h3>
@@ -5944,16 +6524,20 @@ patch-set [neighbors] of turtles
         neither. The lines will always be displayed on top of the patches
         and below the turtles. To change the color of the pen set the color
         of the turtle using <code>set color</code>.
+      </p>
       <p>
         Note: When a turtle's pen is down, all movement commands cause
         lines to be drawn, including jump, setxy, and move-to.
+      </p>
       <p>
         Note: These commands are equivalent to setting the turtle variable
         &quot;pen-mode&quot; to &quot;down&quot; , &quot;up&quot;, and
         &quot;erase&quot;.
+      </p>
       <p>
         Note: On Windows drawing and erasing a line might not erase every
         pixel.
+      </p>
       </div>
     <div class="dict_entry" id="pen-mode">
       <h3>
@@ -5967,6 +6551,7 @@ patch-set [neighbors] of turtles
         turtle's pen. You set the variable to draw lines, erase lines
         or stop either of these actions. Possible values are
         &quot;up&quot;, &quot;down&quot;, and &quot;erase&quot;.
+      </p>
       </div>
     <div class="dict_entry" id="pen-size">
       <h3>
@@ -5979,6 +6564,7 @@ patch-set [neighbors] of turtles
         This is a built-in turtle variable. It holds the width of the line,
         in pixels, that the turtle will draw (or erase) when the pen is
         down (or erasing).
+      </p>
       </div>
     <div class="dict_entry" id="plabel">
       <h3>
@@ -5993,11 +6579,14 @@ patch-set [neighbors] of turtles
         The patch appears in the view with the given value
         &quot;attached&quot; to it as text. You can set this variable to
         add, change, or remove a patch's label.
+      </p>
       <p>
         All patch variables can be directly accessed by any turtle standing
         on the patch.
+      </p>
       <p>
         See also <a href="#plabel-color">plabel-color</a>, <a href="#label">label</a>, <a href="#label-color">label-color</a>.
+      </p>
       </div>
     <div class="dict_entry" id="plabel-color">
       <h3>
@@ -6012,12 +6601,15 @@ patch-set [neighbors] of turtles
         or equal to 0 and less than 140. This number determines what color
         the patch's label appears in (if it has a label). You can set
         this variable to change the color of a patch's label.
+      </p>
       <p>
         All patch variables can be directly accessed by any turtle standing
         on the patch.
+      </p>
       <p>
         See also <a href="#plabel">plabel</a>, <a href="#label">label</a>,
         <a href="#label-color">label-color</a>.
+      </p>
       </div>
     <div class="dict_entry" id="plot">
       <h3>
@@ -6031,6 +6623,7 @@ patch-set [neighbors] of turtles
         plots a point at the updated x-value and a y-value of
         <i>number</i>. (The first time the command is used on a plot, the
         point plotted has an x-value of 0.)
+      </p>
       </div>
     <div class="dict_entry" id="plot-name">
       <h3>
@@ -6041,6 +6634,7 @@ patch-set [neighbors] of turtles
       </h4>
       <p>
         Reports the name of the current plot (a string)
+      </p>
       </div>
     <div class="dict_entry" id="plot-pen-exists">
       <h3>
@@ -6052,6 +6646,7 @@ patch-set [neighbors] of turtles
       <p>
         Reports true if a plot pen with the given name is defined in the
         current plot. Otherwise reports false.
+      </p>
       </div>
     <div class="dict_entry" id="plot-pen-switch-status">
       <h3>
@@ -6065,6 +6660,7 @@ patch-set [neighbors] of turtles
       <p>
         Puts down (or up) the current plot-pen, so that it draws (or
         doesn't). (By default, all pens are down initially.)
+      </p>
       </div>
     <div class="dict_entry" id="plot-pen-reset">
       <h3>
@@ -6078,6 +6674,7 @@ patch-set [neighbors] of turtles
         (0,0), and puts it down. If the pen is a permanent pen, the color,
         mode, and interval are reset to the default values from the plot
         Edit dialog.
+      </p>
       </div>
     <div class="dict_entry" id="plotxy">
       <h3>
@@ -6090,6 +6687,7 @@ patch-set [neighbors] of turtles
         Moves the current plot pen to the point with coordinates
         (<i>number1</i>, <i>number2</i>). If the pen is down, a line, bar,
         or point will be drawn (depending on the pen's mode).
+      </p>
       </div>
     <div class="dict_entry" id="plot-cor-max-or-min">
       <h3>
@@ -6107,10 +6705,12 @@ patch-set [neighbors] of turtles
       <p>
         Reports the minimum or maximum value on the x or y axis of the
         current plot.
+      </p>
       <p>
         These values can be set with the commands set-plot-x-range and
         set-plot-y-range. (Their default values are set from the plot Edit
         dialog.)
+      </p>
       </div>
     <div class="dict_entry" id="position">
       <h3>
@@ -6123,12 +6723,15 @@ patch-set [neighbors] of turtles
       <p>
         On a list, reports the first position of <i>item</i> in
         <i>list</i>, or false if it does not appear.
+      </p>
       <p>
         On strings, reports the position of the first appearance
         <i>string1</i> as a substring of <i>string2</i>, or false if it
         does not appear.
+      </p>
       <p>
         Note: The positions are numbered beginning with 0, not with 1.
+      </p>
       <pre>
 ;; suppose mylist is [2 7 4 7 &quot;Bob&quot;]
 show position 7 mylist
@@ -6140,6 +6743,7 @@ show position &quot;in&quot; &quot;string&quot;
 </pre>
       <p>
         See also <a href="#member">member?</a>.
+      </p>
       </div>
     <div class="dict_entry" id="precision">
       <h3>
@@ -6150,9 +6754,11 @@ show position &quot;in&quot; &quot;string&quot;
       </h4>
       <p>
         Reports <i>number</i> rounded to <i>places</i> decimal places.
+      </p>
       <p>
         If <i>places</i> is negative, the rounding takes place to the left
         of the decimal point.
+      </p>
       <pre>
 show precision 1.23456789 3
 =&gt; 1.235
@@ -6161,6 +6767,7 @@ show precision 3834 -3
 </pre>
       <p>
         See also <a href="#round">round</a>, <a href="#ceiling">ceiling</a>, <a href="#floor">floor</a>.
+      </p>
       </div>
     <div class="dict_entry" id="print">
       <h3>
@@ -6172,12 +6779,15 @@ show precision 3834 -3
       <p>
         Prints <i>value</i> in the Command Center, followed by a carriage
         return.
+      </p>
       <p>
         This agent is <i>not</i> printed before the value, unlike <a href="#show">show</a>.
+      </p>
       <p>
         See also <a href="#show">show</a>, <a href="#type">type</a>,
         <a href="#write">write</a>, <a href="#output-cmds">output-print</a>, and
         <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="pcor">
       <h3>
@@ -6193,14 +6803,18 @@ show precision 3834 -3
         These are built-in patch variables. They hold the x and y
         coordinate of the patch. They are always integers. You cannot set
         these variables, because patches don't move.
+      </p>
       <p>
         pxcor is greater than or equal to min-pxcor and less than or equal
         to max-pxcor; similarly for pycor and min-pycor and max-pycor.
+      </p>
       <p>
         All patch variables can be directly accessed by any turtle standing
         on the patch.
+      </p>
       <p>
         See also <a href="#xcor">xcor</a>, <a href="#ycor">ycor</a>.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="R">
@@ -6217,16 +6831,20 @@ show precision 3834 -3
       <p>
         If <i>number</i> is positive, reports a random integer greater than
         or equal to 0, but strictly less than <i>number</i>.
+      </p>
       <p>
         If <i>number</i> is negative, reports a random integer less than or
         equal to 0, but strictly greater than <i>number</i>.
+      </p>
       <p>
         If <i>number</i> is zero, the result is always 0 as well.
+      </p>
       <p>
         Note: In versions of NetLogo prior to version 2.0, this primitive
         reported a floating point number if given a non-integer input. This
         is no longer the case. If you want a floating point answer, you
         must now use <a href="#random-float">random-float</a> instead.
+      </p>
       <pre>
 show random 3
 ;; prints 0, 1,  or 2
@@ -6237,6 +6855,7 @@ show random 3.5
 </pre>
       <p>
         See also <a href="#random-float">random-float</a>.
+      </p>
       </div>
     <div class="dict_entry" id="random-float">
       <h3>
@@ -6249,12 +6868,15 @@ show random 3.5
         If <i>number</i> is positive, reports a random floating point
         number greater than or equal to 0 but strictly less than
         <i>number</i>.
+      </p>
       <p>
         If <i>number</i> is negative, reports a random floating point
         number less than or equal to 0, but strictly greater than
         <i>number</i>.
+      </p>
       <p>
         If <i>number</i> is zero, the result is always 0.
+      </p>
       <pre>
 show random-float 3
 ;; prints a number at least 0 but less than 3,
@@ -6282,21 +6904,26 @@ show random-float 2.5
         <i>mean</i> and, in the case of the normal distribution, the
         <i>standard-deviation</i>. (The standard deviation may not be
         negative.)
+      </p>
       <p>
         random-exponential reports an exponentially distributed random
         floating point number. It is equivalent to <code>(- <i>mean</i>) * ln
         random-float 1.0</code>.
+      </p>
       <p>
         random-gamma reports a gamma-distributed random floating point
         number as controlled by the floating point alpha and lambda
         parameters. Both inputs must be greater than zero. (Note: for
         results with a given mean and variance, use inputs as follows:
         alpha = mean * mean / variance; lambda = 1 / (variance / mean).)
+      </p>
       <p>
         random-normal reports a normally distributed random floating point
         number.
+      </p>
       <p>
         random-poisson reports a Poisson-distributed random integer.
+      </p>
       <pre>
 show random-exponential 2
 ;; prints an exponentially distributed random floating
@@ -6322,6 +6949,7 @@ show random-poisson 3.4
       <p>
         Reports a random integer ranging from min-pxcor (or -y) to
         max-pxcor (or -y) inclusive.
+      </p>
       <pre>
 ask turtles [
   ;; move each turtle to the center of a random patch
@@ -6330,6 +6958,7 @@ ask turtles [
 </pre>
       <p>
         See also <a href="#random-cor">random-xcor</a>, <a href="#random-cor">random-ycor</a>.
+      </p>
       </div>
     <div class="dict_entry" id="random-seed">
       <h3>
@@ -6344,9 +6973,11 @@ ask turtles [
         2147483647; note that this is smaller than the full range of
         integers supported by NetLogo (-9007199254740992 to
         9007199254740992).
+      </p>
       <p>
         See the <a href="programming.html#random-numbers">Random Numbers</a>
         section of the Programming Guide for more details.
+      </p>
       <pre>
 random-seed 47822
 show random 100
@@ -6372,10 +7003,12 @@ show random 100
       <p>
         Reports a random floating point number from the allowable range of
         turtle coordinates along the given axis, x or y.
+      </p>
       <p>
         Turtle coordinates range from min-pxcor - 0.5 (inclusive) to
         max-pxcor + 0.5 (exclusive) horizontally; vertically, substitute -y
         for -x.
+      </p>
       <pre>
 ask turtles [
   ;; move each turtle to a random point
@@ -6384,6 +7017,7 @@ ask turtles [
 </pre>
       <p>
         See also <a href="#random-pcor">random-pxcor</a>, <a href="#random-pcor">random-pycor</a>.
+      </p>
       </div>
     <div class="dict_entry" id="range">
       <h3>
@@ -6398,6 +7032,7 @@ ask turtles [
         Generates a list of numbers, starting at <i>start</i>, ending before
         <i>stop</i>, counting by <i>step</i>. <i>start</i> defaults to 0 and
         <i>step</i> defaults to 1.
+      </p>
         <pre>
 show range 5
 =&gt; [0 1 2 3 4]
@@ -6410,6 +7045,7 @@ show (range 10 0 -1)
 </pre>
       <p>
       See also <a href="#n-values">n-values</a>
+      </p>
     </div>
     <div class="dict_entry" id="read-from-string">
       <h3>
@@ -6423,9 +7059,11 @@ show (range 10 0 -1)
         Center, and reports the resulting value. The result may be a
         number, list, string, or boolean value, or the special value
         &quot;nobody&quot;.
+      </p>
       <p>
         Useful in conjunction with the <a href="#user-input">user-input</a>
         primitive for converting the user's input into usable form.
+      </p>
       <pre>
 show read-from-string &quot;3&quot; + read-from-string &quot;5&quot;
 =&gt; 8
@@ -6451,14 +7089,17 @@ crt read-from-string user-input &quot;Make how many turtles?&quot;
         <i>list</i> has a single item, that item is reported. It is an
         error to reduce an empty list. <i>reporter</i> may be an anonymous
         reporter or the name of a reporter.
+      </p>
       <p>
         The first input passed to the reporter is the result so far, and the
         second input is the next item in the list.
+      </p>
       <p>
         Since it can be difficult to develop an intuition about what
         <code>reduce</code> does, here are some simple examples which, while
         not useful in themselves, may give you a better understanding of
         this primitive:
+      </p>
       <pre>
 show reduce + [1 2 3]
 =&gt; 6
@@ -6477,6 +7118,7 @@ show reduce [ [result-so-far next-item] -&gt; fput next-item result-so-far ] (fp
 </pre>
       <p>
         Here are some more useful examples:
+      </p>
       <pre>
 ;; find the longest string in a list
 to-report longest-string [strings]
@@ -6508,6 +7150,7 @@ show evaluate-polynomial [3 2 1] 4
 </pre>
       <p>
       See also <a href="#filter">filter</a>, <a href="#arrow">-&gt; (anonymous procedure</a>.
+      </p>
     </div>
     <div class="dict_entry" id="remainder">
       <h3>
@@ -6519,6 +7162,7 @@ show evaluate-polynomial [3 2 1] 4
       <p>
         Reports the remainder when <i>number1</i> is divided by
         <i>number2</i>. This is equivalent to the following NetLogo code:
+      </p>
       <pre>
 <i>number1</i> - (int (<i>number1</i> / <i>number2</i>)) * <i>number2</i>
 </pre>
@@ -6531,6 +7175,7 @@ show remainder -8 3
       <p>
         See also <a href="#mod">mod</a>. mod and remainder behave the same
         for positive numbers, but differently for negative numbers.
+      </p>
       </div>
     <div class="dict_entry" id="remove">
       <h3>
@@ -6543,9 +7188,11 @@ show remainder -8 3
       <p>
         For a list, reports a copy of <i>list</i> with all instances of
         <i>item</i> removed.
+      </p>
       <p>
         For strings, reports a copy of <i>string2</i> with all the
         appearances of <i>string1</i> as a substring removed.
+      </p>
       <pre>
 set mylist [2 7 4 7 &quot;Bob&quot;]
 set mylist remove 7 mylist
@@ -6564,6 +7211,7 @@ show remove &quot;to&quot; &quot;phototonic&quot;
       <p>
         Reports a copy of <i>list</i> with all duplicate items removed. The
         first of each item remains in place.
+      </p>
       <pre>
 set mylist [2 7 4 7 &quot;Bob&quot; 7]
 set mylist remove-duplicates mylist
@@ -6581,12 +7229,15 @@ set mylist remove-duplicates mylist
       <p>
         For a list, reports a copy of <i>list</i> with the item at the
         given index removed.
+      </p>
       <p>
         For strings, reports a copy of <i>string</i> with the character at
         the given index removed.
+      </p>
       <p>
         Note that the indices begin from 0, not 1. (The first item is item
         0, the second item is item 1, and so on.)
+      </p>
       <pre>
 set mylist [2 7 4 7 &quot;Bob&quot;]
 set mylist remove-item 2 mylist
@@ -6604,6 +7255,7 @@ show remove-item 2 &quot;string&quot;
       </h4>
       <p>
         Runs <i>commands</i> <i>number</i> times.
+      </p>
       <pre>
 
  pd repeat 36 [ fd 1 rt 10 ]
@@ -6624,9 +7276,11 @@ show remove-item 2 &quot;string&quot;
         of the item to be replaced, starting with 0. (The 6th item in a
         list would have an index of 5.) Note that &quot;replace-item&quot;
         is used in conjunction with &quot;set&quot; to change a list.
+      </p>
       <p>
         Likewise for a string, but the given character of <i>string1</i>
         removed and the contents of <i>string2</i> spliced in instead.
+      </p>
       <pre>
 show replace-item 2 [2 7 4 5] 15
 =&gt; [2 7 15 5]
@@ -6645,6 +7299,7 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
         Immediately exits from the current to-report procedure and reports
         <i>value</i> as the result of that procedure. report and to-report
         are always used in conjunction with each other. See <a href="#to-report">to-report</a> for a discussion of how to use them.
+      </p>
       </div>
     <div class="dict_entry" id="reset-perspective">
       <h3>
@@ -6659,9 +7314,11 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
         patches). (If it wasn't watching, following, or riding anybody,
         nothing happens.) In the 3D view, the observer also returns to its
         default position (above the origin, looking straight down).
+      </p>
       <p>
         See also <a href="#follow">follow</a>, <a href="#ride">ride</a>,
         <a href="#watch">watch</a>.
+      </p>
       </div>
     <div class="dict_entry" id="reset-ticks">
       <h3>
@@ -6674,10 +7331,13 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
       <p>
         Resets the tick counter to zero, sets up all plots, then updates
         all plots (so that the initial state of the world is plotted).
+      </p>
       <p>
         Normally <code>reset-ticks</code> goes at the end of a setup procedure.
+      </p>
       <p>
         See also <a href="#clear-ticks">clear-ticks</a>, <a href="#tick">tick</a>, <a href="#ticks">ticks</a>, <a href="#tick-advance">tick-advance</a>, <a href="#setup-plots">setup-plots</a>, <a href="#update-plots">update-plots</a>.
+      </p>
       </div>
     <div class="dict_entry" id="reset-timer">
       <h3>
@@ -6688,10 +7348,12 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
       </h4>
       <p>
         Resets the timer to zero seconds. See also <a href="#timer">timer</a>.
+      </p>
       <p>
         Note that the timer is different from the tick counter. The timer
         measures elapsed real time in seconds; the tick counter measures
         elapsed model time in ticks.
+      </p>
       </div>
     <div class="dict_entry" id="resize-world">
       <h3>
@@ -6703,17 +7365,21 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
       </h4>
       <p>
         Changes the size of the patch grid.
+      </p>
       <p>
         If the given patch grid coordinates are different than the ones
         in use, all turtles and links die, and the existing patch grid is
         discarded and new patches created. Otherwise, existing turtles
         and links will live if the grid coordinates are unchanged.
+      </p>
       <p>
         Retaining references to old patches or patch sets is inadvisable
         and may subsequently cause runtime errors or other unexpected
         behavior.
+      </p>
       <p>
         See also <a href="#set-patch-size">set-patch-size</a>.
+      </p>
       </div>
     <div class="dict_entry" id="reverse">
       <h3>
@@ -6725,6 +7391,7 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
       </h4>
       <p>
         Reports a reversed copy of the given list or string.
+      </p>
       <pre>
 show mylist
 ;; mylist is [2 7 4 &quot;Bob&quot;]
@@ -6744,8 +7411,10 @@ show reverse &quot;live&quot;
       <p>
         Reports a RGB list when given three numbers describing an RGB
         color. The numbers are range checked to be between 0 and 255.
+      </p>
       <p>
         See also <a href="#hsb">hsb</a>
+      </p>
       </div>
     <div class="dict_entry" id="ride">
       <h3>
@@ -6757,19 +7426,23 @@ show reverse &quot;live&quot;
       </h4>
       <p>
         Set the perspective to <i>turtle</i>.
+      </p>
       <p>
         Every time <i>turtle</i> moves the observer also moves. Thus, in
         the 2D View the turtle will stay at the center of the view. In the
         3D view it is as if looking through the eyes of the turtle. If the
         turtle dies, the perspective resets to the default.
+      </p>
       <p>
         The observer may only watch or follow a single subject.
         Calling <code>ride</code> will remove the highlight created by
         prior calls to <code>watch</code> and <code>watch-me</code>,
         highlighting the ridden turtle instead.
+      </p>
       <p>
         See also <a href="#reset-perspective">reset-perspective</a>,
         <a href="#watch">watch</a>, <a href="#follow">follow</a>, <a href="#subject">subject</a>.
+      </p>
       </div>
     <div class="dict_entry" id="ride-me">
       <h3>
@@ -6781,13 +7454,16 @@ show reverse &quot;live&quot;
       </h4>
       <p>
         Asks the observer to ride this turtle.
+      </p>
       <p>
         The observer may only watch or follow a single subject.
         Calling <code>ride-me</code> will remove the highlight created by
         prior calls to <code>watch</code> and <code>watch-me</code>,
         highlighting this turtle instead.
+      </p>
       <p>
         See also <a href="#ride">ride</a>.
+      </p>
       </div>
     <div class="dict_entry" id="right">
       <h3>
@@ -6801,6 +7477,7 @@ show reverse &quot;live&quot;
       <p>
         The turtle turns right by <i>number</i> degrees. (If <i>number</i>
         is negative, it turns left.)
+      </p>
       </div>
     <div class="dict_entry" id="round">
       <h3>
@@ -6811,9 +7488,11 @@ show reverse &quot;live&quot;
       </h4>
       <p>
         Reports the integer nearest to <i>number</i>.
+      </p>
       <p>
         If the decimal portion of <i>number</i> is exactly .5, the number
         is rounded in the <b>positive</b> direction.
+      </p>
       <p>
         Note that rounding in the positive direction is not always how
         rounding is done in other software programs. (In particular, it
@@ -6826,6 +7505,7 @@ show reverse &quot;live&quot;
         considered to be in one patch or the other, so the turtle is
         considered to be in the patch whose pxcor is -4, because we round
         towards the positive numbers.
+      </p>
       <pre>
 show round 4.2
 =&gt; 4
@@ -6836,6 +7516,7 @@ show round -4.5
 </pre>
       <p>
         See also <a href="#precision">precision</a>, <a href="#ceiling">ceiling</a>, <a href="#floor">floor</a>.
+      </p>
       </div>
     <div class="dict_entry" id="run">
       <h3>
@@ -6853,9 +7534,11 @@ show round -4.5
       <p>
         The <code>run</code> form expects the name of a command, an anonymous command,
         or a string containing commands. This agent then runs them.
+      </p>
       <p>
         The <code>runresult</code> form expects the name of a reporter, an anonymous reporter,
         or a string containing a reporter. This agent runs it and reports the result.
+      </p>
       <p>
         Note that you can't use <code>run</code> to define or redefine
         procedures. If you care about performance, note that the code must
@@ -6864,17 +7547,21 @@ show round -4.5
         string over and over is much faster than running different strings.
         The first run, though, will be many times slower than
         running the same code directly, or in an anonymous command.
+      </p>
       <p>
         Anonymous procedures are recommended over strings whenever possible.
         (An example of when you must use strings is if you accept pieces
         of code from the user of your model.)
+      </p>
       <p>
         Anonymous procedures may freely read and/or set local variables
         and procedure inputs. Trying to do the same with strings may
         or may not work and should not be relied on.
+      </p>
       <p>
         When using anonymous procedures, you can provide them with inputs,
         if you surround the entire call with parentheses. For example:
+      </p>
       <pre>
 (run [ [turtle-count step-count] -&gt; crt turtle-count [ fd step-count ] ] 10 5)
 ;; creates 10 turtles and move them forward 5 steps
@@ -6884,6 +7571,7 @@ show (runresult [ [a b] -&gt; a + b ] 10 5)
 </pre>
         <p>
         See also <a href="#foreach">foreach</a>, <a href="#arrow">-> (anonymous procedure)</a>.
+        </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="S">
@@ -6900,19 +7588,24 @@ show (runresult [ [a b] -&gt; a + b ] 10 5)
       <p>
         Reports a shade of <i>color</i> proportional to the value of
         <i>number</i>.
+      </p>
       <p>
         If <i>range1</i> is less than <i>range2</i>, then the larger the
         number, the lighter the shade of <i>color</i>. But if <i>range2</i>
         is less than <i>range1</i>, the color scaling is inverted.
+      </p>
       <p>
         If <i>number</i> is less than <i>range1</i>, then the darkest shade
         of <i>color</i> is chosen.
+      </p>
       <p>
         If <i>number</i> is greater than <i>range2</i>, then the lightest
         shade of <i>color</i> is chosen.
+      </p>
       <p>
         Note: for <i>color</i> shade is irrelevant, e.g. green and green +
         2 are equivalent, and the same spectrum of colors will be used.
+      </p>
       <pre>
 ask turtles [ set color scale-color red age 0 50 ]
 ;; colors each turtle a shade of red proportional
@@ -6929,16 +7622,20 @@ ask turtles [ set color scale-color red age 0 50 ]
       </h4>
       <p>
         Reports this turtle, patch, or link.
+      </p>
       <p>
         &quot;self&quot; and &quot;myself&quot; are very different.
         &quot;self&quot; is simple; it means &quot;me&quot;.
         &quot;myself&quot; means &quot;the agent who asked me to do what
         I'm doing right now.&quot;
+      </p>
       <p>
         Note that it is always redundant to write <code>[foo] of self</code>.
         This is always equivalent to simply writing <code>foo</code>.
+      </p>
       <p>
         See also <a href="#myself">myself</a>.
+      </p>
       </div>
     <div class="dict_entry" id="semicolon">
       <h3>
@@ -6952,9 +7649,11 @@ ask turtles [ set color scale-color red age 0 50 ]
         for adding &quot;comments&quot; to your code -- text that explains
         the code to human readers. Extra semicolons can be added for visual
         effect.
+      </p>
       <p>
         NetLogo's Edit menu has items that let you comment or uncomment
         whole sections of code.
+      </p>
       </div>
     <div class="dict_entry" id="sentence">
       <h3>
@@ -6969,6 +7668,7 @@ ask turtles [ set color scale-color red age 0 50 ]
         Makes a list out of the values. If any value is a list, its items
         are included in the result directly, rather than being included as
         a sublist. Examples make this clearer:
+      </p>
       <pre>
 show sentence 1 2
 =&gt; [1 2]
@@ -6993,8 +7693,10 @@ show (sentence [1 2] 3 [4 5] (3 + 3) 7)
       </h4>
       <p>
         Sets <i>variable</i> to the given value.
+      </p>
       <p>
         Variable can be any of the following:
+      </p>
       <ul>
         <li>A global variable declared using &quot;globals&quot;
         <li>The global variable associated with a slider, switch, chooser,
@@ -7015,16 +7717,20 @@ show (sentence [1 2] 3 [4 5] (3 + 3) 7)
       </h4>
       <p>
         Sets the current directory that is used by the primitives <a href="#file-delete">file-delete</a>, <a href="#file-exists">file-exists?</a>, and <a href="#file-open">file-open</a>.
+      </p>
       <p>
         The current directory is not used if the above commands are given
         an absolute file path. This is defaulted to the user's home
         directory for new models, and is changed to the model's
         directory when a model is opened.
+      </p>
       <p>
         Note that in Windows file paths the backslash needs to be escaped
         within a string by using another backslash &quot;C:\\&quot;
+      </p>
       <p>
         The change is temporary and is not saved with the model.
+      </p>
       <pre>
 set-current-directory &quot;C:\\NetLogo&quot;
 ;; Assume it is a Windows Machine
@@ -7042,6 +7748,7 @@ file-open &quot;my-file.txt&quot;
       <p>
         Sets the current plot to the plot with the given name (a string).
         Subsequent plotting commands will affect the current plot.
+      </p>
       </div>
     <div class="dict_entry" id="set-current-plot-pen">
       <h3>
@@ -7054,6 +7761,7 @@ file-open &quot;my-file.txt&quot;
         The current plot's current pen is set to the pen named
         <i>penname</i> (a string). If no such pen exists in the current
         plot, a runtime error occurs.
+      </p>
       </div>
     <div class="dict_entry" id="set-default-shape">
       <h3>
@@ -7069,20 +7777,25 @@ file-open &quot;my-file.txt&quot;
         Specifies a default initial shape for all turtles or links, or for
         a particular breed of turtles or links. When a turtle or link is
         created, or it changes breeds, it shape is set to the given shape.
+      </p>
       <p>
         This command doesn't affect existing agents, only agents you
         create afterwards.
+      </p>
       <p>
         The given breed must be either turtles, links, or the name of a
         breed. The given string must be the name of a currently defined
         shape.
+      </p>
       <p>
         In new models, the default shape for all turtles is
         &quot;default&quot;.
+      </p>
       <p>
         Note that specifying a default shape does not prevent you from
         changing an agent's shape later. Agents don't have to be
         stuck with their breed's default shape.
+      </p>
       <pre>
 create-turtles 1 ;; new turtle's shape is &quot;default&quot;
 create-cats 1    ;; new turtle's shape is &quot;default&quot;
@@ -7100,6 +7813,7 @@ ask cats [ set breed dogs ]
 </pre>
       <p>
         See also <a href="#shape">shape</a>.
+      </p>
       </div>
     <div class="dict_entry" id="set-histogram-num-bars">
       <h3>
@@ -7112,8 +7826,10 @@ ask cats [ set breed dogs ]
         Set the current plot pen's plot interval so that, given the
         current x range for the plot, there would be <i>number</i> number
         of bars drawn if the histogram command is called.
+      </p>
       <p>
         See also <a href="#histogram">histogram</a>.
+      </p>
       </div>
     <div class="dict_entry" id="set-line-thickness">
       <h3>
@@ -7126,16 +7842,21 @@ ask cats [ set breed dogs ]
       <p>
         Specifies the thickness of lines and outlined elements in the
         turtle's shape.
+      </p>
       <p>
         The default value is 0. This always produces lines one pixel thick.
+      </p>
       <p>
         Non-zero values are interpreted as thickness in patches. A
         thickness of 1, for example, produces lines which appear one patch
         thick. (It's common to use a smaller value such as 0.5 or 0.2.)
+      </p>
       <p>
         Lines are always at least one pixel thick.
+      </p>
       <p>
         This command is experimental and may change in later releases.
+      </p>
       </div>
     <div class="dict_entry" id="set-patch-size">
       <h3>
@@ -7148,8 +7869,10 @@ ask cats [ set breed dogs ]
       <p>
         Sets the size of the patches of the view in pixels. The size is
         typically an integer, but may also be a floating point number.
+      </p>
       <p>
         See also <a href="#patch-size">patch-size</a>, <a href="#resize-world">resize-world</a>.
+      </p>
       </div>
     <div class="dict_entry" id="set-plot-background-color">
       <h3>
@@ -7164,6 +7887,7 @@ ask cats [ set breed dogs ]
         See the <a href="programming.html#colors">Colors</a> section of the programming guide for more details.
         This change is temporary and is not saved with the model. When the
         plot is cleared, the background color will revert to white.
+      </p>
       <p>
         <b>Note:</b> Plot backgrounds do not support transparency.
         If a list is used to set the color, the alpha component will be ignored.
@@ -7177,6 +7901,7 @@ ask cats [ set breed dogs ]
       </h4>
       <p>
         Sets the color of the current plot pen to <i>color</i>.
+      </p>
       </div>
     <div class="dict_entry" id="set-plot-pen-interval">
       <h3>
@@ -7189,6 +7914,7 @@ ask cats [ set breed dogs ]
         Tells the current plot pen to move a distance of <i>number</i> in
         the x direction during each use of the plot command. (The plot pen
         interval also affects the behavior of the histogram command.)
+      </p>
       </div>
     <div class="dict_entry" id="set-plot-pen-mode">
       <h3>
@@ -7200,6 +7926,7 @@ ask cats [ set breed dogs ]
       <p>
         Sets the mode the current plot pen draws in to <i>number</i>. The
         allowed plot pen modes are:
+      </p>
       <ul>
         <li>0 (line mode) the plot pen draws a line connecting two points
         together.
@@ -7211,6 +7938,7 @@ ask cats [ set breed dogs ]
         </ul>
       <p>
         The default mode for new pens is 0 (line mode).
+      </p>
       </div>
     <div class="dict_entry" id="setup-plots">
       <h3>
@@ -7222,15 +7950,19 @@ ask cats [ set breed dogs ]
       <p>
         For each plot, runs that plot's setup commands, including the
         setup code for any pens in the plot.
+      </p>
       <p>
         <a href="#reset-ticks">reset-ticks</a> has the same effect, so in
         models that use the tick counter, this primitive is not normally
         used.
+      </p>
       <p>
         See the <a href="programming.html#plotting">Plotting section</a> of
         the Programming Guide for more details.
+      </p>
       <p>
         See also <a href="#update-plots">update-plots</a>.
+      </p>
       </div>
     <div class="dict_entry" id="set-plot--range">
       <h3>
@@ -7244,10 +7976,12 @@ ask cats [ set breed dogs ]
       <p>
         Sets the minimum and maximum values of the x or y axis of the
         current plot.
+      </p>
       <p>
         The change is temporary and is not saved with the model. When the
         plot is cleared, the ranges will revert to their default values as
         set in the plot's Edit dialog.
+      </p>
       </div>
     <div class="dict_entry" id="setxy">
       <h3>
@@ -7260,9 +7994,11 @@ ask cats [ set breed dogs ]
       <p>
         The turtle sets its x-coordinate to <i>x</i> and its y-coordinate
         to <i>y</i>.
+      </p>
       <p>
         Equivalent to <code>set xcor x set ycor y</code>, except it happens in
         one time step instead of two.
+      </p>
       <p>
         If <i>x</i> or <i>y</i> is outside the world, NetLogo will throw a
         runtime error, unless wrapping is turned on in the relevant
@@ -7271,6 +8007,7 @@ ask cats [ set breed dogs ]
         <code>max-pxcor = 16</code>, <code>min-pycor = -16</code> and <code>max-pycor
         = 16</code>, asking a turtle to <code>setxy 17 17</code> will move it to
         the center of patch (-16, -16).
+      </p>
       <pre>
 setxy 0 0
 ;; turtle moves to the middle of the center patch
@@ -7281,6 +8018,7 @@ setxy random-pxcor random-pycor
 </pre>
       <p>
         See also <a href="#move-to">move-to</a>.
+      </p>
       </div>
     <div class="dict_entry" id="shade-of">
       <h3>
@@ -7292,6 +8030,7 @@ setxy random-pxcor random-pycor
       <p>
         Reports true if both colors are shades of one another, false
         otherwise.
+      </p>
       <pre>
 show shade-of? blue red
 =&gt; false
@@ -7316,8 +8055,10 @@ show shade-of? gray white
         this variable to change the shape. New turtles and links have the
         shape &quot;default&quot; unless the a different shape has been
         specified using <a href="#set-default-shape">set-default-shape</a>.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 ask turtles [ set shape &quot;wolf&quot; ]
 ;; assumes you have made a &quot;wolf&quot;
@@ -7329,6 +8070,7 @@ ask links [ set shape &quot;link 1&quot; ]
       <p>
         See also <a href="#set-default-shape">set-default-shape</a>,
         <a href="#shapes">shapes</a>.
+      </p>
       </div>
     <div class="dict_entry" id="shapes">
       <h3>
@@ -7340,9 +8082,11 @@ ask links [ set shape &quot;link 1&quot; ]
       <p>
         Reports a list of strings containing all of the turtle shapes in
         the model.
+      </p>
       <p>
         New shapes can be created, or imported from the shapes library or
         from other models, in the <a href="shapes.html">Shapes Editor</a>.
+      </p>
       <pre>
 show shapes
 =&gt; [&quot;default&quot; &quot;airplane&quot; &quot;arrow&quot; &quot;box&quot; &quot;bug&quot; ...
@@ -7361,10 +8105,12 @@ ask turtles [ set shape one-of shapes ]
         and followed by a carriage return. (This agent is included to help
         you keep track of what agents are producing which lines of output.)
         Also, all strings have their quotes included similar to <a href="#write">write</a>.
+      </p>
       <p>
         See also <a href="#print">print</a>, <a href="#type">type</a>,
         <a href="#write">write</a>, <a href="#output-cmds">output-show</a>,
         and <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="show-turtle">
       <h3>
@@ -7377,11 +8123,14 @@ ask turtles [ set shape one-of shapes ]
       </h4>
       <p>
         The turtle becomes visible again.
+      </p>
       <p>
         Note: This command is equivalent to setting the turtle variable
         &quot;hidden?&quot; to false.
+      </p>
       <p>
         See also <a href="#hide-turtle">hide-turtle</a>.
+      </p>
       </div>
     <div class="dict_entry" id="show-link">
       <h3>
@@ -7393,11 +8142,14 @@ ask turtles [ set shape one-of shapes ]
       </h4>
       <p>
         The link becomes visible again.
+      </p>
       <p>
         Note: This command is equivalent to setting the link variable
         &quot;hidden?&quot; to false.
+      </p>
       <p>
         See also <a href="#hide-link">hide-link</a>.
+      </p>
       </div>
     <div class="dict_entry" id="shuffle">
       <h3>
@@ -7409,6 +8161,7 @@ ask turtles [ set shape one-of shapes ]
       <p>
         Reports a new list containing the same items as the input list, but
         in randomized order.
+      </p>
       <pre>
 show shuffle [1 2 3 4 5]
 =&gt; [5 2 4 1 3]
@@ -7426,6 +8179,7 @@ show shuffle [1 2 3 4 5]
       <p>
         Reports the sine of the given angle. Assumes angle is given in
         degrees.
+      </p>
       <pre>
 show sin 270
 =&gt; -1
@@ -7444,6 +8198,7 @@ show sin 270
         turtle's apparent size. The default size is 1, which means that
         the turtle is the same size as a patch. You can set this variable
         to change a turtle's size.
+      </p>
       </div>
     <div class="dict_entry" id="sort">
       <h3>
@@ -7455,17 +8210,21 @@ show sin 270
       </h4>
       <p>
         Reports a sorted list of numbers, strings, or agents.
+      </p>
       <p>
         If the input contains no numbers, strings, or agents, the result is
         the empty list.
+      </p>
       <p>
         If the input contains at least one number, the numbers in the list
         are sorted in ascending order and a new list reported; non-numbers
         are ignored.
+      </p>
       <p>
         Or, if the input contains at least one string, the strings in the
         list are sorted in ascending order and a new list reported;
         non-strings are ignored.
+      </p>
       <p>
         Or, if the input is an agentset or a list containing at least one
         agent, a sorted list of agents (never an agentset) is reported;
@@ -7473,6 +8232,7 @@ show sin 270
         &lt; operator uses. (Patches are sorted with the top left-most patch first
         and the bottom right-most patch last, turtles are sorted by <code>who</code>
         number).
+      </p>
       <pre>
 show sort [3 1 4 2]
 =&gt; [1 2 3 4]
@@ -7502,6 +8262,7 @@ show sort (list [1 2 3] turtles) ; lists and agentsets are not included if they 
 </pre>
       <p>
         See also <a href="#sort-by">sort-by</a>, <a href="#sort-on">sort-on</a>.
+      </p>
       </div>
     <div class="dict_entry" id="sort-by">
       <h3>
@@ -7516,17 +8277,21 @@ show sort (list [1 2 3] turtles) ; lists and agentsets are not included if they 
         items as the input list, in a sorted order defined by the boolean
         reporter. <i>reporter</i> may be an anonymous reporter or
         the name of a reporter.
+      </p>
       <p>
       The two inputs to <i>reporter</i> are the values being compared.
         The reporter should report true if the first argument comes strictly before
         the second in the desired sort order, and false otherwise.
+      </p>
       <p>
         If the input is an agentset or a list of agents, reports a list
         (never an agentset) of agents.
+      </p>
       <p>
         If the input is a list, the sort is stable, that is, the order of
         items considered equal by the reporter is not disturbed. If the
         input is an agentset, ties are broken randomly.
+      </p>
       <pre>
 show sort-by &lt; [3 1 4 2]
 =&gt; [1 2 3 4]
@@ -7537,6 +8302,7 @@ show sort-by [ [string1 string2] -&gt; length string1 &lt; length string2 ] [&qu
 </pre>
       <p>
       See also <a href="#sort">sort</a>, <a href="#sort-on">sort-on</a>, <a href="#arrow">-> (anonymous procedure)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="sort-on">
       <h3>
@@ -7548,9 +8314,11 @@ show sort-by [ [string1 string2] -&gt; length string1 &lt; length string2 ] [&qu
       <p>
         Reports a list of agents, sorted according to each agent's
         value for <i>reporter</i>. Ties are broken randomly.
+      </p>
       <p>
         The values must be all numbers, all strings, or all agents of the
         same type.
+      </p>
       <pre>
 crt 3
 show sort-on [who] turtles
@@ -7564,6 +8332,7 @@ foreach sort-on [size] turtles
 </pre>
       <p>
         See also <a href="#sort">sort</a>, <a href="#sort-by">sort-by</a>.
+      </p>
       </div>
     <div class="dict_entry" id="sprout">
       <h3>
@@ -7581,9 +8350,11 @@ foreach sort-on [size] turtles
         <i>commands</i>. This is useful for giving the new turtles
         different colors, headings, or whatever. (The new turtles are
         created all at once then run one at a time, in random order.)
+      </p>
       <p>
         If the sprout-<i>&lt;breeds&gt;</i> form is used, the new turtles
         are created as members of the given breed.
+      </p>
       <pre>
 sprout 5
 sprout-wolves 10
@@ -7592,6 +8363,7 @@ sprout-sheep 1 [ set color black ]
 </pre>
       <p>
         See also <a href="#create-turtles">create-turtles</a>, <a href="#hatch">hatch</a>.
+      </p>
       </div>
     <div class="dict_entry" id="sqrt">
       <h3>
@@ -7602,6 +8374,7 @@ sprout-sheep 1 [ set color black ]
       </h4>
       <p>
         Reports the square root of <i>number</i>.
+      </p>
       </div>
     <div class="dict_entry" id="stamp">
       <h3>
@@ -7614,9 +8387,11 @@ sprout-sheep 1 [ set color black ]
       <p>
         This turtle or link leaves an image of its shape in the drawing at
         its current location.
+      </p>
       <p>
         Note: The shapes made by stamp may not be pixel-for-pixel identical
         from computer to computer.
+      </p>
       </div>
     <div class="dict_entry" id="stamp-erase">
       <h3>
@@ -7629,9 +8404,11 @@ sprout-sheep 1 [ set color black ]
       <p>
         This turtle or link removes any pixels below it in the drawing
         inside the bounds of its shape.
+      </p>
       <p>
         Note: The shapes made by stamp-erase may not be pixel-for-pixel
         identical from computer to computer.
+      </p>
       </div>
     <div class="dict_entry" id="standard-deviation">
       <h3>
@@ -7643,10 +8420,12 @@ sprout-sheep 1 [ set color black ]
       <p>
         Reports the sample standard deviation of a <i>list</i> of numbers.
         Ignores other types of items.
+      </p>
       <p>
         (Note that this estimates the standard deviation for a
         <i>sample</i>, rather than for a whole <i>population</i>, using
         Bessel's correction.)
+      </p>
       <pre>
 show standard-deviation [1 2 3 4 5 6]
 =&gt; 1.8708286933869707
@@ -7666,6 +8445,7 @@ show standard-deviation [energy] of turtles
       <p>
         User-defined procedure which, if it exists, will be called when a
         model is first loaded in the NetLogo application.
+      </p>
       <pre>
 to startup
   setup
@@ -7674,6 +8454,7 @@ end
       <p>
         <code>startup</code> does not run when a model is run headless from the
         command line, or by parallel BehaviorSpace.
+      </p>
       </div>
     <div class="dict_entry" id="stop">
       <h3>
@@ -7686,6 +8467,7 @@ end
         This agent exits immediately from the enclosing procedure, ask, or
         ask-like construct (e.g. crt, hatch, sprout). Only the enclosing
         procedure or construct stops, not all execution for the agent.
+      </p>
       <pre>
 if not any? turtles [ stop ]
 ;; exits if there are no more turtles
@@ -7694,10 +8476,12 @@ if not any? turtles [ stop ]
         Note: <code>stop</code> can also be used to stop a forever button. See
         <a href="programming.html#buttons">Buttons</a> in the
         Programming Guide for details.
+      </p>
       <p>
         <code>stop</code> can also be used to stop a BehaviorSpace model run. If the go
         commands directly call a procedure, then when that procedure calls <i>stop</i>,
         the run ends.
+      </p>
       </div>
     <div class="dict_entry" id="stop-inspecting">
       <h3>
@@ -7710,6 +8494,7 @@ if not any? turtles [ stop ]
         Closes the agent monitor for the given agent (turtle or patch).
         In the case that no agent monitor is open, <code>stop-inspecting</code> does
         nothing.
+      </p>
       <pre>
 stop-inspecting patch 2 4
 ;; the agent monitor for that patch closes
@@ -7718,6 +8503,7 @@ ask sheep [ stop-inspecting self ]
 </pre>
       <p>
         See <a href="#inspect">inspect</a> and <a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>.
+      </p>
     </div>
     <div class="dict_entry" id="stop-inspecting-dead-agents">
       <h3>
@@ -7729,6 +8515,7 @@ ask sheep [ stop-inspecting self ]
       <p>
         Closes all agent monitors for dead agents.
         See <a href="#inspect">inspect</a> and <a href="#stop-inspecting">stop-inspecting</a>.
+      </p>
     </div>
     <div class="dict_entry" id="subject">
       <h3>
@@ -7740,9 +8527,11 @@ ask sheep [ stop-inspecting self ]
       <p>
         Reports the turtle (or patch) that the observer is currently
         watching, following, or riding. Reports <a href="#nobody">nobody</a> if there is no such turtle (or patch).
+      </p>
       <p>
         See also <a href="#watch">watch</a>, <a href="#follow">follow</a>,
         <a href="#ride">ride</a>.
+      </p>
       </div>
     <div class="dict_entry" id="subliststring">
       <h3>
@@ -7756,8 +8545,10 @@ ask sheep [ stop-inspecting self ]
       <p>
         Reports just a section of the given list or string, ranging between
         the first position (inclusive) and the second position (exclusive).
+      </p>
       <p>
         Note: The positions are numbered beginning with 0, not with 1.
+      </p>
       <pre>
 show sublist [99 88 77 66] 1 3
 =&gt; [88 77]
@@ -7778,12 +8569,14 @@ show substring &quot;apartment&quot; 1 5
         rotated to produce heading1. A positive answer means a clockwise
         rotation, a negative answer counterclockwise. The result is always
         in the range -180 to 180, but is never exactly -180.
+      </p>
       <p>
         Note that simply subtracting the two headings using the - (minus)
         operator wouldn't work. Just subtracting corresponds to always
         rotating clockwise from heading2 to heading1; but sometimes the
         counterclockwise rotation is shorter. For example, the difference
         between 5 degrees and 355 degrees is 10 degrees, not -350 degrees.
+      </p>
       <pre>
 show subtract-headings 80 60
 =&gt; 20
@@ -7808,6 +8601,7 @@ show subtract-headings 0 180
       </h4>
       <p>
         Reports the sum of the items in the list.
+      </p>
       <pre>
 show sum [energy] of turtles
 ;; prints the total of the variable &quot;energy&quot;
@@ -7829,6 +8623,7 @@ show sum [energy] of turtles
       <p>
         Reports the tangent of the given angle. Assumes the angle is given
         in degrees.
+      </p>
       </div>
     <div class="dict_entry" id="thickness">
       <h3>
@@ -7844,6 +8639,7 @@ show sum [energy] of turtles
         default thickness is 0, which means that regardless of patch-size
         the links will always appear 1 pixel wide. You can set this
         variable to change a link's thickness.
+      </p>
       </div>
     <div class="dict_entry" id="tick">
       <h3>
@@ -7855,13 +8651,17 @@ show sum [energy] of turtles
       </h4>
       <p>
         Advances the tick counter by one and updates all plots.
+      </p>
       <p>
         If the tick counter has not been started yet with
         <code>reset-ticks</code>, an error results.
+      </p>
       <p>
         Normally <code>tick</code> goes at the end of a go procedure.
+      </p>
       <p>
         See also <a href="#ticks">ticks</a>, <a href="#tick-advance">tick-advance</a>, <a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>, <a href="#update-plots">update-plots</a>.
+      </p>
       </div>
     <div class="dict_entry" id="tick-advance">
       <h3>
@@ -7875,20 +8675,25 @@ show sum [energy] of turtles
         Advances the tick counter by <i>number</i>. The input may be an
         integer or a floating point number. (Some models divide ticks more
         finely than by ones.) The input may not be negative.
+      </p>
       <p>
         When using <a href="programming.html#view-updates">tick-based view
         updates</a>, the view is normally updated every 1.0 ticks, so using
         <code>tick-advance</code> with a number less then 1.0 may not always
         trigger an update. If you want to make sure that the view is
         updated, you can use the <code>display</code> command.
+      </p>
       <p>
         If the tick counter has not been started yet with
         <code>reset-ticks</code>, an error results.
+      </p>
       <p>
         Does not update plots.
+      </p>
       <p>
         See also <a href="#tick">tick</a>, <a href="#ticks">ticks</a>,
         <a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>.
+      </p>
       </div>
     <div class="dict_entry" id="ticks">
       <h3>
@@ -7900,16 +8705,20 @@ show sum [energy] of turtles
       <p>
         Reports the current value of the tick counter. The result is always
         a number and never negative.
+      </p>
       <p>
         If the tick counter has not been started yet with
         <code>reset-ticks</code>, an error results.
+      </p>
       <p>
         Most models use the <code>tick</code> command to advance the tick
         counter, in which case <code>ticks</code> will always report an
         integer. If the <code>tick-advance</code> command is used, then
         <code>ticks</code> may report a floating point number.
+      </p>
       <p>
         See also <a href="#tick">tick</a>, <a href="#tick-advance">tick-advance</a>, <a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>.
+      </p>
       </div>
     <div class="dict_entry" id="tie">
       <h3>
@@ -7928,17 +8737,21 @@ show sum [energy] of turtles
         turtles can be considered <i>root turtles</i> and <i>leaf
         turtles</i>. Movement or change in heading of either turtle affects
         the location and heading of the other turtle.
+      </p>
       <p>
         When the root turtle moves, the leaf turtles moves the same
         distance, in the same direction. The heading of the leaf turtle is
         not affected. This works with forward, jump, and setting the xcor
         or ycor of the root turtle.
+      </p>
       <p>
         When the root turtle turns right or left, the leaf turtle is
         rotated around the root turtle the same amount. The heading of the
         leaf turtle is also changed by the same amount.
+      </p>
       <p>
         If the link dies, the tie relation is removed.
+      </p>
       <pre>
       crt 2 [ fd 3 ]
       ;; creates a link and ties turtle 1 to turtle 0
@@ -7946,6 +8759,7 @@ show sum [energy] of turtles
 </pre>
       <p>
         See also <a href="#untie">untie</a>
+      </p>
       </div>
     <div class="dict_entry" id="tie-mode">
       <h3>
@@ -7961,8 +8775,10 @@ show sum [energy] of turtles
         mode of the link. You can also set tie-mode to &quot;free&quot; to
         create a non-rigid joint between two turtles (see the <a href="programming.html#tie">Tie section</a> of the Programming Guide for
         details). By default links are not tied.
+      </p>
       <p>
         See also: <a href="#tie">tie</a>, <a href="#untie">untie</a>
+      </p>
       </div>
     <div class="dict_entry" id="timer">
       <h3>
@@ -7977,12 +8793,15 @@ show sum [energy] of turtles
         (Whether you get resolution that high in practice may vary from
         system to system, depending on the capabilities of the underlying
         Java Virtual Machine.)
+      </p>
       <p>
         See also <a href="#reset-timer">reset-timer</a>.
+      </p>
       <p>
         Note that the timer is different from the tick counter. The timer
         measures elapsed real time in seconds; the tick counter measures
         elapsed model time in ticks.
+      </p>
       </div>
     <div class="dict_entry" id="to">
       <h3>
@@ -7994,6 +8813,7 @@ show sum [energy] of turtles
       </h4>
       <p>
         Used to begin a command procedure.
+      </p>
       <pre>
 to setup
   clear-all
@@ -8015,9 +8835,11 @@ end
       </h4>
       <p>
         Used to begin a reporter procedure.
+      </p>
       <p>
         The body of the procedure should use <code>report</code> to report a
         value for the procedure. See <a href="#report">report</a>.
+      </p>
       <pre>
 to-report average [a b]
   report (a + b) / 2
@@ -8044,19 +8866,23 @@ end
       </h4>
       <p>
         Reports the heading from this agent to the given agent.
+      </p>
       <p>
         If wrapping is allowed by the topology and the wrapped distance
         (around the edges of the world) is shorter, towards will use the
         wrapped path.
+      </p>
       <p>
         Note: asking for the heading from an agent to itself, or an agent
         on the same location, will cause a runtime error.
+      </p>
       <pre>
 set heading towards turtle 1
 ;; same as &quot;face turtle 1&quot;
 </pre>
       <p>
         See also <a href="#face">face</a>.
+      </p>
       </div>
     <div class="dict_entry" id="towardsxy">
       <h3>
@@ -8069,15 +8895,19 @@ set heading towards turtle 1
       <p>
         Reports the heading from the turtle or patch towards the point
         (<i>x</i>,<i>y</i>).
+      </p>
       <p>
         If wrapping is allowed by the topology and the wrapped distance
         (around the edges of the world) is shorter, towardsxy will use the
         wrapped path.
+      </p>
       <p>
         Note: asking for the heading to the point the agent is already
         standing on will cause a runtime error.
+      </p>
       <p>
         See also <a href="#facexy">facexy</a>.
+      </p>
       </div>
     <div class="dict_entry" id="turtle">
       <h3>
@@ -8090,6 +8920,7 @@ set heading towards turtle 1
       <p>
         Reports the turtle with the given who number, or <a href="#nobody">nobody</a> if there is no such turtle. For breeded
         turtles you may also use the single breed form to refer to them.
+      </p>
       <pre>
 ask turtle 5 [ set color red ]
 ;; turtle with who number 5 turns red
@@ -8108,6 +8939,7 @@ ask turtle 5 [ set color red ]
         of the inputs. The inputs may be individual turtles, turtle
         agentsets, nobody, or lists (or nested lists) containing any of the
         above.
+      </p>
       <pre>
 turtle-set self
 (turtle-set self turtles-on neighbors)
@@ -8116,6 +8948,7 @@ turtle-set self
 </pre>
       <p>
         See also <a href="#patch-set">patch-set</a>, <a href="#link-set">link-set</a>.
+      </p>
       </div>
     <div class="dict_entry" id="turtles">
       <h3>
@@ -8126,6 +8959,7 @@ turtle-set self
       </h4>
       <p>
         Reports the agentset consisting of all turtles. This is a special agentset that can grow as turtles are added to the world, see <a href="programming.html#special-agentsets">the programming guide for more info</a>.
+      </p>
       <pre>
 show count turtles
 ;; prints the number of turtles
@@ -8144,6 +8978,7 @@ show count turtles
         Reports an agentset containing the turtles on the patch (dx, dy)
         from the caller. (The result may include the caller itself if the
         caller is a turtle.)
+      </p>
       <pre>
 create-turtles 5 [ setxy 2 3 ]
 show count [turtles-at 1 1] of patch 1 2
@@ -8152,6 +8987,7 @@ show count [turtles-at 1 1] of patch 1 2
       <p>
         If the name of a breed is substituted for &quot;turtles&quot;, then
         only turtles of that breed are included.
+      </p>
       </div>
     <div class="dict_entry" id="turtles-here">
       <h3>
@@ -8165,6 +9001,7 @@ show count [turtles-at 1 1] of patch 1 2
       <p>
         Reports an agentset containing all the turtles on the caller's
         patch (including the caller itself if it's a turtle).
+      </p>
       <pre>
 crt 10
 ask turtle 0 [ show count turtles-here ]
@@ -8173,6 +9010,7 @@ ask turtle 0 [ show count turtles-here ]
       <p>
         If the name of a breed is substituted for &quot;turtles&quot;, then
         only turtles of that breed are included.
+      </p>
       <pre>
 breed [cats cat]
 breed [dogs dog]
@@ -8197,6 +9035,7 @@ ask dogs [ show count cats-here ]
         Reports an agentset containing all the turtles that are on the
         given patch or patches, or standing on the same patch as the given
         turtle or turtles.
+      </p>
       <pre>
 ask turtles [
   if not any? turtles-on patch-ahead 1
@@ -8211,6 +9050,7 @@ ask turtles [
       <p>
         If the name of a breed is substituted for &quot;turtles&quot;, then
         only turtles of that breed are included.
+      </p>
       </div>
     <div class="dict_entry" id="turtles-own">
       <h3>
@@ -8225,10 +9065,12 @@ ask turtles [
         <i>&lt;breeds&gt;</i>-own, and patches-own keywords, can only be
         used at the beginning of a program, before any function
         definitions. It defines the variables belonging to each turtle.
+      </p>
       <p>
         If you specify a breed instead of &quot;turtles&quot;, only turtles
         of that breed have the listed variables. (More than one turtle
         breed may list the same variable.)
+      </p>
       <pre>
 breed [cats cat ]
 breed [dogs dog]
@@ -8241,6 +9083,7 @@ dogs-own [hair puppies]
       <p>
         See also <a href="#globals">globals</a>, <a href="#patches-own">patches-own</a>, <a href="#breed">breed</a>,
         <a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>.
+      </p>
       </div>
     <div class="dict_entry" id="type">
       <h3>
@@ -8253,8 +9096,10 @@ dogs-own [hair puppies]
         Prints <i>value</i> in the Command Center, <i>not</i> followed by a
         carriage return (unlike <a href="#print">print</a> and <a href="#show">show</a>). The lack of a carriage return allows you to
         print several values on the same line.
+      </p>
       <p>
         This agent is <i>not</i> printed before the value. unlike <a href="#show">show</a>.
+      </p>
       <pre>
 type 3 type &quot; &quot; print 4
 =&gt; 3 4
@@ -8263,6 +9108,7 @@ type 3 type &quot; &quot; print 4
         See also <a href="#print">print</a>, <a href="#show">show</a>,
         <a href="#write">write</a>, <a href="#output-cmds">output-type</a>, and
         <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="U">
@@ -8284,8 +9130,10 @@ type 3 type &quot; &quot; print 4
         The first input defines the name of the agentset associated with
         the link breed. The second input defines the name of a single
         member of the breed.
+      </p>
       <p>
         Any link of the given link breed:
+      </p>
       <ul>
         <li>is part of the agentset named by the link breed name
         <li>has its built-in variable <code>breed</code> set to that agentset
@@ -8294,6 +9142,7 @@ type 3 type &quot; &quot; print 4
       <p>
         Most often, the agentset is used in conjunction with ask to give
         commands to only the links of a particular breed.
+      </p>
       <pre>
 undirected-link-breed [streets street]
 undirected-link-breed [highways highway]
@@ -8309,6 +9158,7 @@ ask turtle 0 [ show sort my-links ]
 </pre>
       <p>
         See also <a href="#breed">breed</a>, <a href="#directed-link-breed">directed-link-breed</a>
+      </p>
       </div>
     <div class="dict_entry" id="untie">
       <h3>
@@ -8323,11 +9173,14 @@ ask turtle 0 [ show sort my-links ]
         previously tied together. If the link is an undirected link, then
         it will untie <i>end1</i> from <i>end2</i> as well. It does
         <b>not</b> remove the link between the two turtles.
+      </p>
       <p>
         See also <a href="#tie">tie</a>
+      </p>
       <p>
         See the <a href="programming.html#tie">Tie</a> section of the
         Programming Guide for more details.
+      </p>
       </div>
       <div class="dict_entry" id="up-to-n-of">
         <h3>
@@ -8342,6 +9195,7 @@ ask turtle 0 [ show sort my-links ]
           randomly chosen from the input set, with no repeats.  If the
           input does not have enough agents to satisfy the <i>size</i>,
           reports the entire agentset.
+        </p>
         <p>
           From a list, reports a list of size <i>size</i> randomly chosen
           from the input set, with no repeats. The items in the result
@@ -8349,6 +9203,7 @@ ask turtle 0 [ show sort my-links ]
           (If you want them in random order, use shuffle on the result.)
           If the input does not have enough items to satisfy the
           <i>size</i>, reports the entire list.
+        </p>
         <pre>
           ask up-to-n-of 50 patches [ set pcolor green ]
           ;; 50 randomly chosen patches turn green
@@ -8356,6 +9211,7 @@ ask turtle 0 [ show sort my-links ]
         </pre>
         <p>
           See also <a href="#n-of">n-of</a>, <a href="#one-of">one-of</a>.
+        </p>
         </div>
     <div class="dict_entry" id="update-plots">
       <h3>
@@ -8367,15 +9223,19 @@ ask turtle 0 [ show sort my-links ]
       <p>
         For each plot, runs that plot's update commands, including the
         update code for any pens in the plot.
+      </p>
       <p>
         <a href="#tick">tick</a> has the same effect, so in models that use
         the tick counter, this primitive is not normally used. Models that
         use fractional ticks may need <code>update-plots</code>, since <a href="#tick-advance">tick-advance</a> does not update the plots.
+      </p>
       <p>
         See the <a href="programming.html#plotting">Plotting section</a> of
         the Programming Guide for more details.
+      </p>
       <p>
         See also <a href="#setup-plots">setup-plots</a>.
+      </p>
       </div>
     <div class="dict_entry" id="uphill">
       <h3>
@@ -8393,12 +9253,15 @@ ask turtle 0 [ show sort my-links ]
         value than the current patch, the turtle stays put. If there are
         multiple patches with the same highest value, the turtle picks one
         randomly. Non-numeric values are ignored.
+      </p>
       <p>
         uphill considers the eight neighboring patches; uphill4 only
         considers the four neighbors.
+      </p>
       <p>
         Equivalent to the following code (assumes variable values are
         numeric):
+      </p>
       <pre>
 move-to patch-here  ;; go to patch center
 let p max-one-of neighbors [<i>patch-variable</i>]  ;; or neighbors4
@@ -8410,8 +9273,10 @@ if [<i>patch-variable</i>] of p &gt; <i>patch-variable</i> [
       <p>
         Note that the turtle always ends up on a patch center and has a
         heading that is a multiple of 45 (uphill) or 90 (uphill4).
+      </p>
       <p>
         See also <a href="#downhill">downhill</a>, <a href="#downhill">downhill4</a>.
+      </p>
       </div>
     <div class="dict_entry" id="user-directory">
       <h3>
@@ -8423,9 +9288,11 @@ if [<i>patch-variable</i>] of p &gt; <i>patch-variable</i> [
       <p>
         Opens a dialog that allows the user to choose an existing directory
         on the system.
+      </p>
       <p>
         It reports a string with the absolute path or false if the user
         cancels.
+      </p>
       <pre>
 set-current-directory user-directory
 ;; Assumes the user will choose a directory
@@ -8441,9 +9308,11 @@ set-current-directory user-directory
       <p>
         Opens a dialog that allows the user to choose an existing file on
         the system.
+      </p>
       <p>
         It reports a string with the absolute file path or false if the
         user cancels.
+      </p>
       <pre>
 file-open user-file
 ;; Assumes the user will choose a file
@@ -8460,6 +9329,7 @@ file-open user-file
         Opens a dialog that allows the user to choose a location and name
         of a new file to be created. It reports a string with the absolute
         file path or false if the user cancels.
+      </p>
       <pre>
 file-open user-new-file
 ;; Assumes the user will choose a file
@@ -8468,11 +9338,13 @@ file-open user-new-file
         Note that this reporter doesn't actually create the file;
         normally you would create the file using <code>file-open</code>, as in
         the example.
+      </p>
       <p>
         If the user chooses an existing file, they will be asked if they
         wish to replace it or not, but the reporter itself doesn't
         cause the file to be replaced. To do that you would use
         <code>file-delete</code>.
+      </p>
       </div>
     <div class="dict_entry" id="user-input">
       <h3>
@@ -8484,14 +9356,17 @@ file-open user-new-file
       <p>
         Reports the string that a user types into an entry field in a
         dialog with title <i>value</i>.
+      </p>
       <p>
         <i>value</i> may be of any type, but is typically a string.
+      </p>
       <pre>
 show user-input &quot;What is your name?&quot;
 </pre>
       <p>
         See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
         Programming Guide for additional details.
+      </p>
     </div>
     <div class="dict_entry" id="user-message">
       <h3>
@@ -8502,17 +9377,21 @@ show user-input &quot;What is your name?&quot;
       </h4>
       <p>
         Opens a dialog with <i>value</i> displayed as the message to the user.
+      </p>
       <p>
         <i>value</i> may be of any type, but is typically a string.
+      </p>
         <pre>
 user-message (word &quot;There are &quot; count turtles &quot; turtles.&quot;)
 </pre>
         <p>
         Note that if a user closes the <code>user-message</code> dialog
         with the &quot;X&quot; in the corner, the behavior will be the same as if they had clicked &quot;OK&quot;.
+        </p>
         <p>
         See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
         Programming Guide for additional details.
+        </p>
     </div>
     <div class="dict_entry" id="user-one-of">
       <h3>
@@ -8525,10 +9404,13 @@ user-message (word &quot;There are &quot; count turtles &quot; turtles.&quot;)
         Opens a dialog with <i>value</i> displayed as the message and
         <i>list-of-choices</i> displayed as a popup menu for the user to
         select from.
+      </p>
       <p>
         Reports the item in <i>list-of-choices</i> selected by the user.
+      </p>
       <p>
         <i>value</i> may be of any type, but is typically a string.
+      </p>
       <pre>
 if &quot;yes&quot; = user-one-of &quot;Set up the model?&quot; [&quot;yes&quot; &quot;no&quot;]
   [ setup ]
@@ -8536,6 +9418,7 @@ if &quot;yes&quot; = user-one-of &quot;Set up the model?&quot; [&quot;yes&quot; 
         <p>
         See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
         Programming Guide for additional details.
+        </p>
     </div>
     <div class="dict_entry" id="user-yes-or-no">
       <h3>
@@ -8547,8 +9430,10 @@ if &quot;yes&quot; = user-one-of &quot;Set up the model?&quot; [&quot;yes&quot; 
       <p>
         Reports true or false based on the user's response to
         <i>value</i>.
+      </p>
       <p>
         <i>value</i> may be of any type, but is typically a string.
+      </p>
       <pre>
 if user-yes-or-no? &quot;Set up the model?&quot;
   [ setup ]
@@ -8556,6 +9441,7 @@ if user-yes-or-no? &quot;Set up the model?&quot;
         <p>
         See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
         Programming Guide for additional details.
+        </p>
     </div><!-- ======================================== -->
   </div>
     <h2 id="V">
@@ -8572,14 +9458,17 @@ if user-yes-or-no? &quot;Set up the model?&quot;
       <p>
         Reports the sample variance of a <i>list</i> of numbers. Ignores
         other types of items.
+      </p>
       <p>
         (Note that this computes an unbiased estimate of the variance for a
         <i>sample</i>, rather than for a whole <i>population</i>, using
         Bessel's correction.)
+      </p>
       <p>
         The sample variance is the sum of the squares of the deviations of
         the numbers from their mean, divided by one less than the number of
         numbers in the list.
+      </p>
       <pre>
 show variance [2 7 4 3 5]
 =&gt; 3.7
@@ -8602,14 +9491,17 @@ show variance [2 7 4 3 5]
         you can specify fractions of seconds.) Note that you can't
         expect complete precision; the agent will never wait less than the
         given amount, but might wait slightly more.
+      </p>
       <pre>
 repeat 10 [ fd 1 wait 0.5 ]
 </pre>
       <p>
         While the agent is waiting, no other agents can do anything.
         Everything stops until the agent is done.
+      </p>
       <p>
         See also <a href="#every">every</a>.
+      </p>
       </div>
     <div class="dict_entry" id="watch">
       <h3>
@@ -8622,14 +9514,17 @@ repeat 10 [ fd 1 wait 0.5 ]
       <p>
         Puts a spotlight on <i>agent</i>. In the 3D view the observer will
         also turn to face the subject.
+      </p>
       <p>
         The observer may only watch or follow a single subject.
         Calling <code>watch</code> will undo perspective changes caused
         by prior calls to <code>follow</code>, <code>follow-me</code>,
         <code>ride</code>, and <code>ride-me</code>.
+      </p>
       <p>
         See also <a href="#follow">follow</a>, <a href="#subject">subject</a>, <a href="#reset-perspective">reset-perspective</a>,
         <a href="#ride">ride</a>, <a href="#ride-me">ride-me</a>, <a href="#watch-me">watch-me</a>.
+      </p>
       </div>
     <div class="dict_entry" id="watch-me">
       <h3>
@@ -8641,14 +9536,17 @@ repeat 10 [ fd 1 wait 0.5 ]
       </h4>
       <p>
         Asks the observer to watch this agent.
+      </p>
       <p>
         The observer may only watch or follow a single subject.
         Calling <code>watch</code> will undo perspective changes caused
         by prior calls to <code>follow</code>, <code>follow-me</code>,
         <code>ride</code>, and <code>ride-me</code>.
+      </p>
       <p>
         See also <a href="#follow">follow</a>, <a href="#subject">subject</a>, <a href="#reset-perspective">reset-perspective</a>,
         <a href="#ride">ride</a>, <a href="#ride-me">ride-me</a>, <a href="#watch">watch</a>.
+      </p>
       </div>
     <div class="dict_entry" id="while">
       <h3>
@@ -8660,10 +9558,12 @@ repeat 10 [ fd 1 wait 0.5 ]
       <p>
         If <i>reporter</i> reports false, exit the loop. Otherwise run
         <i>commands</i> and repeat.
+      </p>
       <p>
         The reporter may have different values for different agents, so
         some agents may run <i>commands</i> a different number of times
         than other agents.
+      </p>
       <pre>
 while [any? other turtles-here]
   [ fd 1 ]
@@ -8684,12 +9584,15 @@ while [any? other turtles-here]
         &quot;who number&quot; or ID number, an integer greater than or
         equal to zero. You cannot set this variable; a turtle's who
         number never changes.
+      </p>
       <p>
         Who numbers start at 0. A dead turtle's number will not be
         reassigned to a new turtle until you use the <a href="#clear-turtles">clear-turtles</a> or <a href="#clear-all">clear-all</a> commands, at which time who numbering
         starts over again at 0.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 show [who] of turtles with [color = red]
 ;; prints a list of the who numbers of all red turtles
@@ -8704,9 +9607,11 @@ crt 100
       <p>
         You can use the turtle reporter to retrieve a turtle with a given
         who number. See also <a href="#turtle">turtle</a>.
+      </p>
       <p>
         Note that who numbers aren't breed-specific. No two turtles can
         have the same who number, even if they are different breeds:
+      </p>
       <pre>
 clear-turtles
 create-frogs 1
@@ -8720,6 +9625,7 @@ ask turtles [ print who ]
         Even though we only have one mouse, it is <code>mouse 1</code> not
         <code>mouse 0</code>, because the who number 0 was already taken by the
         frog.
+      </p>
       </div>
     <div class="dict_entry" id="with">
       <h3>
@@ -8734,6 +9640,7 @@ ask turtles [ print who ]
         boolean reporter. Reports a new agentset containing only those
         agents that reported true -- in other words, the agents satisfying
         the given condition.
+      </p>
       <pre>
 show count patches with [pcolor = red]
 ;; prints the number of red patches
@@ -8753,6 +9660,7 @@ show count patches with [pcolor = red]
         Reports a link between <i>turtle</i> and the caller (directed or
         undirected, incoming or outgoing). If no link exists then it reports
         nobody. If more than one such link exists, reports a random one.
+      </p>
       <pre>
 crt 2
 ask turtle 0 [
@@ -8762,6 +9670,7 @@ ask turtle 0 [
 </pre>
       <p>
         See also: <a href="#in-link-from">in-link-from</a>, <a href="#out-link-to">out-link-to</a>
+      </p>
       </div>
     <div class="dict_entry" id="with-max">
       <h3>
@@ -8775,12 +9684,14 @@ ask turtle 0 [
         &quot;turtles&quot; or &quot;patches&quot;). On the right, a
         reporter. Reports a new agentset containing all agents reporting
         the maximum value of the given reporter.
+      </p>
       <pre>
 show count patches with-max [pxcor]
 ;; prints the number of patches on the right edge
 </pre>
       <p>
         See also <a href="#max-one-of">max-one-of</a>, <a href="#max-n-of">max-n-of</a>.
+      </p>
       </div>
     <div class="dict_entry" id="with-min">
       <h3>
@@ -8794,12 +9705,14 @@ show count patches with-max [pxcor]
         &quot;turtles&quot; or &quot;patches&quot;). On the right, a
         reporter. Reports a new agentset containing only those agents that
         have the minimum value of the given reporter.
+      </p>
       <pre>
 show count patches with-min [pycor]
 ;; prints the number of patches on the bottom edge
 </pre>
       <p>
         See also <a href="#min-one-of">min-one-of</a>, <a href="#min-n-of">min-n-of</a>.
+      </p>
       </div>
     <div class="dict_entry" id="with-local-randomness">
       <h3>
@@ -8812,8 +9725,10 @@ show count patches with-min [pycor]
         The commands are run without affecting subsequent random events.
         This is useful for performing extra operations (such as output)
         without changing the outcome of a model.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 ;; Run #1:
 random-seed 50 setup repeat 10 [ go ]
@@ -8825,15 +9740,18 @@ repeat 10 [ go ]
       <p>
         Since <code>one-of</code> is used inside
         <code>with-local-randomness</code>, both runs will be identical.
+      </p>
       <p>
         Specifically how it works is, the state of the random number
         generator is remembered before the commands run, then restored
         afterwards. (If you want to run the commands with a fresh random
         state instead of the same random state that will be restored later,
         you can begin the commands with <code>random-seed new-seed</code>.)
+      </p>
       <p>
         The following example demonstrates that the random number generator
         state is the same both before the commands run and afterwards.
+      </p>
       <pre>
 random-seed 10
 with-local-randomness [ print n-values 10 [random 10] ]
@@ -8852,16 +9770,20 @@ print n-values 10 [random 10]
       <p>
         This primitive exists only for backwards compatibility. We
         don't recommend using it in new models.
+      </p>
       <p>
         The agent runs all the commands in the block without allowing other
         agents using <code>ask-concurrent</code> to &quot;interrupt&quot;. That
         is, other agents are put &quot;on hold&quot; and do not run any
         commands until the commands in the block are finished.
+      </p>
       <p>
         Note: This command is only useful in conjunction with
         <code>ask-concurrent</code>.
+      </p>
       <p>
         See also <a href="#ask-concurrent">ask-concurrent</a>.
+      </p>
       </div>
     <div class="dict_entry" id="word">
       <h3>
@@ -8874,6 +9796,7 @@ print n-values 10 [random 10]
       <p>
         Concatenates the inputs together and reports the result as a
         string.
+      </p>
       <pre>
 show word &quot;tur&quot; &quot;tle&quot;
 =&gt; &quot;turtle&quot;
@@ -8902,12 +9825,15 @@ show (word &quot;a&quot; &quot;b&quot; &quot;c&quot; 1 23)
       <p>
         These reporters give the total width and height of the NetLogo
         world.
+      </p>
       <p>
         The width equals max-pxcor - min-pxcor + 1 and the height equals
         max-pycor - min-pycor + 1.
+      </p>
       <p>
         See also <a href="#max-pcor">max-pxcor</a>, <a href="#max-pcor">max-pycor</a>, <a href="#min-pcor">min-pxcor</a>, and
         <a href="#min-pcor">min-pycor</a>
+      </p>
       </div>
     <div class="dict_entry" id="wrap-color">
       <h3>
@@ -8921,12 +9847,14 @@ show (word &quot;a&quot; &quot;b&quot; &quot;c&quot; 1 23)
         range of 0 to 140 (not including 140 itself). If it is not,
         wrap-color &quot;wraps&quot; the numeric input to the 0 to 140
         range.
+      </p>
       <p>
         The wrapping is done by repeatedly adding or subtracting 140 from
         the given number until it is in the 0 to 140 range. (This is the
         same wrapping that is done automatically if you assign an
         out-of-range number to the color turtle variable or pcolor patch
         variable.)
+      </p>
       <pre>
 show wrap-color 150
 =&gt; 10
@@ -8946,9 +9874,11 @@ show wrap-color -10
         string, list, boolean, or nobody to the Command Center, <i>not</i>
         followed by a carriage return (unlike <a href="#print">print</a>
         and <a href="#show">show</a>).
+      </p>
       <p>
         This agent is <i>not</i> printed before the value, unlike <a href="#show">show</a>. Its output also includes quotes around strings
         and is prepended with a space.
+      </p>
       <pre>
 write &quot;hello world&quot;
 =&gt;  &quot;hello world&quot;
@@ -8957,6 +9887,7 @@ write &quot;hello world&quot;
         See also <a href="#print">print</a>, <a href="#show">show</a>,
         <a href="#type">type</a>, <a href="#output-cmds">output-write</a>,
         and <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="X">
@@ -8975,12 +9906,15 @@ write &quot;hello world&quot;
         This is a built-in turtle variable. It holds the current x
         coordinate of the turtle. You can set this variable to change the
         turtle's location.
+      </p>
       <p>
         This variable is always greater than or equal to (min-pxcor - 0.5)
         and strictly less than (max-pxcor + 0.5).
+      </p>
       <p>
         See also <a href="#setxy">setxy</a>, <a href="#ycor">ycor</a>,
         <a href="#pcor">pxcor</a>, <a href="#pcor">pycor</a>,
+      </p>
       </div>
     <div class="dict_entry" id="xor">
       <h3>
@@ -8992,6 +9926,7 @@ write &quot;hello world&quot;
       <p>
         Reports true if either <i>boolean1</i> or <i>boolean2</i> is true,
         but not when both are true.
+      </p>
       <pre>
 if (pxcor &gt; 0) xor (pycor &gt; 0)
   [ set pcolor blue ]
@@ -9015,12 +9950,15 @@ if (pxcor &gt; 0) xor (pycor &gt; 0)
         This is a built-in turtle variable. It holds the current y
         coordinate of the turtle. You can set this variable to change the
         turtle's location.
+      </p>
       <p>
         This variable is always greater than or equal to (min-pycor - 0.5)
         and strictly less than (max-pycor + 0.5).
+      </p>
       <p>
         See also <a href="#setxy">setxy</a>, <a href="#xcor">xcor</a>,
         <a href="#pcor">pxcor</a>, <a href="#pcor">pycor</a>,
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2>
@@ -9042,13 +9980,18 @@ if (pxcor &gt; 0) xor (pycor &gt; 0)
         The variable names in <i>args</i> have the same restrictions
         as variable names of commands and reporters. In addition, they must not match the name of
         any let or procedure variable in their procedure.
+        </p>
         <p>
         Anonymous procedures are commonly used with the primitives
         <a href="#foreach">foreach</a>, <a href="#map">map</a>, <a href="#reduce">reduce</a>,
         <a href="#filter">filter</a>, <a href="#sort-by">sort-by</a>, and <a href="#n-values">n-values</a>. See
         those entries for example usage.
+        </p>
         <p>
         See the <a href="programming.html#anonymous-procedures">Anonymous Procedures section</a> of the
         Programming Guide for details.
+        </p>
       </div>
     </div>
+</body>
+</html>

--- a/autogen/docs/dictionary.html.mustache
+++ b/autogen/docs/dictionary.html.mustache
@@ -68,19 +68,6 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
         </div>
       </div>
     </div>
-<!--
-NOTE!
-</div>
-The reason the h2 headers have an extra &nbsp; in them, like this:
-<h2><a name="A">A&nbsp;</a></h2>
-instead of just:
-<h2><a name="A">A</a></h2>
-is to work around an extremely obscure bug in Internet Explorer
-where without the extra stuff, some of the links from primitives.html
-don't always work on every computer.  (On one computer it was just
-the "I" link that didn't work; on other computers it was more.)
-Go figure! - ST 12/2/04
--->
     <h2>
       Categories
     </h2>
@@ -833,7 +820,7 @@ Go figure! - ST 12/2/04
       <!-- ======================================== -->
     </div>
     <h2>
-      <a>A&nbsp;</a>
+      <a>A</a>
     </h2><!-- ======================================== -->
     <div id="A">
     <div class="dict_entry" id="abs">

--- a/autogen/docs/dictionary.html.mustache
+++ b/autogen/docs/dictionary.html.mustache
@@ -77,10 +77,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       versa. To see which agents (turtles, patches, links, observer) can
       actually run a primitive, consult its dictionary entry.
       <!-- ======================================== -->
-    <h3>
+    <h3 id="turtlegroup">
       Turtle-related
     </h3>
-    <p id="turtlegroup">
+    <p>
       <a href="#back">back</a> (<a href="#back">bk</a>)
       <a href="#turtles-at"><i>&lt;breeds&gt;</i>-at</a>
       <a href="#turtles-here"><i>&lt;breeds&gt;</i>-here</a>
@@ -156,10 +156,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#uphill">uphill</a>
       <a href="#uphill">uphill4</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="patchgroup">
       Patch-related
     </h3>
-    <p id="patchgroup">
+    <p>
       <a href="#clear-patches">clear-patches</a> (<a href="#clear-patches">cp</a>)
       <a href="#diffuse">diffuse</a>
       <a href="#diffuse4">diffuse4</a>
@@ -195,10 +195,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#subject">subject</a>
       <a href="#turtles-here">turtles-here</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="linkgroup">
       Link-related
     </h3>
-    <p id="linkgroup">
+    <p>
       <a href="#both-ends">both-ends</a>
       <a href="#clear-links">clear-links</a>
       <a href="#create-link">create-&lt;breed&gt;-from</a>
@@ -261,10 +261,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#undirected-link-breed">undirected-link-breed</a>
       <a href="#untie">untie</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="agentsetgroup">
       <a>Agentset</a>
     </h3>
-    <p id="agentsetgroup">
+    <p>
       <a href="#all">all?</a>
       <a href="#any">any?</a>
       <a href="#ask">ask</a>
@@ -310,10 +310,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#with-max">with-max</a>
       <a href="#with-min">with-min</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="colorgroup">
       Color
     </h3>
-    <p id="colorgroup">
+    <p>
       <a href="#approximate-hsb">approximate-hsb</a>
       <a href="#approximate-rgb">approximate-rgb</a>
       <a href="#base-colors">base-colors</a>
@@ -329,10 +329,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#shade-of">shade-of?</a>
       <a href="#wrap-color">wrap-color</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="controlgroup">
       Control flow and logic
     </h3>
-    <p id="controlgroup">
+    <p>
       <a href="#and">and</a>
       <a href="#ask">ask</a>
       <a href="#ask-concurrent">ask-concurrent</a>
@@ -364,10 +364,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#without-interruption">without-interruption</a>
       <a href="#xor">xor</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="anonproceduresgroup">
       Anonymous Procedures
     </h3>
-    <p id="anonproceduresgroup">
+    <p>
       <a href="#arrow">-&gt; (anonymous procedure)</a>
       <a href="#filter">filter</a>
       <a href="#foreach">foreach</a>
@@ -380,10 +380,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#run">runresult</a>
       <a href="#sort-by">sort-by</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="worldgroup">
       World
     </h3>
-    <p id="worldgroup">
+    <p>
       <a href="#clear-all">clear-all</a> (<a href="#clear-all">ca</a>)
       <a href="#clear-drawing">clear-drawing</a> (<a href="#clear-drawing">cd</a>)
       <a href="#clear-globals">clear-globals</a>
@@ -410,10 +410,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#world-dim">world-width</a>
       <a href="#world-dim">world-height</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="perspectivegroup">
       Perspective
     </h3>
-    <p id="perspectivegroup">
+    <p>
       <a href="#follow">follow</a>
       <a href="#follow-me">follow-me</a>
       <a href="#reset-perspective">reset-perspective</a> (<a href="#reset-perspective">rp</a>)
@@ -423,10 +423,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#watch">watch</a>
       <a href="#watch-me">watch-me</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="hubnetgroup">
       <a>HubNet</a>
     </h3>
-    <p id="hubnetgroup">
+    <p>
       <a href="#hubnet-broadcast">hubnet-broadcast</a>
       <a href="#hubnet-broadcast-clear-output">hubnet-broadcast-clear-output</a>
       <a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>
@@ -451,10 +451,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#hubnet-send-override">hubnet-send-override</a>
       <a href="#hubnet-send-watch">hubnet-send-watch</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="iogroup">
       Input/output
     </h3>
-    <p id="iogroup">
+    <p>
       <a href="#beep">beep</a>
       <a href="#clear-output">clear-output</a>
       <a href="#date-and-time">date-and-time</a>
@@ -492,10 +492,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#user-yes-or-no">user-yes-or-no?</a>
       <a href="#write">write</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="fileiogroup">
       File
     </h3>
-    <p id="fileiogroup">
+    <p>
       <a href="#file-at-end">file-at-end?</a>
       <a href="#file-close">file-close</a>
       <a href="#file-close-all">file-close-all</a>
@@ -514,10 +514,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#user-file">user-file</a>
       <a href="#user-new-file">user-new-file</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="listsgroup">
       List
     </h3>
-    <p id="listsgroup">
+    <p>
       <a href="#but-first-and-last">but-first</a>
       <a href="#but-first-and-last">but-last</a>
       <a href="#empty">empty?</a>
@@ -558,10 +558,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#subliststring">sublist</a>
       <a href="#up-to-n-of">up-to-n-of</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="stringgroup">
       String
     </h3>
-    <p id="stringgroup">
+    <p>
       <a href="#Symbols">Operators (&lt;, &gt;, =, !=, &lt;=, &gt;=)</a>
       <a href="#but-first-and-last">but-first</a>
       <a href="#but-first-and-last">but-last</a>
@@ -582,10 +582,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#subliststring">substring</a>
       <a href="#word">word</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="mathematicalgroup">
       Mathematical
     </h3>
-    <p id="mathematicalgroup">
+    <p>
       <a href="#Symbols">Arithmetic Operators (+, *, -, /, ^, &lt;, &gt;, =, !=, &lt;=, &gt;=)</a>
       <a href="#abs">abs</a>
       <a href="#acos">acos</a>
@@ -626,10 +626,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#tan">tan</a>
       <a href="#variance">variance</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="plottinggroup">
       Plotting
     </h3>
-    <p id="plottinggroup">
+    <p>
       <a href="#autoplot">autoplot?</a>
       <a href="#auto-plot-status">auto-plot-off</a>
       <a href="#auto-plot-status">auto-plot-on</a>
@@ -662,30 +662,30 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#setup-plots">setup-plots</a>
       <a href="#update-plots">update-plots</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="behaviorspacegroup">
       BehaviorSpace
     </h3>
-    <p id="behaviorspacegroup">
+    <p>
       <a href="#behaviorspace-experiment-name">behaviorspace-experiment-name</a>
       <a href="#behaviorspace-run-number">behaviorspace-run-number</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="systemgroup">
       System
     </h3>
-    <p id="systemgroup">
+    <p>
       <a href="#netlogo-version">netlogo-version</a>
       <a href="#netlogo-web">netlogo-web?</a>
       <!-- ======================================== -->
        <!-- ======================================== -->
        <!-- ======================================== -->
-    <h2>
+    <h2 id="builtinvariables">
       <a>Built-In Variables</a>
     </h2><!-- ======================================== -->
-    <div id="builtinvariables">
-      <h3>
+    <div>
+      <h3 id="turtle-variables">
         <a>Turtles</a>
       </h3>
-      <p id="turtle-variables">
+      <p>
       <a href="#breedvar">breed</a>
       <a href="#color">color</a>
       <a href="#heading">heading</a>
@@ -700,20 +700,20 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#xcor">xcor</a>
       <a href="#ycor">ycor</a>
       <!-- ======================================== -->
-      <h3>
+      <h3 id="patch-variables">
         <a>Patches</a>
       </h3>
-      <p id="patch-variables">
+      <p>
       <a href="#pcolor">pcolor</a>
       <a href="#plabel">plabel</a>
       <a href="#plabel-color">plabel-color</a>
       <a href="#pcor">pxcor</a>
       <a href="#pcor">pycor</a>
       <!-- ======================================== -->
-      <h3>
+      <h3 id="link-variables">
         <a>Links</a>
       </h3>
-      <p id="link-variables">
+      <p>
       <a href="#breed">breed</a>
       <a href="#color">color</a>
       <a href="#end1">end1</a>
@@ -725,19 +725,19 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#thickness">thickness</a>
       <a href="#tie-mode">tie-mode</a>
       <!-- ======================================== -->
-      <h3>
+      <h3 id="other-variables">
         <a>Other</a>
       </h3>
-      <p id="other-variables">
+      <p>
       <a href="#arrow">-&gt;</a>
       <!-- ======================================== -->
       <!-- ======================================== -->
       <!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="Keywords">
       <a>Keywords</a>
     </h2>
-    <p id="Keywords">
+    <p>
       <a href="#breed">breed</a>
       <a href="#directed-link-breed">directed-link-breed</a>
       <a href="#end">end</a>
@@ -753,10 +753,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <!-- ======================================== -->
        <!-- ======================================== -->
        <!-- ======================================== -->
-    <h2>
+    <h2 id="Constants">
       <a>Constants</a>
     </h2><!-- ======================================== -->
-    <div id="Constants">
+    <div>
       <div class="dict_entry" id="mathconstants" data-constants="e pi">
         <h3>
           Mathematical Constants
@@ -819,10 +819,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <!-- ======================================== -->
       <!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="A">
       <a>A</a>
     </h2><!-- ======================================== -->
-    <div id="A">
+    <div>
     <div class="dict_entry" id="abs">
       <h3>
         <a>abs<span class="since">1.0</span></a>
@@ -1193,10 +1193,10 @@ end
         ranges.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="B">
       <a>B</a>
     </h2><!-- ======================================== -->
-    <div id="B">
+    <div>
     <div class="dict_entry" id="back">
       <h3>
         <a>back<span class="since">1.0</span></a>
@@ -1421,10 +1421,10 @@ show but-last &quot;string&quot;
 </pre><!-- ======================================== -->
     </div>
   </div>
-    <h2>
+    <h2 id="C">
       <a>C</a>
     </h2><!-- ======================================== -->
-    <div id="C">
+    <div>
     <div class="dict_entry" id="can-move">
       <h3>
         <a>can-move?<span class="since">3.1</span></a>
@@ -1882,10 +1882,10 @@ end
         <!-- ======================================== -->
       </div>
     </div>
-    <h2>
+    <h2 id="D">
       <a>D</a>
     </h2><!-- ======================================== -->
-    <div id="D">
+    <div>
     <div class="dict_entry" id="date-and-time">
       <h3>
         <a>date-and-time<span class="since">3.0</span></a>
@@ -2181,10 +2181,10 @@ if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
         more appropriate. <!-- ======================================== -->
       </div>
     </div>
-    <h2>
+    <h2 id="E">
       <a>E</a>
     </h2><!-- ======================================== -->
-    <div id="E">
+    <div>
     <div class="dict_entry" id="empty">
       <h3>
         <a>empty?<span class="since">1.0</span></a>
@@ -2473,10 +2473,10 @@ show extract-rgb cyan
         See also <a href="#approximate-rgb">approximate-rgb</a>, <a href="#approximate-hsb">approximate-hsb</a>, <a href="#extract-hsb">extract-hsb</a>.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="F">
       <a>F</a>
     </h2><!-- ======================================== -->
-    <div id="F">
+    <div>
     <div class="dict_entry" id="face">
       <h3>
         <a>face<span class="since">3.0</span></a>
@@ -3023,10 +3023,10 @@ set mylist fput 2 mylist
 </pre>
     </div><!-- ======================================== -->
   </div>
-    <h2>
+    <h2 id="G">
       <a>G</a>
     </h2><!-- ======================================== -->
-    <div id="G">
+    <div>
     <div class="dict_entry" id="globals">
       <h3>
         <a>globals</a>
@@ -3046,10 +3046,10 @@ set mylist fput 2 mylist
         need to be used in many parts of the program.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="H">
       <a>H</a>
     </h2><!-- ======================================== -->
-    <div id="H">
+    <div>
     <div class="dict_entry" id="hatch">
       <h3>
         <a>hatch<span class="since">1.0</span></a>
@@ -3576,10 +3576,10 @@ ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
         <a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
       </div>
     </div> <!-- ======================================== -->
-    <h2>
+    <h2 id="I">
       <a>I</a>
     </h2><!-- ======================================== -->
-    <div id="I">
+    <div>
     <div class="dict_entry" id="if">
       <h3>
         <a>if<span class="since">1.0</span></a>
@@ -4101,10 +4101,10 @@ show item 3 &quot;my-shoe&quot;
 </pre>
     </div><!-- ======================================== -->
   </div>
-    <h2>
+    <h2 id="J">
       <a>J</a>
     </h2><!-- ======================================== -->
-    <div id="J">
+    <div>
     <div class="dict_entry" id="jump">
       <h3>
         <a>jump<span class="since">1.0</span></a>
@@ -4123,10 +4123,10 @@ show item 3 &quot;my-shoe&quot;
         See also <a href="#forward">forward</a>, <a href="#can-move">can-move?</a>.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="L">
       <a>L</a>
     </h2><!-- ======================================== -->
-    <div id="L">
+    <div>
     <div class="dict_entry" id="label">
       <h3>
         <a>label</a>
@@ -4625,10 +4625,10 @@ set mylist lput 42 mylist
 </pre>
       </div><!-- ======================================== -->
     </div>
-      <h2>
+      <h2 id="M">
         <a>M</a>
       </h2><!-- ======================================== -->
-      <div id="M">
+      <div>
       <div class="dict_entry" id="map">
         <h3>
           <a>map<span class="since">1.3</span></a>
@@ -5176,10 +5176,10 @@ ask turtles
           See also <a href="#self">self</a>.
         </div><!-- ======================================== -->
       </div>
-      <h2>
+      <h2 id="N">
         <a>N</a>
       </h2><!-- ======================================== -->
-      <div id="N">
+      <div>
       <div class="dict_entry" id="n-of">
         <h3>
           <a>n-of<span class="since">3.1</span></a>
@@ -5450,10 +5450,10 @@ if not any? turtles [ crt 10 ]
         Reports an empty turtle agentset.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="O">
       <a>O</a>
     </h2><!-- ======================================== -->
-    <div id="O">
+    <div>
     <div class="dict_entry" id="of">
       <h3>
         <a>of<span class="since">4.0</span></a>
@@ -5687,10 +5687,10 @@ ask turtle 1
         Center is used.) See also <a href="programming.html#output">Output (programming guide)</a>.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="P">
       <a>P</a>
     </h2><!-- ======================================== -->
-    <div id="P">
+    <div>
     <div class="dict_entry" id="patch">
       <h3>
         <a>patch<span class="since">1.0</span></a>
@@ -6203,10 +6203,10 @@ show precision 3834 -3
         See also <a href="#xcor">xcor</a>, <a href="#ycor">ycor</a>.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="R">
       <a>R</a>
     </h2><!-- ======================================== -->
-    <div id="R">
+    <div>
     <div class="dict_entry" id="random">
       <h3>
         <a>random<span class="since">1.0</span></a>
@@ -6886,10 +6886,10 @@ show (runresult [ [a b] -&gt; a + b ] 10 5)
         See also <a href="#foreach">foreach</a>, <a href="#arrow">-> (anonymous procedure)</a>.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="S">
       <a>S</a>
     </h2><!-- ======================================== -->
-    <div id="S">
+    <div>
     <div class="dict_entry" id="scale-color">
       <h3>
         <a>scale-color<span class="since">1.0</span></a>
@@ -7815,10 +7815,10 @@ show sum [energy] of turtles
 </pre>
     </div><!-- ======================================== -->
   </div>
-    <h2>
+    <h2 id="T">
       <a>T</a>
     </h2><!-- ======================================== -->
-    <div id="T">
+    <div>
     <div class="dict_entry" id="tan">
       <h3>
         <a>tan<span class="since">1.0</span></a>
@@ -8265,10 +8265,10 @@ type 3 type &quot; &quot; print 4
         <a href="programming.html#output">Output (programming guide)</a>.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="U">
       <a>U</a>
     </h2><!-- ======================================== -->
-    <div id="U">
+    <div>
     <div class="dict_entry" id="undirected-link-breed">
       <h3>
         <a>undirected-link-breed</a>
@@ -8558,10 +8558,10 @@ if user-yes-or-no? &quot;Set up the model?&quot;
         Programming Guide for additional details.
     </div><!-- ======================================== -->
   </div>
-    <h2>
+    <h2 id="V">
       <a>V</a>
     </h2><!-- ======================================== -->
-    <div id="V">
+    <div>
     <div class="dict_entry" id="variance">
       <h3>
         <a>variance<span class="since">1.0</span></a>
@@ -8586,10 +8586,10 @@ show variance [2 7 4 3 5]
 </pre>
     </div><!-- ======================================== -->
   </div>
-    <h2>
+    <h2 id="W">
       <a>W</a>
     </h2><!-- ======================================== -->
-    <div id="W">
+    <div>
     <div class="dict_entry" id="wait">
       <h3>
         <a>wait<span class="since">1.0</span></a>
@@ -8959,10 +8959,10 @@ write &quot;hello world&quot;
         and <a href="programming.html#output">Output (programming guide)</a>.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="X">
       <a>X</a>
     </h2><!-- ======================================== -->
-    <div id="X">
+    <div>
     <div class="dict_entry" id="xcor">
       <h3>
         <a>xcor</a>
@@ -8999,10 +8999,10 @@ if (pxcor &gt; 0) xor (pycor &gt; 0)
 </pre>
     </div><!-- ======================================== -->
   </div>
-    <h2>
+    <h2 id="Y">
       <a>Y</a>
     </h2><!-- ======================================== -->
-    <div id="Y">
+    <div>
     <div class="dict_entry" id="ycor">
       <h3>
         <a>ycor</a>


### PR DESCRIPTION
These commits bring one cosmetic adjustment and two behind-the-scenes changes to the NetLogo dictionary.

Cosmetic adjustment: Titles now visible after following a section link.
Open https://ccl.northwestern.edu/netlogo/docs/dictionary.html on Google Chrome and click _Turtle_ at the top of the page. Chrome jumps to the list of turtle terms, but the title _Turtle-related_ is not visible. The adjusted dictionary will scroll to the position where the title is visible.

Behind-the-scenes changes:
1. Removed an old note from the era of Internet Explorer
2. HTML5-compliant dictionary: Balanced `<p>` tags, corrected erroneous `<i>` tags. Validated online.

Keep up the good work.