### PR TITLE
Docs: Cosmetic adjustment, HTML5 compliance

### DIFF
--- a/autogen/docs/3d.html.mustache
+++ b/autogen/docs/3d.html.mustache
@@ -1,1233 +1,1242 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<title>
-      NetLogo {{version}} User Manual: 3D
-    </title>
-    <link rel="stylesheet" href="netlogo.css" type="text/css">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <style>
-p { margin-left: 1.5em ; }
-    p.bookquote { font-size: 85%; margin-left: 4em; margin-right: 4em; color: #333 ; }
-p.c1 {font-style: italic}
-    </style>
-</head>
-<body>
-  <h1>
-      NetLogo 3D
-    </h1>
-    <p>
-      NetLogo includes the NetLogo 3D application that allows you to create 3D worlds.
-    </p>
-    <p>
-      <b>Notice:</b> NetLogo's support for 3D is less developed than
-      NetLogo 2D. Models created with this release may not be compatible
-      with future versions. While we've made efforts to ensure a quality
-      product, NetLogo 3D has not been subject to the same level of quality
-      control as the main application.
-    </p>
-    <ul>
-      <li>
-        <a href="#introduction">Introduction</a>
-      <li>
-        <a href="#tutorial">Tutorial</a>
-      <li>
-        <a href="#dictionary">Dictionary</a>
-      </ul>
-    <div id="introduction">
-    <h2>
-      <a>Introduction</a>
-    </h2>
-    <p>
-      To get started using NetLogo 3D, launch the NetLogo 3D application
-      and check out the Sample Models in the 3D section of the Models
-      Library.
-    </p>
-    <p>
-      When you're ready to write your own 3D model, look at the Code
-      Examples in the 3D section of the Models Library.
-    </p>
-    <div class="blockquote">
-        <b>Code Example:</b> Turtle Perspective Example 3D helps you learn
-        about the different perspectives.
-      <p>
-        <b>Code Example:</b> Turtle and Observer Motion Example 3D helps
-        you understand how turtles and the observer move in 3D. You can
-        also step through this model with the tutorial below.
-      </p>
-      </div>
-    <h4>
-      <span class="prim_example">3D Worlds</span>
-    </h4>
-    <p class="bookquote">
-      <i>An unspeakable horror seized me. There was a darkness; then a
-      dizzy, sickening sensation of sight that was not like seeing; I saw a
-      Line that was no Line; Space that was not Space: I was myself, and
-      not myself. When I could find voice, I shrieked loud in agony,
-      &quot;Either this is madness or it is Hell.&quot;</i>
-    </p>
-    <p class="bookquote">
-      <i>&quot;It is neither,&quot; calmly replied the voice of the Sphere,
-      &quot;it is Knowledge; it is Three Dimensions: open your eye once
-      again and try to look steadily.&quot;</i>
-      <br>
-      -- Edwin A. Abbott, <i>Flatland: A romance in many dimensions</i>
-    </p>
-    <p>
-      NetLogo 3D's world has width, height and depth. Patches are
-      cubes. In addition to <code><a href="dictionary.html#pcor">pxcor</a></code> and <code><a href="dictionary.html#pcor">pycor</a></code>, patches have <code><a href="#pzcor">pzcor</a></code>.
-    </p>
-    <p>
-      Turtles have three Cartesian coordinates, instead of two, to describe
-      position. In addition to <code><a href="dictionary.html#xcor">xcor</a></code> and <code><a href="dictionary.html#ycor">ycor</a></code>, turtles have <code><a href="#zcor">zcor</a></code>.
-    </p>
-    <p>
-      A turtle's orientation is defined by three turtle variables,
-      <code><a href="dictionary.html#heading">heading</a></code>, <code><a href="#pitch">pitch</a></code> and <code><a href="#roll">roll</a></code>. You
-      can imagine the turtle as having two vectors to define its
-      orientation in 3D space. One vector comes straight out of the nose of
-      the turtle, this is the direction the turtle will travel when it
-      moves forward. The second vector is perpendicular to the forward
-      vector and comes out of the right side of the turtle (as if the
-      turtle were to stick its right arm straight out from its body).
-      Heading is the angle between the forward vector of the turtle
-      projected onto the xy-plane and the vector [0 1 0]. Pitch is the
-      angle between the forward vector of the turtle and the xy-plane and
-      finally roll is the angle between the right vector of the turtle and
-      the xy-plane. When turtle turns right or left in 3D space it rotates
-      around the down vector, that is the vector that is perpendicular to
-      both the forward and right vectors. Depending on the orientation of
-      the turtle more than one of the internal turtle variables may change
-      as the result of a turn.
-    </p>
-    <h4>
-      <span class="prim_example">The observer and the 3D view</span>
-    </h4>
-    <p>
-      The point of view that you see the world from is considered the
-      location and orientation of the observer. This is similar to the 3D
-      view in NetLogo 2D. However, there are a few more ways to control the
-      observer. You can set the point that the observer is facing by using
-      <code>face</code> and <code>facexyz</code> which work the same way as the
-      turtle commands, the observer turns so the center of the view is on
-      the given point or the location of the given agent at the time it is
-      called. You can change the location of the observer using
-      <code>setxyz</code>. The observer will move to view the world as if
-      standing on the given location, the point the observer faces will
-      stay the same. For example create a new model and observer will be
-      located at (0, 0, 49.5), that is, on the z-axis 49.5 patch units away
-      from the origin and the observer is facing the origin, (0, 0, 0). If
-      you <code>setxyz 0 49.5 0</code> the observer will move so it is on the
-      positive y-axis but it will keep the origin at the center of the
-      view. You can also move the observer using the rotation primitives
-      that will allow you to move the observer around the world as if on
-      the surface of a sphere where the center is the location the observer
-      is facing. You may notice from the above examples that the observer
-      is not constrained to be within the bounds of the world.
-    </p>
-    <h4>
-      <span class="prim_example"><a id="custom-shapes">Custom Shapes</a></span>
-    </h4>
-    <p>
-      NetLogo automatically interprets 2D shapes so they are extruded, like
-      a cookie cutter shape in the 3D view. You can also use the primitive
-      <a href="#load-shapes-3d"><code>load-shapes-3d</code></a> to load shapes
-      described in an external file in a custom format described here.
-      Currently we do not import shapes in any standard formats.
-    </p>
-    <p>
-      For each shape in a custom 3D shape file, a 2D shape of the same name
-      must exist as well. You can create the 2D shape in the Turtle Shapes
-      Editor.
-    </p>
-    <p>
-      The input file may contain any number of shapes with any number of
-      rectangular or triangular surfaces. The format of the input file
-      should be as follows:
-    </p>
-    <pre>
-number of shapes in file
-name of first shape
-type of surface ( quads or tris )
-surface1
-surface2
-.
-.
-.
-stop
-type of surface
-surfaceA
-.
-.
-.
-stop
-end-shape
-</pre>
-    <p>
-      Each surface is defined by a unit normal vector and the vertices
-      listed in clockwise order, tris should have three vertices and quads
-      should have four.
-    </p>
-    <pre>
-normal: xn yn zn
-x1 y1 z1
-x2 y2 z2
-x3 y3 z3
-x4 y4 z4
-</pre>
-    <p>
-      A file declaring just a two dimensional, patch-sized, square in the
-      xy-plane centered at the origin would look like this:
-    </p>
-    <pre>
-1
-square
-quads
-normal: 0 0 1
-0.15 0.15 0
--0.15 0.15 0
--0.15 -0.15 0
-0.15 -0.15 0
-normal: 0 0 -1
-0.15 0.15 0
-0.15 -0.15 0
--0.15 -0.15 0
--0.15 0.15 0
-stop
-end-shape
-</pre>
-      </div>
-      <div id="tutorial">
-    <h2>
-      <a>Tutorial</a>
-    </h2>
-    <h4>
-      <span class="prim_example">Step 1: Depth</span>
-    </h4>
-    <p>
-      One of the first things you will notice when you open NetLogo 3D is
-      that the world is a cube instead of a square.
-    </p>
-    <p class="screenshot">
-      <img alt="screen shot" src="images/3d/cube.gif">
-    </p>
-    <p>
-      You can open up the Model Settings, by clicking on the
-      &quot;Settings...&quot; button at the top of the 3D View. You'll
-      notice in addition to <code>max-pxcor</code>, <code>min-pxcor</code>,
-      <code>max-pycor</code>, and <code>min-pycor</code>, there is also <a href="#min-max-pzcor"><code>max-pzcor</code></a> and <a href="#min-max-pzcor"><code>min-pzcor</code></a>.
-    </p>
-    <p class="screenshot">
-      <img alt="screen shot" src="images/3d/properties.gif">
-    </p>
-    <p>
-      The z-axis is perpendicular to both the x-axis and the y-axis, when
-      you <code>reset-perspective</code> it is the axis that comes straight out
-      of the screen. In the default position <code>max-pzcor</code> is the face
-      of the cube nearest to you and <code>min-pzcor</code> is the face
-      farthest from you. As always <code>min-pxcor</code> is on the left,
-      <code>max-pxcor</code> on the right, <code>min-pycor</code> on the bottom,
-      and <code>max-pycor</code> on the top.
-    </p>
-    <p>
-      You'll also notice on the left side of the Model Settings that
-      there are options for wrapping in all three directions, however, they
-      are all checked and grayed out. Topologies are not yet supported in
-      NetLogo 3D, so the world always wraps in all dimensions.
-    </p>
-    <div class="blockquote">
-      <ul>
-        <li>Move to the Command Center and type <code>print count
-        patches</code>.
-        </ul>
-      <p class="question">
-        Is the number smaller or larger than you expected?
-      </p>
-      </div>
-    <p>
-      In a 3D world the number of patches grows very quickly since
-      <code>count patches = world-width * world-height * world-depth</code>.
-      It's important to keep this in mind when you are building your
-      model. Lots of patches can slow your model down or even cause NetLogo
-      to run out of memory.
-    </p>
-    <div class="blockquote">
-      <ul>
-        <li>Type <code>ask patch 1 2 3 [ set pcolor red ]</code> into the
-        Command Center.
-        <li>Use the mouse in the 3D view to rotate the world.
-        </ul>
-    </div>
-    <p>
-      Notice the shape of the patch and its position in relation to the
-      edges of the world. You'll also notice that you now need three
-      coordinates to address patches in a 3D world.
-    </p>
-    <h4>
-      <span class="prim_example">Step 2: Turtle Movement</span>
-    </h4>
-    <div class="blockquote">
-      <ul>
-        <li>Open the Models Library in the File menu. (If you are on a Mac
-        and you don't have a File menu, click on the main NetLogo
-        window first and it should reappear.)
-        <li>Open Turtle and Observer Motion Example 3D in 3D/Code Examples
-        </ul>
-    </div>
-    <p>
-      Take a moment to look for the controls and monitors. In the bottom
-      left you'll notice a group of monitors that describe the location
-      and orientation of the turtle, though until you press the setup
-      button they'll all say &quot;N/A&quot;.
-    </p>
-    <div class="blockquote">
-      <ul>
-        <li>Press the &quot;setup&quot; button
-        </ul>
-    </div>
-    <p>
-      Heading, pitch, and roll are turtle variables that represent the
-      orientation of the turtle. Heading is absolute in relation to the x/y
-      plane; it is the rotation of the turtle around the z-axis.
-    </p>
-    <p class="screenshot">
-      <img alt="screen shot" src="images/3d/heading.gif">
-    </p>
-    <p>
-      Pitch is the angle between the nose of the turtle and the xy-plane.
-      It is relative to heading.
-    </p>
-    <p class="screenshot">
-      <img alt="screen shot" src="images/3d/pitch.gif">
-    </p>
-    <p>
-      Roll is the rotation around the turtle's forward vector. It is
-      relative to heading and pitch.
-    </p>
-    <p class="screenshot">
-      <img alt="screen shot" src="images/3d/roll.gif">
-    </p>
-    <p>
-      When turtles are created with <code>create-turtles</code> or
-      <code>create-ordered-turtles</code>, their initial headings vary but
-      their initial pitch and roll are always zero.
-    </p>
-    <p>
-      Take a look at the &quot;Turtle Movement&quot; buttons.
-    </p>
-    <div class="blockquote">
-      <ul>
-        <li>Press the &quot;left 1&quot; button.
-        </ul>
-      <p class="question">
-        How does the turtle move? Is is the same or different from 2D
-        NetLogo? Which of the turtle variables change?
-      </p>
-      <ul>
-        <li>Press the &quot;pitch-down 1&quot; button.
-        </ul>
-      <p class="question">
-        How does the turtle move? Which of the turtle variables change?
-      </p>
-      <ul>
-        <li>Press the &quot;left 1&quot; button again.
-        </ul>
-      <p class="question">
-        How does the turtle move? Is it different than the last time you
-        pressed the &quot;left 1&quot; button?
-      </p>
-      <ul>
-        <li>Take a little time to play with the Turtle Movement buttons,
-        watching both how the turtle moves and which of the turtle
-        variables change.
-        </ul>
-    </div>
-    <p>
-      You probably noticed that often more than one of the turtle variables
-      may change for a single turn. For this reason we suggest that you use
-      the turtle commands rather than setting the orientation variables
-      directly.
-    </p>
-    <h4>
-      <span class="prim_example">Step 3: Observer Movement</span>
-    </h4>
-    <p>
-      At the bottom of the interface you will see Orbit, Zoom, and Move
-      buttons. If you have ever used the 3D view in NetLogo 2D or if you
-      have been using the mouse controls in the 3D view through this
-      tutorial you have been moving the observer. Changing the point of
-      view in the 3D view is actually moving and changing the orientation
-      of the observer. The observer has x, y and z coordinates, just like a
-      turtle or patch, while turtles and patches are constrained to be
-      inside the world the observer can be anywhere. Like a turtle the
-      observer has a heading, pitch and roll, these variables control where
-      the observer is looking, that is, what you see in the view.
-    </p>
-    <div class="blockquote">
-      <ul>
-        <li>Move to the 3D view, and make sure &quot;Orbit&quot; is
-        selected in the bottom left corner of the view.
-        <li>Click and hold the mouse button in the middle of the view, move
-        the mouse left, right, up, and down.
-        </ul>
-      <p class="question">
-        How does the position and orientation of the observer change?
-      </p>
-      <ul>
-        <li>Press the reset-perspective button in the lower right corner of
-        the view and select &quot;Zoom&quot; in the lower left corner.
-        <li>Click and hold the mouse button in the middle of the view and
-        move the mouse up and down.
-        </ul>
-      <p class="question">
-        Which of the observer variables change? Which stay the same?
-      </p>
-      <ul>
-        <li>Try rotating the world a bit and then zoom again.
-        <li>Press the &quot;Move&quot; button in the lower left corner of
-        the view.
-        <li>Click and hold the mouse button in the middle of the view and
-        move the mouse up, down, left and right.
-        </ul>
-      <p class="question">
-        How does the view change? How do the observer variables change?
-      </p>
-      </div>
-    <p>
-      After you are done exploring the world using the mouse controls you
-      can take a look at the observer control buttons in the lower left
-      portion of the interface.
-    </p>
-    <p>
-      You may already be familiar with the first three buttons in the
-      observer group from your experience with NetLogo 2D. Watch, follow,
-      and ride, are special modes that automatically update the position
-      and orientation of the observer. When in follow or ride mode, the
-      observer position and orientation are the same as the turtle's.
-      Note that follow and ride are functionally exactly the same, the
-      difference is only visual in the 3D view. When in watch mode the
-      observer does not move but updates to face the target agent.
-    </p>
-    <div class="blockquote">
-      <ul>
-        <li>Press the &quot;setup&quot; button again so you are back to the
-        default orientation.
-        <li>Press the &quot;orbit-right&quot; button.
-        </ul>
-      <p class="question">
-        How did the view change? Was it what you expected? How is it
-        similar or different from using the mouse controls?
-      </p>
-      <ul>
-        <li>Take a little time to experiment with orbit, roll and zoom
-        buttons; notice similarities and differences to the mouse controls.
-        </ul>
-    </div>
-    <p>
-      The direction of the orbit commands refer to the direction that the
-      observer moves. That is, imagine that the observer is on the surface
-      of a sphere, the center of the sphere is the point that the observer
-      is facing represented by the blue cross, by default (0,0,0). The
-      observer will always face the center of the sphere and the radius of
-      the sphere will remain constant. The directions, up, down, left, and
-      right, refer to moving along the lines of latitude and the lines of
-      longitude of the sphere. When you zoom the radius of the sphere
-      changes but the center and the observer's orientation in relation
-      to the center of the sphere will remain the same.
-    </p>
-    <div class="blockquote">
-      <ul>
-        <li>Press one of the &quot;setxyz&quot; buttons.
-        </ul>
-      <p class="question">
-        How does the view change? How do the observer variables change?
-      </p>
-      <ul>
-        <li>Press the &quot;facexyz&quot; button.
-        </ul>
-      <p class="question">
-        How does the view change? How do the observer variables change?
-      </p>
-      </div>
-    <p>
-      When you <code>setxyz</code> the center of the sphere remains the same
-      (so the observer automatically keeps that point in the center of the
-      view.) However, the radius of the sphere may change as well as the
-      observer's orientation in relation to the center. When you
-      <code>facexyz</code> or <code>face</code>, the center of the sphere changes
-      but the observer does not move. The radius of the sphere may change,
-      as well as the orientation of the observer.
-    </p>
-    </div>
-    <div id="dictionary">
-    <h2>
-      <a>Dictionary</a>
-    </h2>
-    <h3>
-      Commands and Reporters
-    </h3>
-    <h4>
-      <span class="prim_example">Turtle-related primitives</span>
-    </h4>
-    <a href="#distance-3d">distancexyz</a>
-    <a href="#distance-3d">distancexyz-nowrap</a>
-    <a href="#dz">dz</a>
-    <a href="#left">left</a>
-    <a href="#patch-at-3d">patch-at</a>
-    <a href="#patch-at-heading-pitch-and-distance">patch-at-heading-pitch-and-distance</a>
-    <a href="#tilt-cmds">tilt-down</a>
-    <a href="#tilt-cmds">tilt-up</a>
-    <a href="#right">right</a>
-    <a href="#roll-left">roll-left</a>
-    <a href="#roll-right">roll-right</a>
-    <a href="#setxyz">setxyz</a>
-    <a href="#towards-pitch-cmd">towards-pitch</a>
-    <a href="#towards-pitch-cmd">towards-pitch-nowrap</a>
-    <a href="#towards-pitch-xyz-cmd">towards-pitch-xyz</a>
-    <a href="#towards-pitch-xyz-cmd">towards-pitch-xyz-nowrap</a>
-    <a href="#turtles-at-3d">turtles-at</a>
-    <h4>
-      <span class="prim_example">Patch-related primitives</span>
-    </h4>
-    <a href="#distance-3d">distancexyz</a>
-    <a href="#distance-3d">distancexyz-nowrap</a>
-    <a href="#neighbors-3d">neighbors</a>
-    <a href="#neighbors-3d">neighbors6</a>
-    <a href="#patch">patch</a>
-    <a href="#patch-at-3d">patch-at</a>
-    <a href="#patch-at-heading-pitch-and-distance">patch-at-heading-pitch-and-distance</a>
-    <h4>
-      <span class="prim_example">Agentset primitives</span>
-    </h4>
-    <a href="#at-points-3d">at-points</a>
-    <a href="#turtles-at-3d">breeds-at</a>
-    <a href="#turtles-at-3d">turtles-at</a>
-    <h4>
-      <span class="prim_example">World primitives</span>
-    </h4>
-    <a href="#min-max-pzcor">max-pzcor</a>
-    <a href="#min-max-pzcor">min-pzcor</a>
-    <a href="#random-pzcor">random-pzcor</a>
-    <a href="#random-zcor">random-zcor</a>
-    <a href="#world-depth">world-depth</a>
-    <a href="#load-shapes-3d">load-shapes-3d</a>
-    <h4>
-      <span class="prim_example">Observer primitives</span>
-    </h4>
-    <a href="#face-3d">face</a>
-    <a href="#face-3d">facexyz</a>
-    <a href="#orbit-cmds">orbit-down</a>
-    <a href="#orbit-cmds">orbit-left</a>
-    <a href="#orbit-cmds">orbit-right</a>
-    <a href="#orbit-cmds">orbit-up</a>
-    <a href="#observer-cors">__oxcor</a>
-    <a href="#observer-cors">__oycor</a>
-    <a href="#observer-cors">__ozcor</a>
-    <a href="#setxyz">setxyz</a>
-    <a href="#zoom">zoom</a>
-    <h4>
-      <span class="prim_example">Link primitives</span>
-    </h4><a href="#link-pitch">link-pitch</a>
-    <h3>
-      Built-In Variables
-    </h3>
-    <h4>
-      <span class="prim_example">Turtles</span>
-    </h4>
-    <a href="#zcor">zcor</a>
-    <a href="#pitch">pitch</a>
-    <a href="#roll">roll</a>
-    <h4>
-      <span class="prim_example">Patches</span>
-    </h4>
-    <a href="#pzcor">pzcor</a>
-    <h3>
-      Primitives
-    </h3>
-    <div class="dict_entry" id="at-points-3d">
-      <h3>
-        <a>at-points<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example"><i>agentset</i> at-points [[<i>x1 y1 z1</i>] [<i>x2 y2 z2</i>] ...]</span>
-      </h4>
-      <p>
-        Reports a subset of the given agentset that includes only the
-        agents on the patches the given distances away from this agent. The
-        distances are specified as a list of three-item lists, where the
-        three items are the x, y, and z offsets.
-      </p>
-      <p>
-        If the caller is the observer, then the points are measured
-        relative to the origin, in other words, the points are taken as
-        absolute patch coordinates.
-      </p>
-      <p>
-        If the caller is a turtle, the points are measured relative to the
-        turtle's exact location, and not from the center of the patch
-        under the turtle.
-      </p>
-      <pre>
-ask turtles at-points [[2 4 0] [1 2 1] [10 15 10]]
-[ fd 1 ]  ;; only the turtles on the patches at the
-          ;; distances (2,4,0), (1,2,1) and (10,15,10),
-          ;; relative to the caller, move
-</pre>
-    </div>
-    <div class="dict_entry" id="distance-3d">
-      <h3>
-        <a>distancexyz<span class="since">4.1</span></a>
-        <a>distancexyz-nowrap<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">distancexyz <i>xcor</i> <i>ycor</i> <i>zcor</i></span>
-        <span class="prim_example">distancexyz-nowrap <i>xcor</i> <i>ycor</i> <i>zcor</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        3D versions of <a href="dictionary.html#distancexy">distancexy</a>.
-      </p>
-      <p>
-        Reports the distance from this agent to the point (<i>xcor</i>,
-        <i>ycor</i>, <i>zcor</i>).
-      </p>
-      <p>
-        The distance from a patch is measured from the center of the patch.
-      </p>
-      <p>
-        distancexyz-nowrap always reports the in world distance, never a
-        distance that would require wrapping around the edges of the world.
-        With distancexyz the wrapped distance (around the edges of the
-        world) is used if that distance is shorter than the in world
-        distance.
-      </p>
-      <pre>
-if (distancexyz 0 0 0) &lt; 10
-  [ set color green ]
-;; all turtles less than 10 units from
-;; the center of the screen turn green.
-</pre>
-    </div>
-    <div class="dict_entry" id="dz">
-      <h3>
-        <a>dz<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">dz</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Reports the z-increment (the amount by which the turtle's zcor
-        would change) if the turtle were to take one step forward at its
-        current heading and pitch.
-      </p>
-      <p>
-        NOTE: dz is simply the sine of the turtle's pitch. Both dx and
-        dy have changed in this case. So, dx = cos(pitch) * sin(heading)
-        and dy = cos(pitch) * cos(heading).
-      </p>
-      <p>
-        See also <a href="dictionary.html#dxy">dx</a>, <a href="dictionary.html#dxy">dy</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="face-3d">
-      <h3>
-        <a>face</a>
-        <a>facexyz<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">face <i>agent</i></span>
-        <span class="prim_example">facexyz <i>x</i> <i>y</i> <i>z</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Set the caller's heading and pitch towards <i>agent</i> or
-        towards the point <i>(x,y,z)</i>.
-      </p>
-      <p>
-        If the caller and the target are at the same x and y coordinates
-        the caller's heading will not change. If the caller and the
-        target are also at the same z coordinate the pitch will not change
-        either.
-      </p>
-      </div>
-    <div class="dict_entry" id="left">
-      <h3>
-        <a>left<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">left <i>number</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        The turtle turns left by <i>number</i> degrees, relative to its
-        current orientation. While left in a 2D world only modifies the
-        turtle's heading, left in a 3D world may also modify the
-        turtle's pitch and roll.
-      </p>
-      <p>
-        See also <a href="dictionary.html#left">left</a>, <a href="#tilt-cmds">tilt-up</a>, <a href="#tilt-cmds">tilt-down</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="link-pitch">
-      <h3>
-        <a>link-pitch<span class="since">4.1.2</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">link-pitch</span>
-        <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        Reports the pitch from end1 to end2 of this link.
-      </p>
-      <pre>
-ask link 0 1 [ print link-pitch ]
-;; prints [[towards-pitch other-end] of end1] of link 0 1
-</pre>
-      <p>
-        See also <a href="dictionary.html#link-heading">link-heading</a>,
-        <a href="#pitch">pitch</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="load-shapes-3d">
-      <h3>
-        <a>load-shapes-3d<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">load-shapes-3d <i>filename</i></span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Loads custom 3D shapes from the given file. See the <a href="3d.html">3D guide</a> for more details. You must also add a 2D
-        shape of the same name to the model using the Turtle Shapes Editor.
-        Custom shapes override built-in 3D shapes and converted 2D shapes.
-      </p>
-      </div>
-    <div class="dict_entry" id="min-max-pzcor">
-      <h3>
-        <a>max-pzcor<span class="since">4.1</span></a>
-        <a>min-pzcor<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">max-pzcor</span>
-        <span class="prim_example">min-pzcor</span>
-      </h4>
-      <p>
-        These reporters give the maximum and minimum z-coordinates
-        (respectively) for patches, which determines the size of the world.
-      </p>
-      <p>
-        Unlike in older versions of NetLogo the origin does not have to be
-        at the center of the world. However, the minimum z-coordinate has
-        to be less than or equal to 0 and the maximum z-coordinate has to
-        be greater than or equal to 0.
-      </p>
-      <p>
-        Note: You can set the size of the world only by editing the view --
-        these are reporters which cannot be set.
-      </p>
-      <p>
-        See also <a href="dictionary.html#max-pcor">max-pxcor</a>, <a href="dictionary.html#max-pcor">max-pycor</a>, <a href="dictionary.html#min-pcor">min-pxcor</a>,
-        <a href="dictionary.html#min-pcor">min-pycor</a>, and <a href="#world-depth">world-depth</a>.
-      </div>
-    <div class="dict_entry" id="neighbors-3d">
-      <h3>
-        <a>neighbors<span class="since">4.1</span></a>
-        <a>neighbors6<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">neighbors</span>
-        <span class="prim_example">neighbors6</span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        3D versions of <a href="dictionary.html#neighbors">neighbors</a>
-        and <a href="dictionary.html#neighbors">neighbors4</a>.
-      </p>
-      <p>
-        Reports an agentset containing the 26 surrounding patches
-        (neighbors) or 6 surrounding patches (neighbors6).
-      </p>
-      <pre>
-show sum values-from neighbors [count turtles-here]
-  ;; prints the total number of turtles on the twenty-six
-  ;; patches around this turtle or patch
-ask neighbors6 [ set pcolor red ]
-  ;; turns the six neighboring patches red
-</pre>
-    </div>
-    <div class="dict_entry" id="orbit-cmds">
-      <h3>
-        <a>orbit-down<span class="since">4.1</span></a>
-        <a>orbit-left<span class="since">4.1</span></a>
-        <a>orbit-right<span class="since">4.1</span></a>
-        <a>orbit-up<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">orbit-down <i>number</i></span>
-        <span class="prim_example">orbit-left <i>number</i></span>
-        <span class="prim_example">orbit-right <i>number</i></span>
-        <span class="prim_example">orbit-up <i>number</i></span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Rotate the observer around the last point faced. Imagine the
-        observer is on the surface of a sphere, the last point face is the
-        center of that sphere. Up and down orbit along the lines of
-        longitude and right and left orbit along the lines of latitude. The
-        observer will remain facing the last point faced so the heading and
-        pitch may change as result of orbiting. However, because we assume
-        an absolute north pole (parallel to the positive z-axis) the roll
-        will never change.
-      </p>
-      <p>
-        See also <a href="#setxyz">setxyz</a>, <a href="#face-3d">face</a> and
-        <a href="#zoom">zoom</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="observer-cors">
-      <h3>
-        <a>__oxcor</a>
-        <a>__oycor</a>
-        <a>__ozcor</a>
-      </h3>
-      <h4>
-        <span class="prim_example">__oxcor</span>
-        <span class="prim_example">__oycor</span>
-        <span class="prim_example">__ozcor</span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Reports the x-, y-, or z-coordinate of the observer.
-      </p>
-      <p>
-        See also <a href="#setxyz">setxyz</a>
-      </p>
-      <h3>
-        <a id="patch">patch<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">patch <i>pxcor</i> <i>pycor</i> <i>pzcor</i></span>
-      </h4>
-      <p>
-        3D version of <a href="dictionary.html#patch">patch</a>.
-      </p>
-      <p>
-        Given three integers, reports the single patch with the given
-        pxcor, pycor and pzcor. <i>pxcor</i>, <i>pycor</i> and <i>pzcor</i>
-        must be integers.
-      </p>
-      <pre>
-ask (patch 3 -4 2) [ set pcolor green ]
-;; patch with pxcor of 3 and pycor of -4 and pzcor of 2 turns green
-</pre>
-      <p>
-        See also <a href="dictionary.html#patch">patch</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="patch-at-3d">
-      <h3>
-        <a>patch-at<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">patch-at <i>dx</i> <i>dy</i> <i>dz</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        3D version of <a href="dictionary.html#patch-at">patch-at</a>.
-      </p>
-      <p>
-        Reports the single patch at (dx, dy, dz) from the caller, that is,
-        dx patches east, dy patches north and dz patches up from the
-        caller.
-      </p>
-      <pre>
-ask patch-at 1 -1 1 [ set pcolor green ]
-;; turns the patch just southeast and up from the caller green
-</pre>
-    </div>
-    <div class="dict_entry" id="patch-at-heading-pitch-and-distance">
-      <h3>
-        <a>patch-at-heading-pitch-and-distance<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">patch-at-heading-pitch-and-distance <i>heading</i> <i>pitch</i> <i>distance</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        3D version of <a href="dictionary.html#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
-      </p>
-      <p>
-        patch-at-heading-pitch-and-distance reports the single patch that
-        is the given distance from this turtle or patch, along the given
-        absolute heading and pitch. (In contrast to patch-left-and-ahead
-        and patch-right-and-ahead, this turtle's current heading is not
-        taken into account.)
-      </p>
-      <pre>
-ask patch-at-heading-pitch-and-distance 0 90 1 [ set pcolor green ]
-;; turns the patch directly above the caller green.
-</pre>
-    </div>
-    <div class="dict_entry" id="pitch">
-      <h3>
-        <a>pitch</a>
-      </h3>
-      <h4>
-        <span class="prim_example">pitch</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        This is a built-in turtle variable. Pitch is the angle between the
-        &quot;nose&quot; of the turtle and the xy-plane. Heading and pitch
-        together define the forward vector of the turtle or the direction
-        that the turtle is facing.
-      </p>
-      <p>
-        This is a number greater than or equal to 0 and less than 360. 0 is
-        parallel to the xy-plane, 90 is parallel to the z-axis. While you
-        can set pitch we recommend that you use the primitives to turn the
-        turtle. Depending on the position more than one relative angle
-        (heading, pitch and roll) may change at once.
-      </p>
-      <p>
-        Example:
-      </p>
-      <pre>
-;; assume roll and heading are 0
-set pitch 45      ;; turtle is now north and up
-set heading heading + 10 ;; same effect as &quot;tilt-up 10&quot;
-</pre>
-      <p>
-        See also <a href="dictionary.html#heading">heading</a>, <a href="#roll">roll</a>, <a href="#tilt-cmds">tilt-up</a>, <a href="#tilt-cmds">tilt-down</a>, <a href="#right">right</a>, <a href="#left">left</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="pzcor">
-      <h3>
-        <a>pzcor</a>
-      </h3>
-      <h4>
-        <span class="prim_example">pzcor</span>
-        <img alt="Patch Command" src="images/patch.gif"> <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        This is a built-in patch variable. It holds the z coordinate of the
-        patch. It is always an integer. You cannot set this variable,
-        because patches don't move.
-      </p>
-      <p>
-        pzcor is greater than or equal to min-pzcor and less than or equal
-        to max-pzcor.
-      </p>
-      <p>
-        All patch variables can be directly accessed by any turtle standing
-        on the patch.
-      </p>
-      <p>
-        See also <a href="dictionary.html#pcor">pxcor, pycor</a>, <a href="#zcor">zcor</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="random-pzcor">
-      <h3>
-        <a>random-pzcor<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">random-pzcor</span>
-      </h4>
-      <p>
-        Reports a random integer ranging from min-pzcor to max-pzcor
-        inclusive.
-      </p>
-      <pre>
-ask turtles [
-  ;; move each turtle to the center of a random patch
-  setxyz random-pxcor random-pycor random-pzcor
-]
-</pre>
-      <p>
-        See also <a href="dictionary.html#random-pcor">random-pxcor</a>, <a href="dictionary.html#random-pcor">random-pycor</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="random-zcor">
-      <h3>
-        <a>random-zcor<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">random-zcor</span>
-      </h4>
-      <p>
-        Reports a random floating point number from the allowable range of
-        turtle coordinates along the z axis.
-      </p>
-      <p>
-        Turtle coordinates range from min-pzcor - 0.5 (inclusive) to
-        max-pzcor + 0.5 (exclusive).
-      </p>
-      <pre>
-ask turtles [
-  ;; move each turtle to a random point
-  setxyz random-xcor random-ycor random-zcor
-]
-</pre>
-      <p>
-        See also <a href="dictionary.html#random-cor">random-xcor</a>,
-        <a href="dictionary.html#random-cor">random-ycor</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="right">
-      <h3>
-        <a>right<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">right <i>number</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        The turtle turns right by <i>number</i> degrees, relative to its
-        current orientation. While right in a 2D world only modifies the
-        turtle's heading, right in a 3D world may also modify the
-        turtle's pitch and roll.
-      </p>
-      <p>
-        See also <a href="dictionary.html#right">right</a> and <a href="#left">left</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="roll">
-      <h3>
-        <a>roll</a>
-      </h3>
-      <h4>
-        <span class="prim_example">roll</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        This is a built-in turtle variable. Roll is the angle between the
-        &quot;wing-tip&quot; of the turtle and the xy-plane.
-      </p>
-      <p>
-        This is a number greater than or equal to 0 and less than 360. You
-        can set this variable to make a turtle roll. Since roll is always
-        from the turtle's point of view, rolling right and left only
-        only change roll regardless of turtle orientation.
-      </p>
-      <p>
-        Example:
-      </p>
-      <pre>
-set roll 45      ;; turtle rotated right
-set roll roll + 10 ;; same effect as &quot;roll-right 10&quot;
-</pre>
-      <p>
-        See also <a href="dictionary.html#heading">heading</a>, <a href="#pitch">pitch</a>, <a href="#roll-left">roll-left</a>, <a href="#roll-right">roll-right</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="roll-left">
-      <h3>
-        <a>roll-left<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">roll-left <i>number</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        The wingtip of the turtle rotates to the left <i>number</i> degrees
-        with respect to the current heading and pitch.
-      </p>
-      </div>
-    <div class="dict_entry" id="roll-right">
-      <h3>
-        <a>roll-right<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">roll-right <i>number</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        The wingtip of the turtle rotates to the right <i>number</i>
-        degrees with respect to the current heading and pitch.
-      </p>
-      </div>
-    <div class="dict_entry" id="setxyz">
-      <h3>
-        <a>setxyz<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">setxyz <i>x y z</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        3D version of <a href="dictionary.html#setxy">setxy</a>.
-      </p>
-      <p>
-        The agent, a turtle or the observer, sets its x-coordinate to
-        <i>x</i>, its y-coordinate to <i>y</i> and its z-coordinate to
-        <i>z</i>. When the observer uses <code>setxyz</code> it remains facing
-        the same point so the heading, pitch, and roll, may also change.
-      </p>
-      <p>
-        For turtles equivalent to <code>set xcor x set ycor y set zcor
-        z</code>, except it happens in one time step instead of three.
-      </p>
-      <pre>
-setxyz 0 0 0
-;; agent moves to the middle of the center patch
-</pre>See also <a href="#face-3d">face</a>
-    </div>
-    <div class="dict_entry" id="tilt-cmds">
-      <h3>
-        <a>tilt-down<span class="since">4.1</span></a>
-        <a>tilt-up<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">tilt-down <i>number</i></span>
-        <span class="prim_example">tilt-up <i>number</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        The nose of the turtle rotates by <i>number</i> degrees, relative
-        to its current orientation. Depending on the orientation of the
-        turtle more than one of the relative angles (heading, pitch, and
-        roll) may change when a turtle turns.
-      </p>
-      </div>
-    <div class="dict_entry" id="towards-pitch-cmd">
-      <h3>
-        <a>towards-pitch<span class="since">4.1</span></a>
-        <a>towards-pitch-nowrap<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">towards-pitch <i>agent</i></span>
-        <span class="prim_example">towards-pitch-nowrap <i>agent</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        Reports the pitch from this agent to the given agent.
-      </p>
-      <p>
-        If the wrapped distance (around the edges of the screen) is shorter
-        than the on-screen distance, towards-pitch will report the pitch of
-        the wrapped path. towards-pitch-nowrap never uses the wrapped path.
-      </p>
-      <p>
-        Note: In order to get one turtle to face another you need to use
-        both towards-pitch and towards.
-      </p>
-      <p>
-        Note: asking for the pitch from an agent to itself, or an agent on
-        the same location, will cause a runtime error.
-      </p>
-      <p>
-        See also <a href="dictionary.html#towards">towards</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="towards-pitch-xyz-cmd">
-      <h3>
-        <a>towards-pitch-xyz<span class="since">4.1</span></a>
-        <a>towards-pitch-xyz-nowrap<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">towards-pitch-xyz <i>x</i> <i>y</i> <i>z</i></span>
-        <span class="prim_example">towards-pitch-xyz-no-wrap <i>x</i> <i>y</i> <i>z</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        Reports the pitch from this agent to the coordinates x, y, z
-      </p>
-      <p>
-        If the wrapped distance (around the edges of the screen) is shorter
-        than the on-screen distance, towards-pitch will report the pitch of
-        the wrapped path. towards-pitch-nowrap never uses the wrapped path.
-      </p>
-      <p>
-        Note: In order to get a turtle to face a given location you need to
-        use both towards-pitch-xyz and towardsxy.
-      </p>
-      <p>
-        Note: asking for the pitch from an agent to the location it is
-        standing on will cause a runtime error.
-      </p>
-      <p>
-        See also <a href="dictionary.html#towardsxy">towardsxy</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="turtles-at-3d">
-      <h3>
-        <a>turtles-at<span class="since">4.1</span></a>
-        <a>&lt;breeds&gt;-at</a>
-      </h3>
-      <h4>
-        <span class="prim_example">turtles-at <i>dx</i> <i>dy</i> <i>dz</i></span>
-        <span class="prim_example"><i>&lt;breeds&gt;-at</i> <i>dx</i> <i>dy</i> <i>dz</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        3D versions of <a href="dictionary.html#turtles-at">turtles-at</a>
-        and <a href="dictionary.html#turtles-at">breeds-at</a>.
-      </p>
-      <p>
-        Reports an agentset containing the turtles on the patch (dx, dy,
-        dz) from the caller (including the caller itself if it's a
-        turtle).
-      </p>
-      <pre>
-;; suppose I have 40 turtles at the origin
-show [count turtles-at 0 0 0] of turtle 0
-=&gt; 40
-</pre>
-    </div>
-    <div class="dict_entry" id="world-depth">
-      <h3>
-        <a>world-depth<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">world-depth</span>
-      </h4>
-      <p>
-        Reports the total depth of the NetLogo world.
-      </p>
-      <p>
-        The depth of the world is the same as max-pzcor - min-pzcor + 1.
-      <p>
-        See also <a href="#min-max-pzcor">max-pzcor</a>, <a href="#min-max-pzcor">min-pzcor</a>, <a href="dictionary.html#world-dim">world-width</a>, and <a href="dictionary.html#world-dim">world-height</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="zcor">
-      <h3>
-        <a>zcor</a>
-      </h3>
-      <h4>
-        <span class="prim_example">zcor</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        This is a built-in turtle variable. It holds the current z
-        coordinate of the turtle. This is a floating point number, not an
-        integer. You can set this variable to change the turtle's
-        location.
-      </p>
-      <p>
-        This variable is always greater than or equal to (- screen-edge-z)
-        and strictly less than screen-edge-z.
-      </p>
-      <p>
-        See also <a href="#setxyz">setxy</a>, <a href="dictionary.html#xcor">xcor</a>, <a href="dictionary.html#ycor">ycor</a>, <a href="dictionary.html#pcor">pxcor</a>, <a href="dictionary.html#pcor">pycor</a>, <a href="#pzcor">pzcor</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="zoom">
-      <h3>
-        <a>zoom<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">zoom <i>number</i></span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Move the observer toward the point it is facing, <i>number</i>
-        steps. The observer will never move beyond the point it is facing
-        so if <i>number</i> is greater than the distance to that point it
-        will only move as far as the point it is facing.
-      </p>
-      </div>
-    </div>
-</body>
+	<head>
+		<title>
+			NetLogo {{version}} User Manual: 3D
+		</title>
+		<link rel="stylesheet" href="netlogo.css" type="text/css"/>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+		<style>
+			p { margin-left: 1.5em ; }
+			p.bookquote { font-size: 85%; margin-left: 4em; margin-right: 4em; color: #333 ; }
+			p.c1 {font-style: italic}
+		</style>
+	</head>
+	<body>
+		<h1>
+			NetLogo 3D
+		</h1>
+		<p>
+			NetLogo includes the NetLogo 3D application that allows you to create 3D worlds.
+		</p>
+		<p>
+			<b>Notice:</b> NetLogo's support for 3D is less developed than
+			NetLogo 2D. Models created with this release may not be compatible
+			with future versions. While we've made efforts to ensure a quality
+			product, NetLogo 3D has not been subject to the same level of quality
+			control as the main application.
+		</p>
+		<ul>
+			<li>
+				<a href="#introduction">Introduction</a>
+			</li>
+			<li>
+				<a href="#tutorial">Tutorial</a>
+			</li>
+			<li>
+				<a href="#dictionary">Dictionary</a>
+			</li>
+		</ul>
+		<div id="introduction">
+			<h2>
+				<a>Introduction</a>
+			</h2>
+			<p>
+				To get started using NetLogo 3D, launch the NetLogo 3D application
+				and check out the Sample Models in the 3D section of the Models
+				Library.
+			</p>
+			<p>
+				When you're ready to write your own 3D model, look at the Code
+				Examples in the 3D section of the Models Library.
+			</p>
+			<div class="blockquote">
+				<p>
+					<b>Code Example:</b> Turtle Perspective Example 3D helps you learn
+					about the different perspectives.
+				</p>
+				<p>
+					<b>Code Example:</b> Turtle and Observer Motion Example 3D helps
+					you understand how turtles and the observer move in 3D. You can
+					also step through this model with the tutorial below.
+				</p>
+			</div>
+			<h4>
+				<span class="prim_example">3D Worlds</span>
+			</h4>
+			<p class="bookquote">
+				<i>An unspeakable horror seized me. There was a darkness; then a
+					dizzy, sickening sensation of sight that was not like seeing; I saw a
+					Line that was no Line; Space that was not Space: I was myself, and
+					not myself. When I could find voice, I shrieked loud in agony,
+					&quot;Either this is madness or it is Hell.&quot;</i>
+			</p>
+			<p class="bookquote">
+				<i>&quot;It is neither,&quot; calmly replied the voice of the Sphere,
+					&quot;it is Knowledge; it is Three Dimensions: open your eye once
+					again and try to look steadily.&quot;</i>
+				<br/>
+				-- Edwin A. Abbott, <i>Flatland: A romance in many dimensions</i>
+			</p>
+			<p>
+				NetLogo 3D's world has width, height and depth. Patches are
+				cubes. In addition to <code><a href="dictionary.html#pcor">pxcor</a></code> and <code><a href="dictionary.html#pcor">pycor</a></code>, patches have <code><a href="#pzcor">pzcor</a></code>.
+			</p>
+			<p>
+				Turtles have three Cartesian coordinates, instead of two, to describe
+				position. In addition to <code><a href="dictionary.html#xcor">xcor</a></code> and <code><a href="dictionary.html#ycor">ycor</a></code>, turtles have <code><a href="#zcor">zcor</a></code>.
+			</p>
+			<p>
+				A turtle's orientation is defined by three turtle variables,
+				<code><a href="dictionary.html#heading">heading</a></code>, <code><a href="#pitch">pitch</a></code> and <code><a href="#roll">roll</a></code>. You
+				can imagine the turtle as having two vectors to define its
+				orientation in 3D space. One vector comes straight out of the nose of
+				the turtle, this is the direction the turtle will travel when it
+				moves forward. The second vector is perpendicular to the forward
+				vector and comes out of the right side of the turtle (as if the
+				turtle were to stick its right arm straight out from its body).
+				Heading is the angle between the forward vector of the turtle
+				projected onto the xy-plane and the vector [0 1 0]. Pitch is the
+				angle between the forward vector of the turtle and the xy-plane and
+				finally roll is the angle between the right vector of the turtle and
+				the xy-plane. When turtle turns right or left in 3D space it rotates
+				around the down vector, that is the vector that is perpendicular to
+				both the forward and right vectors. Depending on the orientation of
+				the turtle more than one of the internal turtle variables may change
+				as the result of a turn.
+			</p>
+			<h4>
+				<span class="prim_example">The observer and the 3D view</span>
+			</h4>
+			<p>
+				The point of view that you see the world from is considered the
+				location and orientation of the observer. This is similar to the 3D
+				view in NetLogo 2D. However, there are a few more ways to control the
+				observer. You can set the point that the observer is facing by using
+				<code>face</code> and <code>facexyz</code> which work the same way as the
+				turtle commands, the observer turns so the center of the view is on
+				the given point or the location of the given agent at the time it is
+				called. You can change the location of the observer using
+				<code>setxyz</code>. The observer will move to view the world as if
+				standing on the given location, the point the observer faces will
+				stay the same. For example create a new model and observer will be
+				located at (0, 0, 49.5), that is, on the z-axis 49.5 patch units away
+				from the origin and the observer is facing the origin, (0, 0, 0). If
+				you <code>setxyz 0 49.5 0</code> the observer will move so it is on the
+				positive y-axis but it will keep the origin at the center of the
+				view. You can also move the observer using the rotation primitives
+				that will allow you to move the observer around the world as if on
+				the surface of a sphere where the center is the location the observer
+				is facing. You may notice from the above examples that the observer
+				is not constrained to be within the bounds of the world.
+			</p>
+			<h4>
+				<span class="prim_example"><a id="custom-shapes">Custom Shapes</a></span>
+			</h4>
+			<p>
+				NetLogo automatically interprets 2D shapes so they are extruded, like
+				a cookie cutter shape in the 3D view. You can also use the primitive
+				<a href="#load-shapes-3d"><code>load-shapes-3d</code></a> to load shapes
+				described in an external file in a custom format described here.
+				Currently we do not import shapes in any standard formats.
+			</p>
+			<p>
+				For each shape in a custom 3D shape file, a 2D shape of the same name
+				must exist as well. You can create the 2D shape in the Turtle Shapes
+				Editor.
+			</p>
+			<p>
+				The input file may contain any number of shapes with any number of
+				rectangular or triangular surfaces. The format of the input file
+				should be as follows:
+			</p>
+			<pre>
+				number of shapes in file
+				name of first shape
+				type of surface ( quads or tris )
+				surface1
+				surface2
+				.
+				.
+				.
+				stop
+				type of surface
+				surfaceA
+				.
+				.
+				.
+				stop
+				end-shape
+			</pre>
+			<p>
+				Each surface is defined by a unit normal vector and the vertices
+				listed in clockwise order, tris should have three vertices and quads
+				should have four.
+			</p>
+			<pre>
+				normal: xn yn zn
+				x1 y1 z1
+				x2 y2 z2
+				x3 y3 z3
+				x4 y4 z4
+			</pre>
+			<p>
+				A file declaring just a two dimensional, patch-sized, square in the
+				xy-plane centered at the origin would look like this:
+			</p>
+			<pre>
+				1
+				square
+				quads
+				normal: 0 0 1
+				0.15 0.15 0
+				-0.15 0.15 0
+				-0.15 -0.15 0
+				0.15 -0.15 0
+				normal: 0 0 -1
+				0.15 0.15 0
+				0.15 -0.15 0
+				-0.15 -0.15 0
+				-0.15 0.15 0
+				stop
+				end-shape
+			</pre>
+		</div>
+		<div id="tutorial">
+			<h2>
+				<a>Tutorial</a>
+			</h2>
+			<h4>
+				<span class="prim_example">Step 1: Depth</span>
+			</h4>
+			<p>
+				One of the first things you will notice when you open NetLogo 3D is
+				that the world is a cube instead of a square.
+			</p>
+			<p class="screenshot">
+				<img alt="screen shot" src="images/3d/cube.gif"/>
+			</p>
+			<p>
+				You can open up the Model Settings, by clicking on the
+				&quot;Settings...&quot; button at the top of the 3D View. You'll
+				notice in addition to <code>max-pxcor</code>, <code>min-pxcor</code>,
+				<code>max-pycor</code>, and <code>min-pycor</code>, there is also <a href="#min-max-pzcor"><code>max-pzcor</code></a> and <a href="#min-max-pzcor"><code>min-pzcor</code></a>.
+			</p>
+			<p class="screenshot">
+				<img alt="screen shot" src="images/3d/properties.gif"/>
+			</p>
+			<p>
+				The z-axis is perpendicular to both the x-axis and the y-axis, when
+				you <code>reset-perspective</code> it is the axis that comes straight out
+				of the screen. In the default position <code>max-pzcor</code> is the face
+				of the cube nearest to you and <code>min-pzcor</code> is the face
+				farthest from you. As always <code>min-pxcor</code> is on the left,
+				<code>max-pxcor</code> on the right, <code>min-pycor</code> on the bottom,
+				and <code>max-pycor</code> on the top.
+			</p>
+			<p>
+				You'll also notice on the left side of the Model Settings that
+				there are options for wrapping in all three directions, however, they
+				are all checked and grayed out. Topologies are not yet supported in
+				NetLogo 3D, so the world always wraps in all dimensions.
+			</p>
+			<div class="blockquote">
+				<ul>
+					<li>Move to the Command Center and type <code>print count
+							patches</code>.</li>
+				</ul>
+				<p class="question">
+					Is the number smaller or larger than you expected?
+				</p>
+			</div>
+			<p>
+				In a 3D world the number of patches grows very quickly since
+				<code>count patches = world-width * world-height * world-depth</code>.
+				It's important to keep this in mind when you are building your
+				model. Lots of patches can slow your model down or even cause NetLogo
+				to run out of memory.
+			</p>
+			<div class="blockquote">
+				<ul>
+					<li>Type <code>ask patch 1 2 3 [ set pcolor red ]</code> into the
+						Command Center.</li>
+					<li>Use the mouse in the 3D view to rotate the world.</li>
+				</ul>
+			</div>
+			<p>
+				Notice the shape of the patch and its position in relation to the
+				edges of the world. You'll also notice that you now need three
+				coordinates to address patches in a 3D world.
+			</p>
+			<h4>
+				<span class="prim_example">Step 2: Turtle Movement</span>
+			</h4>
+			<div class="blockquote">
+				<ul>
+					<li>Open the Models Library in the File menu. (If you are on a Mac
+						and you don't have a File menu, click on the main NetLogo
+						window first and it should reappear.)
+					</li>
+					<li>Open Turtle and Observer Motion Example 3D in 3D/Code Examples
+					</li>
+				</ul>
+			</div>
+			<p>
+				Take a moment to look for the controls and monitors. In the bottom
+				left you'll notice a group of monitors that describe the location
+				and orientation of the turtle, though until you press the setup
+				button they'll all say &quot;N/A&quot;.
+			</p>
+			<div class="blockquote">
+				<ul>
+					<li>Press the &quot;setup&quot; button</li>
+				</ul>
+			</div>
+			<p>
+				Heading, pitch, and roll are turtle variables that represent the
+				orientation of the turtle. Heading is absolute in relation to the x/y
+				plane; it is the rotation of the turtle around the z-axis.
+			</p>
+			<p class="screenshot">
+				<img alt="screen shot" src="images/3d/heading.gif"/>
+			</p>
+			<p>
+				Pitch is the angle between the nose of the turtle and the xy-plane.
+				It is relative to heading.
+			</p>
+			<p class="screenshot">
+				<img alt="screen shot" src="images/3d/pitch.gif"/>
+			</p>
+			<p>
+				Roll is the rotation around the turtle's forward vector. It is
+				relative to heading and pitch.
+			</p>
+			<p class="screenshot">
+				<img alt="screen shot" src="images/3d/roll.gif"/>
+			</p>
+			<p>
+				When turtles are created with <code>create-turtles</code> or
+				<code>create-ordered-turtles</code>, their initial headings vary but
+				their initial pitch and roll are always zero.
+			</p>
+			<p>
+				Take a look at the &quot;Turtle Movement&quot; buttons.
+			</p>
+			<div class="blockquote">
+				<ul>
+					<li>Press the &quot;left 1&quot; button.</li>
+				</ul>
+				<p class="question">
+					How does the turtle move? Is is the same or different from 2D
+					NetLogo? Which of the turtle variables change?
+				</p>
+				<ul>
+					<li>Press the &quot;pitch-down 1&quot; button.</li>
+				</ul>
+				<p class="question">
+					How does the turtle move? Which of the turtle variables change?
+				</p>
+				<ul>
+					<li>Press the &quot;left 1&quot; button again.</li>
+				</ul>
+				<p class="question">
+					How does the turtle move? Is it different than the last time you
+					pressed the &quot;left 1&quot; button?
+				</p>
+				<ul>
+					<li>Take a little time to play with the Turtle Movement buttons,
+						watching both how the turtle moves and which of the turtle
+						variables change.</li>
+				</ul>
+			</div>
+			<p>
+				You probably noticed that often more than one of the turtle variables
+				may change for a single turn. For this reason we suggest that you use
+				the turtle commands rather than setting the orientation variables
+				directly.
+			</p>
+			<h4>
+				<span class="prim_example">Step 3: Observer Movement</span>
+			</h4>
+			<p>
+				At the bottom of the interface you will see Orbit, Zoom, and Move
+				buttons. If you have ever used the 3D view in NetLogo 2D or if you
+				have been using the mouse controls in the 3D view through this
+				tutorial you have been moving the observer. Changing the point of
+				view in the 3D view is actually moving and changing the orientation
+				of the observer. The observer has x, y and z coordinates, just like a
+				turtle or patch, while turtles and patches are constrained to be
+				inside the world the observer can be anywhere. Like a turtle the
+				observer has a heading, pitch and roll, these variables control where
+				the observer is looking, that is, what you see in the view.
+			</p>
+			<div class="blockquote">
+				<ul>
+					<li>Move to the 3D view, and make sure &quot;Orbit&quot; is
+						selected in the bottom left corner of the view.</li>
+					<li>Click and hold the mouse button in the middle of the view, move
+						the mouse left, right, up, and down.</li>
+				</ul>
+				<p class="question">
+					How does the position and orientation of the observer change?
+				</p>
+				<ul>
+					<li>Press the reset-perspective button in the lower right corner of
+						the view and select &quot;Zoom&quot; in the lower left corner.</li>
+					<li>Click and hold the mouse button in the middle of the view and
+						move the mouse up and down.</li>
+				</ul>
+				<p class="question">
+					Which of the observer variables change? Which stay the same?
+				</p>
+				<ul>
+					<li>Try rotating the world a bit and then zoom again.</li>
+					<li>Press the &quot;Move&quot; button in the lower left corner of
+						the view.</li>
+					<li>Click and hold the mouse button in the middle of the view and
+						move the mouse up, down, left and right.</li>
+				</ul>
+				<p class="question">
+					How does the view change? How do the observer variables change?
+				</p>
+			</div>
+			<p>
+				After you are done exploring the world using the mouse controls you
+				can take a look at the observer control buttons in the lower left
+				portion of the interface.
+			</p>
+			<p>
+				You may already be familiar with the first three buttons in the
+				observer group from your experience with NetLogo 2D. Watch, follow,
+				and ride, are special modes that automatically update the position
+				and orientation of the observer. When in follow or ride mode, the
+				observer position and orientation are the same as the turtle's.
+				Note that follow and ride are functionally exactly the same, the
+				difference is only visual in the 3D view. When in watch mode the
+				observer does not move but updates to face the target agent.
+			</p>
+			<div class="blockquote">
+				<ul>
+					<li>Press the &quot;setup&quot; button again so you are back to the
+						default orientation.</li>
+					<li>Press the &quot;orbit-right&quot; button.</li>
+				</ul>
+				<p class="question">
+					How did the view change? Was it what you expected? How is it
+					similar or different from using the mouse controls?
+				</p>
+				<ul>
+					<li>Take a little time to experiment with orbit, roll and zoom
+						buttons; notice similarities and differences to the mouse controls.</li>
+				</ul>
+			</div>
+			<p>
+				The direction of the orbit commands refer to the direction that the
+				observer moves. That is, imagine that the observer is on the surface
+				of a sphere, the center of the sphere is the point that the observer
+				is facing represented by the blue cross, by default (0,0,0). The
+				observer will always face the center of the sphere and the radius of
+				the sphere will remain constant. The directions, up, down, left, and
+				right, refer to moving along the lines of latitude and the lines of
+				longitude of the sphere. When you zoom the radius of the sphere
+				changes but the center and the observer's orientation in relation
+				to the center of the sphere will remain the same.
+			</p>
+			<div class="blockquote">
+				<ul>
+					<li>Press one of the &quot;setxyz&quot; buttons.</li>
+				</ul>
+				<p class="question">
+					How does the view change? How do the observer variables change?
+				</p>
+				<ul>
+					<li>Press the &quot;facexyz&quot; button.</li>
+				</ul>
+				<p class="question">
+					How does the view change? How do the observer variables change?
+				</p>
+			</div>
+			<p>
+				When you <code>setxyz</code> the center of the sphere remains the same
+				(so the observer automatically keeps that point in the center of the
+				view.) However, the radius of the sphere may change as well as the
+				observer's orientation in relation to the center. When you
+				<code>facexyz</code> or <code>face</code>, the center of the sphere changes
+				but the observer does not move. The radius of the sphere may change,
+				as well as the orientation of the observer.
+			</p>
+		</div>
+		<div id="dictionary">
+			<h2>
+				<a>Dictionary</a>
+			</h2>
+			<h3>
+				Commands and Reporters
+			</h3>
+			<h4>
+				<span class="prim_example">Turtle-related primitives</span>
+			</h4>
+			<a href="#distance-3d">distancexyz</a>
+			<a href="#distance-3d">distancexyz-nowrap</a>
+			<a href="#dz">dz</a>
+			<a href="#left">left</a>
+			<a href="#patch-at-3d">patch-at</a>
+			<a href="#patch-at-heading-pitch-and-distance">patch-at-heading-pitch-and-distance</a>
+			<a href="#tilt-cmds">tilt-down</a>
+			<a href="#tilt-cmds">tilt-up</a>
+			<a href="#right">right</a>
+			<a href="#roll-left">roll-left</a>
+			<a href="#roll-right">roll-right</a>
+			<a href="#setxyz">setxyz</a>
+			<a href="#towards-pitch-cmd">towards-pitch</a>
+			<a href="#towards-pitch-cmd">towards-pitch-nowrap</a>
+			<a href="#towards-pitch-xyz-cmd">towards-pitch-xyz</a>
+			<a href="#towards-pitch-xyz-cmd">towards-pitch-xyz-nowrap</a>
+			<a href="#turtles-at-3d">turtles-at</a>
+			<h4>
+				<span class="prim_example">Patch-related primitives</span>
+			</h4>
+			<a href="#distance-3d">distancexyz</a>
+			<a href="#distance-3d">distancexyz-nowrap</a>
+			<a href="#neighbors-3d">neighbors</a>
+			<a href="#neighbors-3d">neighbors6</a>
+			<a href="#patch">patch</a>
+			<a href="#patch-at-3d">patch-at</a>
+			<a href="#patch-at-heading-pitch-and-distance">patch-at-heading-pitch-and-distance</a>
+			<h4>
+				<span class="prim_example">Agentset primitives</span>
+			</h4>
+			<a href="#at-points-3d">at-points</a>
+			<a href="#turtles-at-3d">breeds-at</a>
+			<a href="#turtles-at-3d">turtles-at</a>
+			<h4>
+				<span class="prim_example">World primitives</span>
+			</h4>
+			<a href="#min-max-pzcor">max-pzcor</a>
+			<a href="#min-max-pzcor">min-pzcor</a>
+			<a href="#random-pzcor">random-pzcor</a>
+			<a href="#random-zcor">random-zcor</a>
+			<a href="#world-depth">world-depth</a>
+			<a href="#load-shapes-3d">load-shapes-3d</a>
+			<h4>
+				<span class="prim_example">Observer primitives</span>
+			</h4>
+			<a href="#face-3d">face</a>
+			<a href="#face-3d">facexyz</a>
+			<a href="#orbit-cmds">orbit-down</a>
+			<a href="#orbit-cmds">orbit-left</a>
+			<a href="#orbit-cmds">orbit-right</a>
+			<a href="#orbit-cmds">orbit-up</a>
+			<a href="#observer-cors">__oxcor</a>
+			<a href="#observer-cors">__oycor</a>
+			<a href="#observer-cors">__ozcor</a>
+			<a href="#setxyz">setxyz</a>
+			<a href="#zoom">zoom</a>
+			<h4>
+				<span class="prim_example">Link primitives</span>
+			</h4><a href="#link-pitch">link-pitch</a>
+			<h3>
+				Built-In Variables
+			</h3>
+			<h4>
+				<span class="prim_example">Turtles</span>
+			</h4>
+			<a href="#zcor">zcor</a>
+			<a href="#pitch">pitch</a>
+			<a href="#roll">roll</a>
+			<h4>
+				<span class="prim_example">Patches</span>
+			</h4>
+			<a href="#pzcor">pzcor</a>
+			<h3>
+				Primitives
+			</h3>
+			<div class="dict_entry" id="at-points-3d">
+				<h3>
+					<a>at-points<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example"><i>agentset</i> at-points [[<i>x1 y1 z1</i>] [<i>x2 y2 z2</i>] ...]</span>
+				</h4>
+				<p>
+					Reports a subset of the given agentset that includes only the
+					agents on the patches the given distances away from this agent. The
+					distances are specified as a list of three-item lists, where the
+					three items are the x, y, and z offsets.
+				</p>
+				<p>
+					If the caller is the observer, then the points are measured
+					relative to the origin, in other words, the points are taken as
+					absolute patch coordinates.
+				</p>
+				<p>
+					If the caller is a turtle, the points are measured relative to the
+					turtle's exact location, and not from the center of the patch
+					under the turtle.
+				</p>
+				<pre>
+					ask turtles at-points [[2 4 0] [1 2 1] [10 15 10]]
+					[ fd 1 ]  ;; only the turtles on the patches at the
+					;; distances (2,4,0), (1,2,1) and (10,15,10),
+					;; relative to the caller, move
+				</pre>
+			</div>
+			<div class="dict_entry" id="distance-3d">
+				<h3>
+					<a>distancexyz<span class="since">4.1</span></a>
+					<a>distancexyz-nowrap<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">distancexyz <i>xcor</i> <i>ycor</i> <i>zcor</i></span>
+					<span class="prim_example">distancexyz-nowrap <i>xcor</i> <i>ycor</i> <i>zcor</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					3D versions of <a href="dictionary.html#distancexy">distancexy</a>.
+				</p>
+				<p>
+					Reports the distance from this agent to the point (<i>xcor</i>,
+					<i>ycor</i>, <i>zcor</i>).
+				</p>
+				<p>
+					The distance from a patch is measured from the center of the patch.
+				</p>
+				<p>
+					distancexyz-nowrap always reports the in world distance, never a
+					distance that would require wrapping around the edges of the world.
+					With distancexyz the wrapped distance (around the edges of the
+					world) is used if that distance is shorter than the in world
+					distance.
+				</p>
+				<pre>
+					if (distancexyz 0 0 0) &lt; 10
+					[ set color green ]
+					;; all turtles less than 10 units from
+					;; the center of the screen turn green.
+				</pre>
+			</div>
+			<div class="dict_entry" id="dz">
+				<h3>
+					<a>dz<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">dz</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Reports the z-increment (the amount by which the turtle's zcor
+					would change) if the turtle were to take one step forward at its
+					current heading and pitch.
+				</p>
+				<p>
+					NOTE: dz is simply the sine of the turtle's pitch. Both dx and
+					dy have changed in this case. So, dx = cos(pitch) * sin(heading)
+					and dy = cos(pitch) * cos(heading).
+				</p>
+				<p>
+					See also <a href="dictionary.html#dxy">dx</a>, <a href="dictionary.html#dxy">dy</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="face-3d">
+				<h3>
+					<a>face</a>
+					<a>facexyz<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">face <i>agent</i></span>
+					<span class="prim_example">facexyz <i>x</i> <i>y</i> <i>z</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Set the caller's heading and pitch towards <i>agent</i> or
+					towards the point <i>(x,y,z)</i>.
+				</p>
+				<p>
+					If the caller and the target are at the same x and y coordinates
+					the caller's heading will not change. If the caller and the
+					target are also at the same z coordinate the pitch will not change
+					either.
+				</p>
+			</div>
+			<div class="dict_entry" id="left">
+				<h3>
+					<a>left<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">left <i>number</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					The turtle turns left by <i>number</i> degrees, relative to its
+					current orientation. While left in a 2D world only modifies the
+					turtle's heading, left in a 3D world may also modify the
+					turtle's pitch and roll.
+				</p>
+				<p>
+					See also <a href="dictionary.html#left">left</a>, <a href="#tilt-cmds">tilt-up</a>, <a href="#tilt-cmds">tilt-down</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="link-pitch">
+				<h3>
+					<a>link-pitch<span class="since">4.1.2</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">link-pitch</span>
+					<img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					Reports the pitch from end1 to end2 of this link.
+				</p>
+				<pre>
+					ask link 0 1 [ print link-pitch ]
+					;; prints [[towards-pitch other-end] of end1] of link 0 1
+				</pre>
+				<p>
+					See also <a href="dictionary.html#link-heading">link-heading</a>,
+					<a href="#pitch">pitch</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="load-shapes-3d">
+				<h3>
+					<a>load-shapes-3d<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">load-shapes-3d <i>filename</i></span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Loads custom 3D shapes from the given file. See the <a href="3d.html">3D guide</a> for more details. You must also add a 2D
+					shape of the same name to the model using the Turtle Shapes Editor.
+					Custom shapes override built-in 3D shapes and converted 2D shapes.
+				</p>
+			</div>
+			<div class="dict_entry" id="min-max-pzcor">
+				<h3>
+					<a>max-pzcor<span class="since">4.1</span></a>
+					<a>min-pzcor<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">max-pzcor</span>
+					<span class="prim_example">min-pzcor</span>
+				</h4>
+				<p>
+					These reporters give the maximum and minimum z-coordinates
+					(respectively) for patches, which determines the size of the world.
+				</p>
+				<p>
+					Unlike in older versions of NetLogo the origin does not have to be
+					at the center of the world. However, the minimum z-coordinate has
+					to be less than or equal to 0 and the maximum z-coordinate has to
+					be greater than or equal to 0.
+				</p>
+				<p>
+					Note: You can set the size of the world only by editing the view --
+					these are reporters which cannot be set.
+				</p>
+				<p>
+					See also <a href="dictionary.html#max-pcor">max-pxcor</a>, <a href="dictionary.html#max-pcor">max-pycor</a>, <a href="dictionary.html#min-pcor">min-pxcor</a>,
+					<a href="dictionary.html#min-pcor">min-pycor</a>, and <a href="#world-depth">world-depth</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="neighbors-3d">
+				<h3>
+					<a>neighbors<span class="since">4.1</span></a>
+					<a>neighbors6<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">neighbors</span>
+					<span class="prim_example">neighbors6</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					3D versions of <a href="dictionary.html#neighbors">neighbors</a>
+					and <a href="dictionary.html#neighbors">neighbors4</a>.
+				</p>
+				<p>
+					Reports an agentset containing the 26 surrounding patches
+					(neighbors) or 6 surrounding patches (neighbors6).
+				</p>
+				<pre>
+					show sum values-from neighbors [count turtles-here]
+					;; prints the total number of turtles on the twenty-six
+					;; patches around this turtle or patch
+					ask neighbors6 [ set pcolor red ]
+					;; turns the six neighboring patches red
+				</pre>
+			</div>
+			<div class="dict_entry" id="orbit-cmds">
+				<h3>
+					<a>orbit-down<span class="since">4.1</span></a>
+					<a>orbit-left<span class="since">4.1</span></a>
+					<a>orbit-right<span class="since">4.1</span></a>
+					<a>orbit-up<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">orbit-down <i>number</i></span>
+					<span class="prim_example">orbit-left <i>number</i></span>
+					<span class="prim_example">orbit-right <i>number</i></span>
+					<span class="prim_example">orbit-up <i>number</i></span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Rotate the observer around the last point faced. Imagine the
+					observer is on the surface of a sphere, the last point face is the
+					center of that sphere. Up and down orbit along the lines of
+					longitude and right and left orbit along the lines of latitude. The
+					observer will remain facing the last point faced so the heading and
+					pitch may change as result of orbiting. However, because we assume
+					an absolute north pole (parallel to the positive z-axis) the roll
+					will never change.
+				</p>
+				<p>
+					See also <a href="#setxyz">setxyz</a>, <a href="#face-3d">face</a> and
+					<a href="#zoom">zoom</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="observer-cors">
+				<h3>
+					<a>__oxcor</a>
+					<a>__oycor</a>
+					<a>__ozcor</a>
+				</h3>
+				<h4>
+					<span class="prim_example">__oxcor</span>
+					<span class="prim_example">__oycor</span>
+					<span class="prim_example">__ozcor</span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Reports the x-, y-, or z-coordinate of the observer.
+				</p>
+				<p>
+					See also <a href="#setxyz">setxyz</a>
+				</p>
+				<h3>
+					<a id="patch">patch<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">patch <i>pxcor</i> <i>pycor</i> <i>pzcor</i></span>
+				</h4>
+				<p>
+					3D version of <a href="dictionary.html#patch">patch</a>.
+				</p>
+				<p>
+					Given three integers, reports the single patch with the given
+					pxcor, pycor and pzcor. <i>pxcor</i>, <i>pycor</i> and <i>pzcor</i>
+					must be integers.
+				</p>
+				<pre>
+					ask (patch 3 -4 2) [ set pcolor green ]
+					;; patch with pxcor of 3 and pycor of -4 and pzcor of 2 turns green
+				</pre>
+				<p>
+					See also <a href="dictionary.html#patch">patch</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="patch-at-3d">
+				<h3>
+					<a>patch-at<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">patch-at <i>dx</i> <i>dy</i> <i>dz</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					3D version of <a href="dictionary.html#patch-at">patch-at</a>.
+				</p>
+				<p>
+					Reports the single patch at (dx, dy, dz) from the caller, that is,
+					dx patches east, dy patches north and dz patches up from the
+					caller.
+				</p>
+				<pre>
+					ask patch-at 1 -1 1 [ set pcolor green ]
+					;; turns the patch just southeast and up from the caller green
+				</pre>
+			</div>
+			<div class="dict_entry" id="patch-at-heading-pitch-and-distance">
+				<h3>
+					<a>patch-at-heading-pitch-and-distance<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">patch-at-heading-pitch-and-distance <i>heading</i> <i>pitch</i> <i>distance</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					3D version of <a href="dictionary.html#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
+				</p>
+				<p>
+					patch-at-heading-pitch-and-distance reports the single patch that
+					is the given distance from this turtle or patch, along the given
+					absolute heading and pitch. (In contrast to patch-left-and-ahead
+					and patch-right-and-ahead, this turtle's current heading is not
+					taken into account.)
+				</p>
+				<pre>
+					ask patch-at-heading-pitch-and-distance 0 90 1 [ set pcolor green ]
+					;; turns the patch directly above the caller green.
+				</pre>
+			</div>
+			<div class="dict_entry" id="pitch">
+				<h3>
+					<a>pitch</a>
+				</h3>
+				<h4>
+					<span class="prim_example">pitch</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					This is a built-in turtle variable. Pitch is the angle between the
+					&quot;nose&quot; of the turtle and the xy-plane. Heading and pitch
+					together define the forward vector of the turtle or the direction
+					that the turtle is facing.
+				</p>
+				<p>
+					This is a number greater than or equal to 0 and less than 360. 0 is
+					parallel to the xy-plane, 90 is parallel to the z-axis. While you
+					can set pitch we recommend that you use the primitives to turn the
+					turtle. Depending on the position more than one relative angle
+					(heading, pitch and roll) may change at once.
+				</p>
+				<p>
+					Example:
+				</p>
+				<pre>
+					;; assume roll and heading are 0
+					set pitch 45      ;; turtle is now north and up
+					set heading heading + 10 ;; same effect as &quot;tilt-up 10&quot;
+				</pre>
+				<p>
+					See also <a href="dictionary.html#heading">heading</a>, <a href="#roll">roll</a>, <a href="#tilt-cmds">tilt-up</a>, <a href="#tilt-cmds">tilt-down</a>, <a href="#right">right</a>, <a href="#left">left</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="pzcor">
+				<h3>
+					<a>pzcor</a>
+				</h3>
+				<h4>
+					<span class="prim_example">pzcor</span>
+					<img alt="Patch Command" src="images/patch.gif"/> <img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					This is a built-in patch variable. It holds the z coordinate of the
+					patch. It is always an integer. You cannot set this variable,
+					because patches don't move.
+				</p>
+				<p>
+					pzcor is greater than or equal to min-pzcor and less than or equal
+					to max-pzcor.
+				</p>
+				<p>
+					All patch variables can be directly accessed by any turtle standing
+					on the patch.
+				</p>
+				<p>
+					See also <a href="dictionary.html#pcor">pxcor, pycor</a>, <a href="#zcor">zcor</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="random-pzcor">
+				<h3>
+					<a>random-pzcor<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">random-pzcor</span>
+				</h4>
+				<p>
+					Reports a random integer ranging from min-pzcor to max-pzcor
+					inclusive.
+				</p>
+				<pre>
+					ask turtles [
+					;; move each turtle to the center of a random patch
+					setxyz random-pxcor random-pycor random-pzcor
+					]
+				</pre>
+				<p>
+					See also <a href="dictionary.html#random-pcor">random-pxcor</a>, <a href="dictionary.html#random-pcor">random-pycor</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="random-zcor">
+				<h3>
+					<a>random-zcor<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">random-zcor</span>
+				</h4>
+				<p>
+					Reports a random floating point number from the allowable range of
+					turtle coordinates along the z axis.
+				</p>
+				<p>
+					Turtle coordinates range from min-pzcor - 0.5 (inclusive) to
+					max-pzcor + 0.5 (exclusive).
+				</p>
+				<pre>
+					ask turtles [
+					;; move each turtle to a random point
+					setxyz random-xcor random-ycor random-zcor
+					]
+				</pre>
+				<p>
+					See also <a href="dictionary.html#random-cor">random-xcor</a>,
+					<a href="dictionary.html#random-cor">random-ycor</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="right">
+				<h3>
+					<a>right<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">right <i>number</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					The turtle turns right by <i>number</i> degrees, relative to its
+					current orientation. While right in a 2D world only modifies the
+					turtle's heading, right in a 3D world may also modify the
+					turtle's pitch and roll.
+				</p>
+				<p>
+					See also <a href="dictionary.html#right">right</a> and <a href="#left">left</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="roll">
+				<h3>
+					<a>roll</a>
+				</h3>
+				<h4>
+					<span class="prim_example">roll</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					This is a built-in turtle variable. Roll is the angle between the
+					&quot;wing-tip&quot; of the turtle and the xy-plane.
+				</p>
+				<p>
+					This is a number greater than or equal to 0 and less than 360. You
+					can set this variable to make a turtle roll. Since roll is always
+					from the turtle's point of view, rolling right and left only
+					only change roll regardless of turtle orientation.
+				</p>
+				<p>
+					Example:
+				</p>
+				<pre>
+					set roll 45      ;; turtle rotated right
+					set roll roll + 10 ;; same effect as &quot;roll-right 10&quot;
+				</pre>
+				<p>
+					See also <a href="dictionary.html#heading">heading</a>, <a href="#pitch">pitch</a>, <a href="#roll-left">roll-left</a>, <a href="#roll-right">roll-right</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="roll-left">
+				<h3>
+					<a>roll-left<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">roll-left <i>number</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					The wingtip of the turtle rotates to the left <i>number</i> degrees
+					with respect to the current heading and pitch.
+				</p>
+			</div>
+			<div class="dict_entry" id="roll-right">
+				<h3>
+					<a>roll-right<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">roll-right <i>number</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					The wingtip of the turtle rotates to the right <i>number</i>
+					degrees with respect to the current heading and pitch.
+				</p>
+			</div>
+			<div class="dict_entry" id="setxyz">
+				<h3>
+					<a>setxyz<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">setxyz <i>x y z</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					3D version of <a href="dictionary.html#setxy">setxy</a>.
+				</p>
+				<p>
+					The agent, a turtle or the observer, sets its x-coordinate to
+					<i>x</i>, its y-coordinate to <i>y</i> and its z-coordinate to
+					<i>z</i>. When the observer uses <code>setxyz</code> it remains facing
+					the same point so the heading, pitch, and roll, may also change.
+				</p>
+				<p>
+					For turtles equivalent to <code>set xcor x set ycor y set zcor
+						z</code>, except it happens in one time step instead of three.
+				</p>
+				<pre>
+					setxyz 0 0 0
+					;; agent moves to the middle of the center patch
+				</pre>See also <a href="#face-3d">face</a>
+			</div>
+			<div class="dict_entry" id="tilt-cmds">
+				<h3>
+					<a>tilt-down<span class="since">4.1</span></a>
+					<a>tilt-up<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">tilt-down <i>number</i></span>
+					<span class="prim_example">tilt-up <i>number</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					The nose of the turtle rotates by <i>number</i> degrees, relative
+					to its current orientation. Depending on the orientation of the
+					turtle more than one of the relative angles (heading, pitch, and
+					roll) may change when a turtle turns.
+				</p>
+			</div>
+			<div class="dict_entry" id="towards-pitch-cmd">
+				<h3>
+					<a>towards-pitch<span class="since">4.1</span></a>
+					<a>towards-pitch-nowrap<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">towards-pitch <i>agent</i></span>
+					<span class="prim_example">towards-pitch-nowrap <i>agent</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					Reports the pitch from this agent to the given agent.
+				</p>
+				<p>
+					If the wrapped distance (around the edges of the screen) is shorter
+					than the on-screen distance, towards-pitch will report the pitch of
+					the wrapped path. towards-pitch-nowrap never uses the wrapped path.
+				</p>
+				<p>
+					Note: In order to get one turtle to face another you need to use
+					both towards-pitch and towards.
+				</p>
+				<p>
+					Note: asking for the pitch from an agent to itself, or an agent on
+					the same location, will cause a runtime error.
+				</p>
+				<p>
+					See also <a href="dictionary.html#towards">towards</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="towards-pitch-xyz-cmd">
+				<h3>
+					<a>towards-pitch-xyz<span class="since">4.1</span></a>
+					<a>towards-pitch-xyz-nowrap<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">towards-pitch-xyz <i>x</i> <i>y</i> <i>z</i></span>
+					<span class="prim_example">towards-pitch-xyz-no-wrap <i>x</i> <i>y</i> <i>z</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					Reports the pitch from this agent to the coordinates x, y, z
+				</p>
+				<p>
+					If the wrapped distance (around the edges of the screen) is shorter
+					than the on-screen distance, towards-pitch will report the pitch of
+					the wrapped path. towards-pitch-nowrap never uses the wrapped path.
+				</p>
+				<p>
+					Note: In order to get a turtle to face a given location you need to
+					use both towards-pitch-xyz and towardsxy.
+				</p>
+				<p>
+					Note: asking for the pitch from an agent to the location it is
+					standing on will cause a runtime error.
+				</p>
+				<p>
+					See also <a href="dictionary.html#towardsxy">towardsxy</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="turtles-at-3d">
+				<h3>
+					<a>turtles-at<span class="since">4.1</span></a>
+					<a>&lt;breeds&gt;-at</a>
+				</h3>
+				<h4>
+					<span class="prim_example">turtles-at <i>dx</i> <i>dy</i> <i>dz</i></span>
+					<span class="prim_example"><i>&lt;breeds&gt;-at</i> <i>dx</i> <i>dy</i> <i>dz</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					3D versions of <a href="dictionary.html#turtles-at">turtles-at</a>
+					and <a href="dictionary.html#turtles-at">breeds-at</a>.
+				</p>
+				<p>
+					Reports an agentset containing the turtles on the patch (dx, dy,
+					dz) from the caller (including the caller itself if it's a
+					turtle).
+				</p>
+				<pre>
+					;; suppose I have 40 turtles at the origin
+					show [count turtles-at 0 0 0] of turtle 0
+					=&gt; 40
+				</pre>
+			</div>
+			<div class="dict_entry" id="world-depth">
+				<h3>
+					<a>world-depth<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">world-depth</span>
+				</h4>
+				<p>
+					Reports the total depth of the NetLogo world.
+				</p>
+				<p>
+					The depth of the world is the same as max-pzcor - min-pzcor + 1.
+				</p>
+				<p>
+					See also <a href="#min-max-pzcor">max-pzcor</a>, <a href="#min-max-pzcor">min-pzcor</a>, <a href="dictionary.html#world-dim">world-width</a>, and <a href="dictionary.html#world-dim">world-height</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="zcor">
+				<h3>
+					<a>zcor</a>
+				</h3>
+				<h4>
+					<span class="prim_example">zcor</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					This is a built-in turtle variable. It holds the current z
+					coordinate of the turtle. This is a floating point number, not an
+					integer. You can set this variable to change the turtle's
+					location.
+				</p>
+				<p>
+					This variable is always greater than or equal to (- screen-edge-z)
+					and strictly less than screen-edge-z.
+				</p>
+				<p>
+					See also <a href="#setxyz">setxy</a>, <a href="dictionary.html#xcor">xcor</a>, <a href="dictionary.html#ycor">ycor</a>, <a href="dictionary.html#pcor">pxcor</a>, <a href="dictionary.html#pcor">pycor</a>, <a href="#pzcor">pzcor</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="zoom">
+				<h3>
+					<a>zoom<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">zoom <i>number</i></span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Move the observer toward the point it is facing, <i>number</i>
+					steps. The observer will never move beyond the point it is facing
+					so if <i>number</i> is greater than the distance to that point it
+					will only move as far as the point it is facing.
+				</p>
+			</div>
+		</div>
+	</body>
 </html>

--- a/autogen/docs/3d.html.mustache
+++ b/autogen/docs/3d.html.mustache
@@ -151,56 +151,56 @@
         should be as follows:
       </p>
       <pre>
-        number of shapes in file
-        name of first shape
-        type of surface ( quads or tris )
-        surface1
-        surface2
-        .
-        .
-        .
-        stop
-        type of surface
-        surfaceA
-        .
-        .
-        .
-        stop
-        end-shape
-      </pre>
+number of shapes in file
+name of first shape
+type of surface ( quads or tris )
+surface1
+surface2
+.
+.
+.
+stop
+type of surface
+surfaceA
+.
+.
+.
+stop
+end-shape
+</pre>
       <p>
         Each surface is defined by a unit normal vector and the vertices
         listed in clockwise order, tris should have three vertices and quads
         should have four.
       </p>
       <pre>
-        normal: xn yn zn
-        x1 y1 z1
-        x2 y2 z2
-        x3 y3 z3
-        x4 y4 z4
-      </pre>
+normal: xn yn zn
+x1 y1 z1
+x2 y2 z2
+x3 y3 z3
+x4 y4 z4
+</pre>
       <p>
         A file declaring just a two dimensional, patch-sized, square in the
         xy-plane centered at the origin would look like this:
       </p>
       <pre>
-        1
-        square
-        quads
-        normal: 0 0 1
-        0.15 0.15 0
-        -0.15 0.15 0
-        -0.15 -0.15 0
-        0.15 -0.15 0
-        normal: 0 0 -1
-        0.15 0.15 0
-        0.15 -0.15 0
-        -0.15 -0.15 0
-        -0.15 0.15 0
-        stop
-        end-shape
-      </pre>
+1
+square
+quads
+normal: 0 0 1
+0.15 0.15 0
+-0.15 0.15 0
+-0.15 -0.15 0
+0.15 -0.15 0
+normal: 0 0 -1
+0.15 0.15 0
+0.15 -0.15 0
+-0.15 -0.15 0
+-0.15 0.15 0
+stop
+end-shape
+</pre>
     </div>
     <div id="tutorial">
       <h2>
@@ -575,11 +575,11 @@
           under the turtle.
         </p>
         <pre>
-          ask turtles at-points [[2 4 0] [1 2 1] [10 15 10]]
-          [ fd 1 ]  ;; only the turtles on the patches at the
-          ;; distances (2,4,0), (1,2,1) and (10,15,10),
-          ;; relative to the caller, move
-        </pre>
+ask turtles at-points [[2 4 0] [1 2 1] [10 15 10]]
+[ fd 1 ]  ;; only the turtles on the patches at the
+;; distances (2,4,0), (1,2,1) and (10,15,10),
+;; relative to the caller, move
+</pre>
       </div>
       <div class="dict_entry" id="distance-3d">
         <h3>
@@ -609,11 +609,11 @@
           distance.
         </p>
         <pre>
-          if (distancexyz 0 0 0) &lt; 10
-          [ set color green ]
-          ;; all turtles less than 10 units from
-          ;; the center of the screen turn green.
-        </pre>
+if (distancexyz 0 0 0) &lt; 10
+[ set color green ]
+;; all turtles less than 10 units from
+;; the center of the screen turn green.
+</pre>
       </div>
       <div class="dict_entry" id="dz">
         <h3>
@@ -688,9 +688,9 @@
           Reports the pitch from end1 to end2 of this link.
         </p>
         <pre>
-          ask link 0 1 [ print link-pitch ]
-          ;; prints [[towards-pitch other-end] of end1] of link 0 1
-        </pre>
+ask link 0 1 [ print link-pitch ]
+;; prints [[towards-pitch other-end] of end1] of link 0 1
+</pre>
         <p>
           See also <a href="dictionary.html#link-heading">link-heading</a>,
           <a href="#pitch">pitch</a>
@@ -757,12 +757,12 @@
           (neighbors) or 6 surrounding patches (neighbors6).
         </p>
         <pre>
-          show sum values-from neighbors [count turtles-here]
-          ;; prints the total number of turtles on the twenty-six
-          ;; patches around this turtle or patch
-          ask neighbors6 [ set pcolor red ]
-          ;; turns the six neighboring patches red
-        </pre>
+show sum values-from neighbors [count turtles-here]
+;; prints the total number of turtles on the twenty-six
+;; patches around this turtle or patch
+ask neighbors6 [ set pcolor red ]
+;; turns the six neighboring patches red
+</pre>
       </div>
       <div class="dict_entry" id="orbit-cmds">
         <h3>
@@ -826,9 +826,9 @@
           must be integers.
         </p>
         <pre>
-          ask (patch 3 -4 2) [ set pcolor green ]
-          ;; patch with pxcor of 3 and pycor of -4 and pzcor of 2 turns green
-        </pre>
+ask (patch 3 -4 2) [ set pcolor green ]
+;; patch with pxcor of 3 and pycor of -4 and pzcor of 2 turns green
+</pre>
         <p>
           See also <a href="dictionary.html#patch">patch</a>
         </p>
@@ -850,9 +850,9 @@
           caller.
         </p>
         <pre>
-          ask patch-at 1 -1 1 [ set pcolor green ]
-          ;; turns the patch just southeast and up from the caller green
-        </pre>
+ask patch-at 1 -1 1 [ set pcolor green ]
+;; turns the patch just southeast and up from the caller green
+</pre>
       </div>
       <div class="dict_entry" id="patch-at-heading-pitch-and-distance">
         <h3>
@@ -873,9 +873,9 @@
           taken into account.)
         </p>
         <pre>
-          ask patch-at-heading-pitch-and-distance 0 90 1 [ set pcolor green ]
-          ;; turns the patch directly above the caller green.
-        </pre>
+ask patch-at-heading-pitch-and-distance 0 90 1 [ set pcolor green ]
+;; turns the patch directly above the caller green.
+</pre>
       </div>
       <div class="dict_entry" id="pitch">
         <h3>
@@ -902,10 +902,10 @@
           Example:
         </p>
         <pre>
-          ;; assume roll and heading are 0
-          set pitch 45      ;; turtle is now north and up
-          set heading heading + 10 ;; same effect as &quot;tilt-up 10&quot;
-        </pre>
+;; assume roll and heading are 0
+set pitch 45      ;; turtle is now north and up
+set heading heading + 10 ;; same effect as &quot;tilt-up 10&quot;
+</pre>
         <p>
           See also <a href="dictionary.html#heading">heading</a>, <a href="#roll">roll</a>, <a href="#tilt-cmds">tilt-up</a>, <a href="#tilt-cmds">tilt-down</a>, <a href="#right">right</a>, <a href="#left">left</a>
         </p>
@@ -947,11 +947,11 @@
           inclusive.
         </p>
         <pre>
-          ask turtles [
-          ;; move each turtle to the center of a random patch
-          setxyz random-pxcor random-pycor random-pzcor
-          ]
-        </pre>
+ask turtles [
+;; move each turtle to the center of a random patch
+setxyz random-pxcor random-pycor random-pzcor
+]
+</pre>
         <p>
           See also <a href="dictionary.html#random-pcor">random-pxcor</a>, <a href="dictionary.html#random-pcor">random-pycor</a>.
         </p>
@@ -972,11 +972,11 @@
           max-pzcor + 0.5 (exclusive).
         </p>
         <pre>
-          ask turtles [
-          ;; move each turtle to a random point
-          setxyz random-xcor random-ycor random-zcor
-          ]
-        </pre>
+ask turtles [
+;; move each turtle to a random point
+setxyz random-xcor random-ycor random-zcor
+]
+</pre>
         <p>
           See also <a href="dictionary.html#random-cor">random-xcor</a>,
           <a href="dictionary.html#random-cor">random-ycor</a>.
@@ -1022,9 +1022,9 @@
           Example:
         </p>
         <pre>
-          set roll 45      ;; turtle rotated right
-          set roll roll + 10 ;; same effect as &quot;roll-right 10&quot;
-        </pre>
+set roll 45      ;; turtle rotated right
+set roll roll + 10 ;; same effect as &quot;roll-right 10&quot;
+</pre>
         <p>
           See also <a href="dictionary.html#heading">heading</a>, <a href="#pitch">pitch</a>, <a href="#roll-left">roll-left</a>, <a href="#roll-right">roll-right</a>.
         </p>
@@ -1077,9 +1077,9 @@
             z</code>, except it happens in one time step instead of three.
         </p>
         <pre>
-          setxyz 0 0 0
-          ;; agent moves to the middle of the center patch
-        </pre>See also <a href="#face-3d">face</a>
+setxyz 0 0 0
+;; agent moves to the middle of the center patch
+</pre>See also <a href="#face-3d">face</a>
       </div>
       <div class="dict_entry" id="tilt-cmds">
         <h3>
@@ -1178,10 +1178,10 @@
           turtle).
         </p>
         <pre>
-          ;; suppose I have 40 turtles at the origin
-          show [count turtles-at 0 0 0] of turtle 0
-          =&gt; 40
-        </pre>
+;; suppose I have 40 turtles at the origin
+show [count turtles-at 0 0 0] of turtle 0
+=&gt; 40
+</pre>
       </div>
       <div class="dict_entry" id="world-depth">
         <h3>

--- a/autogen/docs/3d.html.mustache
+++ b/autogen/docs/3d.html.mustache
@@ -1,27 +1,31 @@
 <!DOCTYPE html>
+<html lang="en">
+<head>
 <title>
       NetLogo {{version}} User Manual: 3D
     </title>
     <link rel="stylesheet" href="netlogo.css" type="text/css">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <style type="text/css">
+    <style>
 p { margin-left: 1.5em ; }
     p.bookquote { font-size: 85%; margin-left: 4em; margin-right: 4em; color: #333 ; }
-    </style>
-    <style type="text/css">
 p.c1 {font-style: italic}
     </style>
+</head>
+<body>
   <h1>
       NetLogo 3D
     </h1>
     <p>
       NetLogo includes the NetLogo 3D application that allows you to create 3D worlds.
+    </p>
     <p>
       <b>Notice:</b> NetLogo's support for 3D is less developed than
       NetLogo 2D. Models created with this release may not be compatible
       with future versions. While we've made efforts to ensure a quality
       product, NetLogo 3D has not been subject to the same level of quality
       control as the main application.
+    </p>
     <ul>
       <li>
         <a href="#introduction">Introduction</a>
@@ -38,9 +42,11 @@ p.c1 {font-style: italic}
       To get started using NetLogo 3D, launch the NetLogo 3D application
       and check out the Sample Models in the 3D section of the Models
       Library.
+    </p>
     <p>
       When you're ready to write your own 3D model, look at the Code
       Examples in the 3D section of the Models Library.
+    </p>
     <div class="blockquote">
         <b>Code Example:</b> Turtle Perspective Example 3D helps you learn
         about the different perspectives.
@@ -48,6 +54,7 @@ p.c1 {font-style: italic}
         <b>Code Example:</b> Turtle and Observer Motion Example 3D helps
         you understand how turtles and the observer move in 3D. You can
         also step through this model with the tutorial below.
+      </p>
       </div>
     <h4>
       <span class="prim_example">3D Worlds</span>
@@ -58,18 +65,22 @@ p.c1 {font-style: italic}
       Line that was no Line; Space that was not Space: I was myself, and
       not myself. When I could find voice, I shrieked loud in agony,
       &quot;Either this is madness or it is Hell.&quot;</i>
+    </p>
     <p class="bookquote">
       <i>&quot;It is neither,&quot; calmly replied the voice of the Sphere,
       &quot;it is Knowledge; it is Three Dimensions: open your eye once
       again and try to look steadily.&quot;</i>
       <br>
       -- Edwin A. Abbott, <i>Flatland: A romance in many dimensions</i>
+    </p>
     <p>
       NetLogo 3D's world has width, height and depth. Patches are
       cubes. In addition to <code><a href="dictionary.html#pcor">pxcor</a></code> and <code><a href="dictionary.html#pcor">pycor</a></code>, patches have <code><a href="#pzcor">pzcor</a></code>.
+    </p>
     <p>
       Turtles have three Cartesian coordinates, instead of two, to describe
       position. In addition to <code><a href="dictionary.html#xcor">xcor</a></code> and <code><a href="dictionary.html#ycor">ycor</a></code>, turtles have <code><a href="#zcor">zcor</a></code>.
+    </p>
     <p>
       A turtle's orientation is defined by three turtle variables,
       <code><a href="dictionary.html#heading">heading</a></code>, <code><a href="#pitch">pitch</a></code> and <code><a href="#roll">roll</a></code>. You
@@ -88,6 +99,7 @@ p.c1 {font-style: italic}
       both the forward and right vectors. Depending on the orientation of
       the turtle more than one of the internal turtle variables may change
       as the result of a turn.
+    </p>
     <h4>
       <span class="prim_example">The observer and the 3D view</span>
     </h4>
@@ -112,6 +124,7 @@ p.c1 {font-style: italic}
       the surface of a sphere where the center is the location the observer
       is facing. You may notice from the above examples that the observer
       is not constrained to be within the bounds of the world.
+    </p>
     <h4>
       <span class="prim_example"><a id="custom-shapes">Custom Shapes</a></span>
     </h4>
@@ -121,14 +134,17 @@ p.c1 {font-style: italic}
       <a href="#load-shapes-3d"><code>load-shapes-3d</code></a> to load shapes
       described in an external file in a custom format described here.
       Currently we do not import shapes in any standard formats.
+    </p>
     <p>
       For each shape in a custom 3D shape file, a 2D shape of the same name
       must exist as well. You can create the 2D shape in the Turtle Shapes
       Editor.
+    </p>
     <p>
       The input file may contain any number of shapes with any number of
       rectangular or triangular surfaces. The format of the input file
       should be as follows:
+    </p>
     <pre>
 number of shapes in file
 name of first shape
@@ -151,6 +167,7 @@ end-shape
       Each surface is defined by a unit normal vector and the vertices
       listed in clockwise order, tris should have three vertices and quads
       should have four.
+    </p>
     <pre>
 normal: xn yn zn
 x1 y1 z1
@@ -161,6 +178,7 @@ x4 y4 z4
     <p>
       A file declaring just a two dimensional, patch-sized, square in the
       xy-plane centered at the origin would look like this:
+    </p>
     <pre>
 1
 square
@@ -189,15 +207,19 @@ end-shape
     <p>
       One of the first things you will notice when you open NetLogo 3D is
       that the world is a cube instead of a square.
+    </p>
     <p class="screenshot">
       <img alt="screen shot" src="images/3d/cube.gif">
+    </p>
     <p>
       You can open up the Model Settings, by clicking on the
       &quot;Settings...&quot; button at the top of the 3D View. You'll
       notice in addition to <code>max-pxcor</code>, <code>min-pxcor</code>,
       <code>max-pycor</code>, and <code>min-pycor</code>, there is also <a href="#min-max-pzcor"><code>max-pzcor</code></a> and <a href="#min-max-pzcor"><code>min-pzcor</code></a>.
+    </p>
     <p class="screenshot">
       <img alt="screen shot" src="images/3d/properties.gif">
+    </p>
     <p>
       The z-axis is perpendicular to both the x-axis and the y-axis, when
       you <code>reset-perspective</code> it is the axis that comes straight out
@@ -206,11 +228,13 @@ end-shape
       farthest from you. As always <code>min-pxcor</code> is on the left,
       <code>max-pxcor</code> on the right, <code>min-pycor</code> on the bottom,
       and <code>max-pycor</code> on the top.
+    </p>
     <p>
       You'll also notice on the left side of the Model Settings that
       there are options for wrapping in all three directions, however, they
       are all checked and grayed out. Topologies are not yet supported in
       NetLogo 3D, so the world always wraps in all dimensions.
+    </p>
     <div class="blockquote">
       <ul>
         <li>Move to the Command Center and type <code>print count
@@ -218,6 +242,7 @@ end-shape
         </ul>
       <p class="question">
         Is the number smaller or larger than you expected?
+      </p>
       </div>
     <p>
       In a 3D world the number of patches grows very quickly since
@@ -225,6 +250,7 @@ end-shape
       It's important to keep this in mind when you are building your
       model. Lots of patches can slow your model down or even cause NetLogo
       to run out of memory.
+    </p>
     <div class="blockquote">
       <ul>
         <li>Type <code>ask patch 1 2 3 [ set pcolor red ]</code> into the
@@ -236,6 +262,7 @@ end-shape
       Notice the shape of the patch and its position in relation to the
       edges of the world. You'll also notice that you now need three
       coordinates to address patches in a 3D world.
+    </p>
     <h4>
       <span class="prim_example">Step 2: Turtle Movement</span>
     </h4>
@@ -252,6 +279,7 @@ end-shape
       left you'll notice a group of monitors that describe the location
       and orientation of the turtle, though until you press the setup
       button they'll all say &quot;N/A&quot;.
+    </p>
     <div class="blockquote">
       <ul>
         <li>Press the &quot;setup&quot; button
@@ -261,24 +289,32 @@ end-shape
       Heading, pitch, and roll are turtle variables that represent the
       orientation of the turtle. Heading is absolute in relation to the x/y
       plane; it is the rotation of the turtle around the z-axis.
+    </p>
     <p class="screenshot">
       <img alt="screen shot" src="images/3d/heading.gif">
+    </p>
     <p>
       Pitch is the angle between the nose of the turtle and the xy-plane.
       It is relative to heading.
+    </p>
     <p class="screenshot">
       <img alt="screen shot" src="images/3d/pitch.gif">
+    </p>
     <p>
       Roll is the rotation around the turtle's forward vector. It is
       relative to heading and pitch.
+    </p>
     <p class="screenshot">
       <img alt="screen shot" src="images/3d/roll.gif">
+    </p>
     <p>
       When turtles are created with <code>create-turtles</code> or
       <code>create-ordered-turtles</code>, their initial headings vary but
       their initial pitch and roll are always zero.
+    </p>
     <p>
       Take a look at the &quot;Turtle Movement&quot; buttons.
+    </p>
     <div class="blockquote">
       <ul>
         <li>Press the &quot;left 1&quot; button.
@@ -286,17 +322,20 @@ end-shape
       <p class="question">
         How does the turtle move? Is is the same or different from 2D
         NetLogo? Which of the turtle variables change?
+      </p>
       <ul>
         <li>Press the &quot;pitch-down 1&quot; button.
         </ul>
       <p class="question">
         How does the turtle move? Which of the turtle variables change?
+      </p>
       <ul>
         <li>Press the &quot;left 1&quot; button again.
         </ul>
       <p class="question">
         How does the turtle move? Is it different than the last time you
         pressed the &quot;left 1&quot; button?
+      </p>
       <ul>
         <li>Take a little time to play with the Turtle Movement buttons,
         watching both how the turtle moves and which of the turtle
@@ -308,6 +347,7 @@ end-shape
       may change for a single turn. For this reason we suggest that you use
       the turtle commands rather than setting the orientation variables
       directly.
+    </p>
     <h4>
       <span class="prim_example">Step 3: Observer Movement</span>
     </h4>
@@ -322,6 +362,7 @@ end-shape
       inside the world the observer can be anywhere. Like a turtle the
       observer has a heading, pitch and roll, these variables control where
       the observer is looking, that is, what you see in the view.
+    </p>
     <div class="blockquote">
       <ul>
         <li>Move to the 3D view, and make sure &quot;Orbit&quot; is
@@ -331,6 +372,7 @@ end-shape
         </ul>
       <p class="question">
         How does the position and orientation of the observer change?
+      </p>
       <ul>
         <li>Press the reset-perspective button in the lower right corner of
         the view and select &quot;Zoom&quot; in the lower left corner.
@@ -339,6 +381,7 @@ end-shape
         </ul>
       <p class="question">
         Which of the observer variables change? Which stay the same?
+      </p>
       <ul>
         <li>Try rotating the world a bit and then zoom again.
         <li>Press the &quot;Move&quot; button in the lower left corner of
@@ -348,11 +391,13 @@ end-shape
         </ul>
       <p class="question">
         How does the view change? How do the observer variables change?
+      </p>
       </div>
     <p>
       After you are done exploring the world using the mouse controls you
       can take a look at the observer control buttons in the lower left
       portion of the interface.
+    </p>
     <p>
       You may already be familiar with the first three buttons in the
       observer group from your experience with NetLogo 2D. Watch, follow,
@@ -362,6 +407,7 @@ end-shape
       Note that follow and ride are functionally exactly the same, the
       difference is only visual in the 3D view. When in watch mode the
       observer does not move but updates to face the target agent.
+    </p>
     <div class="blockquote">
       <ul>
         <li>Press the &quot;setup&quot; button again so you are back to the
@@ -371,6 +417,7 @@ end-shape
       <p class="question">
         How did the view change? Was it what you expected? How is it
         similar or different from using the mouse controls?
+      </p>
       <ul>
         <li>Take a little time to experiment with orbit, roll and zoom
         buttons; notice similarities and differences to the mouse controls.
@@ -387,17 +434,20 @@ end-shape
       longitude of the sphere. When you zoom the radius of the sphere
       changes but the center and the observer's orientation in relation
       to the center of the sphere will remain the same.
+    </p>
     <div class="blockquote">
       <ul>
         <li>Press one of the &quot;setxyz&quot; buttons.
         </ul>
       <p class="question">
         How does the view change? How do the observer variables change?
+      </p>
       <ul>
         <li>Press the &quot;facexyz&quot; button.
         </ul>
       <p class="question">
         How does the view change? How do the observer variables change?
+      </p>
       </div>
     <p>
       When you <code>setxyz</code> the center of the sphere remains the same
@@ -407,6 +457,7 @@ end-shape
       <code>facexyz</code> or <code>face</code>, the center of the sphere changes
       but the observer does not move. The radius of the sphere may change,
       as well as the orientation of the observer.
+    </p>
     </div>
     <div id="dictionary">
     <h2>
@@ -505,14 +556,17 @@ end-shape
         agents on the patches the given distances away from this agent. The
         distances are specified as a list of three-item lists, where the
         three items are the x, y, and z offsets.
+      </p>
       <p>
         If the caller is the observer, then the points are measured
         relative to the origin, in other words, the points are taken as
         absolute patch coordinates.
+      </p>
       <p>
         If the caller is a turtle, the points are measured relative to the
         turtle's exact location, and not from the center of the patch
         under the turtle.
+      </p>
       <pre>
 ask turtles at-points [[2 4 0] [1 2 1] [10 15 10]]
 [ fd 1 ]  ;; only the turtles on the patches at the
@@ -532,17 +586,21 @@ ask turtles at-points [[2 4 0] [1 2 1] [10 15 10]]
       </h4>
       <p>
         3D versions of <a href="dictionary.html#distancexy">distancexy</a>.
+      </p>
       <p>
         Reports the distance from this agent to the point (<i>xcor</i>,
         <i>ycor</i>, <i>zcor</i>).
+      </p>
       <p>
         The distance from a patch is measured from the center of the patch.
+      </p>
       <p>
         distancexyz-nowrap always reports the in world distance, never a
         distance that would require wrapping around the edges of the world.
         With distancexyz the wrapped distance (around the edges of the
         world) is used if that distance is shorter than the in world
         distance.
+      </p>
       <pre>
 if (distancexyz 0 0 0) &lt; 10
   [ set color green ]
@@ -562,12 +620,15 @@ if (distancexyz 0 0 0) &lt; 10
         Reports the z-increment (the amount by which the turtle's zcor
         would change) if the turtle were to take one step forward at its
         current heading and pitch.
+      </p>
       <p>
         NOTE: dz is simply the sine of the turtle's pitch. Both dx and
         dy have changed in this case. So, dx = cos(pitch) * sin(heading)
         and dy = cos(pitch) * cos(heading).
+      </p>
       <p>
         See also <a href="dictionary.html#dxy">dx</a>, <a href="dictionary.html#dxy">dy</a>.
+      </p>
       </div>
     <div class="dict_entry" id="face-3d">
       <h3>
@@ -582,11 +643,13 @@ if (distancexyz 0 0 0) &lt; 10
       <p>
         Set the caller's heading and pitch towards <i>agent</i> or
         towards the point <i>(x,y,z)</i>.
+      </p>
       <p>
         If the caller and the target are at the same x and y coordinates
         the caller's heading will not change. If the caller and the
         target are also at the same z coordinate the pitch will not change
         either.
+      </p>
       </div>
     <div class="dict_entry" id="left">
       <h3>
@@ -601,8 +664,10 @@ if (distancexyz 0 0 0) &lt; 10
         current orientation. While left in a 2D world only modifies the
         turtle's heading, left in a 3D world may also modify the
         turtle's pitch and roll.
+      </p>
       <p>
         See also <a href="dictionary.html#left">left</a>, <a href="#tilt-cmds">tilt-up</a>, <a href="#tilt-cmds">tilt-down</a>
+      </p>
       </div>
     <div class="dict_entry" id="link-pitch">
       <h3>
@@ -614,6 +679,7 @@ if (distancexyz 0 0 0) &lt; 10
       </h4>
       <p>
         Reports the pitch from end1 to end2 of this link.
+      </p>
       <pre>
 ask link 0 1 [ print link-pitch ]
 ;; prints [[towards-pitch other-end] of end1] of link 0 1
@@ -621,6 +687,7 @@ ask link 0 1 [ print link-pitch ]
       <p>
         See also <a href="dictionary.html#link-heading">link-heading</a>,
         <a href="#pitch">pitch</a>
+      </p>
       </div>
     <div class="dict_entry" id="load-shapes-3d">
       <h3>
@@ -634,6 +701,7 @@ ask link 0 1 [ print link-pitch ]
         Loads custom 3D shapes from the given file. See the <a href="3d.html">3D guide</a> for more details. You must also add a 2D
         shape of the same name to the model using the Turtle Shapes Editor.
         Custom shapes override built-in 3D shapes and converted 2D shapes.
+      </p>
       </div>
     <div class="dict_entry" id="min-max-pzcor">
       <h3>
@@ -647,14 +715,17 @@ ask link 0 1 [ print link-pitch ]
       <p>
         These reporters give the maximum and minimum z-coordinates
         (respectively) for patches, which determines the size of the world.
+      </p>
       <p>
         Unlike in older versions of NetLogo the origin does not have to be
         at the center of the world. However, the minimum z-coordinate has
         to be less than or equal to 0 and the maximum z-coordinate has to
         be greater than or equal to 0.
+      </p>
       <p>
         Note: You can set the size of the world only by editing the view --
         these are reporters which cannot be set.
+      </p>
       <p>
         See also <a href="dictionary.html#max-pcor">max-pxcor</a>, <a href="dictionary.html#max-pcor">max-pycor</a>, <a href="dictionary.html#min-pcor">min-pxcor</a>,
         <a href="dictionary.html#min-pcor">min-pycor</a>, and <a href="#world-depth">world-depth</a>.
@@ -672,9 +743,11 @@ ask link 0 1 [ print link-pitch ]
       <p>
         3D versions of <a href="dictionary.html#neighbors">neighbors</a>
         and <a href="dictionary.html#neighbors">neighbors4</a>.
+      </p>
       <p>
         Reports an agentset containing the 26 surrounding patches
         (neighbors) or 6 surrounding patches (neighbors6).
+      </p>
       <pre>
 show sum values-from neighbors [count turtles-here]
   ;; prints the total number of turtles on the twenty-six
@@ -706,9 +779,11 @@ ask neighbors6 [ set pcolor red ]
         pitch may change as result of orbiting. However, because we assume
         an absolute north pole (parallel to the positive z-axis) the roll
         will never change.
+      </p>
       <p>
         See also <a href="#setxyz">setxyz</a>, <a href="#face-3d">face</a> and
         <a href="#zoom">zoom</a>
+      </p>
       </div>
     <div class="dict_entry" id="observer-cors">
       <h3>
@@ -724,8 +799,10 @@ ask neighbors6 [ set pcolor red ]
       </h4>
       <p>
         Reports the x-, y-, or z-coordinate of the observer.
+      </p>
       <p>
         See also <a href="#setxyz">setxyz</a>
+      </p>
       <h3>
         <a id="patch">patch<span class="since">4.1</span></a>
       </h3>
@@ -734,16 +811,19 @@ ask neighbors6 [ set pcolor red ]
       </h4>
       <p>
         3D version of <a href="dictionary.html#patch">patch</a>.
+      </p>
       <p>
         Given three integers, reports the single patch with the given
         pxcor, pycor and pzcor. <i>pxcor</i>, <i>pycor</i> and <i>pzcor</i>
         must be integers.
+      </p>
       <pre>
 ask (patch 3 -4 2) [ set pcolor green ]
 ;; patch with pxcor of 3 and pycor of -4 and pzcor of 2 turns green
 </pre>
       <p>
         See also <a href="dictionary.html#patch">patch</a>
+      </p>
       </div>
     <div class="dict_entry" id="patch-at-3d">
       <h3>
@@ -755,10 +835,12 @@ ask (patch 3 -4 2) [ set pcolor green ]
       </h4>
       <p>
         3D version of <a href="dictionary.html#patch-at">patch-at</a>.
+      </p>
       <p>
         Reports the single patch at (dx, dy, dz) from the caller, that is,
         dx patches east, dy patches north and dz patches up from the
         caller.
+      </p>
       <pre>
 ask patch-at 1 -1 1 [ set pcolor green ]
 ;; turns the patch just southeast and up from the caller green
@@ -774,12 +856,14 @@ ask patch-at 1 -1 1 [ set pcolor green ]
       </h4>
       <p>
         3D version of <a href="dictionary.html#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
+      </p>
       <p>
         patch-at-heading-pitch-and-distance reports the single patch that
         is the given distance from this turtle or patch, along the given
         absolute heading and pitch. (In contrast to patch-left-and-ahead
         and patch-right-and-ahead, this turtle's current heading is not
         taken into account.)
+      </p>
       <pre>
 ask patch-at-heading-pitch-and-distance 0 90 1 [ set pcolor green ]
 ;; turns the patch directly above the caller green.
@@ -798,14 +882,17 @@ ask patch-at-heading-pitch-and-distance 0 90 1 [ set pcolor green ]
         &quot;nose&quot; of the turtle and the xy-plane. Heading and pitch
         together define the forward vector of the turtle or the direction
         that the turtle is facing.
+      </p>
       <p>
         This is a number greater than or equal to 0 and less than 360. 0 is
         parallel to the xy-plane, 90 is parallel to the z-axis. While you
         can set pitch we recommend that you use the primitives to turn the
         turtle. Depending on the position more than one relative angle
         (heading, pitch and roll) may change at once.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 ;; assume roll and heading are 0
 set pitch 45      ;; turtle is now north and up
@@ -813,6 +900,7 @@ set heading heading + 10 ;; same effect as &quot;tilt-up 10&quot;
 </pre>
       <p>
         See also <a href="dictionary.html#heading">heading</a>, <a href="#roll">roll</a>, <a href="#tilt-cmds">tilt-up</a>, <a href="#tilt-cmds">tilt-down</a>, <a href="#right">right</a>, <a href="#left">left</a>
+      </p>
       </div>
     <div class="dict_entry" id="pzcor">
       <h3>
@@ -826,14 +914,18 @@ set heading heading + 10 ;; same effect as &quot;tilt-up 10&quot;
         This is a built-in patch variable. It holds the z coordinate of the
         patch. It is always an integer. You cannot set this variable,
         because patches don't move.
+      </p>
       <p>
         pzcor is greater than or equal to min-pzcor and less than or equal
         to max-pzcor.
+      </p>
       <p>
         All patch variables can be directly accessed by any turtle standing
         on the patch.
+      </p>
       <p>
         See also <a href="dictionary.html#pcor">pxcor, pycor</a>, <a href="#zcor">zcor</a>.
+      </p>
       </div>
     <div class="dict_entry" id="random-pzcor">
       <h3>
@@ -845,6 +937,7 @@ set heading heading + 10 ;; same effect as &quot;tilt-up 10&quot;
       <p>
         Reports a random integer ranging from min-pzcor to max-pzcor
         inclusive.
+      </p>
       <pre>
 ask turtles [
   ;; move each turtle to the center of a random patch
@@ -853,6 +946,7 @@ ask turtles [
 </pre>
       <p>
         See also <a href="dictionary.html#random-pcor">random-pxcor</a>, <a href="dictionary.html#random-pcor">random-pycor</a>.
+      </p>
       </div>
     <div class="dict_entry" id="random-zcor">
       <h3>
@@ -864,9 +958,11 @@ ask turtles [
       <p>
         Reports a random floating point number from the allowable range of
         turtle coordinates along the z axis.
+      </p>
       <p>
         Turtle coordinates range from min-pzcor - 0.5 (inclusive) to
         max-pzcor + 0.5 (exclusive).
+      </p>
       <pre>
 ask turtles [
   ;; move each turtle to a random point
@@ -876,6 +972,7 @@ ask turtles [
       <p>
         See also <a href="dictionary.html#random-cor">random-xcor</a>,
         <a href="dictionary.html#random-cor">random-ycor</a>.
+      </p>
       </div>
     <div class="dict_entry" id="right">
       <h3>
@@ -890,8 +987,10 @@ ask turtles [
         current orientation. While right in a 2D world only modifies the
         turtle's heading, right in a 3D world may also modify the
         turtle's pitch and roll.
+      </p>
       <p>
         See also <a href="dictionary.html#right">right</a> and <a href="#left">left</a>
+      </p>
       </div>
     <div class="dict_entry" id="roll">
       <h3>
@@ -904,19 +1003,23 @@ ask turtles [
       <p>
         This is a built-in turtle variable. Roll is the angle between the
         &quot;wing-tip&quot; of the turtle and the xy-plane.
+      </p>
       <p>
         This is a number greater than or equal to 0 and less than 360. You
         can set this variable to make a turtle roll. Since roll is always
         from the turtle's point of view, rolling right and left only
         only change roll regardless of turtle orientation.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 set roll 45      ;; turtle rotated right
 set roll roll + 10 ;; same effect as &quot;roll-right 10&quot;
 </pre>
       <p>
         See also <a href="dictionary.html#heading">heading</a>, <a href="#pitch">pitch</a>, <a href="#roll-left">roll-left</a>, <a href="#roll-right">roll-right</a>.
+      </p>
       </div>
     <div class="dict_entry" id="roll-left">
       <h3>
@@ -929,6 +1032,7 @@ set roll roll + 10 ;; same effect as &quot;roll-right 10&quot;
       <p>
         The wingtip of the turtle rotates to the left <i>number</i> degrees
         with respect to the current heading and pitch.
+      </p>
       </div>
     <div class="dict_entry" id="roll-right">
       <h3>
@@ -941,6 +1045,7 @@ set roll roll + 10 ;; same effect as &quot;roll-right 10&quot;
       <p>
         The wingtip of the turtle rotates to the right <i>number</i>
         degrees with respect to the current heading and pitch.
+      </p>
       </div>
     <div class="dict_entry" id="setxyz">
       <h3>
@@ -952,14 +1057,17 @@ set roll roll + 10 ;; same effect as &quot;roll-right 10&quot;
       </h4>
       <p>
         3D version of <a href="dictionary.html#setxy">setxy</a>.
+      </p>
       <p>
         The agent, a turtle or the observer, sets its x-coordinate to
         <i>x</i>, its y-coordinate to <i>y</i> and its z-coordinate to
         <i>z</i>. When the observer uses <code>setxyz</code> it remains facing
         the same point so the heading, pitch, and roll, may also change.
+      </p>
       <p>
         For turtles equivalent to <code>set xcor x set ycor y set zcor
         z</code>, except it happens in one time step instead of three.
+      </p>
       <pre>
 setxyz 0 0 0
 ;; agent moves to the middle of the center patch
@@ -980,6 +1088,7 @@ setxyz 0 0 0
         to its current orientation. Depending on the orientation of the
         turtle more than one of the relative angles (heading, pitch, and
         roll) may change when a turtle turns.
+      </p>
       </div>
     <div class="dict_entry" id="towards-pitch-cmd">
       <h3>
@@ -993,18 +1102,23 @@ setxyz 0 0 0
       </h4>
       <p>
         Reports the pitch from this agent to the given agent.
+      </p>
       <p>
         If the wrapped distance (around the edges of the screen) is shorter
         than the on-screen distance, towards-pitch will report the pitch of
         the wrapped path. towards-pitch-nowrap never uses the wrapped path.
+      </p>
       <p>
         Note: In order to get one turtle to face another you need to use
         both towards-pitch and towards.
+      </p>
       <p>
         Note: asking for the pitch from an agent to itself, or an agent on
         the same location, will cause a runtime error.
+      </p>
       <p>
         See also <a href="dictionary.html#towards">towards</a>
+      </p>
       </div>
     <div class="dict_entry" id="towards-pitch-xyz-cmd">
       <h3>
@@ -1018,18 +1132,23 @@ setxyz 0 0 0
       </h4>
       <p>
         Reports the pitch from this agent to the coordinates x, y, z
+      </p>
       <p>
         If the wrapped distance (around the edges of the screen) is shorter
         than the on-screen distance, towards-pitch will report the pitch of
         the wrapped path. towards-pitch-nowrap never uses the wrapped path.
+      </p>
       <p>
         Note: In order to get a turtle to face a given location you need to
         use both towards-pitch-xyz and towardsxy.
+      </p>
       <p>
         Note: asking for the pitch from an agent to the location it is
         standing on will cause a runtime error.
+      </p>
       <p>
         See also <a href="dictionary.html#towardsxy">towardsxy</a>
+      </p>
       </div>
     <div class="dict_entry" id="turtles-at-3d">
       <h3>
@@ -1044,10 +1163,12 @@ setxyz 0 0 0
       <p>
         3D versions of <a href="dictionary.html#turtles-at">turtles-at</a>
         and <a href="dictionary.html#turtles-at">breeds-at</a>.
+      </p>
       <p>
         Reports an agentset containing the turtles on the patch (dx, dy,
         dz) from the caller (including the caller itself if it's a
         turtle).
+      </p>
       <pre>
 ;; suppose I have 40 turtles at the origin
 show [count turtles-at 0 0 0] of turtle 0
@@ -1063,10 +1184,12 @@ show [count turtles-at 0 0 0] of turtle 0
       </h4>
       <p>
         Reports the total depth of the NetLogo world.
+      </p>
       <p>
         The depth of the world is the same as max-pzcor - min-pzcor + 1.
       <p>
         See also <a href="#min-max-pzcor">max-pzcor</a>, <a href="#min-max-pzcor">min-pzcor</a>, <a href="dictionary.html#world-dim">world-width</a>, and <a href="dictionary.html#world-dim">world-height</a>
+      </p>
       </div>
     <div class="dict_entry" id="zcor">
       <h3>
@@ -1081,11 +1204,14 @@ show [count turtles-at 0 0 0] of turtle 0
         coordinate of the turtle. This is a floating point number, not an
         integer. You can set this variable to change the turtle's
         location.
+      </p>
       <p>
         This variable is always greater than or equal to (- screen-edge-z)
         and strictly less than screen-edge-z.
+      </p>
       <p>
         See also <a href="#setxyz">setxy</a>, <a href="dictionary.html#xcor">xcor</a>, <a href="dictionary.html#ycor">ycor</a>, <a href="dictionary.html#pcor">pxcor</a>, <a href="dictionary.html#pcor">pycor</a>, <a href="#pzcor">pzcor</a>
+      </p>
       </div>
     <div class="dict_entry" id="zoom">
       <h3>
@@ -1100,6 +1226,8 @@ show [count turtles-at 0 0 0] of turtle 0
         steps. The observer will never move beyond the point it is facing
         so if <i>number</i> is greater than the distance to that point it
         will only move as far as the point it is facing.
+      </p>
       </div>
     </div>
-
+</body>
+</html>

--- a/autogen/docs/3d.html.mustache
+++ b/autogen/docs/3d.html.mustache
@@ -577,8 +577,8 @@ end-shape
         <pre>
 ask turtles at-points [[2 4 0] [1 2 1] [10 15 10]]
 [ fd 1 ]  ;; only the turtles on the patches at the
-;; distances (2,4,0), (1,2,1) and (10,15,10),
-;; relative to the caller, move
+          ;; distances (2,4,0), (1,2,1) and (10,15,10),
+          ;; relative to the caller, move
 </pre>
       </div>
       <div class="dict_entry" id="distance-3d">
@@ -610,7 +610,7 @@ ask turtles at-points [[2 4 0] [1 2 1] [10 15 10]]
         </p>
         <pre>
 if (distancexyz 0 0 0) &lt; 10
-[ set color green ]
+  [ set color green ]
 ;; all turtles less than 10 units from
 ;; the center of the screen turn green.
 </pre>
@@ -758,10 +758,10 @@ ask link 0 1 [ print link-pitch ]
         </p>
         <pre>
 show sum values-from neighbors [count turtles-here]
-;; prints the total number of turtles on the twenty-six
-;; patches around this turtle or patch
+  ;; prints the total number of turtles on the twenty-six
+  ;; patches around this turtle or patch
 ask neighbors6 [ set pcolor red ]
-;; turns the six neighboring patches red
+  ;; turns the six neighboring patches red
 </pre>
       </div>
       <div class="dict_entry" id="orbit-cmds">
@@ -948,8 +948,8 @@ set heading heading + 10 ;; same effect as &quot;tilt-up 10&quot;
         </p>
         <pre>
 ask turtles [
-;; move each turtle to the center of a random patch
-setxyz random-pxcor random-pycor random-pzcor
+  ;; move each turtle to the center of a random patch
+  setxyz random-pxcor random-pycor random-pzcor
 ]
 </pre>
         <p>
@@ -973,8 +973,8 @@ setxyz random-pxcor random-pycor random-pzcor
         </p>
         <pre>
 ask turtles [
-;; move each turtle to a random point
-setxyz random-xcor random-ycor random-zcor
+  ;; move each turtle to a random point
+  setxyz random-xcor random-ycor random-zcor
 ]
 </pre>
         <p>

--- a/autogen/docs/3d.html.mustache
+++ b/autogen/docs/3d.html.mustache
@@ -1,1242 +1,1242 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<title>
-			NetLogo {{version}} User Manual: 3D
-		</title>
-		<link rel="stylesheet" href="netlogo.css" type="text/css"/>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-		<style>
-			p { margin-left: 1.5em ; }
-			p.bookquote { font-size: 85%; margin-left: 4em; margin-right: 4em; color: #333 ; }
-			p.c1 {font-style: italic}
-		</style>
-	</head>
-	<body>
-		<h1>
-			NetLogo 3D
-		</h1>
-		<p>
-			NetLogo includes the NetLogo 3D application that allows you to create 3D worlds.
-		</p>
-		<p>
-			<b>Notice:</b> NetLogo's support for 3D is less developed than
-			NetLogo 2D. Models created with this release may not be compatible
-			with future versions. While we've made efforts to ensure a quality
-			product, NetLogo 3D has not been subject to the same level of quality
-			control as the main application.
-		</p>
-		<ul>
-			<li>
-				<a href="#introduction">Introduction</a>
-			</li>
-			<li>
-				<a href="#tutorial">Tutorial</a>
-			</li>
-			<li>
-				<a href="#dictionary">Dictionary</a>
-			</li>
-		</ul>
-		<div id="introduction">
-			<h2>
-				<a>Introduction</a>
-			</h2>
-			<p>
-				To get started using NetLogo 3D, launch the NetLogo 3D application
-				and check out the Sample Models in the 3D section of the Models
-				Library.
-			</p>
-			<p>
-				When you're ready to write your own 3D model, look at the Code
-				Examples in the 3D section of the Models Library.
-			</p>
-			<div class="blockquote">
-				<p>
-					<b>Code Example:</b> Turtle Perspective Example 3D helps you learn
-					about the different perspectives.
-				</p>
-				<p>
-					<b>Code Example:</b> Turtle and Observer Motion Example 3D helps
-					you understand how turtles and the observer move in 3D. You can
-					also step through this model with the tutorial below.
-				</p>
-			</div>
-			<h4>
-				<span class="prim_example">3D Worlds</span>
-			</h4>
-			<p class="bookquote">
-				<i>An unspeakable horror seized me. There was a darkness; then a
-					dizzy, sickening sensation of sight that was not like seeing; I saw a
-					Line that was no Line; Space that was not Space: I was myself, and
-					not myself. When I could find voice, I shrieked loud in agony,
-					&quot;Either this is madness or it is Hell.&quot;</i>
-			</p>
-			<p class="bookquote">
-				<i>&quot;It is neither,&quot; calmly replied the voice of the Sphere,
-					&quot;it is Knowledge; it is Three Dimensions: open your eye once
-					again and try to look steadily.&quot;</i>
-				<br/>
-				-- Edwin A. Abbott, <i>Flatland: A romance in many dimensions</i>
-			</p>
-			<p>
-				NetLogo 3D's world has width, height and depth. Patches are
-				cubes. In addition to <code><a href="dictionary.html#pcor">pxcor</a></code> and <code><a href="dictionary.html#pcor">pycor</a></code>, patches have <code><a href="#pzcor">pzcor</a></code>.
-			</p>
-			<p>
-				Turtles have three Cartesian coordinates, instead of two, to describe
-				position. In addition to <code><a href="dictionary.html#xcor">xcor</a></code> and <code><a href="dictionary.html#ycor">ycor</a></code>, turtles have <code><a href="#zcor">zcor</a></code>.
-			</p>
-			<p>
-				A turtle's orientation is defined by three turtle variables,
-				<code><a href="dictionary.html#heading">heading</a></code>, <code><a href="#pitch">pitch</a></code> and <code><a href="#roll">roll</a></code>. You
-				can imagine the turtle as having two vectors to define its
-				orientation in 3D space. One vector comes straight out of the nose of
-				the turtle, this is the direction the turtle will travel when it
-				moves forward. The second vector is perpendicular to the forward
-				vector and comes out of the right side of the turtle (as if the
-				turtle were to stick its right arm straight out from its body).
-				Heading is the angle between the forward vector of the turtle
-				projected onto the xy-plane and the vector [0 1 0]. Pitch is the
-				angle between the forward vector of the turtle and the xy-plane and
-				finally roll is the angle between the right vector of the turtle and
-				the xy-plane. When turtle turns right or left in 3D space it rotates
-				around the down vector, that is the vector that is perpendicular to
-				both the forward and right vectors. Depending on the orientation of
-				the turtle more than one of the internal turtle variables may change
-				as the result of a turn.
-			</p>
-			<h4>
-				<span class="prim_example">The observer and the 3D view</span>
-			</h4>
-			<p>
-				The point of view that you see the world from is considered the
-				location and orientation of the observer. This is similar to the 3D
-				view in NetLogo 2D. However, there are a few more ways to control the
-				observer. You can set the point that the observer is facing by using
-				<code>face</code> and <code>facexyz</code> which work the same way as the
-				turtle commands, the observer turns so the center of the view is on
-				the given point or the location of the given agent at the time it is
-				called. You can change the location of the observer using
-				<code>setxyz</code>. The observer will move to view the world as if
-				standing on the given location, the point the observer faces will
-				stay the same. For example create a new model and observer will be
-				located at (0, 0, 49.5), that is, on the z-axis 49.5 patch units away
-				from the origin and the observer is facing the origin, (0, 0, 0). If
-				you <code>setxyz 0 49.5 0</code> the observer will move so it is on the
-				positive y-axis but it will keep the origin at the center of the
-				view. You can also move the observer using the rotation primitives
-				that will allow you to move the observer around the world as if on
-				the surface of a sphere where the center is the location the observer
-				is facing. You may notice from the above examples that the observer
-				is not constrained to be within the bounds of the world.
-			</p>
-			<h4>
-				<span class="prim_example"><a id="custom-shapes">Custom Shapes</a></span>
-			</h4>
-			<p>
-				NetLogo automatically interprets 2D shapes so they are extruded, like
-				a cookie cutter shape in the 3D view. You can also use the primitive
-				<a href="#load-shapes-3d"><code>load-shapes-3d</code></a> to load shapes
-				described in an external file in a custom format described here.
-				Currently we do not import shapes in any standard formats.
-			</p>
-			<p>
-				For each shape in a custom 3D shape file, a 2D shape of the same name
-				must exist as well. You can create the 2D shape in the Turtle Shapes
-				Editor.
-			</p>
-			<p>
-				The input file may contain any number of shapes with any number of
-				rectangular or triangular surfaces. The format of the input file
-				should be as follows:
-			</p>
-			<pre>
-				number of shapes in file
-				name of first shape
-				type of surface ( quads or tris )
-				surface1
-				surface2
-				.
-				.
-				.
-				stop
-				type of surface
-				surfaceA
-				.
-				.
-				.
-				stop
-				end-shape
-			</pre>
-			<p>
-				Each surface is defined by a unit normal vector and the vertices
-				listed in clockwise order, tris should have three vertices and quads
-				should have four.
-			</p>
-			<pre>
-				normal: xn yn zn
-				x1 y1 z1
-				x2 y2 z2
-				x3 y3 z3
-				x4 y4 z4
-			</pre>
-			<p>
-				A file declaring just a two dimensional, patch-sized, square in the
-				xy-plane centered at the origin would look like this:
-			</p>
-			<pre>
-				1
-				square
-				quads
-				normal: 0 0 1
-				0.15 0.15 0
-				-0.15 0.15 0
-				-0.15 -0.15 0
-				0.15 -0.15 0
-				normal: 0 0 -1
-				0.15 0.15 0
-				0.15 -0.15 0
-				-0.15 -0.15 0
-				-0.15 0.15 0
-				stop
-				end-shape
-			</pre>
-		</div>
-		<div id="tutorial">
-			<h2>
-				<a>Tutorial</a>
-			</h2>
-			<h4>
-				<span class="prim_example">Step 1: Depth</span>
-			</h4>
-			<p>
-				One of the first things you will notice when you open NetLogo 3D is
-				that the world is a cube instead of a square.
-			</p>
-			<p class="screenshot">
-				<img alt="screen shot" src="images/3d/cube.gif"/>
-			</p>
-			<p>
-				You can open up the Model Settings, by clicking on the
-				&quot;Settings...&quot; button at the top of the 3D View. You'll
-				notice in addition to <code>max-pxcor</code>, <code>min-pxcor</code>,
-				<code>max-pycor</code>, and <code>min-pycor</code>, there is also <a href="#min-max-pzcor"><code>max-pzcor</code></a> and <a href="#min-max-pzcor"><code>min-pzcor</code></a>.
-			</p>
-			<p class="screenshot">
-				<img alt="screen shot" src="images/3d/properties.gif"/>
-			</p>
-			<p>
-				The z-axis is perpendicular to both the x-axis and the y-axis, when
-				you <code>reset-perspective</code> it is the axis that comes straight out
-				of the screen. In the default position <code>max-pzcor</code> is the face
-				of the cube nearest to you and <code>min-pzcor</code> is the face
-				farthest from you. As always <code>min-pxcor</code> is on the left,
-				<code>max-pxcor</code> on the right, <code>min-pycor</code> on the bottom,
-				and <code>max-pycor</code> on the top.
-			</p>
-			<p>
-				You'll also notice on the left side of the Model Settings that
-				there are options for wrapping in all three directions, however, they
-				are all checked and grayed out. Topologies are not yet supported in
-				NetLogo 3D, so the world always wraps in all dimensions.
-			</p>
-			<div class="blockquote">
-				<ul>
-					<li>Move to the Command Center and type <code>print count
-							patches</code>.</li>
-				</ul>
-				<p class="question">
-					Is the number smaller or larger than you expected?
-				</p>
-			</div>
-			<p>
-				In a 3D world the number of patches grows very quickly since
-				<code>count patches = world-width * world-height * world-depth</code>.
-				It's important to keep this in mind when you are building your
-				model. Lots of patches can slow your model down or even cause NetLogo
-				to run out of memory.
-			</p>
-			<div class="blockquote">
-				<ul>
-					<li>Type <code>ask patch 1 2 3 [ set pcolor red ]</code> into the
-						Command Center.</li>
-					<li>Use the mouse in the 3D view to rotate the world.</li>
-				</ul>
-			</div>
-			<p>
-				Notice the shape of the patch and its position in relation to the
-				edges of the world. You'll also notice that you now need three
-				coordinates to address patches in a 3D world.
-			</p>
-			<h4>
-				<span class="prim_example">Step 2: Turtle Movement</span>
-			</h4>
-			<div class="blockquote">
-				<ul>
-					<li>Open the Models Library in the File menu. (If you are on a Mac
-						and you don't have a File menu, click on the main NetLogo
-						window first and it should reappear.)
-					</li>
-					<li>Open Turtle and Observer Motion Example 3D in 3D/Code Examples
-					</li>
-				</ul>
-			</div>
-			<p>
-				Take a moment to look for the controls and monitors. In the bottom
-				left you'll notice a group of monitors that describe the location
-				and orientation of the turtle, though until you press the setup
-				button they'll all say &quot;N/A&quot;.
-			</p>
-			<div class="blockquote">
-				<ul>
-					<li>Press the &quot;setup&quot; button</li>
-				</ul>
-			</div>
-			<p>
-				Heading, pitch, and roll are turtle variables that represent the
-				orientation of the turtle. Heading is absolute in relation to the x/y
-				plane; it is the rotation of the turtle around the z-axis.
-			</p>
-			<p class="screenshot">
-				<img alt="screen shot" src="images/3d/heading.gif"/>
-			</p>
-			<p>
-				Pitch is the angle between the nose of the turtle and the xy-plane.
-				It is relative to heading.
-			</p>
-			<p class="screenshot">
-				<img alt="screen shot" src="images/3d/pitch.gif"/>
-			</p>
-			<p>
-				Roll is the rotation around the turtle's forward vector. It is
-				relative to heading and pitch.
-			</p>
-			<p class="screenshot">
-				<img alt="screen shot" src="images/3d/roll.gif"/>
-			</p>
-			<p>
-				When turtles are created with <code>create-turtles</code> or
-				<code>create-ordered-turtles</code>, their initial headings vary but
-				their initial pitch and roll are always zero.
-			</p>
-			<p>
-				Take a look at the &quot;Turtle Movement&quot; buttons.
-			</p>
-			<div class="blockquote">
-				<ul>
-					<li>Press the &quot;left 1&quot; button.</li>
-				</ul>
-				<p class="question">
-					How does the turtle move? Is is the same or different from 2D
-					NetLogo? Which of the turtle variables change?
-				</p>
-				<ul>
-					<li>Press the &quot;pitch-down 1&quot; button.</li>
-				</ul>
-				<p class="question">
-					How does the turtle move? Which of the turtle variables change?
-				</p>
-				<ul>
-					<li>Press the &quot;left 1&quot; button again.</li>
-				</ul>
-				<p class="question">
-					How does the turtle move? Is it different than the last time you
-					pressed the &quot;left 1&quot; button?
-				</p>
-				<ul>
-					<li>Take a little time to play with the Turtle Movement buttons,
-						watching both how the turtle moves and which of the turtle
-						variables change.</li>
-				</ul>
-			</div>
-			<p>
-				You probably noticed that often more than one of the turtle variables
-				may change for a single turn. For this reason we suggest that you use
-				the turtle commands rather than setting the orientation variables
-				directly.
-			</p>
-			<h4>
-				<span class="prim_example">Step 3: Observer Movement</span>
-			</h4>
-			<p>
-				At the bottom of the interface you will see Orbit, Zoom, and Move
-				buttons. If you have ever used the 3D view in NetLogo 2D or if you
-				have been using the mouse controls in the 3D view through this
-				tutorial you have been moving the observer. Changing the point of
-				view in the 3D view is actually moving and changing the orientation
-				of the observer. The observer has x, y and z coordinates, just like a
-				turtle or patch, while turtles and patches are constrained to be
-				inside the world the observer can be anywhere. Like a turtle the
-				observer has a heading, pitch and roll, these variables control where
-				the observer is looking, that is, what you see in the view.
-			</p>
-			<div class="blockquote">
-				<ul>
-					<li>Move to the 3D view, and make sure &quot;Orbit&quot; is
-						selected in the bottom left corner of the view.</li>
-					<li>Click and hold the mouse button in the middle of the view, move
-						the mouse left, right, up, and down.</li>
-				</ul>
-				<p class="question">
-					How does the position and orientation of the observer change?
-				</p>
-				<ul>
-					<li>Press the reset-perspective button in the lower right corner of
-						the view and select &quot;Zoom&quot; in the lower left corner.</li>
-					<li>Click and hold the mouse button in the middle of the view and
-						move the mouse up and down.</li>
-				</ul>
-				<p class="question">
-					Which of the observer variables change? Which stay the same?
-				</p>
-				<ul>
-					<li>Try rotating the world a bit and then zoom again.</li>
-					<li>Press the &quot;Move&quot; button in the lower left corner of
-						the view.</li>
-					<li>Click and hold the mouse button in the middle of the view and
-						move the mouse up, down, left and right.</li>
-				</ul>
-				<p class="question">
-					How does the view change? How do the observer variables change?
-				</p>
-			</div>
-			<p>
-				After you are done exploring the world using the mouse controls you
-				can take a look at the observer control buttons in the lower left
-				portion of the interface.
-			</p>
-			<p>
-				You may already be familiar with the first three buttons in the
-				observer group from your experience with NetLogo 2D. Watch, follow,
-				and ride, are special modes that automatically update the position
-				and orientation of the observer. When in follow or ride mode, the
-				observer position and orientation are the same as the turtle's.
-				Note that follow and ride are functionally exactly the same, the
-				difference is only visual in the 3D view. When in watch mode the
-				observer does not move but updates to face the target agent.
-			</p>
-			<div class="blockquote">
-				<ul>
-					<li>Press the &quot;setup&quot; button again so you are back to the
-						default orientation.</li>
-					<li>Press the &quot;orbit-right&quot; button.</li>
-				</ul>
-				<p class="question">
-					How did the view change? Was it what you expected? How is it
-					similar or different from using the mouse controls?
-				</p>
-				<ul>
-					<li>Take a little time to experiment with orbit, roll and zoom
-						buttons; notice similarities and differences to the mouse controls.</li>
-				</ul>
-			</div>
-			<p>
-				The direction of the orbit commands refer to the direction that the
-				observer moves. That is, imagine that the observer is on the surface
-				of a sphere, the center of the sphere is the point that the observer
-				is facing represented by the blue cross, by default (0,0,0). The
-				observer will always face the center of the sphere and the radius of
-				the sphere will remain constant. The directions, up, down, left, and
-				right, refer to moving along the lines of latitude and the lines of
-				longitude of the sphere. When you zoom the radius of the sphere
-				changes but the center and the observer's orientation in relation
-				to the center of the sphere will remain the same.
-			</p>
-			<div class="blockquote">
-				<ul>
-					<li>Press one of the &quot;setxyz&quot; buttons.</li>
-				</ul>
-				<p class="question">
-					How does the view change? How do the observer variables change?
-				</p>
-				<ul>
-					<li>Press the &quot;facexyz&quot; button.</li>
-				</ul>
-				<p class="question">
-					How does the view change? How do the observer variables change?
-				</p>
-			</div>
-			<p>
-				When you <code>setxyz</code> the center of the sphere remains the same
-				(so the observer automatically keeps that point in the center of the
-				view.) However, the radius of the sphere may change as well as the
-				observer's orientation in relation to the center. When you
-				<code>facexyz</code> or <code>face</code>, the center of the sphere changes
-				but the observer does not move. The radius of the sphere may change,
-				as well as the orientation of the observer.
-			</p>
-		</div>
-		<div id="dictionary">
-			<h2>
-				<a>Dictionary</a>
-			</h2>
-			<h3>
-				Commands and Reporters
-			</h3>
-			<h4>
-				<span class="prim_example">Turtle-related primitives</span>
-			</h4>
-			<a href="#distance-3d">distancexyz</a>
-			<a href="#distance-3d">distancexyz-nowrap</a>
-			<a href="#dz">dz</a>
-			<a href="#left">left</a>
-			<a href="#patch-at-3d">patch-at</a>
-			<a href="#patch-at-heading-pitch-and-distance">patch-at-heading-pitch-and-distance</a>
-			<a href="#tilt-cmds">tilt-down</a>
-			<a href="#tilt-cmds">tilt-up</a>
-			<a href="#right">right</a>
-			<a href="#roll-left">roll-left</a>
-			<a href="#roll-right">roll-right</a>
-			<a href="#setxyz">setxyz</a>
-			<a href="#towards-pitch-cmd">towards-pitch</a>
-			<a href="#towards-pitch-cmd">towards-pitch-nowrap</a>
-			<a href="#towards-pitch-xyz-cmd">towards-pitch-xyz</a>
-			<a href="#towards-pitch-xyz-cmd">towards-pitch-xyz-nowrap</a>
-			<a href="#turtles-at-3d">turtles-at</a>
-			<h4>
-				<span class="prim_example">Patch-related primitives</span>
-			</h4>
-			<a href="#distance-3d">distancexyz</a>
-			<a href="#distance-3d">distancexyz-nowrap</a>
-			<a href="#neighbors-3d">neighbors</a>
-			<a href="#neighbors-3d">neighbors6</a>
-			<a href="#patch">patch</a>
-			<a href="#patch-at-3d">patch-at</a>
-			<a href="#patch-at-heading-pitch-and-distance">patch-at-heading-pitch-and-distance</a>
-			<h4>
-				<span class="prim_example">Agentset primitives</span>
-			</h4>
-			<a href="#at-points-3d">at-points</a>
-			<a href="#turtles-at-3d">breeds-at</a>
-			<a href="#turtles-at-3d">turtles-at</a>
-			<h4>
-				<span class="prim_example">World primitives</span>
-			</h4>
-			<a href="#min-max-pzcor">max-pzcor</a>
-			<a href="#min-max-pzcor">min-pzcor</a>
-			<a href="#random-pzcor">random-pzcor</a>
-			<a href="#random-zcor">random-zcor</a>
-			<a href="#world-depth">world-depth</a>
-			<a href="#load-shapes-3d">load-shapes-3d</a>
-			<h4>
-				<span class="prim_example">Observer primitives</span>
-			</h4>
-			<a href="#face-3d">face</a>
-			<a href="#face-3d">facexyz</a>
-			<a href="#orbit-cmds">orbit-down</a>
-			<a href="#orbit-cmds">orbit-left</a>
-			<a href="#orbit-cmds">orbit-right</a>
-			<a href="#orbit-cmds">orbit-up</a>
-			<a href="#observer-cors">__oxcor</a>
-			<a href="#observer-cors">__oycor</a>
-			<a href="#observer-cors">__ozcor</a>
-			<a href="#setxyz">setxyz</a>
-			<a href="#zoom">zoom</a>
-			<h4>
-				<span class="prim_example">Link primitives</span>
-			</h4><a href="#link-pitch">link-pitch</a>
-			<h3>
-				Built-In Variables
-			</h3>
-			<h4>
-				<span class="prim_example">Turtles</span>
-			</h4>
-			<a href="#zcor">zcor</a>
-			<a href="#pitch">pitch</a>
-			<a href="#roll">roll</a>
-			<h4>
-				<span class="prim_example">Patches</span>
-			</h4>
-			<a href="#pzcor">pzcor</a>
-			<h3>
-				Primitives
-			</h3>
-			<div class="dict_entry" id="at-points-3d">
-				<h3>
-					<a>at-points<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example"><i>agentset</i> at-points [[<i>x1 y1 z1</i>] [<i>x2 y2 z2</i>] ...]</span>
-				</h4>
-				<p>
-					Reports a subset of the given agentset that includes only the
-					agents on the patches the given distances away from this agent. The
-					distances are specified as a list of three-item lists, where the
-					three items are the x, y, and z offsets.
-				</p>
-				<p>
-					If the caller is the observer, then the points are measured
-					relative to the origin, in other words, the points are taken as
-					absolute patch coordinates.
-				</p>
-				<p>
-					If the caller is a turtle, the points are measured relative to the
-					turtle's exact location, and not from the center of the patch
-					under the turtle.
-				</p>
-				<pre>
-					ask turtles at-points [[2 4 0] [1 2 1] [10 15 10]]
-					[ fd 1 ]  ;; only the turtles on the patches at the
-					;; distances (2,4,0), (1,2,1) and (10,15,10),
-					;; relative to the caller, move
-				</pre>
-			</div>
-			<div class="dict_entry" id="distance-3d">
-				<h3>
-					<a>distancexyz<span class="since">4.1</span></a>
-					<a>distancexyz-nowrap<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">distancexyz <i>xcor</i> <i>ycor</i> <i>zcor</i></span>
-					<span class="prim_example">distancexyz-nowrap <i>xcor</i> <i>ycor</i> <i>zcor</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					3D versions of <a href="dictionary.html#distancexy">distancexy</a>.
-				</p>
-				<p>
-					Reports the distance from this agent to the point (<i>xcor</i>,
-					<i>ycor</i>, <i>zcor</i>).
-				</p>
-				<p>
-					The distance from a patch is measured from the center of the patch.
-				</p>
-				<p>
-					distancexyz-nowrap always reports the in world distance, never a
-					distance that would require wrapping around the edges of the world.
-					With distancexyz the wrapped distance (around the edges of the
-					world) is used if that distance is shorter than the in world
-					distance.
-				</p>
-				<pre>
-					if (distancexyz 0 0 0) &lt; 10
-					[ set color green ]
-					;; all turtles less than 10 units from
-					;; the center of the screen turn green.
-				</pre>
-			</div>
-			<div class="dict_entry" id="dz">
-				<h3>
-					<a>dz<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">dz</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Reports the z-increment (the amount by which the turtle's zcor
-					would change) if the turtle were to take one step forward at its
-					current heading and pitch.
-				</p>
-				<p>
-					NOTE: dz is simply the sine of the turtle's pitch. Both dx and
-					dy have changed in this case. So, dx = cos(pitch) * sin(heading)
-					and dy = cos(pitch) * cos(heading).
-				</p>
-				<p>
-					See also <a href="dictionary.html#dxy">dx</a>, <a href="dictionary.html#dxy">dy</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="face-3d">
-				<h3>
-					<a>face</a>
-					<a>facexyz<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">face <i>agent</i></span>
-					<span class="prim_example">facexyz <i>x</i> <i>y</i> <i>z</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Set the caller's heading and pitch towards <i>agent</i> or
-					towards the point <i>(x,y,z)</i>.
-				</p>
-				<p>
-					If the caller and the target are at the same x and y coordinates
-					the caller's heading will not change. If the caller and the
-					target are also at the same z coordinate the pitch will not change
-					either.
-				</p>
-			</div>
-			<div class="dict_entry" id="left">
-				<h3>
-					<a>left<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">left <i>number</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					The turtle turns left by <i>number</i> degrees, relative to its
-					current orientation. While left in a 2D world only modifies the
-					turtle's heading, left in a 3D world may also modify the
-					turtle's pitch and roll.
-				</p>
-				<p>
-					See also <a href="dictionary.html#left">left</a>, <a href="#tilt-cmds">tilt-up</a>, <a href="#tilt-cmds">tilt-down</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="link-pitch">
-				<h3>
-					<a>link-pitch<span class="since">4.1.2</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">link-pitch</span>
-					<img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					Reports the pitch from end1 to end2 of this link.
-				</p>
-				<pre>
-					ask link 0 1 [ print link-pitch ]
-					;; prints [[towards-pitch other-end] of end1] of link 0 1
-				</pre>
-				<p>
-					See also <a href="dictionary.html#link-heading">link-heading</a>,
-					<a href="#pitch">pitch</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="load-shapes-3d">
-				<h3>
-					<a>load-shapes-3d<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">load-shapes-3d <i>filename</i></span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Loads custom 3D shapes from the given file. See the <a href="3d.html">3D guide</a> for more details. You must also add a 2D
-					shape of the same name to the model using the Turtle Shapes Editor.
-					Custom shapes override built-in 3D shapes and converted 2D shapes.
-				</p>
-			</div>
-			<div class="dict_entry" id="min-max-pzcor">
-				<h3>
-					<a>max-pzcor<span class="since">4.1</span></a>
-					<a>min-pzcor<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">max-pzcor</span>
-					<span class="prim_example">min-pzcor</span>
-				</h4>
-				<p>
-					These reporters give the maximum and minimum z-coordinates
-					(respectively) for patches, which determines the size of the world.
-				</p>
-				<p>
-					Unlike in older versions of NetLogo the origin does not have to be
-					at the center of the world. However, the minimum z-coordinate has
-					to be less than or equal to 0 and the maximum z-coordinate has to
-					be greater than or equal to 0.
-				</p>
-				<p>
-					Note: You can set the size of the world only by editing the view --
-					these are reporters which cannot be set.
-				</p>
-				<p>
-					See also <a href="dictionary.html#max-pcor">max-pxcor</a>, <a href="dictionary.html#max-pcor">max-pycor</a>, <a href="dictionary.html#min-pcor">min-pxcor</a>,
-					<a href="dictionary.html#min-pcor">min-pycor</a>, and <a href="#world-depth">world-depth</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="neighbors-3d">
-				<h3>
-					<a>neighbors<span class="since">4.1</span></a>
-					<a>neighbors6<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">neighbors</span>
-					<span class="prim_example">neighbors6</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					3D versions of <a href="dictionary.html#neighbors">neighbors</a>
-					and <a href="dictionary.html#neighbors">neighbors4</a>.
-				</p>
-				<p>
-					Reports an agentset containing the 26 surrounding patches
-					(neighbors) or 6 surrounding patches (neighbors6).
-				</p>
-				<pre>
-					show sum values-from neighbors [count turtles-here]
-					;; prints the total number of turtles on the twenty-six
-					;; patches around this turtle or patch
-					ask neighbors6 [ set pcolor red ]
-					;; turns the six neighboring patches red
-				</pre>
-			</div>
-			<div class="dict_entry" id="orbit-cmds">
-				<h3>
-					<a>orbit-down<span class="since">4.1</span></a>
-					<a>orbit-left<span class="since">4.1</span></a>
-					<a>orbit-right<span class="since">4.1</span></a>
-					<a>orbit-up<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">orbit-down <i>number</i></span>
-					<span class="prim_example">orbit-left <i>number</i></span>
-					<span class="prim_example">orbit-right <i>number</i></span>
-					<span class="prim_example">orbit-up <i>number</i></span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Rotate the observer around the last point faced. Imagine the
-					observer is on the surface of a sphere, the last point face is the
-					center of that sphere. Up and down orbit along the lines of
-					longitude and right and left orbit along the lines of latitude. The
-					observer will remain facing the last point faced so the heading and
-					pitch may change as result of orbiting. However, because we assume
-					an absolute north pole (parallel to the positive z-axis) the roll
-					will never change.
-				</p>
-				<p>
-					See also <a href="#setxyz">setxyz</a>, <a href="#face-3d">face</a> and
-					<a href="#zoom">zoom</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="observer-cors">
-				<h3>
-					<a>__oxcor</a>
-					<a>__oycor</a>
-					<a>__ozcor</a>
-				</h3>
-				<h4>
-					<span class="prim_example">__oxcor</span>
-					<span class="prim_example">__oycor</span>
-					<span class="prim_example">__ozcor</span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Reports the x-, y-, or z-coordinate of the observer.
-				</p>
-				<p>
-					See also <a href="#setxyz">setxyz</a>
-				</p>
-				<h3>
-					<a id="patch">patch<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">patch <i>pxcor</i> <i>pycor</i> <i>pzcor</i></span>
-				</h4>
-				<p>
-					3D version of <a href="dictionary.html#patch">patch</a>.
-				</p>
-				<p>
-					Given three integers, reports the single patch with the given
-					pxcor, pycor and pzcor. <i>pxcor</i>, <i>pycor</i> and <i>pzcor</i>
-					must be integers.
-				</p>
-				<pre>
-					ask (patch 3 -4 2) [ set pcolor green ]
-					;; patch with pxcor of 3 and pycor of -4 and pzcor of 2 turns green
-				</pre>
-				<p>
-					See also <a href="dictionary.html#patch">patch</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="patch-at-3d">
-				<h3>
-					<a>patch-at<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">patch-at <i>dx</i> <i>dy</i> <i>dz</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					3D version of <a href="dictionary.html#patch-at">patch-at</a>.
-				</p>
-				<p>
-					Reports the single patch at (dx, dy, dz) from the caller, that is,
-					dx patches east, dy patches north and dz patches up from the
-					caller.
-				</p>
-				<pre>
-					ask patch-at 1 -1 1 [ set pcolor green ]
-					;; turns the patch just southeast and up from the caller green
-				</pre>
-			</div>
-			<div class="dict_entry" id="patch-at-heading-pitch-and-distance">
-				<h3>
-					<a>patch-at-heading-pitch-and-distance<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">patch-at-heading-pitch-and-distance <i>heading</i> <i>pitch</i> <i>distance</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					3D version of <a href="dictionary.html#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
-				</p>
-				<p>
-					patch-at-heading-pitch-and-distance reports the single patch that
-					is the given distance from this turtle or patch, along the given
-					absolute heading and pitch. (In contrast to patch-left-and-ahead
-					and patch-right-and-ahead, this turtle's current heading is not
-					taken into account.)
-				</p>
-				<pre>
-					ask patch-at-heading-pitch-and-distance 0 90 1 [ set pcolor green ]
-					;; turns the patch directly above the caller green.
-				</pre>
-			</div>
-			<div class="dict_entry" id="pitch">
-				<h3>
-					<a>pitch</a>
-				</h3>
-				<h4>
-					<span class="prim_example">pitch</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					This is a built-in turtle variable. Pitch is the angle between the
-					&quot;nose&quot; of the turtle and the xy-plane. Heading and pitch
-					together define the forward vector of the turtle or the direction
-					that the turtle is facing.
-				</p>
-				<p>
-					This is a number greater than or equal to 0 and less than 360. 0 is
-					parallel to the xy-plane, 90 is parallel to the z-axis. While you
-					can set pitch we recommend that you use the primitives to turn the
-					turtle. Depending on the position more than one relative angle
-					(heading, pitch and roll) may change at once.
-				</p>
-				<p>
-					Example:
-				</p>
-				<pre>
-					;; assume roll and heading are 0
-					set pitch 45      ;; turtle is now north and up
-					set heading heading + 10 ;; same effect as &quot;tilt-up 10&quot;
-				</pre>
-				<p>
-					See also <a href="dictionary.html#heading">heading</a>, <a href="#roll">roll</a>, <a href="#tilt-cmds">tilt-up</a>, <a href="#tilt-cmds">tilt-down</a>, <a href="#right">right</a>, <a href="#left">left</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="pzcor">
-				<h3>
-					<a>pzcor</a>
-				</h3>
-				<h4>
-					<span class="prim_example">pzcor</span>
-					<img alt="Patch Command" src="images/patch.gif"/> <img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					This is a built-in patch variable. It holds the z coordinate of the
-					patch. It is always an integer. You cannot set this variable,
-					because patches don't move.
-				</p>
-				<p>
-					pzcor is greater than or equal to min-pzcor and less than or equal
-					to max-pzcor.
-				</p>
-				<p>
-					All patch variables can be directly accessed by any turtle standing
-					on the patch.
-				</p>
-				<p>
-					See also <a href="dictionary.html#pcor">pxcor, pycor</a>, <a href="#zcor">zcor</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="random-pzcor">
-				<h3>
-					<a>random-pzcor<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">random-pzcor</span>
-				</h4>
-				<p>
-					Reports a random integer ranging from min-pzcor to max-pzcor
-					inclusive.
-				</p>
-				<pre>
-					ask turtles [
-					;; move each turtle to the center of a random patch
-					setxyz random-pxcor random-pycor random-pzcor
-					]
-				</pre>
-				<p>
-					See also <a href="dictionary.html#random-pcor">random-pxcor</a>, <a href="dictionary.html#random-pcor">random-pycor</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="random-zcor">
-				<h3>
-					<a>random-zcor<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">random-zcor</span>
-				</h4>
-				<p>
-					Reports a random floating point number from the allowable range of
-					turtle coordinates along the z axis.
-				</p>
-				<p>
-					Turtle coordinates range from min-pzcor - 0.5 (inclusive) to
-					max-pzcor + 0.5 (exclusive).
-				</p>
-				<pre>
-					ask turtles [
-					;; move each turtle to a random point
-					setxyz random-xcor random-ycor random-zcor
-					]
-				</pre>
-				<p>
-					See also <a href="dictionary.html#random-cor">random-xcor</a>,
-					<a href="dictionary.html#random-cor">random-ycor</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="right">
-				<h3>
-					<a>right<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">right <i>number</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					The turtle turns right by <i>number</i> degrees, relative to its
-					current orientation. While right in a 2D world only modifies the
-					turtle's heading, right in a 3D world may also modify the
-					turtle's pitch and roll.
-				</p>
-				<p>
-					See also <a href="dictionary.html#right">right</a> and <a href="#left">left</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="roll">
-				<h3>
-					<a>roll</a>
-				</h3>
-				<h4>
-					<span class="prim_example">roll</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					This is a built-in turtle variable. Roll is the angle between the
-					&quot;wing-tip&quot; of the turtle and the xy-plane.
-				</p>
-				<p>
-					This is a number greater than or equal to 0 and less than 360. You
-					can set this variable to make a turtle roll. Since roll is always
-					from the turtle's point of view, rolling right and left only
-					only change roll regardless of turtle orientation.
-				</p>
-				<p>
-					Example:
-				</p>
-				<pre>
-					set roll 45      ;; turtle rotated right
-					set roll roll + 10 ;; same effect as &quot;roll-right 10&quot;
-				</pre>
-				<p>
-					See also <a href="dictionary.html#heading">heading</a>, <a href="#pitch">pitch</a>, <a href="#roll-left">roll-left</a>, <a href="#roll-right">roll-right</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="roll-left">
-				<h3>
-					<a>roll-left<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">roll-left <i>number</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					The wingtip of the turtle rotates to the left <i>number</i> degrees
-					with respect to the current heading and pitch.
-				</p>
-			</div>
-			<div class="dict_entry" id="roll-right">
-				<h3>
-					<a>roll-right<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">roll-right <i>number</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					The wingtip of the turtle rotates to the right <i>number</i>
-					degrees with respect to the current heading and pitch.
-				</p>
-			</div>
-			<div class="dict_entry" id="setxyz">
-				<h3>
-					<a>setxyz<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">setxyz <i>x y z</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					3D version of <a href="dictionary.html#setxy">setxy</a>.
-				</p>
-				<p>
-					The agent, a turtle or the observer, sets its x-coordinate to
-					<i>x</i>, its y-coordinate to <i>y</i> and its z-coordinate to
-					<i>z</i>. When the observer uses <code>setxyz</code> it remains facing
-					the same point so the heading, pitch, and roll, may also change.
-				</p>
-				<p>
-					For turtles equivalent to <code>set xcor x set ycor y set zcor
-						z</code>, except it happens in one time step instead of three.
-				</p>
-				<pre>
-					setxyz 0 0 0
-					;; agent moves to the middle of the center patch
-				</pre>See also <a href="#face-3d">face</a>
-			</div>
-			<div class="dict_entry" id="tilt-cmds">
-				<h3>
-					<a>tilt-down<span class="since">4.1</span></a>
-					<a>tilt-up<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">tilt-down <i>number</i></span>
-					<span class="prim_example">tilt-up <i>number</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					The nose of the turtle rotates by <i>number</i> degrees, relative
-					to its current orientation. Depending on the orientation of the
-					turtle more than one of the relative angles (heading, pitch, and
-					roll) may change when a turtle turns.
-				</p>
-			</div>
-			<div class="dict_entry" id="towards-pitch-cmd">
-				<h3>
-					<a>towards-pitch<span class="since">4.1</span></a>
-					<a>towards-pitch-nowrap<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">towards-pitch <i>agent</i></span>
-					<span class="prim_example">towards-pitch-nowrap <i>agent</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					Reports the pitch from this agent to the given agent.
-				</p>
-				<p>
-					If the wrapped distance (around the edges of the screen) is shorter
-					than the on-screen distance, towards-pitch will report the pitch of
-					the wrapped path. towards-pitch-nowrap never uses the wrapped path.
-				</p>
-				<p>
-					Note: In order to get one turtle to face another you need to use
-					both towards-pitch and towards.
-				</p>
-				<p>
-					Note: asking for the pitch from an agent to itself, or an agent on
-					the same location, will cause a runtime error.
-				</p>
-				<p>
-					See also <a href="dictionary.html#towards">towards</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="towards-pitch-xyz-cmd">
-				<h3>
-					<a>towards-pitch-xyz<span class="since">4.1</span></a>
-					<a>towards-pitch-xyz-nowrap<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">towards-pitch-xyz <i>x</i> <i>y</i> <i>z</i></span>
-					<span class="prim_example">towards-pitch-xyz-no-wrap <i>x</i> <i>y</i> <i>z</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					Reports the pitch from this agent to the coordinates x, y, z
-				</p>
-				<p>
-					If the wrapped distance (around the edges of the screen) is shorter
-					than the on-screen distance, towards-pitch will report the pitch of
-					the wrapped path. towards-pitch-nowrap never uses the wrapped path.
-				</p>
-				<p>
-					Note: In order to get a turtle to face a given location you need to
-					use both towards-pitch-xyz and towardsxy.
-				</p>
-				<p>
-					Note: asking for the pitch from an agent to the location it is
-					standing on will cause a runtime error.
-				</p>
-				<p>
-					See also <a href="dictionary.html#towardsxy">towardsxy</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="turtles-at-3d">
-				<h3>
-					<a>turtles-at<span class="since">4.1</span></a>
-					<a>&lt;breeds&gt;-at</a>
-				</h3>
-				<h4>
-					<span class="prim_example">turtles-at <i>dx</i> <i>dy</i> <i>dz</i></span>
-					<span class="prim_example"><i>&lt;breeds&gt;-at</i> <i>dx</i> <i>dy</i> <i>dz</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					3D versions of <a href="dictionary.html#turtles-at">turtles-at</a>
-					and <a href="dictionary.html#turtles-at">breeds-at</a>.
-				</p>
-				<p>
-					Reports an agentset containing the turtles on the patch (dx, dy,
-					dz) from the caller (including the caller itself if it's a
-					turtle).
-				</p>
-				<pre>
-					;; suppose I have 40 turtles at the origin
-					show [count turtles-at 0 0 0] of turtle 0
-					=&gt; 40
-				</pre>
-			</div>
-			<div class="dict_entry" id="world-depth">
-				<h3>
-					<a>world-depth<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">world-depth</span>
-				</h4>
-				<p>
-					Reports the total depth of the NetLogo world.
-				</p>
-				<p>
-					The depth of the world is the same as max-pzcor - min-pzcor + 1.
-				</p>
-				<p>
-					See also <a href="#min-max-pzcor">max-pzcor</a>, <a href="#min-max-pzcor">min-pzcor</a>, <a href="dictionary.html#world-dim">world-width</a>, and <a href="dictionary.html#world-dim">world-height</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="zcor">
-				<h3>
-					<a>zcor</a>
-				</h3>
-				<h4>
-					<span class="prim_example">zcor</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					This is a built-in turtle variable. It holds the current z
-					coordinate of the turtle. This is a floating point number, not an
-					integer. You can set this variable to change the turtle's
-					location.
-				</p>
-				<p>
-					This variable is always greater than or equal to (- screen-edge-z)
-					and strictly less than screen-edge-z.
-				</p>
-				<p>
-					See also <a href="#setxyz">setxy</a>, <a href="dictionary.html#xcor">xcor</a>, <a href="dictionary.html#ycor">ycor</a>, <a href="dictionary.html#pcor">pxcor</a>, <a href="dictionary.html#pcor">pycor</a>, <a href="#pzcor">pzcor</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="zoom">
-				<h3>
-					<a>zoom<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">zoom <i>number</i></span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Move the observer toward the point it is facing, <i>number</i>
-					steps. The observer will never move beyond the point it is facing
-					so if <i>number</i> is greater than the distance to that point it
-					will only move as far as the point it is facing.
-				</p>
-			</div>
-		</div>
-	</body>
+  <head>
+    <title>
+      NetLogo {{version}} User Manual: 3D
+    </title>
+    <link rel="stylesheet" href="netlogo.css" type="text/css"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <style>
+      p { margin-left: 1.5em ; }
+      p.bookquote { font-size: 85%; margin-left: 4em; margin-right: 4em; color: #333 ; }
+      p.c1 {font-style: italic}
+    </style>
+  </head>
+  <body>
+    <h1>
+      NetLogo 3D
+    </h1>
+    <p>
+      NetLogo includes the NetLogo 3D application that allows you to create 3D worlds.
+    </p>
+    <p>
+      <b>Notice:</b> NetLogo's support for 3D is less developed than
+      NetLogo 2D. Models created with this release may not be compatible
+      with future versions. While we've made efforts to ensure a quality
+      product, NetLogo 3D has not been subject to the same level of quality
+      control as the main application.
+    </p>
+    <ul>
+      <li>
+        <a href="#introduction">Introduction</a>
+      </li>
+      <li>
+        <a href="#tutorial">Tutorial</a>
+      </li>
+      <li>
+        <a href="#dictionary">Dictionary</a>
+      </li>
+    </ul>
+    <div id="introduction">
+      <h2>
+        <a>Introduction</a>
+      </h2>
+      <p>
+        To get started using NetLogo 3D, launch the NetLogo 3D application
+        and check out the Sample Models in the 3D section of the Models
+        Library.
+      </p>
+      <p>
+        When you're ready to write your own 3D model, look at the Code
+        Examples in the 3D section of the Models Library.
+      </p>
+      <div class="blockquote">
+        <p>
+          <b>Code Example:</b> Turtle Perspective Example 3D helps you learn
+          about the different perspectives.
+        </p>
+        <p>
+          <b>Code Example:</b> Turtle and Observer Motion Example 3D helps
+          you understand how turtles and the observer move in 3D. You can
+          also step through this model with the tutorial below.
+        </p>
+      </div>
+      <h4>
+        <span class="prim_example">3D Worlds</span>
+      </h4>
+      <p class="bookquote">
+        <i>An unspeakable horror seized me. There was a darkness; then a
+          dizzy, sickening sensation of sight that was not like seeing; I saw a
+          Line that was no Line; Space that was not Space: I was myself, and
+          not myself. When I could find voice, I shrieked loud in agony,
+          &quot;Either this is madness or it is Hell.&quot;</i>
+      </p>
+      <p class="bookquote">
+        <i>&quot;It is neither,&quot; calmly replied the voice of the Sphere,
+          &quot;it is Knowledge; it is Three Dimensions: open your eye once
+          again and try to look steadily.&quot;</i>
+        <br/>
+        -- Edwin A. Abbott, <i>Flatland: A romance in many dimensions</i>
+      </p>
+      <p>
+        NetLogo 3D's world has width, height and depth. Patches are
+        cubes. In addition to <code><a href="dictionary.html#pcor">pxcor</a></code> and <code><a href="dictionary.html#pcor">pycor</a></code>, patches have <code><a href="#pzcor">pzcor</a></code>.
+      </p>
+      <p>
+        Turtles have three Cartesian coordinates, instead of two, to describe
+        position. In addition to <code><a href="dictionary.html#xcor">xcor</a></code> and <code><a href="dictionary.html#ycor">ycor</a></code>, turtles have <code><a href="#zcor">zcor</a></code>.
+      </p>
+      <p>
+        A turtle's orientation is defined by three turtle variables,
+        <code><a href="dictionary.html#heading">heading</a></code>, <code><a href="#pitch">pitch</a></code> and <code><a href="#roll">roll</a></code>. You
+        can imagine the turtle as having two vectors to define its
+        orientation in 3D space. One vector comes straight out of the nose of
+        the turtle, this is the direction the turtle will travel when it
+        moves forward. The second vector is perpendicular to the forward
+        vector and comes out of the right side of the turtle (as if the
+        turtle were to stick its right arm straight out from its body).
+        Heading is the angle between the forward vector of the turtle
+        projected onto the xy-plane and the vector [0 1 0]. Pitch is the
+        angle between the forward vector of the turtle and the xy-plane and
+        finally roll is the angle between the right vector of the turtle and
+        the xy-plane. When turtle turns right or left in 3D space it rotates
+        around the down vector, that is the vector that is perpendicular to
+        both the forward and right vectors. Depending on the orientation of
+        the turtle more than one of the internal turtle variables may change
+        as the result of a turn.
+      </p>
+      <h4>
+        <span class="prim_example">The observer and the 3D view</span>
+      </h4>
+      <p>
+        The point of view that you see the world from is considered the
+        location and orientation of the observer. This is similar to the 3D
+        view in NetLogo 2D. However, there are a few more ways to control the
+        observer. You can set the point that the observer is facing by using
+        <code>face</code> and <code>facexyz</code> which work the same way as the
+        turtle commands, the observer turns so the center of the view is on
+        the given point or the location of the given agent at the time it is
+        called. You can change the location of the observer using
+        <code>setxyz</code>. The observer will move to view the world as if
+        standing on the given location, the point the observer faces will
+        stay the same. For example create a new model and observer will be
+        located at (0, 0, 49.5), that is, on the z-axis 49.5 patch units away
+        from the origin and the observer is facing the origin, (0, 0, 0). If
+        you <code>setxyz 0 49.5 0</code> the observer will move so it is on the
+        positive y-axis but it will keep the origin at the center of the
+        view. You can also move the observer using the rotation primitives
+        that will allow you to move the observer around the world as if on
+        the surface of a sphere where the center is the location the observer
+        is facing. You may notice from the above examples that the observer
+        is not constrained to be within the bounds of the world.
+      </p>
+      <h4>
+        <span class="prim_example"><a id="custom-shapes">Custom Shapes</a></span>
+      </h4>
+      <p>
+        NetLogo automatically interprets 2D shapes so they are extruded, like
+        a cookie cutter shape in the 3D view. You can also use the primitive
+        <a href="#load-shapes-3d"><code>load-shapes-3d</code></a> to load shapes
+        described in an external file in a custom format described here.
+        Currently we do not import shapes in any standard formats.
+      </p>
+      <p>
+        For each shape in a custom 3D shape file, a 2D shape of the same name
+        must exist as well. You can create the 2D shape in the Turtle Shapes
+        Editor.
+      </p>
+      <p>
+        The input file may contain any number of shapes with any number of
+        rectangular or triangular surfaces. The format of the input file
+        should be as follows:
+      </p>
+      <pre>
+        number of shapes in file
+        name of first shape
+        type of surface ( quads or tris )
+        surface1
+        surface2
+        .
+        .
+        .
+        stop
+        type of surface
+        surfaceA
+        .
+        .
+        .
+        stop
+        end-shape
+      </pre>
+      <p>
+        Each surface is defined by a unit normal vector and the vertices
+        listed in clockwise order, tris should have three vertices and quads
+        should have four.
+      </p>
+      <pre>
+        normal: xn yn zn
+        x1 y1 z1
+        x2 y2 z2
+        x3 y3 z3
+        x4 y4 z4
+      </pre>
+      <p>
+        A file declaring just a two dimensional, patch-sized, square in the
+        xy-plane centered at the origin would look like this:
+      </p>
+      <pre>
+        1
+        square
+        quads
+        normal: 0 0 1
+        0.15 0.15 0
+        -0.15 0.15 0
+        -0.15 -0.15 0
+        0.15 -0.15 0
+        normal: 0 0 -1
+        0.15 0.15 0
+        0.15 -0.15 0
+        -0.15 -0.15 0
+        -0.15 0.15 0
+        stop
+        end-shape
+      </pre>
+    </div>
+    <div id="tutorial">
+      <h2>
+        <a>Tutorial</a>
+      </h2>
+      <h4>
+        <span class="prim_example">Step 1: Depth</span>
+      </h4>
+      <p>
+        One of the first things you will notice when you open NetLogo 3D is
+        that the world is a cube instead of a square.
+      </p>
+      <p class="screenshot">
+        <img alt="screen shot" src="images/3d/cube.gif"/>
+      </p>
+      <p>
+        You can open up the Model Settings, by clicking on the
+        &quot;Settings...&quot; button at the top of the 3D View. You'll
+        notice in addition to <code>max-pxcor</code>, <code>min-pxcor</code>,
+        <code>max-pycor</code>, and <code>min-pycor</code>, there is also <a href="#min-max-pzcor"><code>max-pzcor</code></a> and <a href="#min-max-pzcor"><code>min-pzcor</code></a>.
+      </p>
+      <p class="screenshot">
+        <img alt="screen shot" src="images/3d/properties.gif"/>
+      </p>
+      <p>
+        The z-axis is perpendicular to both the x-axis and the y-axis, when
+        you <code>reset-perspective</code> it is the axis that comes straight out
+        of the screen. In the default position <code>max-pzcor</code> is the face
+        of the cube nearest to you and <code>min-pzcor</code> is the face
+        farthest from you. As always <code>min-pxcor</code> is on the left,
+        <code>max-pxcor</code> on the right, <code>min-pycor</code> on the bottom,
+        and <code>max-pycor</code> on the top.
+      </p>
+      <p>
+        You'll also notice on the left side of the Model Settings that
+        there are options for wrapping in all three directions, however, they
+        are all checked and grayed out. Topologies are not yet supported in
+        NetLogo 3D, so the world always wraps in all dimensions.
+      </p>
+      <div class="blockquote">
+        <ul>
+          <li>Move to the Command Center and type <code>print count
+              patches</code>.</li>
+        </ul>
+        <p class="question">
+          Is the number smaller or larger than you expected?
+        </p>
+      </div>
+      <p>
+        In a 3D world the number of patches grows very quickly since
+        <code>count patches = world-width * world-height * world-depth</code>.
+        It's important to keep this in mind when you are building your
+        model. Lots of patches can slow your model down or even cause NetLogo
+        to run out of memory.
+      </p>
+      <div class="blockquote">
+        <ul>
+          <li>Type <code>ask patch 1 2 3 [ set pcolor red ]</code> into the
+            Command Center.</li>
+          <li>Use the mouse in the 3D view to rotate the world.</li>
+        </ul>
+      </div>
+      <p>
+        Notice the shape of the patch and its position in relation to the
+        edges of the world. You'll also notice that you now need three
+        coordinates to address patches in a 3D world.
+      </p>
+      <h4>
+        <span class="prim_example">Step 2: Turtle Movement</span>
+      </h4>
+      <div class="blockquote">
+        <ul>
+          <li>Open the Models Library in the File menu. (If you are on a Mac
+            and you don't have a File menu, click on the main NetLogo
+            window first and it should reappear.)
+          </li>
+          <li>Open Turtle and Observer Motion Example 3D in 3D/Code Examples
+          </li>
+        </ul>
+      </div>
+      <p>
+        Take a moment to look for the controls and monitors. In the bottom
+        left you'll notice a group of monitors that describe the location
+        and orientation of the turtle, though until you press the setup
+        button they'll all say &quot;N/A&quot;.
+      </p>
+      <div class="blockquote">
+        <ul>
+          <li>Press the &quot;setup&quot; button</li>
+        </ul>
+      </div>
+      <p>
+        Heading, pitch, and roll are turtle variables that represent the
+        orientation of the turtle. Heading is absolute in relation to the x/y
+        plane; it is the rotation of the turtle around the z-axis.
+      </p>
+      <p class="screenshot">
+        <img alt="screen shot" src="images/3d/heading.gif"/>
+      </p>
+      <p>
+        Pitch is the angle between the nose of the turtle and the xy-plane.
+        It is relative to heading.
+      </p>
+      <p class="screenshot">
+        <img alt="screen shot" src="images/3d/pitch.gif"/>
+      </p>
+      <p>
+        Roll is the rotation around the turtle's forward vector. It is
+        relative to heading and pitch.
+      </p>
+      <p class="screenshot">
+        <img alt="screen shot" src="images/3d/roll.gif"/>
+      </p>
+      <p>
+        When turtles are created with <code>create-turtles</code> or
+        <code>create-ordered-turtles</code>, their initial headings vary but
+        their initial pitch and roll are always zero.
+      </p>
+      <p>
+        Take a look at the &quot;Turtle Movement&quot; buttons.
+      </p>
+      <div class="blockquote">
+        <ul>
+          <li>Press the &quot;left 1&quot; button.</li>
+        </ul>
+        <p class="question">
+          How does the turtle move? Is is the same or different from 2D
+          NetLogo? Which of the turtle variables change?
+        </p>
+        <ul>
+          <li>Press the &quot;pitch-down 1&quot; button.</li>
+        </ul>
+        <p class="question">
+          How does the turtle move? Which of the turtle variables change?
+        </p>
+        <ul>
+          <li>Press the &quot;left 1&quot; button again.</li>
+        </ul>
+        <p class="question">
+          How does the turtle move? Is it different than the last time you
+          pressed the &quot;left 1&quot; button?
+        </p>
+        <ul>
+          <li>Take a little time to play with the Turtle Movement buttons,
+            watching both how the turtle moves and which of the turtle
+            variables change.</li>
+        </ul>
+      </div>
+      <p>
+        You probably noticed that often more than one of the turtle variables
+        may change for a single turn. For this reason we suggest that you use
+        the turtle commands rather than setting the orientation variables
+        directly.
+      </p>
+      <h4>
+        <span class="prim_example">Step 3: Observer Movement</span>
+      </h4>
+      <p>
+        At the bottom of the interface you will see Orbit, Zoom, and Move
+        buttons. If you have ever used the 3D view in NetLogo 2D or if you
+        have been using the mouse controls in the 3D view through this
+        tutorial you have been moving the observer. Changing the point of
+        view in the 3D view is actually moving and changing the orientation
+        of the observer. The observer has x, y and z coordinates, just like a
+        turtle or patch, while turtles and patches are constrained to be
+        inside the world the observer can be anywhere. Like a turtle the
+        observer has a heading, pitch and roll, these variables control where
+        the observer is looking, that is, what you see in the view.
+      </p>
+      <div class="blockquote">
+        <ul>
+          <li>Move to the 3D view, and make sure &quot;Orbit&quot; is
+            selected in the bottom left corner of the view.</li>
+          <li>Click and hold the mouse button in the middle of the view, move
+            the mouse left, right, up, and down.</li>
+        </ul>
+        <p class="question">
+          How does the position and orientation of the observer change?
+        </p>
+        <ul>
+          <li>Press the reset-perspective button in the lower right corner of
+            the view and select &quot;Zoom&quot; in the lower left corner.</li>
+          <li>Click and hold the mouse button in the middle of the view and
+            move the mouse up and down.</li>
+        </ul>
+        <p class="question">
+          Which of the observer variables change? Which stay the same?
+        </p>
+        <ul>
+          <li>Try rotating the world a bit and then zoom again.</li>
+          <li>Press the &quot;Move&quot; button in the lower left corner of
+            the view.</li>
+          <li>Click and hold the mouse button in the middle of the view and
+            move the mouse up, down, left and right.</li>
+        </ul>
+        <p class="question">
+          How does the view change? How do the observer variables change?
+        </p>
+      </div>
+      <p>
+        After you are done exploring the world using the mouse controls you
+        can take a look at the observer control buttons in the lower left
+        portion of the interface.
+      </p>
+      <p>
+        You may already be familiar with the first three buttons in the
+        observer group from your experience with NetLogo 2D. Watch, follow,
+        and ride, are special modes that automatically update the position
+        and orientation of the observer. When in follow or ride mode, the
+        observer position and orientation are the same as the turtle's.
+        Note that follow and ride are functionally exactly the same, the
+        difference is only visual in the 3D view. When in watch mode the
+        observer does not move but updates to face the target agent.
+      </p>
+      <div class="blockquote">
+        <ul>
+          <li>Press the &quot;setup&quot; button again so you are back to the
+            default orientation.</li>
+          <li>Press the &quot;orbit-right&quot; button.</li>
+        </ul>
+        <p class="question">
+          How did the view change? Was it what you expected? How is it
+          similar or different from using the mouse controls?
+        </p>
+        <ul>
+          <li>Take a little time to experiment with orbit, roll and zoom
+            buttons; notice similarities and differences to the mouse controls.</li>
+        </ul>
+      </div>
+      <p>
+        The direction of the orbit commands refer to the direction that the
+        observer moves. That is, imagine that the observer is on the surface
+        of a sphere, the center of the sphere is the point that the observer
+        is facing represented by the blue cross, by default (0,0,0). The
+        observer will always face the center of the sphere and the radius of
+        the sphere will remain constant. The directions, up, down, left, and
+        right, refer to moving along the lines of latitude and the lines of
+        longitude of the sphere. When you zoom the radius of the sphere
+        changes but the center and the observer's orientation in relation
+        to the center of the sphere will remain the same.
+      </p>
+      <div class="blockquote">
+        <ul>
+          <li>Press one of the &quot;setxyz&quot; buttons.</li>
+        </ul>
+        <p class="question">
+          How does the view change? How do the observer variables change?
+        </p>
+        <ul>
+          <li>Press the &quot;facexyz&quot; button.</li>
+        </ul>
+        <p class="question">
+          How does the view change? How do the observer variables change?
+        </p>
+      </div>
+      <p>
+        When you <code>setxyz</code> the center of the sphere remains the same
+        (so the observer automatically keeps that point in the center of the
+        view.) However, the radius of the sphere may change as well as the
+        observer's orientation in relation to the center. When you
+        <code>facexyz</code> or <code>face</code>, the center of the sphere changes
+        but the observer does not move. The radius of the sphere may change,
+        as well as the orientation of the observer.
+      </p>
+    </div>
+    <div id="dictionary">
+      <h2>
+        <a>Dictionary</a>
+      </h2>
+      <h3>
+        Commands and Reporters
+      </h3>
+      <h4>
+        <span class="prim_example">Turtle-related primitives</span>
+      </h4>
+      <a href="#distance-3d">distancexyz</a>
+      <a href="#distance-3d">distancexyz-nowrap</a>
+      <a href="#dz">dz</a>
+      <a href="#left">left</a>
+      <a href="#patch-at-3d">patch-at</a>
+      <a href="#patch-at-heading-pitch-and-distance">patch-at-heading-pitch-and-distance</a>
+      <a href="#tilt-cmds">tilt-down</a>
+      <a href="#tilt-cmds">tilt-up</a>
+      <a href="#right">right</a>
+      <a href="#roll-left">roll-left</a>
+      <a href="#roll-right">roll-right</a>
+      <a href="#setxyz">setxyz</a>
+      <a href="#towards-pitch-cmd">towards-pitch</a>
+      <a href="#towards-pitch-cmd">towards-pitch-nowrap</a>
+      <a href="#towards-pitch-xyz-cmd">towards-pitch-xyz</a>
+      <a href="#towards-pitch-xyz-cmd">towards-pitch-xyz-nowrap</a>
+      <a href="#turtles-at-3d">turtles-at</a>
+      <h4>
+        <span class="prim_example">Patch-related primitives</span>
+      </h4>
+      <a href="#distance-3d">distancexyz</a>
+      <a href="#distance-3d">distancexyz-nowrap</a>
+      <a href="#neighbors-3d">neighbors</a>
+      <a href="#neighbors-3d">neighbors6</a>
+      <a href="#patch">patch</a>
+      <a href="#patch-at-3d">patch-at</a>
+      <a href="#patch-at-heading-pitch-and-distance">patch-at-heading-pitch-and-distance</a>
+      <h4>
+        <span class="prim_example">Agentset primitives</span>
+      </h4>
+      <a href="#at-points-3d">at-points</a>
+      <a href="#turtles-at-3d">breeds-at</a>
+      <a href="#turtles-at-3d">turtles-at</a>
+      <h4>
+        <span class="prim_example">World primitives</span>
+      </h4>
+      <a href="#min-max-pzcor">max-pzcor</a>
+      <a href="#min-max-pzcor">min-pzcor</a>
+      <a href="#random-pzcor">random-pzcor</a>
+      <a href="#random-zcor">random-zcor</a>
+      <a href="#world-depth">world-depth</a>
+      <a href="#load-shapes-3d">load-shapes-3d</a>
+      <h4>
+        <span class="prim_example">Observer primitives</span>
+      </h4>
+      <a href="#face-3d">face</a>
+      <a href="#face-3d">facexyz</a>
+      <a href="#orbit-cmds">orbit-down</a>
+      <a href="#orbit-cmds">orbit-left</a>
+      <a href="#orbit-cmds">orbit-right</a>
+      <a href="#orbit-cmds">orbit-up</a>
+      <a href="#observer-cors">__oxcor</a>
+      <a href="#observer-cors">__oycor</a>
+      <a href="#observer-cors">__ozcor</a>
+      <a href="#setxyz">setxyz</a>
+      <a href="#zoom">zoom</a>
+      <h4>
+        <span class="prim_example">Link primitives</span>
+      </h4><a href="#link-pitch">link-pitch</a>
+      <h3>
+        Built-In Variables
+      </h3>
+      <h4>
+        <span class="prim_example">Turtles</span>
+      </h4>
+      <a href="#zcor">zcor</a>
+      <a href="#pitch">pitch</a>
+      <a href="#roll">roll</a>
+      <h4>
+        <span class="prim_example">Patches</span>
+      </h4>
+      <a href="#pzcor">pzcor</a>
+      <h3>
+        Primitives
+      </h3>
+      <div class="dict_entry" id="at-points-3d">
+        <h3>
+          <a>at-points<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example"><i>agentset</i> at-points [[<i>x1 y1 z1</i>] [<i>x2 y2 z2</i>] ...]</span>
+        </h4>
+        <p>
+          Reports a subset of the given agentset that includes only the
+          agents on the patches the given distances away from this agent. The
+          distances are specified as a list of three-item lists, where the
+          three items are the x, y, and z offsets.
+        </p>
+        <p>
+          If the caller is the observer, then the points are measured
+          relative to the origin, in other words, the points are taken as
+          absolute patch coordinates.
+        </p>
+        <p>
+          If the caller is a turtle, the points are measured relative to the
+          turtle's exact location, and not from the center of the patch
+          under the turtle.
+        </p>
+        <pre>
+          ask turtles at-points [[2 4 0] [1 2 1] [10 15 10]]
+          [ fd 1 ]  ;; only the turtles on the patches at the
+          ;; distances (2,4,0), (1,2,1) and (10,15,10),
+          ;; relative to the caller, move
+        </pre>
+      </div>
+      <div class="dict_entry" id="distance-3d">
+        <h3>
+          <a>distancexyz<span class="since">4.1</span></a>
+          <a>distancexyz-nowrap<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">distancexyz <i>xcor</i> <i>ycor</i> <i>zcor</i></span>
+          <span class="prim_example">distancexyz-nowrap <i>xcor</i> <i>ycor</i> <i>zcor</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          3D versions of <a href="dictionary.html#distancexy">distancexy</a>.
+        </p>
+        <p>
+          Reports the distance from this agent to the point (<i>xcor</i>,
+          <i>ycor</i>, <i>zcor</i>).
+        </p>
+        <p>
+          The distance from a patch is measured from the center of the patch.
+        </p>
+        <p>
+          distancexyz-nowrap always reports the in world distance, never a
+          distance that would require wrapping around the edges of the world.
+          With distancexyz the wrapped distance (around the edges of the
+          world) is used if that distance is shorter than the in world
+          distance.
+        </p>
+        <pre>
+          if (distancexyz 0 0 0) &lt; 10
+          [ set color green ]
+          ;; all turtles less than 10 units from
+          ;; the center of the screen turn green.
+        </pre>
+      </div>
+      <div class="dict_entry" id="dz">
+        <h3>
+          <a>dz<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">dz</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Reports the z-increment (the amount by which the turtle's zcor
+          would change) if the turtle were to take one step forward at its
+          current heading and pitch.
+        </p>
+        <p>
+          NOTE: dz is simply the sine of the turtle's pitch. Both dx and
+          dy have changed in this case. So, dx = cos(pitch) * sin(heading)
+          and dy = cos(pitch) * cos(heading).
+        </p>
+        <p>
+          See also <a href="dictionary.html#dxy">dx</a>, <a href="dictionary.html#dxy">dy</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="face-3d">
+        <h3>
+          <a>face</a>
+          <a>facexyz<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">face <i>agent</i></span>
+          <span class="prim_example">facexyz <i>x</i> <i>y</i> <i>z</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Set the caller's heading and pitch towards <i>agent</i> or
+          towards the point <i>(x,y,z)</i>.
+        </p>
+        <p>
+          If the caller and the target are at the same x and y coordinates
+          the caller's heading will not change. If the caller and the
+          target are also at the same z coordinate the pitch will not change
+          either.
+        </p>
+      </div>
+      <div class="dict_entry" id="left">
+        <h3>
+          <a>left<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">left <i>number</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          The turtle turns left by <i>number</i> degrees, relative to its
+          current orientation. While left in a 2D world only modifies the
+          turtle's heading, left in a 3D world may also modify the
+          turtle's pitch and roll.
+        </p>
+        <p>
+          See also <a href="dictionary.html#left">left</a>, <a href="#tilt-cmds">tilt-up</a>, <a href="#tilt-cmds">tilt-down</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="link-pitch">
+        <h3>
+          <a>link-pitch<span class="since">4.1.2</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">link-pitch</span>
+          <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          Reports the pitch from end1 to end2 of this link.
+        </p>
+        <pre>
+          ask link 0 1 [ print link-pitch ]
+          ;; prints [[towards-pitch other-end] of end1] of link 0 1
+        </pre>
+        <p>
+          See also <a href="dictionary.html#link-heading">link-heading</a>,
+          <a href="#pitch">pitch</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="load-shapes-3d">
+        <h3>
+          <a>load-shapes-3d<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">load-shapes-3d <i>filename</i></span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Loads custom 3D shapes from the given file. See the <a href="3d.html">3D guide</a> for more details. You must also add a 2D
+          shape of the same name to the model using the Turtle Shapes Editor.
+          Custom shapes override built-in 3D shapes and converted 2D shapes.
+        </p>
+      </div>
+      <div class="dict_entry" id="min-max-pzcor">
+        <h3>
+          <a>max-pzcor<span class="since">4.1</span></a>
+          <a>min-pzcor<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">max-pzcor</span>
+          <span class="prim_example">min-pzcor</span>
+        </h4>
+        <p>
+          These reporters give the maximum and minimum z-coordinates
+          (respectively) for patches, which determines the size of the world.
+        </p>
+        <p>
+          Unlike in older versions of NetLogo the origin does not have to be
+          at the center of the world. However, the minimum z-coordinate has
+          to be less than or equal to 0 and the maximum z-coordinate has to
+          be greater than or equal to 0.
+        </p>
+        <p>
+          Note: You can set the size of the world only by editing the view --
+          these are reporters which cannot be set.
+        </p>
+        <p>
+          See also <a href="dictionary.html#max-pcor">max-pxcor</a>, <a href="dictionary.html#max-pcor">max-pycor</a>, <a href="dictionary.html#min-pcor">min-pxcor</a>,
+          <a href="dictionary.html#min-pcor">min-pycor</a>, and <a href="#world-depth">world-depth</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="neighbors-3d">
+        <h3>
+          <a>neighbors<span class="since">4.1</span></a>
+          <a>neighbors6<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">neighbors</span>
+          <span class="prim_example">neighbors6</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          3D versions of <a href="dictionary.html#neighbors">neighbors</a>
+          and <a href="dictionary.html#neighbors">neighbors4</a>.
+        </p>
+        <p>
+          Reports an agentset containing the 26 surrounding patches
+          (neighbors) or 6 surrounding patches (neighbors6).
+        </p>
+        <pre>
+          show sum values-from neighbors [count turtles-here]
+          ;; prints the total number of turtles on the twenty-six
+          ;; patches around this turtle or patch
+          ask neighbors6 [ set pcolor red ]
+          ;; turns the six neighboring patches red
+        </pre>
+      </div>
+      <div class="dict_entry" id="orbit-cmds">
+        <h3>
+          <a>orbit-down<span class="since">4.1</span></a>
+          <a>orbit-left<span class="since">4.1</span></a>
+          <a>orbit-right<span class="since">4.1</span></a>
+          <a>orbit-up<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">orbit-down <i>number</i></span>
+          <span class="prim_example">orbit-left <i>number</i></span>
+          <span class="prim_example">orbit-right <i>number</i></span>
+          <span class="prim_example">orbit-up <i>number</i></span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Rotate the observer around the last point faced. Imagine the
+          observer is on the surface of a sphere, the last point face is the
+          center of that sphere. Up and down orbit along the lines of
+          longitude and right and left orbit along the lines of latitude. The
+          observer will remain facing the last point faced so the heading and
+          pitch may change as result of orbiting. However, because we assume
+          an absolute north pole (parallel to the positive z-axis) the roll
+          will never change.
+        </p>
+        <p>
+          See also <a href="#setxyz">setxyz</a>, <a href="#face-3d">face</a> and
+          <a href="#zoom">zoom</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="observer-cors">
+        <h3>
+          <a>__oxcor</a>
+          <a>__oycor</a>
+          <a>__ozcor</a>
+        </h3>
+        <h4>
+          <span class="prim_example">__oxcor</span>
+          <span class="prim_example">__oycor</span>
+          <span class="prim_example">__ozcor</span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Reports the x-, y-, or z-coordinate of the observer.
+        </p>
+        <p>
+          See also <a href="#setxyz">setxyz</a>
+        </p>
+        <h3>
+          <a id="patch">patch<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">patch <i>pxcor</i> <i>pycor</i> <i>pzcor</i></span>
+        </h4>
+        <p>
+          3D version of <a href="dictionary.html#patch">patch</a>.
+        </p>
+        <p>
+          Given three integers, reports the single patch with the given
+          pxcor, pycor and pzcor. <i>pxcor</i>, <i>pycor</i> and <i>pzcor</i>
+          must be integers.
+        </p>
+        <pre>
+          ask (patch 3 -4 2) [ set pcolor green ]
+          ;; patch with pxcor of 3 and pycor of -4 and pzcor of 2 turns green
+        </pre>
+        <p>
+          See also <a href="dictionary.html#patch">patch</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="patch-at-3d">
+        <h3>
+          <a>patch-at<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">patch-at <i>dx</i> <i>dy</i> <i>dz</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          3D version of <a href="dictionary.html#patch-at">patch-at</a>.
+        </p>
+        <p>
+          Reports the single patch at (dx, dy, dz) from the caller, that is,
+          dx patches east, dy patches north and dz patches up from the
+          caller.
+        </p>
+        <pre>
+          ask patch-at 1 -1 1 [ set pcolor green ]
+          ;; turns the patch just southeast and up from the caller green
+        </pre>
+      </div>
+      <div class="dict_entry" id="patch-at-heading-pitch-and-distance">
+        <h3>
+          <a>patch-at-heading-pitch-and-distance<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">patch-at-heading-pitch-and-distance <i>heading</i> <i>pitch</i> <i>distance</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          3D version of <a href="dictionary.html#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
+        </p>
+        <p>
+          patch-at-heading-pitch-and-distance reports the single patch that
+          is the given distance from this turtle or patch, along the given
+          absolute heading and pitch. (In contrast to patch-left-and-ahead
+          and patch-right-and-ahead, this turtle's current heading is not
+          taken into account.)
+        </p>
+        <pre>
+          ask patch-at-heading-pitch-and-distance 0 90 1 [ set pcolor green ]
+          ;; turns the patch directly above the caller green.
+        </pre>
+      </div>
+      <div class="dict_entry" id="pitch">
+        <h3>
+          <a>pitch</a>
+        </h3>
+        <h4>
+          <span class="prim_example">pitch</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          This is a built-in turtle variable. Pitch is the angle between the
+          &quot;nose&quot; of the turtle and the xy-plane. Heading and pitch
+          together define the forward vector of the turtle or the direction
+          that the turtle is facing.
+        </p>
+        <p>
+          This is a number greater than or equal to 0 and less than 360. 0 is
+          parallel to the xy-plane, 90 is parallel to the z-axis. While you
+          can set pitch we recommend that you use the primitives to turn the
+          turtle. Depending on the position more than one relative angle
+          (heading, pitch and roll) may change at once.
+        </p>
+        <p>
+          Example:
+        </p>
+        <pre>
+          ;; assume roll and heading are 0
+          set pitch 45      ;; turtle is now north and up
+          set heading heading + 10 ;; same effect as &quot;tilt-up 10&quot;
+        </pre>
+        <p>
+          See also <a href="dictionary.html#heading">heading</a>, <a href="#roll">roll</a>, <a href="#tilt-cmds">tilt-up</a>, <a href="#tilt-cmds">tilt-down</a>, <a href="#right">right</a>, <a href="#left">left</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="pzcor">
+        <h3>
+          <a>pzcor</a>
+        </h3>
+        <h4>
+          <span class="prim_example">pzcor</span>
+          <img alt="Patch Command" src="images/patch.gif"/> <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          This is a built-in patch variable. It holds the z coordinate of the
+          patch. It is always an integer. You cannot set this variable,
+          because patches don't move.
+        </p>
+        <p>
+          pzcor is greater than or equal to min-pzcor and less than or equal
+          to max-pzcor.
+        </p>
+        <p>
+          All patch variables can be directly accessed by any turtle standing
+          on the patch.
+        </p>
+        <p>
+          See also <a href="dictionary.html#pcor">pxcor, pycor</a>, <a href="#zcor">zcor</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="random-pzcor">
+        <h3>
+          <a>random-pzcor<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">random-pzcor</span>
+        </h4>
+        <p>
+          Reports a random integer ranging from min-pzcor to max-pzcor
+          inclusive.
+        </p>
+        <pre>
+          ask turtles [
+          ;; move each turtle to the center of a random patch
+          setxyz random-pxcor random-pycor random-pzcor
+          ]
+        </pre>
+        <p>
+          See also <a href="dictionary.html#random-pcor">random-pxcor</a>, <a href="dictionary.html#random-pcor">random-pycor</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="random-zcor">
+        <h3>
+          <a>random-zcor<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">random-zcor</span>
+        </h4>
+        <p>
+          Reports a random floating point number from the allowable range of
+          turtle coordinates along the z axis.
+        </p>
+        <p>
+          Turtle coordinates range from min-pzcor - 0.5 (inclusive) to
+          max-pzcor + 0.5 (exclusive).
+        </p>
+        <pre>
+          ask turtles [
+          ;; move each turtle to a random point
+          setxyz random-xcor random-ycor random-zcor
+          ]
+        </pre>
+        <p>
+          See also <a href="dictionary.html#random-cor">random-xcor</a>,
+          <a href="dictionary.html#random-cor">random-ycor</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="right">
+        <h3>
+          <a>right<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">right <i>number</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          The turtle turns right by <i>number</i> degrees, relative to its
+          current orientation. While right in a 2D world only modifies the
+          turtle's heading, right in a 3D world may also modify the
+          turtle's pitch and roll.
+        </p>
+        <p>
+          See also <a href="dictionary.html#right">right</a> and <a href="#left">left</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="roll">
+        <h3>
+          <a>roll</a>
+        </h3>
+        <h4>
+          <span class="prim_example">roll</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          This is a built-in turtle variable. Roll is the angle between the
+          &quot;wing-tip&quot; of the turtle and the xy-plane.
+        </p>
+        <p>
+          This is a number greater than or equal to 0 and less than 360. You
+          can set this variable to make a turtle roll. Since roll is always
+          from the turtle's point of view, rolling right and left only
+          only change roll regardless of turtle orientation.
+        </p>
+        <p>
+          Example:
+        </p>
+        <pre>
+          set roll 45      ;; turtle rotated right
+          set roll roll + 10 ;; same effect as &quot;roll-right 10&quot;
+        </pre>
+        <p>
+          See also <a href="dictionary.html#heading">heading</a>, <a href="#pitch">pitch</a>, <a href="#roll-left">roll-left</a>, <a href="#roll-right">roll-right</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="roll-left">
+        <h3>
+          <a>roll-left<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">roll-left <i>number</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          The wingtip of the turtle rotates to the left <i>number</i> degrees
+          with respect to the current heading and pitch.
+        </p>
+      </div>
+      <div class="dict_entry" id="roll-right">
+        <h3>
+          <a>roll-right<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">roll-right <i>number</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          The wingtip of the turtle rotates to the right <i>number</i>
+          degrees with respect to the current heading and pitch.
+        </p>
+      </div>
+      <div class="dict_entry" id="setxyz">
+        <h3>
+          <a>setxyz<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">setxyz <i>x y z</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          3D version of <a href="dictionary.html#setxy">setxy</a>.
+        </p>
+        <p>
+          The agent, a turtle or the observer, sets its x-coordinate to
+          <i>x</i>, its y-coordinate to <i>y</i> and its z-coordinate to
+          <i>z</i>. When the observer uses <code>setxyz</code> it remains facing
+          the same point so the heading, pitch, and roll, may also change.
+        </p>
+        <p>
+          For turtles equivalent to <code>set xcor x set ycor y set zcor
+            z</code>, except it happens in one time step instead of three.
+        </p>
+        <pre>
+          setxyz 0 0 0
+          ;; agent moves to the middle of the center patch
+        </pre>See also <a href="#face-3d">face</a>
+      </div>
+      <div class="dict_entry" id="tilt-cmds">
+        <h3>
+          <a>tilt-down<span class="since">4.1</span></a>
+          <a>tilt-up<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">tilt-down <i>number</i></span>
+          <span class="prim_example">tilt-up <i>number</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          The nose of the turtle rotates by <i>number</i> degrees, relative
+          to its current orientation. Depending on the orientation of the
+          turtle more than one of the relative angles (heading, pitch, and
+          roll) may change when a turtle turns.
+        </p>
+      </div>
+      <div class="dict_entry" id="towards-pitch-cmd">
+        <h3>
+          <a>towards-pitch<span class="since">4.1</span></a>
+          <a>towards-pitch-nowrap<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">towards-pitch <i>agent</i></span>
+          <span class="prim_example">towards-pitch-nowrap <i>agent</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          Reports the pitch from this agent to the given agent.
+        </p>
+        <p>
+          If the wrapped distance (around the edges of the screen) is shorter
+          than the on-screen distance, towards-pitch will report the pitch of
+          the wrapped path. towards-pitch-nowrap never uses the wrapped path.
+        </p>
+        <p>
+          Note: In order to get one turtle to face another you need to use
+          both towards-pitch and towards.
+        </p>
+        <p>
+          Note: asking for the pitch from an agent to itself, or an agent on
+          the same location, will cause a runtime error.
+        </p>
+        <p>
+          See also <a href="dictionary.html#towards">towards</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="towards-pitch-xyz-cmd">
+        <h3>
+          <a>towards-pitch-xyz<span class="since">4.1</span></a>
+          <a>towards-pitch-xyz-nowrap<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">towards-pitch-xyz <i>x</i> <i>y</i> <i>z</i></span>
+          <span class="prim_example">towards-pitch-xyz-no-wrap <i>x</i> <i>y</i> <i>z</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          Reports the pitch from this agent to the coordinates x, y, z
+        </p>
+        <p>
+          If the wrapped distance (around the edges of the screen) is shorter
+          than the on-screen distance, towards-pitch will report the pitch of
+          the wrapped path. towards-pitch-nowrap never uses the wrapped path.
+        </p>
+        <p>
+          Note: In order to get a turtle to face a given location you need to
+          use both towards-pitch-xyz and towardsxy.
+        </p>
+        <p>
+          Note: asking for the pitch from an agent to the location it is
+          standing on will cause a runtime error.
+        </p>
+        <p>
+          See also <a href="dictionary.html#towardsxy">towardsxy</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="turtles-at-3d">
+        <h3>
+          <a>turtles-at<span class="since">4.1</span></a>
+          <a>&lt;breeds&gt;-at</a>
+        </h3>
+        <h4>
+          <span class="prim_example">turtles-at <i>dx</i> <i>dy</i> <i>dz</i></span>
+          <span class="prim_example"><i>&lt;breeds&gt;-at</i> <i>dx</i> <i>dy</i> <i>dz</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          3D versions of <a href="dictionary.html#turtles-at">turtles-at</a>
+          and <a href="dictionary.html#turtles-at">breeds-at</a>.
+        </p>
+        <p>
+          Reports an agentset containing the turtles on the patch (dx, dy,
+          dz) from the caller (including the caller itself if it's a
+          turtle).
+        </p>
+        <pre>
+          ;; suppose I have 40 turtles at the origin
+          show [count turtles-at 0 0 0] of turtle 0
+          =&gt; 40
+        </pre>
+      </div>
+      <div class="dict_entry" id="world-depth">
+        <h3>
+          <a>world-depth<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">world-depth</span>
+        </h4>
+        <p>
+          Reports the total depth of the NetLogo world.
+        </p>
+        <p>
+          The depth of the world is the same as max-pzcor - min-pzcor + 1.
+        </p>
+        <p>
+          See also <a href="#min-max-pzcor">max-pzcor</a>, <a href="#min-max-pzcor">min-pzcor</a>, <a href="dictionary.html#world-dim">world-width</a>, and <a href="dictionary.html#world-dim">world-height</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="zcor">
+        <h3>
+          <a>zcor</a>
+        </h3>
+        <h4>
+          <span class="prim_example">zcor</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          This is a built-in turtle variable. It holds the current z
+          coordinate of the turtle. This is a floating point number, not an
+          integer. You can set this variable to change the turtle's
+          location.
+        </p>
+        <p>
+          This variable is always greater than or equal to (- screen-edge-z)
+          and strictly less than screen-edge-z.
+        </p>
+        <p>
+          See also <a href="#setxyz">setxy</a>, <a href="dictionary.html#xcor">xcor</a>, <a href="dictionary.html#ycor">ycor</a>, <a href="dictionary.html#pcor">pxcor</a>, <a href="dictionary.html#pcor">pycor</a>, <a href="#pzcor">pzcor</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="zoom">
+        <h3>
+          <a>zoom<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">zoom <i>number</i></span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Move the observer toward the point it is facing, <i>number</i>
+          steps. The observer will never move beyond the point it is facing
+          so if <i>number</i> is greater than the distance to that point it
+          will only move as far as the point it is facing.
+        </p>
+      </div>
+    </div>
+  </body>
 </html>

--- a/autogen/docs/copyright.html.mustache
+++ b/autogen/docs/copyright.html.mustache
@@ -1,670 +1,677 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<title>
-  NetLogo {{version}} User Manual: Copyright and License
-</title>
-<link rel="stylesheet" href="netlogo.css" type="text/css">
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<style>
-  .license {
-    padding: 2em;
-    background-color: #ffc;
-    border-style: solid;
-    border-width: 1pt;
-    font-family: courier;
-    font-size: 80%;
-  }
-</style>
-</head>
-<body>
-  <h1>
-    Copyright and License Information
-  </h1>
-  <div class="version">
-    NetLogo {{version}} User Manual
-  </div>
-    <h2>
-      How to reference
-    </h2>
-    <p>
-      If you use or refer to NetLogo in a publication, we ask that you cite
-      it. The correct citation is: Wilensky, U. (1999). NetLogo. <a href="http://ccl.northwestern.edu/netlogo/" target="_blank">http://ccl.northwestern.edu/netlogo/</a>.
-      Center for Connected Learning and Computer-Based Modeling,
-      Northwestern University, Evanston, IL.
-    </p>
-    <p>
-      For HubNet, cite: Wilensky, U. &amp; Stroup, W., 1999. HubNet.
-      <a href="http://ccl.northwestern.edu/netlogo/hubnet.html" target="_blank">http://ccl.northwestern.edu/netlogo/hubnet.html</a>.
-      Center for Connected Learning and Computer-Based Modeling,
-      Northwestern University. Evanston, IL.
-    </p>
-    <p>
-      For models in the Models Library, the correct citation is included in
-      the &quot;Credits and References&quot; section of each model's
-      Info tab.
-    </p>
-    <h2>
-      Acknowledgments
-    </h2>
-    <p>
-      The CCL gratefully acknowledges two decades of support for our NetLogo work.
-      The original support came from the National Science Foundation -- grant numbers
-      REC-9814682 and REC-0126227. Further support has come from REC-0003285, REC-0115699,
-      DRL-0196044, CCF-ITR-0326542, DRL-REC/ROLE-0440113, SBE-0624318, EEC-0648316,
-      IIS-0713619, DRL-RED-9552950, DRL-REC-9632612, and DRL-DRK12-1020101, IIS-1441552,
-      CNS-1441016, CNS-1441041, CNS-1138461, IIS-1438813, IIS-1147621, DRL-REC-1343873,
-      IIS-1438813, IIS-1441552, CNS-1441041, IIS-1546120, DRL-1546122, DRL-1614745
-      and DRL-1640201. Additional support came from the Spencer Foundation,
-      Texas Instruments, the Brady Fund, the Murphy fund,
-      and the Northwestern Institute on Complex Systems.
-    </p>
-    <h2>
-      NetLogo license
-    </h2>
-    <p>
-      Copyright 1999-{{year}} by Uri Wilensky.
-    </p>
-    <p>
-      This program is free software; you can redistribute it and/or modify
-      it under the terms of the GNU General Public License as published by
-      the Free Software Foundation; either version 2 of the License, or (at
-      your option) any later version.
-    </p>
-    <p>
-      This program is distributed in the hope that it will be useful, but
-      WITHOUT ANY WARRANTY; without even the implied warranty of
-      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-      General Public License for more details.
-    </p>
-    <p>
-      You should have received a copy of the GNU General Public License
-      along with this program; if not, write to the Free Software
-      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-      02110-1301, USA.
-    <h2>
-      Commercial licenses
-    </h2>
-    <p>
-      Commercial licenses are also available. To inquire about commercial
-      licenses, please contact Uri Wilensky at <a href="mailto:netlogo-commercial-admin@ccl.northwestern.edu">netlogo-commercial-admin@ccl.northwestern.edu</a>.
-    </p>
-    <h2>
-      NetLogo User Manual license
-    </h2>
-    <p>
-      Copyright 1999-{{year}} by Uri Wilensky.
-    </p>
-    <p>
-      <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank"><img alt="Creative Commons License" style="border-width:0" src="images/cc-by-sa-3.0.png"></a>
-      <br>
-      The NetLogo User Manual by <a href="http://ccl.northwestern.edu/netlogo/" target="_blank">Uri Wilensky</a> is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons
-      Attribution-ShareAlike 3.0 Unported License</a>.
-    </p>
-    <h2>
-      Open source
-    </h2>
-    <p>
-      The NetLogo source code is hosted at <a href="https://github.com/NetLogo/NetLogo" target="_blank">https://github.com/NetLogo/NetLogo</a>.
-      Contributions from interested users are welcome.
-    </p>
-    <h2>
-      Third party licenses
-    </h2>
-    <h3>
-      Scala
-    </h3>
-    <p>
-      Much of NetLogo is written in the Scala language and uses the Scala
-      standard libraries. The license for Scala is as follows:
-    </p>
-    <div class="license">
-      <p>Copyright (c) 2002 - EPFL</p>
-      <p>Copyright (c) 2011 - Lightbend, Inc.</p>
+	<head>
+		<title>
+			NetLogo {{version}} User Manual: Copyright and License
+		</title>
+		<link rel="stylesheet" href="netlogo.css" type="text/css"/>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+		<style>
+			.license {
+			padding: 2em;
+			background-color: #ffc;
+			border-style: solid;
+			border-width: 1pt;
+			font-family: courier;
+			font-size: 80%;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>
+			Copyright and License Information
+		</h1>
+		<div class="version">
+			NetLogo {{version}} User Manual
+		</div>
+		<h2>
+			How to reference
+		</h2>
+		<p>
+			If you use or refer to NetLogo in a publication, we ask that you cite
+			it. The correct citation is: Wilensky, U. (1999). NetLogo. <a href="http://ccl.northwestern.edu/netlogo/" target="_blank">http://ccl.northwestern.edu/netlogo/</a>.
+			Center for Connected Learning and Computer-Based Modeling,
+			Northwestern University, Evanston, IL.
+		</p>
+		<p>
+			For HubNet, cite: Wilensky, U. &amp; Stroup, W., 1999. HubNet.
+			<a href="http://ccl.northwestern.edu/netlogo/hubnet.html" target="_blank">http://ccl.northwestern.edu/netlogo/hubnet.html</a>.
+			Center for Connected Learning and Computer-Based Modeling,
+			Northwestern University. Evanston, IL.
+		</p>
+		<p>
+			For models in the Models Library, the correct citation is included in
+			the &quot;Credits and References&quot; section of each model's
+			Info tab.
+		</p>
+		<h2>
+			Acknowledgments
+		</h2>
+		<p>
+			The CCL gratefully acknowledges two decades of support for our NetLogo work.
+			The original support came from the National Science Foundation -- grant numbers
+			REC-9814682 and REC-0126227. Further support has come from REC-0003285, REC-0115699,
+			DRL-0196044, CCF-ITR-0326542, DRL-REC/ROLE-0440113, SBE-0624318, EEC-0648316,
+			IIS-0713619, DRL-RED-9552950, DRL-REC-9632612, and DRL-DRK12-1020101, IIS-1441552,
+			CNS-1441016, CNS-1441041, CNS-1138461, IIS-1438813, IIS-1147621, DRL-REC-1343873,
+			IIS-1438813, IIS-1441552, CNS-1441041, IIS-1546120, DRL-1546122, DRL-1614745
+			and DRL-1640201. Additional support came from the Spencer Foundation,
+			Texas Instruments, the Brady Fund, the Murphy fund,
+			and the Northwestern Institute on Complex Systems.
+		</p>
+		<h2>
+			NetLogo license
+		</h2>
+		<p>
+			Copyright 1999-{{year}} by Uri Wilensky.
+		</p>
+		<p>
+			This program is free software; you can redistribute it and/or modify
+			it under the terms of the GNU General Public License as published by
+			the Free Software Foundation; either version 2 of the License, or (at
+			your option) any later version.
+		</p>
+		<p>
+			This program is distributed in the hope that it will be useful, but
+			WITHOUT ANY WARRANTY; without even the implied warranty of
+			MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+			General Public License for more details.
+		</p>
+		<p>
+			You should have received a copy of the GNU General Public License
+			along with this program; if not, write to the Free Software
+			Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+			02110-1301, USA.
+		</p>
+		<h2>
+			Commercial licenses
+		</h2>
+		<p>
+			Commercial licenses are also available. To inquire about commercial
+			licenses, please contact Uri Wilensky at <a href="mailto:netlogo-commercial-admin@ccl.northwestern.edu">netlogo-commercial-admin@ccl.northwestern.edu</a>.
+		</p>
+		<h2>
+			NetLogo User Manual license
+		</h2>
+		<p>
+			Copyright 1999-{{year}} by Uri Wilensky.
+		</p>
+		<p>
+			<a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank"><img alt="Creative Commons License" style="border-width:0" src="images/cc-by-sa-3.0.png"/></a>
+			<br/>
+			The NetLogo User Manual by <a href="http://ccl.northwestern.edu/netlogo/" target="_blank">Uri Wilensky</a> is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons
+				Attribution-ShareAlike 3.0 Unported License</a>.
+		</p>
+		<h2>
+			Open source
+		</h2>
+		<p>
+			The NetLogo source code is hosted at <a href="https://github.com/NetLogo/NetLogo" target="_blank">https://github.com/NetLogo/NetLogo</a>.
+			Contributions from interested users are welcome.
+		</p>
+		<h2>
+			Third party licenses
+		</h2>
+		<h3>
+			Scala
+		</h3>
+		<p>
+			Much of NetLogo is written in the Scala language and uses the Scala
+			standard libraries. The license for Scala is as follows:
+		</p>
+		<div class="license">
+			<p>Copyright (c) 2002 - EPFL</p>
+			<p>Copyright (c) 2011 - Lightbend, Inc.</p>
 
-      <p>All rights reserved.</p>
+			<p>All rights reserved.</p>
 
-      <p>
-      Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-      </p>
+			<p>
+				Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+			</p>
 
-      <ul>
-        <li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</li>
-        <li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.</li>
-        <li>Neither the name of the EPFL nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.</li>
-      </ul>
-      <p>
-      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot;
-      AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-      IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-      IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-      INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-      BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
-      OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-      WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-      </p>
-    </div>
-    <h3>
-      MersenneTwisterFast
-    </h3>
-    <p>
-      For random number generation, NetLogo uses the MersenneTwisterFast
-      class by Sean Luke. The copyright for that code is as follows:
-    </p>
-    <div class="license">
-      <p>
-        Copyright (c) 2003 by Sean Luke.
-        <br>
-        Portions copyright (c) 1993 by Michael Lecuyer.
-        <br>
-        All rights reserved.
-      </p>
-      <p>
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions
-        are met:
-      </p>
-      <ul>
-        <li>Redistributions of source code must retain the above copyright
-        notice, this list of conditions and the following disclaimer.
-        <li>Redistributions in binary form must reproduce the above
-        copyright notice, this list of conditions and the following
-        disclaimer in the documentation and/or other materials provided
-        with the distribution.
-        <li>Neither the name of the copyright owners, their employers, nor
-        the names of its contributors may be used to endorse or promote
-        products derived from this software without specific prior written
-        permission.
-        </ul>
-      <p>
-        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-        &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
-        BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-        FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-        THE COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-        INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-        HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-        STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-        OF THE POSSIBILITY OF SUCH DAMAGE.
-      </p>
-      </div>
-    <h3>
-      Colt
-    </h3>
-    <p>
-      Parts of NetLogo (specifically, the random-gamma primitive) are based
-      on code from the Colt library (<a href="http://acs.lbl.gov/~hoschek/colt/">http://acs.lbl.gov/~hoschek/colt/</a>).
-      The copyright for that code is as follows:
-    </p>
-    <div class="license">
-      <p>
-        Copyright 1999 CERN - European Organization for Nuclear Research.
-        Permission to use, copy, modify, distribute and sell this software
-        and its documentation for any purpose is hereby granted without
-        fee, provided that the above copyright notice appear in all copies
-        and that both that copyright notice and this permission notice
-        appear in supporting documentation. CERN makes no representations
-        about the suitability of this software for any purpose. It is
-        provided &quot;as is&quot; without expressed or implied warranty.
-      </p>
-      </div>
-    <h3>
-      Config
-    </h3>
-    <p>
-      NetLogo uses the Typesafe "Config" library.
-      Copyright (C) 2011-2012 Typesafe Inc. <a href="http://typesafe.com">http://typesafe.com</a>
-      The Config library is licensed under the Apache 2.0 License.
-      You may obtain a copy of the license at <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>.
-    </p>
-    <h3>
-      Apache Commons Codec (TM)
-    </h3>
-      The NetLogo compiler uses a digest method from the Apache Commons Codec (TM) library.
-      Apache Commons Codec (TM) is copyright and trademark 2002-2014 the Apache Software Foundation.
+			<ul>
+				<li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</li>
+				<li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.</li>
+				<li>Neither the name of the EPFL nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.</li>
+			</ul>
+			<p>
+				THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot;
+				AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+				IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+				IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+				INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+				BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+				OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+				WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+				ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+			</p>
+		</div>
+		<h3>
+			MersenneTwisterFast
+		</h3>
+		<p>
+			For random number generation, NetLogo uses the MersenneTwisterFast
+			class by Sean Luke. The copyright for that code is as follows:
+		</p>
+		<div class="license">
+			<p>
+				Copyright (c) 2003 by Sean Luke.
+				<br/>
+				Portions copyright (c) 1993 by Michael Lecuyer.
+				<br/>
+				All rights reserved.
+			</p>
+			<p>
+				Redistribution and use in source and binary forms, with or without
+				modification, are permitted provided that the following conditions
+				are met:
+			</p>
+			<ul>
+				<li>Redistributions of source code must retain the above copyright
+					notice, this list of conditions and the following disclaimer.
+				</li>
+				<li>Redistributions in binary form must reproduce the above
+					copyright notice, this list of conditions and the following
+					disclaimer in the documentation and/or other materials provided
+					with the distribution.
+				</li>
+				<li>Neither the name of the copyright owners, their employers, nor
+					the names of its contributors may be used to endorse or promote
+					products derived from this software without specific prior written
+					permission.
+				</li>
+			</ul>
+			<p>
+				THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+				&quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+				BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+				FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+				THE COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+				INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+				(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+				SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+				HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+				STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+				ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+				OF THE POSSIBILITY OF SUCH DAMAGE.
+			</p>
+		</div>
+		<h3>
+			Colt
+		</h3>
+		<p>
+			Parts of NetLogo (specifically, the random-gamma primitive) are based
+			on code from the Colt library (<a href="http://acs.lbl.gov/~hoschek/colt/">http://acs.lbl.gov/~hoschek/colt/</a>).
+			The copyright for that code is as follows:
+		</p>
+		<div class="license">
+			<p>
+				Copyright 1999 CERN - European Organization for Nuclear Research.
+				Permission to use, copy, modify, distribute and sell this software
+				and its documentation for any purpose is hereby granted without
+				fee, provided that the above copyright notice appear in all copies
+				and that both that copyright notice and this permission notice
+				appear in supporting documentation. CERN makes no representations
+				about the suitability of this software for any purpose. It is
+				provided &quot;as is&quot; without expressed or implied warranty.
+			</p>
+		</div>
+		<h3>
+			Config
+		</h3>
+		<p>
+			NetLogo uses the Typesafe "Config" library.
+			Copyright (C) 2011-2012 Typesafe Inc. <a href="http://typesafe.com">http://typesafe.com</a>
+			The Config library is licensed under the Apache 2.0 License.
+			You may obtain a copy of the license at <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>.
+		</p>
+		<h3>
+			Apache Commons Codec (TM)
+		</h3>
+		The NetLogo compiler uses a digest method from the Apache Commons Codec (TM) library.
+		Apache Commons Codec (TM) is copyright and trademark 2002-2014 the Apache Software Foundation.
 
-      It is licensed under the Apache 2.0 License. You may obtain a copy of the license at
-      <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>.
-    <h3>
-      Flexmark
-    </h3>
-    <p>
-      NetLogo uses the Flexmark library (and extensions) for the info tab. The copyright and license are as follows:
-    </p>
-    <div class="license">
-      Copyright (c) 2015-2016, Atlassian Pty Ltd
-      All rights reserved.
+		It is licensed under the Apache 2.0 License. You may obtain a copy of the license at
+		<a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>.
+		<h3>
+			Flexmark
+		</h3>
+		<p>
+			NetLogo uses the Flexmark library (and extensions) for the info tab. The copyright and license are as follows:
+		</p>
+		<div class="license">
+			Copyright (c) 2015-2016, Atlassian Pty Ltd
+			All rights reserved.
 
-      Copyright (c) 2016, Vladimir Schneider,
-      All rights reserved.
+			Copyright (c) 2016, Vladimir Schneider,
+			All rights reserved.
 
-      Redistribution and use in source and binary forms, with or without
-      modification, are permitted provided that the following conditions are met:
+			Redistribution and use in source and binary forms, with or without
+			modification, are permitted provided that the following conditions are met:
 
-      * Redistributions of source code must retain the above copyright notice, this
-        list of conditions and the following disclaimer.
+			* Redistributions of source code must retain the above copyright notice, this
+			list of conditions and the following disclaimer.
 
-      * Redistributions in binary form must reproduce the above copyright notice,
-        this list of conditions and the following disclaimer in the documentation
-        and/or other materials provided with the distribution.
+			* Redistributions in binary form must reproduce the above copyright notice,
+			this list of conditions and the following disclaimer in the documentation
+			and/or other materials provided with the distribution.
 
-      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-      AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-      IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-      DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-      FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-      DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-      SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-      CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-      OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-    </div>
-    <h3>
-      JHotDraw
-    </h3>
-    <p>
-      For the system dynamics modeler, NetLogo uses the JHotDraw library,
-      which is Copyright (c) 1996, 1997 by IFA Informatik and Erich Gamma.
-      The library is covered by the GNU LGPL (Lesser General Public
-      License). The text of that license is included in the
-      &quot;docs&quot; folder which accompanies the NetLogo download, and
-      is also available from <a href="http://www.gnu.org/copyleft/lesser.html">http://www.gnu.org/copyleft/lesser.html</a>
-      .
-    </p>
-    <h3>
-      JOGL
-    </h3>
-    <p>
-      For 3D graphics rendering, NetLogo uses JOGL, a Java API for OpenGL, and Gluegen, an automatic code generation tool.
-      For more information about JOGL and Gluegen, see <a href="http://jogamp.org/">jogamp.org/</a>.
-      Both libraries are distributed under the BSD license:
-    </p>
-    <div class="license">
-      Copyright 2010 JogAmp Community. All rights reserved.
-      <p>
-      Redistribution and use in source and binary forms, with or without modification, are
-      permitted provided that the following conditions are met:
-      </p>
-      <p>
-      1. Redistributions of source code must retain the above copyright notice, this list of
-      conditions and the following disclaimer.
-      </p>
-      <p>
-      2. Redistributions in binary form must reproduce the above copyright notice, this list
-      of conditions and the following disclaimer in the documentation and/or other materials
-      provided with the distribution.
-      </p>
-      <p>
-      THIS SOFTWARE IS PROVIDED BY JogAmp Community ``AS IS'' AND ANY EXPRESS OR IMPLIED
-      WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-      FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JogAmp Community OR
-      CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-      CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-      SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-      ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-      NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-      ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-      </p>
-      <p>
-      The views and conclusions contained in the software and documentation are those of the
-      authors and should not be interpreted as representing official policies, either expressed
-      or implied, of JogAmp Community.
-      </p>
-      <p>
-      You can address the JogAmp Community via:
-      Web                http://jogamp.org/
-      Forum/Mailinglist  http://forum.jogamp.org
-      Chatrooms
-      IRC              irc.freenode.net #jogamp
-      Jabber           conference.jabber.org room: jogamp (deprecated!)
-      Repository         http://jogamp.org/git/
-      Email              mediastream _at_ jogamp _dot_ org
-      </p>
-    </div>
-    <h3>
-      Matrix3D
-    </h3>
-    <p>
-      For 3D matrix operations, NetLogo uses the Matrix3D class. It is
-      distributed under the following license:
-    </p>
-    <div class="license">
-      Copyright (c) 1994-1996 Sun Microsystems, Inc. All Rights Reserved.
-      <p>
-        Sun grants you (&quot;Licensee&quot;) a non-exclusive, royalty
-        free, license to use, modify and redistribute this software in
-        source and binary code form, provided that i) this copyright notice
-        and license appear on all copies of the software; and ii) Licensee
-        does not utilize the software in a manner which is disparaging to
-        Sun.
-      </p>
-      <p>
-        This software is provided &quot;AS IS,&quot; without a warranty of
-        any kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND
-        WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY,
-        FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY
-        EXCLUDED. SUN AND ITS LICENSORS SHALL NOT BE LIABLE FOR ANY DAMAGES
-        SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR
-        DISTRIBUTING THE SOFTWARE OR ITS DERIVATIVES. IN NO EVENT WILL SUN
-        OR ITS LICENSORS BE LIABLE FOR ANY LOST REVENUE, PROFIT OR DATA, OR
-        FOR DIRECT, INDIRECT, SPECIAL, CONSEQUENTIAL, INCIDENTAL OR
-        PUNITIVE DAMAGES, HOWEVER CAUSED AND REGARDLESS OF THE THEORY OF
-        LIABILITY, ARISING OUT OF THE USE OF OR INABILITY TO USE SOFTWARE,
-        EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-      </p>
-      <p>
-        This software is not designed or intended for use in on-line
-        control of aircraft, air traffic, aircraft navigation or aircraft
-        communications; or in the design, construction, operation or
-        maintenance of any nuclear facility. Licensee represents and
-        warrants that it will not use or redistribute the Software for such
-        purposes.
-      </p>
-      </div>
-    <h3>
-      ASM
-    </h3>
-    <p>
-      For Java bytecode generation, NetLogo uses the ASM library. It is
-      distributed under the following license:
-    </p>
-    <div class="license">
-      <p>
-        Copyright (c) 2000-2011 INRIA, France Telecom. All rights reserved.
-      </p>
-      <p>
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions
-        are met:
-      </p>
-      <p>
-        1. Redistributions of source code must retain the above copyright
-        notice, this list of conditions and the following disclaimer.
-      </p>
-      <p>
-        2. Redistributions in binary form must reproduce the above
-        copyright notice, this list of conditions and the following
-        disclaimer in the documentation and/or other materials provided
-        with the distribution.
-      </p>
-      <p>
-        3. Neither the name of the copyright holders nor the names of its
-        contributors may be used to endorse or promote products derived
-        from this software without specific prior written permission.
-      </p>
-      <p>
-        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-        &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
-        BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-        FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-        THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-        INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-        HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-        STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-        OF THE POSSIBILITY OF SUCH DAMAGE.
-      </p>
-      </div>
-    <h3>
-      Log4j
-    </h3>
-    <p>
-      For logging, NetLogo uses the Log4j library. The copyright and
-      license for the library are as follows:
-    </p>
-    <div class="license">
-      <p>
-        Copyright 2007 The Apache Software Foundation
-      </p>
-      <p>
-        Licensed under the Apache License, Version 2.0 (the
-        &quot;License&quot;); you may not use this file except in
-        compliance with the License. You may obtain a copy of the License
-        at
-      </p>
-      <p>
-        <a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">http://www.apache.org/licenses/LICENSE-2.0</a>
-      </p>
-      <p>
-        Unless required by applicable law or agreed to in writing, software
-        distributed under the License is distributed on an &quot;AS
-        IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-        either express or implied. See the License for the specific
-        language governing permissions and limitations under the License.
-      </p>
-      </div>
-    <h3>
-      PicoContainer
-    </h3>
-    <p>
-      For dependency injection, NetLogo uses the PicoContainer library. The
-      copyright and license for the library are as follows:
-    </p>
-    <div class="license">
-      <p>
-        Copyright (c) 2004-2011, PicoContainer Organization All rights
-        reserved.
-      </p>
-      <p>
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions
-        are met:
-      </p>
-      <ul>
-        <li>Redistributions of source code must retain the above copyright
-        notice, this list of conditions and the following disclaimer.
-        <li>Redistributions in binary form must reproduce the above
-        copyright notice, this list of conditions and the following
-        disclaimer in the documentation and/or other materials provided
-        with the distribution.
-        <li>Neither the name of the PicoContainer Organization nor the
-        names of its contributors may be used to endorse or promote
-        products derived from this software without specific prior written
-        permission.
-        </ul>
-      <p>
-        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-        &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
-        BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-        FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-        THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-        INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-        HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-        STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-        OF THE POSSIBILITY OF SUCH DAMAGE.
-      </p>
-      </div>
-    <h3>
-      Parboiled
-    </h3>
-    <p>
-      For reading models, NetLogo uses the Parboiled library. The copyright and license for Parboiled are as follows:
-    </p>
-    <div class="license">
-      This software is licensed under the Apache 2 license, quoted below.
+			THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+			AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+			IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+			DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+			FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+			DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+			SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+			CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+			OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+			OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+		</div>
+		<h3>
+			JHotDraw
+		</h3>
+		<p>
+			For the system dynamics modeler, NetLogo uses the JHotDraw library,
+			which is Copyright (c) 1996, 1997 by IFA Informatik and Erich Gamma.
+			The library is covered by the GNU LGPL (Lesser General Public
+			License). The text of that license is included in the
+			&quot;docs&quot; folder which accompanies the NetLogo download, and
+			is also available from <a href="http://www.gnu.org/copyleft/lesser.html">http://www.gnu.org/copyleft/lesser.html</a>
+			.
+		</p>
+		<h3>
+			JOGL
+		</h3>
+		<p>
+			For 3D graphics rendering, NetLogo uses JOGL, a Java API for OpenGL, and Gluegen, an automatic code generation tool.
+			For more information about JOGL and Gluegen, see <a href="http://jogamp.org/">jogamp.org/</a>.
+			Both libraries are distributed under the BSD license:
+		</p>
+		<div class="license">
+			Copyright 2010 JogAmp Community. All rights reserved.
+			<p>
+				Redistribution and use in source and binary forms, with or without modification, are
+				permitted provided that the following conditions are met:
+			</p>
+			<p>
+				1. Redistributions of source code must retain the above copyright notice, this list of
+				conditions and the following disclaimer.
+			</p>
+			<p>
+				2. Redistributions in binary form must reproduce the above copyright notice, this list
+				of conditions and the following disclaimer in the documentation and/or other materials
+				provided with the distribution.
+			</p>
+			<p>
+				THIS SOFTWARE IS PROVIDED BY JogAmp Community ``AS IS'' AND ANY EXPRESS OR IMPLIED
+				WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+				FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JogAmp Community OR
+				CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+				CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+				SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+				ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+				NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+				ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+			</p>
+			<p>
+				The views and conclusions contained in the software and documentation are those of the
+				authors and should not be interpreted as representing official policies, either expressed
+				or implied, of JogAmp Community.
+			</p>
+			<p>
+				You can address the JogAmp Community via:
+				Web                http://jogamp.org/
+				Forum/Mailinglist  http://forum.jogamp.org
+				Chatrooms
+				IRC              irc.freenode.net #jogamp
+				Jabber           conference.jabber.org room: jogamp (deprecated!)
+				Repository         http://jogamp.org/git/
+				Email              mediastream _at_ jogamp _dot_ org
+			</p>
+		</div>
+		<h3>
+			Matrix3D
+		</h3>
+		<p>
+			For 3D matrix operations, NetLogo uses the Matrix3D class. It is
+			distributed under the following license:
+		</p>
+		<div class="license">
+			Copyright (c) 1994-1996 Sun Microsystems, Inc. All Rights Reserved.
+			<p>
+				Sun grants you (&quot;Licensee&quot;) a non-exclusive, royalty
+				free, license to use, modify and redistribute this software in
+				source and binary code form, provided that i) this copyright notice
+				and license appear on all copies of the software; and ii) Licensee
+				does not utilize the software in a manner which is disparaging to
+				Sun.
+			</p>
+			<p>
+				This software is provided &quot;AS IS,&quot; without a warranty of
+				any kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND
+				WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY,
+				FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY
+				EXCLUDED. SUN AND ITS LICENSORS SHALL NOT BE LIABLE FOR ANY DAMAGES
+				SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR
+				DISTRIBUTING THE SOFTWARE OR ITS DERIVATIVES. IN NO EVENT WILL SUN
+				OR ITS LICENSORS BE LIABLE FOR ANY LOST REVENUE, PROFIT OR DATA, OR
+				FOR DIRECT, INDIRECT, SPECIAL, CONSEQUENTIAL, INCIDENTAL OR
+				PUNITIVE DAMAGES, HOWEVER CAUSED AND REGARDLESS OF THE THEORY OF
+				LIABILITY, ARISING OUT OF THE USE OF OR INABILITY TO USE SOFTWARE,
+				EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+			</p>
+			<p>
+				This software is not designed or intended for use in on-line
+				control of aircraft, air traffic, aircraft navigation or aircraft
+				communications; or in the design, construction, operation or
+				maintenance of any nuclear facility. Licensee represents and
+				warrants that it will not use or redistribute the Software for such
+				purposes.
+			</p>
+		</div>
+		<h3>
+			ASM
+		</h3>
+		<p>
+			For Java bytecode generation, NetLogo uses the ASM library. It is
+			distributed under the following license:
+		</p>
+		<div class="license">
+			<p>
+				Copyright (c) 2000-2011 INRIA, France Telecom. All rights reserved.
+			</p>
+			<p>
+				Redistribution and use in source and binary forms, with or without
+				modification, are permitted provided that the following conditions
+				are met:
+			</p>
+			<p>
+				1. Redistributions of source code must retain the above copyright
+				notice, this list of conditions and the following disclaimer.
+			</p>
+			<p>
+				2. Redistributions in binary form must reproduce the above
+				copyright notice, this list of conditions and the following
+				disclaimer in the documentation and/or other materials provided
+				with the distribution.
+			</p>
+			<p>
+				3. Neither the name of the copyright holders nor the names of its
+				contributors may be used to endorse or promote products derived
+				from this software without specific prior written permission.
+			</p>
+			<p>
+				THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+				&quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+				BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+				FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+				THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+				INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+				(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+				SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+				HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+				STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+				ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+				OF THE POSSIBILITY OF SUCH DAMAGE.
+			</p>
+		</div>
+		<h3>
+			Log4j
+		</h3>
+		<p>
+			For logging, NetLogo uses the Log4j library. The copyright and
+			license for the library are as follows:
+		</p>
+		<div class="license">
+			<p>
+				Copyright 2007 The Apache Software Foundation
+			</p>
+			<p>
+				Licensed under the Apache License, Version 2.0 (the
+				&quot;License&quot;); you may not use this file except in
+				compliance with the License. You may obtain a copy of the License
+				at
+			</p>
+			<p>
+				<a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">http://www.apache.org/licenses/LICENSE-2.0</a>
+			</p>
+			<p>
+				Unless required by applicable law or agreed to in writing, software
+				distributed under the License is distributed on an &quot;AS
+				IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+				either express or implied. See the License for the specific
+				language governing permissions and limitations under the License.
+			</p>
+		</div>
+		<h3>
+			PicoContainer
+		</h3>
+		<p>
+			For dependency injection, NetLogo uses the PicoContainer library. The
+			copyright and license for the library are as follows:
+		</p>
+		<div class="license">
+			<p>
+				Copyright (c) 2004-2011, PicoContainer Organization All rights
+				reserved.
+			</p>
+			<p>
+				Redistribution and use in source and binary forms, with or without
+				modification, are permitted provided that the following conditions
+				are met:
+			</p>
+			<ul>
+				<li>Redistributions of source code must retain the above copyright
+					notice, this list of conditions and the following disclaimer.
+				</li>
+				<li>Redistributions in binary form must reproduce the above
+					copyright notice, this list of conditions and the following
+					disclaimer in the documentation and/or other materials provided
+					with the distribution.
+				</li>
+				<li>Neither the name of the PicoContainer Organization nor the
+					names of its contributors may be used to endorse or promote
+					products derived from this software without specific prior written
+					permission.
+				</li>
+			</ul>
+			<p>
+				THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+				&quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+				BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+				FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+				THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+				INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+				(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+				SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+				HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+				STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+				ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+				OF THE POSSIBILITY OF SUCH DAMAGE.
+			</p>
+		</div>
+		<h3>
+			Parboiled
+		</h3>
+		<p>
+			For reading models, NetLogo uses the Parboiled library. The copyright and license for Parboiled are as follows:
+		</p>
+		<div class="license">
+			This software is licensed under the Apache 2 license, quoted below.
 
-      Copyright © 2009-2013 Mathias Doenitz <a href="http://parboiled2.org">http://parboiled2.org</a>
-      Copyright © 2013 Alexander Myltsev
+			Copyright © 2009-2013 Mathias Doenitz <a href="http://parboiled2.org">http://parboiled2.org</a>
+			Copyright © 2013 Alexander Myltsev
 
-      Licensed under the Apache License, Version 2.0 (the "License"); you may not
-      use this file except in compliance with the License. You may obtain a copy of
-      the License at
+			Licensed under the Apache License, Version 2.0 (the "License"); you may not
+			use this file except in compliance with the License. You may obtain a copy of
+			the License at
 
-      [http://www.apache.org/licenses/LICENSE-2.0]
+			[http://www.apache.org/licenses/LICENSE-2.0]
 
-      Unless required by applicable law or agreed to in writing, software
-      distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-      WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-      License for the specific language governing permissions and limitations under
-      the License.
-     </div>
-    <h3>
-      RSyntaxTextArea
-    </h3>
-    <p>The NetLogo editor uses the RSyntaxTextArea library.
-    The copyright and license are as follows:
-    </p>
-    <div class="license">
-      Redistribution and use in source and binary forms, with or without
-      modification, are permitted provided that the following conditions are met:
-          * Redistributions of source code must retain the above copyright
-            notice, this list of conditions and the following disclaimer.
-          * Redistributions in binary form must reproduce the above copyright
-            notice, this list of conditions and the following disclaimer in the
-            documentation and/or other materials provided with the distribution.
-          * Neither the name of the author nor the names of its contributors may
-            be used to endorse or promote products derived from this software
-            without specific prior written permission.
+			Unless required by applicable law or agreed to in writing, software
+			distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+			WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+			License for the specific language governing permissions and limitations under
+			the License.
+		</div>
+		<h3>
+			RSyntaxTextArea
+		</h3>
+		<p>The NetLogo editor uses the RSyntaxTextArea library.
+			The copyright and license are as follows:
+		</p>
+		<div class="license">
+			Redistribution and use in source and binary forms, with or without
+			modification, are permitted provided that the following conditions are met:
+			* Redistributions of source code must retain the above copyright
+			notice, this list of conditions and the following disclaimer.
+			* Redistributions in binary form must reproduce the above copyright
+			notice, this list of conditions and the following disclaimer in the
+			documentation and/or other materials provided with the distribution.
+			* Neither the name of the author nor the names of its contributors may
+			be used to endorse or promote products derived from this software
+			without specific prior written permission.
 
-      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-      ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-      WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-      DISCLAIMED. IN NO EVENT SHALL &amp;COPYRIGHT HOLDER&amp; BE LIABLE FOR ANY
-      DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-      (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-      LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-      ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-      SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-    </div>
-    <h3>
-      JCodec
-    </h3>
-    <p>
-    The NetLogo <code>vid</code> extension makes use of the JCodec library.
-    The copyright and license for JCodec are as follows:
-    </p>
-    <div class="license">
-      Redistribution  and  use  in   source  and   binary   forms,  with  or  without
-      modification, are permitted provided  that the following  conditions  are  met:
+			THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+			ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+			WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+			DISCLAIMED. IN NO EVENT SHALL &amp;COPYRIGHT HOLDER&amp; BE LIABLE FOR ANY
+			DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+			(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+			LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+			ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+			(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+			SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+		</div>
+		<h3>
+			JCodec
+		</h3>
+		<p>
+			The NetLogo <code>vid</code> extension makes use of the JCodec library.
+			The copyright and license for JCodec are as follows:
+		</p>
+		<div class="license">
+			Redistribution  and  use  in   source  and   binary   forms,  with  or  without
+			modification, are permitted provided  that the following  conditions  are  met:
 
-      Redistributions of  source code  must  retain the above  copyright notice, this
-      list of conditions and the following disclaimer. Redistributions in binary form
-      must  reproduce  the above  copyright notice, this  list of conditions  and the
-      following disclaimer in the documentation and/or other  materials provided with
-      the distribution.
+			Redistributions of  source code  must  retain the above  copyright notice, this
+			list of conditions and the following disclaimer. Redistributions in binary form
+			must  reproduce  the above  copyright notice, this  list of conditions  and the
+			following disclaimer in the documentation and/or other  materials provided with
+			the distribution.
 
-      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-      ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO, THE  IMPLIED
-      WARRANTIES  OF  MERCHANTABILITY  AND  FITNESS  FOR  A  PARTICULAR  PURPOSE  ARE
-      DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-      ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,  OR CONSEQUENTIAL DAMAGES
-      (INCLUDING,  BUT NOT LIMITED TO,  PROCUREMENT OF SUBSTITUTE GOODS  OR SERVICES;
-      LOSS OF USE, DATA, OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-      ANY  THEORY  OF  LIABILITY,  WHETHER  IN  CONTRACT,  STRICT LIABILITY,  OR TORT
-      (INCLUDING  NEGLIGENCE OR OTHERWISE)  ARISING IN ANY WAY OUT OF THE USE OF THIS
-      SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-    </div>
-    <h3>
-      Java-Objective-C Bridge
-    </h3>
-    <p>
-      NetLogo on Mac OS X makes use of the Java-Objective-C Bridge library.
-      This library was created by Steve Hannah and is distributed under the Apache 2.0 license,
-      available at <a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a>.
-    </p>
-    <h3>
-      Webcam-capture
-    </h3>
-    The NetLogo <code>vid</code> extension makes use of the Webcam-capture library.
-    The copyright and license for Webcam-capture are as follows:
-    <div class="license">
-      The MIT License (MIT)
+			THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+			ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO, THE  IMPLIED
+			WARRANTIES  OF  MERCHANTABILITY  AND  FITNESS  FOR  A  PARTICULAR  PURPOSE  ARE
+			DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+			ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,  OR CONSEQUENTIAL DAMAGES
+			(INCLUDING,  BUT NOT LIMITED TO,  PROCUREMENT OF SUBSTITUTE GOODS  OR SERVICES;
+			LOSS OF USE, DATA, OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+			ANY  THEORY  OF  LIABILITY,  WHETHER  IN  CONTRACT,  STRICT LIABILITY,  OR TORT
+			(INCLUDING  NEGLIGENCE OR OTHERWISE)  ARISING IN ANY WAY OUT OF THE USE OF THIS
+			SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+		</div>
+		<h3>
+			Java-Objective-C Bridge
+		</h3>
+		<p>
+			NetLogo on Mac OS X makes use of the Java-Objective-C Bridge library.
+			This library was created by Steve Hannah and is distributed under the Apache 2.0 license,
+			available at <a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a>.
+		</p>
+		<h3>
+			Webcam-capture
+		</h3>
+		The NetLogo <code>vid</code> extension makes use of the Webcam-capture library.
+		The copyright and license for Webcam-capture are as follows:
+		<div class="license">
+			The MIT License (MIT)
 
-      Copyright (c) 2012 - 2015 Bartosz Firyn and Contributors
+			Copyright (c) 2012 - 2015 Bartosz Firyn and Contributors
 
-      Permission is hereby granted, free of charge, to any person obtaining a copy
-      of this software and associated documentation files (the "Software"), to deal
-      in the Software without restriction, including without limitation the rights
-      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-      copies of the Software, and to permit persons to whom the Software is
-      furnished to do so, subject to the following conditions:
+			Permission is hereby granted, free of charge, to any person obtaining a copy
+			of this software and associated documentation files (the "Software"), to deal
+			in the Software without restriction, including without limitation the rights
+			to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+			copies of the Software, and to permit persons to whom the Software is
+			furnished to do so, subject to the following conditions:
 
-      The above copyright notice and this permission notice shall be included in all
-      copies or substantial portions of the Software.
+			The above copyright notice and this permission notice shall be included in all
+			copies or substantial portions of the Software.
 
-      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-      SOFTWARE.
-    </div>
-    <h3>
-      Guava
-    </h3>
-      The NetLogo <code>ls</code> extension makes use of the Guava library.
-      Guava is released under the Apache License 2.0 (<a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">http://www.apache.org/licenses/LICENSE-2.0</a>)
-    <h3>
-      Gephi
-    </h3>
-    <p>
-    The <code>nw</code> extension makes use of the Gephi library.
-    Gephi is licensed under the following terms:
-    </p>
-    <div class="license">
-      Gephi Dual License Header and License Notice
-      <p>
-      The Gephi Consortium elects to use only the GNU General Public License version 3 (GPL) for any software where a choice of GPL license versions are made available with the language indicating that GPLv3 or any later version may be used, or where a choice of which version of the GPL is applied is unspecified.
-      </p>
-      <p>
-      For more information on the license please see: the Gephi License FAQs.
-      </p>
-      <p>
-      License headers are available on http://www.opensource.org/licenses/CDDL-1.0 and http://www.gnu.org/licenses/gpl.html.
-      </p>
-    </div>
-    <h3>
-      R Extension
-    </h3>
-    <p>
-    The NetLogo R Extension is licensed under the following terms:
-    </p>
-    <div class="license">
-      The R extension is Copyright (C) 2009-2016 Jan C. Thiele and
-      Copyright (C) 2016 Uri Wilensky / The Center for Connected Learning.
+			THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+			IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+			FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+			AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+			LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+			OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+			SOFTWARE.
+		</div>
+		<h3>
+			Guava
+		</h3>
+		The NetLogo <code>ls</code> extension makes use of the Guava library.
+		Guava is released under the Apache License 2.0 (<a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">http://www.apache.org/licenses/LICENSE-2.0</a>)
+		<h3>
+			Gephi
+		</h3>
+		<p>
+			The <code>nw</code> extension makes use of the Gephi library.
+			Gephi is licensed under the following terms:
+		</p>
+		<div class="license">
+			Gephi Dual License Header and License Notice
+			<p>
+				The Gephi Consortium elects to use only the GNU General Public License version 3 (GPL) for any software where a choice of GPL license versions are made available with the language indicating that GPLv3 or any later version may be used, or where a choice of which version of the GPL is applied is unspecified.
+			</p>
+			<p>
+				For more information on the license please see: the Gephi License FAQs.
+			</p>
+			<p>
+				License headers are available on http://www.opensource.org/licenses/CDDL-1.0 and http://www.gnu.org/licenses/gpl.html.
+			</p>
+		</div>
+		<h3>
+			R Extension
+		</h3>
+		<p>
+			The NetLogo R Extension is licensed under the following terms:
+		</p>
+		<div class="license">
+			The R extension is Copyright (C) 2009-2016 Jan C. Thiele and
+			Copyright (C) 2016 Uri Wilensky / The Center for Connected Learning.
 
-      NetLogo-R-Extension is free software; you can redistribute it and/or
-      modify it under the terms of the GNU General Public License
-      as published by the Free Software Foundation; either version 2
-      of the License, or (at your option) any later version.
+			NetLogo-R-Extension is free software; you can redistribute it and/or
+			modify it under the terms of the GNU General Public License
+			as published by the Free Software Foundation; either version 2
+			of the License, or (at your option) any later version.
 
-      This program is distributed in the hope that it will be useful,
-      but WITHOUT ANY WARRANTY; without even the implied warranty of
-      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-      GNU General Public License for more details.
+			This program is distributed in the hope that it will be useful,
+			but WITHOUT ANY WARRANTY; without even the implied warranty of
+			MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+			GNU General Public License for more details.
 
-      You should have received a copy of the GNU General Public License
-      along with NetLogo-R-Extension (located in GPL.txt).
-      If not, see <a href="http://www.gnu.org/licenses/">http://www.gnu.org/licenses</a>.
-    </div>
-    <h3>
-      JNA
-    </h3>
-    <p>
-    The NetLogo R Extension makes use of the JNA library.
-    The JNA library is licensed under the following terms:
-    </p>
+			You should have received a copy of the GNU General Public License
+			along with NetLogo-R-Extension (located in GPL.txt).
+			If not, see <a href="http://www.gnu.org/licenses/">http://www.gnu.org/licenses</a>.
+		</div>
+		<h3>
+			JNA
+		</h3>
+		<p>
+			The NetLogo R Extension makes use of the JNA library.
+			The JNA library is licensed under the following terms:
+		</p>
 
-    <div class="license">
-      This copy of JNA is licensed under the
-      Apache (Software) License, version 2.0 ("the License").
-      See the License for details about distribution rights, and the
-      specific rights regarding derivate works.
+		<div class="license">
+			This copy of JNA is licensed under the
+			Apache (Software) License, version 2.0 ("the License").
+			See the License for details about distribution rights, and the
+			specific rights regarding derivate works.
 
-      You may obtain a copy of the License at:
+			You may obtain a copy of the License at:
 
-      http://www.apache.org/licenses/
-    </div>
-</body>
+			http://www.apache.org/licenses/
+		</div>
+	</body>
 </html>

--- a/autogen/docs/copyright.html.mustache
+++ b/autogen/docs/copyright.html.mustache
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
+<html lang="en">
+<head>
 <title>
   NetLogo {{version}} User Manual: Copyright and License
 </title>
 <link rel="stylesheet" href="netlogo.css" type="text/css">
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<style type="text/css">
+<style>
   .license {
     padding: 2em;
     background-color: #ffc;
@@ -14,6 +16,8 @@
     font-size: 80%;
   }
 </style>
+</head>
+<body>
   <h1>
     Copyright and License Information
   </h1>
@@ -28,15 +32,18 @@
       it. The correct citation is: Wilensky, U. (1999). NetLogo. <a href="http://ccl.northwestern.edu/netlogo/" target="_blank">http://ccl.northwestern.edu/netlogo/</a>.
       Center for Connected Learning and Computer-Based Modeling,
       Northwestern University, Evanston, IL.
+    </p>
     <p>
       For HubNet, cite: Wilensky, U. &amp; Stroup, W., 1999. HubNet.
       <a href="http://ccl.northwestern.edu/netlogo/hubnet.html" target="_blank">http://ccl.northwestern.edu/netlogo/hubnet.html</a>.
       Center for Connected Learning and Computer-Based Modeling,
       Northwestern University. Evanston, IL.
+    </p>
     <p>
       For models in the Models Library, the correct citation is included in
       the &quot;Credits and References&quot; section of each model's
       Info tab.
+    </p>
     <h2>
       Acknowledgments
     </h2>
@@ -51,21 +58,25 @@
       and DRL-1640201. Additional support came from the Spencer Foundation,
       Texas Instruments, the Brady Fund, the Murphy fund,
       and the Northwestern Institute on Complex Systems.
+    </p>
     <h2>
       NetLogo license
     </h2>
     <p>
       Copyright 1999-{{year}} by Uri Wilensky.
+    </p>
     <p>
       This program is free software; you can redistribute it and/or modify
       it under the terms of the GNU General Public License as published by
       the Free Software Foundation; either version 2 of the License, or (at
       your option) any later version.
+    </p>
     <p>
       This program is distributed in the hope that it will be useful, but
       WITHOUT ANY WARRANTY; without even the implied warranty of
       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
       General Public License for more details.
+    </p>
     <p>
       You should have received a copy of the GNU General Public License
       along with this program; if not, write to the Free Software
@@ -77,22 +88,26 @@
     <p>
       Commercial licenses are also available. To inquire about commercial
       licenses, please contact Uri Wilensky at <a href="mailto:netlogo-commercial-admin@ccl.northwestern.edu">netlogo-commercial-admin@ccl.northwestern.edu</a>.
+    </p>
     <h2>
       NetLogo User Manual license
     </h2>
     <p>
       Copyright 1999-{{year}} by Uri Wilensky.
+    </p>
     <p>
       <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank"><img alt="Creative Commons License" style="border-width:0" src="images/cc-by-sa-3.0.png"></a>
       <br>
-      <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">The NetLogo User Manual</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="http://ccl.northwestern.edu/netlogo/" property="cc:attributionName" rel="cc:attributionURL" target="_blank">Uri Wilensky</a> is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons
+      The NetLogo User Manual by <a href="http://ccl.northwestern.edu/netlogo/" target="_blank">Uri Wilensky</a> is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons
       Attribution-ShareAlike 3.0 Unported License</a>.
+    </p>
     <h2>
       Open source
     </h2>
     <p>
       The NetLogo source code is hosted at <a href="https://github.com/NetLogo/NetLogo" target="_blank">https://github.com/NetLogo/NetLogo</a>.
       Contributions from interested users are welcome.
+    </p>
     <h2>
       Third party licenses
     </h2>
@@ -102,6 +117,7 @@
     <p>
       Much of NetLogo is written in the Scala language and uses the Scala
       standard libraries. The license for Scala is as follows:
+    </p>
     <div class="license">
       <p>Copyright (c) 2002 - EPFL</p>
       <p>Copyright (c) 2011 - Lightbend, Inc.</p>
@@ -110,13 +126,13 @@
 
       <p>
       Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+      </p>
 
       <ul>
         <li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</li>
         <li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.</li>
         <li>Neither the name of the EPFL nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.</li>
       </ul>
-      </p>
       <p>
       THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot;
       AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -135,6 +151,7 @@
     <p>
       For random number generation, NetLogo uses the MersenneTwisterFast
       class by Sean Luke. The copyright for that code is as follows:
+    </p>
     <div class="license">
       <p>
         Copyright (c) 2003 by Sean Luke.
@@ -142,10 +159,12 @@
         Portions copyright (c) 1993 by Michael Lecuyer.
         <br>
         All rights reserved.
+      </p>
       <p>
         Redistribution and use in source and binary forms, with or without
         modification, are permitted provided that the following conditions
         are met:
+      </p>
       <ul>
         <li>Redistributions of source code must retain the above copyright
         notice, this list of conditions and the following disclaimer.
@@ -171,6 +190,7 @@
         STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
         ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
         OF THE POSSIBILITY OF SUCH DAMAGE.
+      </p>
       </div>
     <h3>
       Colt
@@ -179,6 +199,7 @@
       Parts of NetLogo (specifically, the random-gamma primitive) are based
       on code from the Colt library (<a href="http://acs.lbl.gov/~hoschek/colt/">http://acs.lbl.gov/~hoschek/colt/</a>).
       The copyright for that code is as follows:
+    </p>
     <div class="license">
       <p>
         Copyright 1999 CERN - European Organization for Nuclear Research.
@@ -189,6 +210,7 @@
         appear in supporting documentation. CERN makes no representations
         about the suitability of this software for any purpose. It is
         provided &quot;as is&quot; without expressed or implied warranty.
+      </p>
       </div>
     <h3>
       Config
@@ -198,6 +220,7 @@
       Copyright (C) 2011-2012 Typesafe Inc. <a href="http://typesafe.com">http://typesafe.com</a>
       The Config library is licensed under the Apache 2.0 License.
       You may obtain a copy of the license at <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>.
+    </p>
     <h3>
       Apache Commons Codec (TM)
     </h3>
@@ -211,6 +234,7 @@
     </h3>
     <p>
       NetLogo uses the Flexmark library (and extensions) for the info tab. The copyright and license are as follows:
+    </p>
     <div class="license">
       Copyright (c) 2015-2016, Atlassian Pty Ltd
       All rights reserved.
@@ -250,6 +274,7 @@
       &quot;docs&quot; folder which accompanies the NetLogo download, and
       is also available from <a href="http://www.gnu.org/copyleft/lesser.html">http://www.gnu.org/copyleft/lesser.html</a>
       .
+    </p>
     <h3>
       JOGL
     </h3>
@@ -257,18 +282,22 @@
       For 3D graphics rendering, NetLogo uses JOGL, a Java API for OpenGL, and Gluegen, an automatic code generation tool.
       For more information about JOGL and Gluegen, see <a href="http://jogamp.org/">jogamp.org/</a>.
       Both libraries are distributed under the BSD license:
+    </p>
     <div class="license">
       Copyright 2010 JogAmp Community. All rights reserved.
       <p>
       Redistribution and use in source and binary forms, with or without modification, are
       permitted provided that the following conditions are met:
+      </p>
       <p>
       1. Redistributions of source code must retain the above copyright notice, this list of
       conditions and the following disclaimer.
+      </p>
       <p>
       2. Redistributions in binary form must reproduce the above copyright notice, this list
       of conditions and the following disclaimer in the documentation and/or other materials
       provided with the distribution.
+      </p>
       <p>
       THIS SOFTWARE IS PROVIDED BY JogAmp Community ``AS IS'' AND ANY EXPRESS OR IMPLIED
       WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
@@ -279,10 +308,12 @@
       ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
       NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
       ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+      </p>
       <p>
       The views and conclusions contained in the software and documentation are those of the
       authors and should not be interpreted as representing official policies, either expressed
       or implied, of JogAmp Community.
+      </p>
       <p>
       You can address the JogAmp Community via:
       Web                http://jogamp.org/
@@ -292,6 +323,7 @@
       Jabber           conference.jabber.org room: jogamp (deprecated!)
       Repository         http://jogamp.org/git/
       Email              mediastream _at_ jogamp _dot_ org
+      </p>
     </div>
     <h3>
       Matrix3D
@@ -299,6 +331,7 @@
     <p>
       For 3D matrix operations, NetLogo uses the Matrix3D class. It is
       distributed under the following license:
+    </p>
     <div class="license">
       Copyright (c) 1994-1996 Sun Microsystems, Inc. All Rights Reserved.
       <p>
@@ -308,6 +341,7 @@
         and license appear on all copies of the software; and ii) Licensee
         does not utilize the software in a manner which is disparaging to
         Sun.
+      </p>
       <p>
         This software is provided &quot;AS IS,&quot; without a warranty of
         any kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND
@@ -321,6 +355,7 @@
         PUNITIVE DAMAGES, HOWEVER CAUSED AND REGARDLESS OF THE THEORY OF
         LIABILITY, ARISING OUT OF THE USE OF OR INABILITY TO USE SOFTWARE,
         EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </p>
       <p>
         This software is not designed or intended for use in on-line
         control of aircraft, air traffic, aircraft navigation or aircraft
@@ -328,6 +363,7 @@
         maintenance of any nuclear facility. Licensee represents and
         warrants that it will not use or redistribute the Software for such
         purposes.
+      </p>
       </div>
     <h3>
       ASM
@@ -335,25 +371,31 @@
     <p>
       For Java bytecode generation, NetLogo uses the ASM library. It is
       distributed under the following license:
+    </p>
     <div class="license">
       <p>
         Copyright (c) 2000-2011 INRIA, France Telecom. All rights reserved.
+      </p>
       <p>
         Redistribution and use in source and binary forms, with or without
         modification, are permitted provided that the following conditions
         are met:
+      </p>
       <p>
         1. Redistributions of source code must retain the above copyright
         notice, this list of conditions and the following disclaimer.
+      </p>
       <p>
         2. Redistributions in binary form must reproduce the above
         copyright notice, this list of conditions and the following
         disclaimer in the documentation and/or other materials provided
         with the distribution.
+      </p>
       <p>
         3. Neither the name of the copyright holders nor the names of its
         contributors may be used to endorse or promote products derived
         from this software without specific prior written permission.
+      </p>
       <p>
         THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
         &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
@@ -367,6 +409,7 @@
         STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
         ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
         OF THE POSSIBILITY OF SUCH DAMAGE.
+      </p>
       </div>
     <h3>
       Log4j
@@ -374,22 +417,27 @@
     <p>
       For logging, NetLogo uses the Log4j library. The copyright and
       license for the library are as follows:
+    </p>
     <div class="license">
       <p>
         Copyright 2007 The Apache Software Foundation
+      </p>
       <p>
         Licensed under the Apache License, Version 2.0 (the
         &quot;License&quot;); you may not use this file except in
         compliance with the License. You may obtain a copy of the License
         at
+      </p>
       <p>
         <a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">http://www.apache.org/licenses/LICENSE-2.0</a>
+      </p>
       <p>
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an &quot;AS
         IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
         either express or implied. See the License for the specific
         language governing permissions and limitations under the License.
+      </p>
       </div>
     <h3>
       PicoContainer
@@ -397,14 +445,17 @@
     <p>
       For dependency injection, NetLogo uses the PicoContainer library. The
       copyright and license for the library are as follows:
+    </p>
     <div class="license">
       <p>
         Copyright (c) 2004-2011, PicoContainer Organization All rights
         reserved.
+      </p>
       <p>
         Redistribution and use in source and binary forms, with or without
         modification, are permitted provided that the following conditions
         are met:
+      </p>
       <ul>
         <li>Redistributions of source code must retain the above copyright
         notice, this list of conditions and the following disclaimer.
@@ -430,12 +481,14 @@
         STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
         ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
         OF THE POSSIBILITY OF SUCH DAMAGE.
+      </p>
       </div>
     <h3>
       Parboiled
     </h3>
     <p>
       For reading models, NetLogo uses the Parboiled library. The copyright and license for Parboiled are as follows:
+    </p>
     <div class="license">
       This software is licensed under the Apache 2 license, quoted below.
 
@@ -459,6 +512,7 @@
     </h3>
     <p>The NetLogo editor uses the RSyntaxTextArea library.
     The copyright and license are as follows:
+    </p>
     <div class="license">
       Redistribution and use in source and binary forms, with or without
       modification, are permitted provided that the following conditions are met:
@@ -488,6 +542,7 @@
     <p>
     The NetLogo <code>vid</code> extension makes use of the JCodec library.
     The copyright and license for JCodec are as follows:
+    </p>
     <div class="license">
       Redistribution  and  use  in   source  and   binary   forms,  with  or  without
       modification, are permitted provided  that the following  conditions  are  met:
@@ -516,6 +571,7 @@
       NetLogo on Mac OS X makes use of the Java-Objective-C Bridge library.
       This library was created by Steve Hannah and is distributed under the Apache 2.0 license,
       available at <a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a>.
+    </p>
     <h3>
       Webcam-capture
     </h3>
@@ -555,20 +611,25 @@
     <p>
     The <code>nw</code> extension makes use of the Gephi library.
     Gephi is licensed under the following terms:
+    </p>
     <div class="license">
       Gephi Dual License Header and License Notice
       <p>
       The Gephi Consortium elects to use only the GNU General Public License version 3 (GPL) for any software where a choice of GPL license versions are made available with the language indicating that GPLv3 or any later version may be used, or where a choice of which version of the GPL is applied is unspecified.
+      </p>
       <p>
       For more information on the license please see: the Gephi License FAQs.
+      </p>
       <p>
       License headers are available on http://www.opensource.org/licenses/CDDL-1.0 and http://www.gnu.org/licenses/gpl.html.
+      </p>
     </div>
     <h3>
       R Extension
     </h3>
     <p>
     The NetLogo R Extension is licensed under the following terms:
+    </p>
     <div class="license">
       The R extension is Copyright (C) 2009-2016 Jan C. Thiele and
       Copyright (C) 2016 Uri Wilensky / The Center for Connected Learning.
@@ -593,6 +654,7 @@
     <p>
     The NetLogo R Extension makes use of the JNA library.
     The JNA library is licensed under the following terms:
+    </p>
 
     <div class="license">
       This copy of JNA is licensed under the
@@ -604,3 +666,5 @@
 
       http://www.apache.org/licenses/
     </div>
+</body>
+</html>

--- a/autogen/docs/copyright.html.mustache
+++ b/autogen/docs/copyright.html.mustache
@@ -1,677 +1,677 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<title>
-			NetLogo {{version}} User Manual: Copyright and License
-		</title>
-		<link rel="stylesheet" href="netlogo.css" type="text/css"/>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-		<style>
-			.license {
-			padding: 2em;
-			background-color: #ffc;
-			border-style: solid;
-			border-width: 1pt;
-			font-family: courier;
-			font-size: 80%;
-			}
-		</style>
-	</head>
-	<body>
-		<h1>
-			Copyright and License Information
-		</h1>
-		<div class="version">
-			NetLogo {{version}} User Manual
-		</div>
-		<h2>
-			How to reference
-		</h2>
-		<p>
-			If you use or refer to NetLogo in a publication, we ask that you cite
-			it. The correct citation is: Wilensky, U. (1999). NetLogo. <a href="http://ccl.northwestern.edu/netlogo/" target="_blank">http://ccl.northwestern.edu/netlogo/</a>.
-			Center for Connected Learning and Computer-Based Modeling,
-			Northwestern University, Evanston, IL.
-		</p>
-		<p>
-			For HubNet, cite: Wilensky, U. &amp; Stroup, W., 1999. HubNet.
-			<a href="http://ccl.northwestern.edu/netlogo/hubnet.html" target="_blank">http://ccl.northwestern.edu/netlogo/hubnet.html</a>.
-			Center for Connected Learning and Computer-Based Modeling,
-			Northwestern University. Evanston, IL.
-		</p>
-		<p>
-			For models in the Models Library, the correct citation is included in
-			the &quot;Credits and References&quot; section of each model's
-			Info tab.
-		</p>
-		<h2>
-			Acknowledgments
-		</h2>
-		<p>
-			The CCL gratefully acknowledges two decades of support for our NetLogo work.
-			The original support came from the National Science Foundation -- grant numbers
-			REC-9814682 and REC-0126227. Further support has come from REC-0003285, REC-0115699,
-			DRL-0196044, CCF-ITR-0326542, DRL-REC/ROLE-0440113, SBE-0624318, EEC-0648316,
-			IIS-0713619, DRL-RED-9552950, DRL-REC-9632612, and DRL-DRK12-1020101, IIS-1441552,
-			CNS-1441016, CNS-1441041, CNS-1138461, IIS-1438813, IIS-1147621, DRL-REC-1343873,
-			IIS-1438813, IIS-1441552, CNS-1441041, IIS-1546120, DRL-1546122, DRL-1614745
-			and DRL-1640201. Additional support came from the Spencer Foundation,
-			Texas Instruments, the Brady Fund, the Murphy fund,
-			and the Northwestern Institute on Complex Systems.
-		</p>
-		<h2>
-			NetLogo license
-		</h2>
-		<p>
-			Copyright 1999-{{year}} by Uri Wilensky.
-		</p>
-		<p>
-			This program is free software; you can redistribute it and/or modify
-			it under the terms of the GNU General Public License as published by
-			the Free Software Foundation; either version 2 of the License, or (at
-			your option) any later version.
-		</p>
-		<p>
-			This program is distributed in the hope that it will be useful, but
-			WITHOUT ANY WARRANTY; without even the implied warranty of
-			MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-			General Public License for more details.
-		</p>
-		<p>
-			You should have received a copy of the GNU General Public License
-			along with this program; if not, write to the Free Software
-			Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-			02110-1301, USA.
-		</p>
-		<h2>
-			Commercial licenses
-		</h2>
-		<p>
-			Commercial licenses are also available. To inquire about commercial
-			licenses, please contact Uri Wilensky at <a href="mailto:netlogo-commercial-admin@ccl.northwestern.edu">netlogo-commercial-admin@ccl.northwestern.edu</a>.
-		</p>
-		<h2>
-			NetLogo User Manual license
-		</h2>
-		<p>
-			Copyright 1999-{{year}} by Uri Wilensky.
-		</p>
-		<p>
-			<a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank"><img alt="Creative Commons License" style="border-width:0" src="images/cc-by-sa-3.0.png"/></a>
-			<br/>
-			The NetLogo User Manual by <a href="http://ccl.northwestern.edu/netlogo/" target="_blank">Uri Wilensky</a> is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons
-				Attribution-ShareAlike 3.0 Unported License</a>.
-		</p>
-		<h2>
-			Open source
-		</h2>
-		<p>
-			The NetLogo source code is hosted at <a href="https://github.com/NetLogo/NetLogo" target="_blank">https://github.com/NetLogo/NetLogo</a>.
-			Contributions from interested users are welcome.
-		</p>
-		<h2>
-			Third party licenses
-		</h2>
-		<h3>
-			Scala
-		</h3>
-		<p>
-			Much of NetLogo is written in the Scala language and uses the Scala
-			standard libraries. The license for Scala is as follows:
-		</p>
-		<div class="license">
-			<p>Copyright (c) 2002 - EPFL</p>
-			<p>Copyright (c) 2011 - Lightbend, Inc.</p>
+  <head>
+    <title>
+      NetLogo {{version}} User Manual: Copyright and License
+    </title>
+    <link rel="stylesheet" href="netlogo.css" type="text/css"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <style>
+      .license {
+      padding: 2em;
+      background-color: #ffc;
+      border-style: solid;
+      border-width: 1pt;
+      font-family: courier;
+      font-size: 80%;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>
+      Copyright and License Information
+    </h1>
+    <div class="version">
+      NetLogo {{version}} User Manual
+    </div>
+    <h2>
+      How to reference
+    </h2>
+    <p>
+      If you use or refer to NetLogo in a publication, we ask that you cite
+      it. The correct citation is: Wilensky, U. (1999). NetLogo. <a href="http://ccl.northwestern.edu/netlogo/" target="_blank">http://ccl.northwestern.edu/netlogo/</a>.
+      Center for Connected Learning and Computer-Based Modeling,
+      Northwestern University, Evanston, IL.
+    </p>
+    <p>
+      For HubNet, cite: Wilensky, U. &amp; Stroup, W., 1999. HubNet.
+      <a href="http://ccl.northwestern.edu/netlogo/hubnet.html" target="_blank">http://ccl.northwestern.edu/netlogo/hubnet.html</a>.
+      Center for Connected Learning and Computer-Based Modeling,
+      Northwestern University. Evanston, IL.
+    </p>
+    <p>
+      For models in the Models Library, the correct citation is included in
+      the &quot;Credits and References&quot; section of each model's
+      Info tab.
+    </p>
+    <h2>
+      Acknowledgments
+    </h2>
+    <p>
+      The CCL gratefully acknowledges two decades of support for our NetLogo work.
+      The original support came from the National Science Foundation -- grant numbers
+      REC-9814682 and REC-0126227. Further support has come from REC-0003285, REC-0115699,
+      DRL-0196044, CCF-ITR-0326542, DRL-REC/ROLE-0440113, SBE-0624318, EEC-0648316,
+      IIS-0713619, DRL-RED-9552950, DRL-REC-9632612, and DRL-DRK12-1020101, IIS-1441552,
+      CNS-1441016, CNS-1441041, CNS-1138461, IIS-1438813, IIS-1147621, DRL-REC-1343873,
+      IIS-1438813, IIS-1441552, CNS-1441041, IIS-1546120, DRL-1546122, DRL-1614745
+      and DRL-1640201. Additional support came from the Spencer Foundation,
+      Texas Instruments, the Brady Fund, the Murphy fund,
+      and the Northwestern Institute on Complex Systems.
+    </p>
+    <h2>
+      NetLogo license
+    </h2>
+    <p>
+      Copyright 1999-{{year}} by Uri Wilensky.
+    </p>
+    <p>
+      This program is free software; you can redistribute it and/or modify
+      it under the terms of the GNU General Public License as published by
+      the Free Software Foundation; either version 2 of the License, or (at
+      your option) any later version.
+    </p>
+    <p>
+      This program is distributed in the hope that it will be useful, but
+      WITHOUT ANY WARRANTY; without even the implied warranty of
+      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+      General Public License for more details.
+    </p>
+    <p>
+      You should have received a copy of the GNU General Public License
+      along with this program; if not, write to the Free Software
+      Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+      02110-1301, USA.
+    </p>
+    <h2>
+      Commercial licenses
+    </h2>
+    <p>
+      Commercial licenses are also available. To inquire about commercial
+      licenses, please contact Uri Wilensky at <a href="mailto:netlogo-commercial-admin@ccl.northwestern.edu">netlogo-commercial-admin@ccl.northwestern.edu</a>.
+    </p>
+    <h2>
+      NetLogo User Manual license
+    </h2>
+    <p>
+      Copyright 1999-{{year}} by Uri Wilensky.
+    </p>
+    <p>
+      <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank"><img alt="Creative Commons License" style="border-width:0" src="images/cc-by-sa-3.0.png"/></a>
+      <br/>
+      The NetLogo User Manual by <a href="http://ccl.northwestern.edu/netlogo/" target="_blank">Uri Wilensky</a> is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons
+        Attribution-ShareAlike 3.0 Unported License</a>.
+    </p>
+    <h2>
+      Open source
+    </h2>
+    <p>
+      The NetLogo source code is hosted at <a href="https://github.com/NetLogo/NetLogo" target="_blank">https://github.com/NetLogo/NetLogo</a>.
+      Contributions from interested users are welcome.
+    </p>
+    <h2>
+      Third party licenses
+    </h2>
+    <h3>
+      Scala
+    </h3>
+    <p>
+      Much of NetLogo is written in the Scala language and uses the Scala
+      standard libraries. The license for Scala is as follows:
+    </p>
+    <div class="license">
+      <p>Copyright (c) 2002 - EPFL</p>
+      <p>Copyright (c) 2011 - Lightbend, Inc.</p>
 
-			<p>All rights reserved.</p>
+      <p>All rights reserved.</p>
 
-			<p>
-				Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-			</p>
+      <p>
+        Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+      </p>
 
-			<ul>
-				<li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</li>
-				<li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.</li>
-				<li>Neither the name of the EPFL nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.</li>
-			</ul>
-			<p>
-				THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot;
-				AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-				IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-				IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-				INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-				BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
-				OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-				WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-				ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-			</p>
-		</div>
-		<h3>
-			MersenneTwisterFast
-		</h3>
-		<p>
-			For random number generation, NetLogo uses the MersenneTwisterFast
-			class by Sean Luke. The copyright for that code is as follows:
-		</p>
-		<div class="license">
-			<p>
-				Copyright (c) 2003 by Sean Luke.
-				<br/>
-				Portions copyright (c) 1993 by Michael Lecuyer.
-				<br/>
-				All rights reserved.
-			</p>
-			<p>
-				Redistribution and use in source and binary forms, with or without
-				modification, are permitted provided that the following conditions
-				are met:
-			</p>
-			<ul>
-				<li>Redistributions of source code must retain the above copyright
-					notice, this list of conditions and the following disclaimer.
-				</li>
-				<li>Redistributions in binary form must reproduce the above
-					copyright notice, this list of conditions and the following
-					disclaimer in the documentation and/or other materials provided
-					with the distribution.
-				</li>
-				<li>Neither the name of the copyright owners, their employers, nor
-					the names of its contributors may be used to endorse or promote
-					products derived from this software without specific prior written
-					permission.
-				</li>
-			</ul>
-			<p>
-				THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-				&quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
-				BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-				FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-				THE COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-				INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-				(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-				SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-				HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-				STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-				ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-				OF THE POSSIBILITY OF SUCH DAMAGE.
-			</p>
-		</div>
-		<h3>
-			Colt
-		</h3>
-		<p>
-			Parts of NetLogo (specifically, the random-gamma primitive) are based
-			on code from the Colt library (<a href="http://acs.lbl.gov/~hoschek/colt/">http://acs.lbl.gov/~hoschek/colt/</a>).
-			The copyright for that code is as follows:
-		</p>
-		<div class="license">
-			<p>
-				Copyright 1999 CERN - European Organization for Nuclear Research.
-				Permission to use, copy, modify, distribute and sell this software
-				and its documentation for any purpose is hereby granted without
-				fee, provided that the above copyright notice appear in all copies
-				and that both that copyright notice and this permission notice
-				appear in supporting documentation. CERN makes no representations
-				about the suitability of this software for any purpose. It is
-				provided &quot;as is&quot; without expressed or implied warranty.
-			</p>
-		</div>
-		<h3>
-			Config
-		</h3>
-		<p>
-			NetLogo uses the Typesafe "Config" library.
-			Copyright (C) 2011-2012 Typesafe Inc. <a href="http://typesafe.com">http://typesafe.com</a>
-			The Config library is licensed under the Apache 2.0 License.
-			You may obtain a copy of the license at <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>.
-		</p>
-		<h3>
-			Apache Commons Codec (TM)
-		</h3>
-		The NetLogo compiler uses a digest method from the Apache Commons Codec (TM) library.
-		Apache Commons Codec (TM) is copyright and trademark 2002-2014 the Apache Software Foundation.
+      <ul>
+        <li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</li>
+        <li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.</li>
+        <li>Neither the name of the EPFL nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.</li>
+      </ul>
+      <p>
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot;
+        AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+        IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+        INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+        BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+        OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+        WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+      </p>
+    </div>
+    <h3>
+      MersenneTwisterFast
+    </h3>
+    <p>
+      For random number generation, NetLogo uses the MersenneTwisterFast
+      class by Sean Luke. The copyright for that code is as follows:
+    </p>
+    <div class="license">
+      <p>
+        Copyright (c) 2003 by Sean Luke.
+        <br/>
+        Portions copyright (c) 1993 by Michael Lecuyer.
+        <br/>
+        All rights reserved.
+      </p>
+      <p>
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions
+        are met:
+      </p>
+      <ul>
+        <li>Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+        </li>
+        <li>Redistributions in binary form must reproduce the above
+          copyright notice, this list of conditions and the following
+          disclaimer in the documentation and/or other materials provided
+          with the distribution.
+        </li>
+        <li>Neither the name of the copyright owners, their employers, nor
+          the names of its contributors may be used to endorse or promote
+          products derived from this software without specific prior written
+          permission.
+        </li>
+      </ul>
+      <p>
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+        &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+        BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+        FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+        THE COPYRIGHT OWNERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+        INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+        HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+        STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+        OF THE POSSIBILITY OF SUCH DAMAGE.
+      </p>
+    </div>
+    <h3>
+      Colt
+    </h3>
+    <p>
+      Parts of NetLogo (specifically, the random-gamma primitive) are based
+      on code from the Colt library (<a href="http://acs.lbl.gov/~hoschek/colt/">http://acs.lbl.gov/~hoschek/colt/</a>).
+      The copyright for that code is as follows:
+    </p>
+    <div class="license">
+      <p>
+        Copyright 1999 CERN - European Organization for Nuclear Research.
+        Permission to use, copy, modify, distribute and sell this software
+        and its documentation for any purpose is hereby granted without
+        fee, provided that the above copyright notice appear in all copies
+        and that both that copyright notice and this permission notice
+        appear in supporting documentation. CERN makes no representations
+        about the suitability of this software for any purpose. It is
+        provided &quot;as is&quot; without expressed or implied warranty.
+      </p>
+    </div>
+    <h3>
+      Config
+    </h3>
+    <p>
+      NetLogo uses the Typesafe "Config" library.
+      Copyright (C) 2011-2012 Typesafe Inc. <a href="http://typesafe.com">http://typesafe.com</a>
+      The Config library is licensed under the Apache 2.0 License.
+      You may obtain a copy of the license at <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>.
+    </p>
+    <h3>
+      Apache Commons Codec (TM)
+    </h3>
+    The NetLogo compiler uses a digest method from the Apache Commons Codec (TM) library.
+    Apache Commons Codec (TM) is copyright and trademark 2002-2014 the Apache Software Foundation.
 
-		It is licensed under the Apache 2.0 License. You may obtain a copy of the license at
-		<a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>.
-		<h3>
-			Flexmark
-		</h3>
-		<p>
-			NetLogo uses the Flexmark library (and extensions) for the info tab. The copyright and license are as follows:
-		</p>
-		<div class="license">
-			Copyright (c) 2015-2016, Atlassian Pty Ltd
-			All rights reserved.
+    It is licensed under the Apache 2.0 License. You may obtain a copy of the license at
+    <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>.
+    <h3>
+      Flexmark
+    </h3>
+    <p>
+      NetLogo uses the Flexmark library (and extensions) for the info tab. The copyright and license are as follows:
+    </p>
+    <div class="license">
+      Copyright (c) 2015-2016, Atlassian Pty Ltd
+      All rights reserved.
 
-			Copyright (c) 2016, Vladimir Schneider,
-			All rights reserved.
+      Copyright (c) 2016, Vladimir Schneider,
+      All rights reserved.
 
-			Redistribution and use in source and binary forms, with or without
-			modification, are permitted provided that the following conditions are met:
+      Redistribution and use in source and binary forms, with or without
+      modification, are permitted provided that the following conditions are met:
 
-			* Redistributions of source code must retain the above copyright notice, this
-			list of conditions and the following disclaimer.
+      * Redistributions of source code must retain the above copyright notice, this
+      list of conditions and the following disclaimer.
 
-			* Redistributions in binary form must reproduce the above copyright notice,
-			this list of conditions and the following disclaimer in the documentation
-			and/or other materials provided with the distribution.
+      * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
 
-			THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-			AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-			IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-			DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-			FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-			DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-			SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-			CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-			OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-			OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-		</div>
-		<h3>
-			JHotDraw
-		</h3>
-		<p>
-			For the system dynamics modeler, NetLogo uses the JHotDraw library,
-			which is Copyright (c) 1996, 1997 by IFA Informatik and Erich Gamma.
-			The library is covered by the GNU LGPL (Lesser General Public
-			License). The text of that license is included in the
-			&quot;docs&quot; folder which accompanies the NetLogo download, and
-			is also available from <a href="http://www.gnu.org/copyleft/lesser.html">http://www.gnu.org/copyleft/lesser.html</a>
-			.
-		</p>
-		<h3>
-			JOGL
-		</h3>
-		<p>
-			For 3D graphics rendering, NetLogo uses JOGL, a Java API for OpenGL, and Gluegen, an automatic code generation tool.
-			For more information about JOGL and Gluegen, see <a href="http://jogamp.org/">jogamp.org/</a>.
-			Both libraries are distributed under the BSD license:
-		</p>
-		<div class="license">
-			Copyright 2010 JogAmp Community. All rights reserved.
-			<p>
-				Redistribution and use in source and binary forms, with or without modification, are
-				permitted provided that the following conditions are met:
-			</p>
-			<p>
-				1. Redistributions of source code must retain the above copyright notice, this list of
-				conditions and the following disclaimer.
-			</p>
-			<p>
-				2. Redistributions in binary form must reproduce the above copyright notice, this list
-				of conditions and the following disclaimer in the documentation and/or other materials
-				provided with the distribution.
-			</p>
-			<p>
-				THIS SOFTWARE IS PROVIDED BY JogAmp Community ``AS IS'' AND ANY EXPRESS OR IMPLIED
-				WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-				FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JogAmp Community OR
-				CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-				CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-				SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-				ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-				NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-				ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-			</p>
-			<p>
-				The views and conclusions contained in the software and documentation are those of the
-				authors and should not be interpreted as representing official policies, either expressed
-				or implied, of JogAmp Community.
-			</p>
-			<p>
-				You can address the JogAmp Community via:
-				Web                http://jogamp.org/
-				Forum/Mailinglist  http://forum.jogamp.org
-				Chatrooms
-				IRC              irc.freenode.net #jogamp
-				Jabber           conference.jabber.org room: jogamp (deprecated!)
-				Repository         http://jogamp.org/git/
-				Email              mediastream _at_ jogamp _dot_ org
-			</p>
-		</div>
-		<h3>
-			Matrix3D
-		</h3>
-		<p>
-			For 3D matrix operations, NetLogo uses the Matrix3D class. It is
-			distributed under the following license:
-		</p>
-		<div class="license">
-			Copyright (c) 1994-1996 Sun Microsystems, Inc. All Rights Reserved.
-			<p>
-				Sun grants you (&quot;Licensee&quot;) a non-exclusive, royalty
-				free, license to use, modify and redistribute this software in
-				source and binary code form, provided that i) this copyright notice
-				and license appear on all copies of the software; and ii) Licensee
-				does not utilize the software in a manner which is disparaging to
-				Sun.
-			</p>
-			<p>
-				This software is provided &quot;AS IS,&quot; without a warranty of
-				any kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND
-				WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY,
-				FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY
-				EXCLUDED. SUN AND ITS LICENSORS SHALL NOT BE LIABLE FOR ANY DAMAGES
-				SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR
-				DISTRIBUTING THE SOFTWARE OR ITS DERIVATIVES. IN NO EVENT WILL SUN
-				OR ITS LICENSORS BE LIABLE FOR ANY LOST REVENUE, PROFIT OR DATA, OR
-				FOR DIRECT, INDIRECT, SPECIAL, CONSEQUENTIAL, INCIDENTAL OR
-				PUNITIVE DAMAGES, HOWEVER CAUSED AND REGARDLESS OF THE THEORY OF
-				LIABILITY, ARISING OUT OF THE USE OF OR INABILITY TO USE SOFTWARE,
-				EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-			</p>
-			<p>
-				This software is not designed or intended for use in on-line
-				control of aircraft, air traffic, aircraft navigation or aircraft
-				communications; or in the design, construction, operation or
-				maintenance of any nuclear facility. Licensee represents and
-				warrants that it will not use or redistribute the Software for such
-				purposes.
-			</p>
-		</div>
-		<h3>
-			ASM
-		</h3>
-		<p>
-			For Java bytecode generation, NetLogo uses the ASM library. It is
-			distributed under the following license:
-		</p>
-		<div class="license">
-			<p>
-				Copyright (c) 2000-2011 INRIA, France Telecom. All rights reserved.
-			</p>
-			<p>
-				Redistribution and use in source and binary forms, with or without
-				modification, are permitted provided that the following conditions
-				are met:
-			</p>
-			<p>
-				1. Redistributions of source code must retain the above copyright
-				notice, this list of conditions and the following disclaimer.
-			</p>
-			<p>
-				2. Redistributions in binary form must reproduce the above
-				copyright notice, this list of conditions and the following
-				disclaimer in the documentation and/or other materials provided
-				with the distribution.
-			</p>
-			<p>
-				3. Neither the name of the copyright holders nor the names of its
-				contributors may be used to endorse or promote products derived
-				from this software without specific prior written permission.
-			</p>
-			<p>
-				THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-				&quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
-				BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-				FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-				THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-				INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-				(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-				SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-				HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-				STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-				ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-				OF THE POSSIBILITY OF SUCH DAMAGE.
-			</p>
-		</div>
-		<h3>
-			Log4j
-		</h3>
-		<p>
-			For logging, NetLogo uses the Log4j library. The copyright and
-			license for the library are as follows:
-		</p>
-		<div class="license">
-			<p>
-				Copyright 2007 The Apache Software Foundation
-			</p>
-			<p>
-				Licensed under the Apache License, Version 2.0 (the
-				&quot;License&quot;); you may not use this file except in
-				compliance with the License. You may obtain a copy of the License
-				at
-			</p>
-			<p>
-				<a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">http://www.apache.org/licenses/LICENSE-2.0</a>
-			</p>
-			<p>
-				Unless required by applicable law or agreed to in writing, software
-				distributed under the License is distributed on an &quot;AS
-				IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-				either express or implied. See the License for the specific
-				language governing permissions and limitations under the License.
-			</p>
-		</div>
-		<h3>
-			PicoContainer
-		</h3>
-		<p>
-			For dependency injection, NetLogo uses the PicoContainer library. The
-			copyright and license for the library are as follows:
-		</p>
-		<div class="license">
-			<p>
-				Copyright (c) 2004-2011, PicoContainer Organization All rights
-				reserved.
-			</p>
-			<p>
-				Redistribution and use in source and binary forms, with or without
-				modification, are permitted provided that the following conditions
-				are met:
-			</p>
-			<ul>
-				<li>Redistributions of source code must retain the above copyright
-					notice, this list of conditions and the following disclaimer.
-				</li>
-				<li>Redistributions in binary form must reproduce the above
-					copyright notice, this list of conditions and the following
-					disclaimer in the documentation and/or other materials provided
-					with the distribution.
-				</li>
-				<li>Neither the name of the PicoContainer Organization nor the
-					names of its contributors may be used to endorse or promote
-					products derived from this software without specific prior written
-					permission.
-				</li>
-			</ul>
-			<p>
-				THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-				&quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
-				BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-				FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-				THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-				INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-				(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-				SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-				HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-				STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-				ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-				OF THE POSSIBILITY OF SUCH DAMAGE.
-			</p>
-		</div>
-		<h3>
-			Parboiled
-		</h3>
-		<p>
-			For reading models, NetLogo uses the Parboiled library. The copyright and license for Parboiled are as follows:
-		</p>
-		<div class="license">
-			This software is licensed under the Apache 2 license, quoted below.
+      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+      AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+      IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+      DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+      FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+      DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+      SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+      CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+      OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    </div>
+    <h3>
+      JHotDraw
+    </h3>
+    <p>
+      For the system dynamics modeler, NetLogo uses the JHotDraw library,
+      which is Copyright (c) 1996, 1997 by IFA Informatik and Erich Gamma.
+      The library is covered by the GNU LGPL (Lesser General Public
+      License). The text of that license is included in the
+      &quot;docs&quot; folder which accompanies the NetLogo download, and
+      is also available from <a href="http://www.gnu.org/copyleft/lesser.html">http://www.gnu.org/copyleft/lesser.html</a>
+      .
+    </p>
+    <h3>
+      JOGL
+    </h3>
+    <p>
+      For 3D graphics rendering, NetLogo uses JOGL, a Java API for OpenGL, and Gluegen, an automatic code generation tool.
+      For more information about JOGL and Gluegen, see <a href="http://jogamp.org/">jogamp.org/</a>.
+      Both libraries are distributed under the BSD license:
+    </p>
+    <div class="license">
+      Copyright 2010 JogAmp Community. All rights reserved.
+      <p>
+        Redistribution and use in source and binary forms, with or without modification, are
+        permitted provided that the following conditions are met:
+      </p>
+      <p>
+        1. Redistributions of source code must retain the above copyright notice, this list of
+        conditions and the following disclaimer.
+      </p>
+      <p>
+        2. Redistributions in binary form must reproduce the above copyright notice, this list
+        of conditions and the following disclaimer in the documentation and/or other materials
+        provided with the distribution.
+      </p>
+      <p>
+        THIS SOFTWARE IS PROVIDED BY JogAmp Community ``AS IS'' AND ANY EXPRESS OR IMPLIED
+        WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+        FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JogAmp Community OR
+        CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+        CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+        ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+        NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+        ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+      </p>
+      <p>
+        The views and conclusions contained in the software and documentation are those of the
+        authors and should not be interpreted as representing official policies, either expressed
+        or implied, of JogAmp Community.
+      </p>
+      <p>
+        You can address the JogAmp Community via:
+        Web                http://jogamp.org/
+        Forum/Mailinglist  http://forum.jogamp.org
+        Chatrooms
+        IRC              irc.freenode.net #jogamp
+        Jabber           conference.jabber.org room: jogamp (deprecated!)
+        Repository         http://jogamp.org/git/
+        Email              mediastream _at_ jogamp _dot_ org
+      </p>
+    </div>
+    <h3>
+      Matrix3D
+    </h3>
+    <p>
+      For 3D matrix operations, NetLogo uses the Matrix3D class. It is
+      distributed under the following license:
+    </p>
+    <div class="license">
+      Copyright (c) 1994-1996 Sun Microsystems, Inc. All Rights Reserved.
+      <p>
+        Sun grants you (&quot;Licensee&quot;) a non-exclusive, royalty
+        free, license to use, modify and redistribute this software in
+        source and binary code form, provided that i) this copyright notice
+        and license appear on all copies of the software; and ii) Licensee
+        does not utilize the software in a manner which is disparaging to
+        Sun.
+      </p>
+      <p>
+        This software is provided &quot;AS IS,&quot; without a warranty of
+        any kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND
+        WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY
+        EXCLUDED. SUN AND ITS LICENSORS SHALL NOT BE LIABLE FOR ANY DAMAGES
+        SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR
+        DISTRIBUTING THE SOFTWARE OR ITS DERIVATIVES. IN NO EVENT WILL SUN
+        OR ITS LICENSORS BE LIABLE FOR ANY LOST REVENUE, PROFIT OR DATA, OR
+        FOR DIRECT, INDIRECT, SPECIAL, CONSEQUENTIAL, INCIDENTAL OR
+        PUNITIVE DAMAGES, HOWEVER CAUSED AND REGARDLESS OF THE THEORY OF
+        LIABILITY, ARISING OUT OF THE USE OF OR INABILITY TO USE SOFTWARE,
+        EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </p>
+      <p>
+        This software is not designed or intended for use in on-line
+        control of aircraft, air traffic, aircraft navigation or aircraft
+        communications; or in the design, construction, operation or
+        maintenance of any nuclear facility. Licensee represents and
+        warrants that it will not use or redistribute the Software for such
+        purposes.
+      </p>
+    </div>
+    <h3>
+      ASM
+    </h3>
+    <p>
+      For Java bytecode generation, NetLogo uses the ASM library. It is
+      distributed under the following license:
+    </p>
+    <div class="license">
+      <p>
+        Copyright (c) 2000-2011 INRIA, France Telecom. All rights reserved.
+      </p>
+      <p>
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions
+        are met:
+      </p>
+      <p>
+        1. Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      </p>
+      <p>
+        2. Redistributions in binary form must reproduce the above
+        copyright notice, this list of conditions and the following
+        disclaimer in the documentation and/or other materials provided
+        with the distribution.
+      </p>
+      <p>
+        3. Neither the name of the copyright holders nor the names of its
+        contributors may be used to endorse or promote products derived
+        from this software without specific prior written permission.
+      </p>
+      <p>
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+        &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+        BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+        FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+        THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+        INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+        HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+        STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+        OF THE POSSIBILITY OF SUCH DAMAGE.
+      </p>
+    </div>
+    <h3>
+      Log4j
+    </h3>
+    <p>
+      For logging, NetLogo uses the Log4j library. The copyright and
+      license for the library are as follows:
+    </p>
+    <div class="license">
+      <p>
+        Copyright 2007 The Apache Software Foundation
+      </p>
+      <p>
+        Licensed under the Apache License, Version 2.0 (the
+        &quot;License&quot;); you may not use this file except in
+        compliance with the License. You may obtain a copy of the License
+        at
+      </p>
+      <p>
+        <a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">http://www.apache.org/licenses/LICENSE-2.0</a>
+      </p>
+      <p>
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an &quot;AS
+        IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+        either express or implied. See the License for the specific
+        language governing permissions and limitations under the License.
+      </p>
+    </div>
+    <h3>
+      PicoContainer
+    </h3>
+    <p>
+      For dependency injection, NetLogo uses the PicoContainer library. The
+      copyright and license for the library are as follows:
+    </p>
+    <div class="license">
+      <p>
+        Copyright (c) 2004-2011, PicoContainer Organization All rights
+        reserved.
+      </p>
+      <p>
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions
+        are met:
+      </p>
+      <ul>
+        <li>Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+        </li>
+        <li>Redistributions in binary form must reproduce the above
+          copyright notice, this list of conditions and the following
+          disclaimer in the documentation and/or other materials provided
+          with the distribution.
+        </li>
+        <li>Neither the name of the PicoContainer Organization nor the
+          names of its contributors may be used to endorse or promote
+          products derived from this software without specific prior written
+          permission.
+        </li>
+      </ul>
+      <p>
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+        &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+        BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+        FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+        THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+        INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+        HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+        STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+        ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+        OF THE POSSIBILITY OF SUCH DAMAGE.
+      </p>
+    </div>
+    <h3>
+      Parboiled
+    </h3>
+    <p>
+      For reading models, NetLogo uses the Parboiled library. The copyright and license for Parboiled are as follows:
+    </p>
+    <div class="license">
+      This software is licensed under the Apache 2 license, quoted below.
 
-			Copyright © 2009-2013 Mathias Doenitz <a href="http://parboiled2.org">http://parboiled2.org</a>
-			Copyright © 2013 Alexander Myltsev
+      Copyright © 2009-2013 Mathias Doenitz <a href="http://parboiled2.org">http://parboiled2.org</a>
+      Copyright © 2013 Alexander Myltsev
 
-			Licensed under the Apache License, Version 2.0 (the "License"); you may not
-			use this file except in compliance with the License. You may obtain a copy of
-			the License at
+      Licensed under the Apache License, Version 2.0 (the "License"); you may not
+      use this file except in compliance with the License. You may obtain a copy of
+      the License at
 
-			[http://www.apache.org/licenses/LICENSE-2.0]
+      [http://www.apache.org/licenses/LICENSE-2.0]
 
-			Unless required by applicable law or agreed to in writing, software
-			distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-			WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-			License for the specific language governing permissions and limitations under
-			the License.
-		</div>
-		<h3>
-			RSyntaxTextArea
-		</h3>
-		<p>The NetLogo editor uses the RSyntaxTextArea library.
-			The copyright and license are as follows:
-		</p>
-		<div class="license">
-			Redistribution and use in source and binary forms, with or without
-			modification, are permitted provided that the following conditions are met:
-			* Redistributions of source code must retain the above copyright
-			notice, this list of conditions and the following disclaimer.
-			* Redistributions in binary form must reproduce the above copyright
-			notice, this list of conditions and the following disclaimer in the
-			documentation and/or other materials provided with the distribution.
-			* Neither the name of the author nor the names of its contributors may
-			be used to endorse or promote products derived from this software
-			without specific prior written permission.
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+      WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+      License for the specific language governing permissions and limitations under
+      the License.
+    </div>
+    <h3>
+      RSyntaxTextArea
+    </h3>
+    <p>The NetLogo editor uses the RSyntaxTextArea library.
+      The copyright and license are as follows:
+    </p>
+    <div class="license">
+      Redistribution and use in source and binary forms, with or without
+      modification, are permitted provided that the following conditions are met:
+      * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+      * Neither the name of the author nor the names of its contributors may
+      be used to endorse or promote products derived from this software
+      without specific prior written permission.
 
-			THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-			ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-			WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-			DISCLAIMED. IN NO EVENT SHALL &amp;COPYRIGHT HOLDER&amp; BE LIABLE FOR ANY
-			DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-			(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-			LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-			ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-			(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-			SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-		</div>
-		<h3>
-			JCodec
-		</h3>
-		<p>
-			The NetLogo <code>vid</code> extension makes use of the JCodec library.
-			The copyright and license for JCodec are as follows:
-		</p>
-		<div class="license">
-			Redistribution  and  use  in   source  and   binary   forms,  with  or  without
-			modification, are permitted provided  that the following  conditions  are  met:
+      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+      ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+      WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+      DISCLAIMED. IN NO EVENT SHALL &amp;COPYRIGHT HOLDER&amp; BE LIABLE FOR ANY
+      DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+      (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+      LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+      ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+      SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    </div>
+    <h3>
+      JCodec
+    </h3>
+    <p>
+      The NetLogo <code>vid</code> extension makes use of the JCodec library.
+      The copyright and license for JCodec are as follows:
+    </p>
+    <div class="license">
+      Redistribution  and  use  in   source  and   binary   forms,  with  or  without
+      modification, are permitted provided  that the following  conditions  are  met:
 
-			Redistributions of  source code  must  retain the above  copyright notice, this
-			list of conditions and the following disclaimer. Redistributions in binary form
-			must  reproduce  the above  copyright notice, this  list of conditions  and the
-			following disclaimer in the documentation and/or other  materials provided with
-			the distribution.
+      Redistributions of  source code  must  retain the above  copyright notice, this
+      list of conditions and the following disclaimer. Redistributions in binary form
+      must  reproduce  the above  copyright notice, this  list of conditions  and the
+      following disclaimer in the documentation and/or other  materials provided with
+      the distribution.
 
-			THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-			ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO, THE  IMPLIED
-			WARRANTIES  OF  MERCHANTABILITY  AND  FITNESS  FOR  A  PARTICULAR  PURPOSE  ARE
-			DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-			ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,  OR CONSEQUENTIAL DAMAGES
-			(INCLUDING,  BUT NOT LIMITED TO,  PROCUREMENT OF SUBSTITUTE GOODS  OR SERVICES;
-			LOSS OF USE, DATA, OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-			ANY  THEORY  OF  LIABILITY,  WHETHER  IN  CONTRACT,  STRICT LIABILITY,  OR TORT
-			(INCLUDING  NEGLIGENCE OR OTHERWISE)  ARISING IN ANY WAY OUT OF THE USE OF THIS
-			SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-		</div>
-		<h3>
-			Java-Objective-C Bridge
-		</h3>
-		<p>
-			NetLogo on Mac OS X makes use of the Java-Objective-C Bridge library.
-			This library was created by Steve Hannah and is distributed under the Apache 2.0 license,
-			available at <a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a>.
-		</p>
-		<h3>
-			Webcam-capture
-		</h3>
-		The NetLogo <code>vid</code> extension makes use of the Webcam-capture library.
-		The copyright and license for Webcam-capture are as follows:
-		<div class="license">
-			The MIT License (MIT)
+      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+      ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO, THE  IMPLIED
+      WARRANTIES  OF  MERCHANTABILITY  AND  FITNESS  FOR  A  PARTICULAR  PURPOSE  ARE
+      DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+      ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,  OR CONSEQUENTIAL DAMAGES
+      (INCLUDING,  BUT NOT LIMITED TO,  PROCUREMENT OF SUBSTITUTE GOODS  OR SERVICES;
+      LOSS OF USE, DATA, OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+      ANY  THEORY  OF  LIABILITY,  WHETHER  IN  CONTRACT,  STRICT LIABILITY,  OR TORT
+      (INCLUDING  NEGLIGENCE OR OTHERWISE)  ARISING IN ANY WAY OUT OF THE USE OF THIS
+      SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    </div>
+    <h3>
+      Java-Objective-C Bridge
+    </h3>
+    <p>
+      NetLogo on Mac OS X makes use of the Java-Objective-C Bridge library.
+      This library was created by Steve Hannah and is distributed under the Apache 2.0 license,
+      available at <a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a>.
+    </p>
+    <h3>
+      Webcam-capture
+    </h3>
+    The NetLogo <code>vid</code> extension makes use of the Webcam-capture library.
+    The copyright and license for Webcam-capture are as follows:
+    <div class="license">
+      The MIT License (MIT)
 
-			Copyright (c) 2012 - 2015 Bartosz Firyn and Contributors
+      Copyright (c) 2012 - 2015 Bartosz Firyn and Contributors
 
-			Permission is hereby granted, free of charge, to any person obtaining a copy
-			of this software and associated documentation files (the "Software"), to deal
-			in the Software without restriction, including without limitation the rights
-			to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-			copies of the Software, and to permit persons to whom the Software is
-			furnished to do so, subject to the following conditions:
+      Permission is hereby granted, free of charge, to any person obtaining a copy
+      of this software and associated documentation files (the "Software"), to deal
+      in the Software without restriction, including without limitation the rights
+      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      copies of the Software, and to permit persons to whom the Software is
+      furnished to do so, subject to the following conditions:
 
-			The above copyright notice and this permission notice shall be included in all
-			copies or substantial portions of the Software.
+      The above copyright notice and this permission notice shall be included in all
+      copies or substantial portions of the Software.
 
-			THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-			IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-			FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-			AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-			LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-			OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-			SOFTWARE.
-		</div>
-		<h3>
-			Guava
-		</h3>
-		The NetLogo <code>ls</code> extension makes use of the Guava library.
-		Guava is released under the Apache License 2.0 (<a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">http://www.apache.org/licenses/LICENSE-2.0</a>)
-		<h3>
-			Gephi
-		</h3>
-		<p>
-			The <code>nw</code> extension makes use of the Gephi library.
-			Gephi is licensed under the following terms:
-		</p>
-		<div class="license">
-			Gephi Dual License Header and License Notice
-			<p>
-				The Gephi Consortium elects to use only the GNU General Public License version 3 (GPL) for any software where a choice of GPL license versions are made available with the language indicating that GPLv3 or any later version may be used, or where a choice of which version of the GPL is applied is unspecified.
-			</p>
-			<p>
-				For more information on the license please see: the Gephi License FAQs.
-			</p>
-			<p>
-				License headers are available on http://www.opensource.org/licenses/CDDL-1.0 and http://www.gnu.org/licenses/gpl.html.
-			</p>
-		</div>
-		<h3>
-			R Extension
-		</h3>
-		<p>
-			The NetLogo R Extension is licensed under the following terms:
-		</p>
-		<div class="license">
-			The R extension is Copyright (C) 2009-2016 Jan C. Thiele and
-			Copyright (C) 2016 Uri Wilensky / The Center for Connected Learning.
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+      SOFTWARE.
+    </div>
+    <h3>
+      Guava
+    </h3>
+    The NetLogo <code>ls</code> extension makes use of the Guava library.
+    Guava is released under the Apache License 2.0 (<a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">http://www.apache.org/licenses/LICENSE-2.0</a>)
+    <h3>
+      Gephi
+    </h3>
+    <p>
+      The <code>nw</code> extension makes use of the Gephi library.
+      Gephi is licensed under the following terms:
+    </p>
+    <div class="license">
+      Gephi Dual License Header and License Notice
+      <p>
+        The Gephi Consortium elects to use only the GNU General Public License version 3 (GPL) for any software where a choice of GPL license versions are made available with the language indicating that GPLv3 or any later version may be used, or where a choice of which version of the GPL is applied is unspecified.
+      </p>
+      <p>
+        For more information on the license please see: the Gephi License FAQs.
+      </p>
+      <p>
+        License headers are available on http://www.opensource.org/licenses/CDDL-1.0 and http://www.gnu.org/licenses/gpl.html.
+      </p>
+    </div>
+    <h3>
+      R Extension
+    </h3>
+    <p>
+      The NetLogo R Extension is licensed under the following terms:
+    </p>
+    <div class="license">
+      The R extension is Copyright (C) 2009-2016 Jan C. Thiele and
+      Copyright (C) 2016 Uri Wilensky / The Center for Connected Learning.
 
-			NetLogo-R-Extension is free software; you can redistribute it and/or
-			modify it under the terms of the GNU General Public License
-			as published by the Free Software Foundation; either version 2
-			of the License, or (at your option) any later version.
+      NetLogo-R-Extension is free software; you can redistribute it and/or
+      modify it under the terms of the GNU General Public License
+      as published by the Free Software Foundation; either version 2
+      of the License, or (at your option) any later version.
 
-			This program is distributed in the hope that it will be useful,
-			but WITHOUT ANY WARRANTY; without even the implied warranty of
-			MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-			GNU General Public License for more details.
+      This program is distributed in the hope that it will be useful,
+      but WITHOUT ANY WARRANTY; without even the implied warranty of
+      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+      GNU General Public License for more details.
 
-			You should have received a copy of the GNU General Public License
-			along with NetLogo-R-Extension (located in GPL.txt).
-			If not, see <a href="http://www.gnu.org/licenses/">http://www.gnu.org/licenses</a>.
-		</div>
-		<h3>
-			JNA
-		</h3>
-		<p>
-			The NetLogo R Extension makes use of the JNA library.
-			The JNA library is licensed under the following terms:
-		</p>
+      You should have received a copy of the GNU General Public License
+      along with NetLogo-R-Extension (located in GPL.txt).
+      If not, see <a href="http://www.gnu.org/licenses/">http://www.gnu.org/licenses</a>.
+    </div>
+    <h3>
+      JNA
+    </h3>
+    <p>
+      The NetLogo R Extension makes use of the JNA library.
+      The JNA library is licensed under the following terms:
+    </p>
 
-		<div class="license">
-			This copy of JNA is licensed under the
-			Apache (Software) License, version 2.0 ("the License").
-			See the License for details about distribution rights, and the
-			specific rights regarding derivate works.
+    <div class="license">
+      This copy of JNA is licensed under the
+      Apache (Software) License, version 2.0 ("the License").
+      See the License for details about distribution rights, and the
+      specific rights regarding derivate works.
 
-			You may obtain a copy of the License at:
+      You may obtain a copy of the License at:
 
-			http://www.apache.org/licenses/
-		</div>
-	</body>
+      http://www.apache.org/licenses/
+    </div>
+  </body>
 </html>

--- a/autogen/docs/dictTemplate.html.mustache
+++ b/autogen/docs/dictTemplate.html.mustache
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
+<html lang="en">
 <head>
   <title>NetLogo Help:{{#containedPrims}} {{.}}{{/containedPrims}}</title>
 
   <link rel="stylesheet" href="../netlogo.css" type="text/css">
-  <meta http-equiv="Content-Type" content="text/html; charset=us-ascii">
-  <style type="text/css">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <style>
     p { margin-left: 1.5em ; }
     h3 { font-size: 115% ; }
     h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
@@ -14,5 +15,6 @@
   {{{html}}}
   <p>
     Take me to the full <a href="../index2.html">NetLogo Dictionary</a>
+	</p>
 </body>
 </html>

--- a/autogen/docs/dictTemplate.html.mustache
+++ b/autogen/docs/dictTemplate.html.mustache
@@ -1,20 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<title>NetLogo Help:{{#containedPrims}} {{.}}{{/containedPrims}}</title>
+  <head>
+    <title>NetLogo Help:{{#containedPrims}} {{.}}{{/containedPrims}}</title>
 
-		<link rel="stylesheet" href="../netlogo.css" type="text/css"/>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-		<style>
-			p { margin-left: 1.5em ; }
-			h3 { font-size: 115% ; }
-			h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
-		</style>
-	</head>
-	<body>
-		{{{html}}}
-		<p>
-			Take me to the full <a href="../index2.html">NetLogo Dictionary</a>
-		</p>
-	</body>
+    <link rel="stylesheet" href="../netlogo.css" type="text/css"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <style>
+      p { margin-left: 1.5em ; }
+      h3 { font-size: 115% ; }
+      h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
+    </style>
+  </head>
+  <body>
+    {{{html}}}
+    <p>
+      Take me to the full <a href="../index2.html">NetLogo Dictionary</a>
+    </p>
+  </body>
 </html>

--- a/autogen/docs/dictTemplate.html.mustache
+++ b/autogen/docs/dictTemplate.html.mustache
@@ -1,20 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <title>NetLogo Help:{{#containedPrims}} {{.}}{{/containedPrims}}</title>
+	<head>
+		<title>NetLogo Help:{{#containedPrims}} {{.}}{{/containedPrims}}</title>
 
-  <link rel="stylesheet" href="../netlogo.css" type="text/css">
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <style>
-    p { margin-left: 1.5em ; }
-    h3 { font-size: 115% ; }
-    h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
-  </style>
-</head>
-<body>
-  {{{html}}}
-  <p>
-    Take me to the full <a href="../index2.html">NetLogo Dictionary</a>
-	</p>
-</body>
+		<link rel="stylesheet" href="../netlogo.css" type="text/css"/>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+		<style>
+			p { margin-left: 1.5em ; }
+			h3 { font-size: 115% ; }
+			h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
+		</style>
+	</head>
+	<body>
+		{{{html}}}
+		<p>
+			Take me to the full <a href="../index2.html">NetLogo Dictionary</a>
+		</p>
+	</body>
 </html>

--- a/autogen/docs/dictionary.html.mustache
+++ b/autogen/docs/dictionary.html.mustache
@@ -1,14 +1,18 @@
-<!DOCTYPE html>
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
 <title>
   NetLogo {{version}} User Manual: NetLogo Dictionary
 </title>
 <link rel="stylesheet" href="netlogo.css" type="text/css">
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<style type="text/css">
+<style>
 p  { margin-left: 1.5em ; }
 h3 { font-size: 115% ; }
 h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
 </style>
+</head>
+<body>
 <h1>
   NetLogo Dictionary
 </h1>
@@ -76,6 +80,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       primitive might still be used by patches or the observer, and vice
       versa. To see which agents (turtles, patches, links, observer) can
       actually run a primitive, consult its dictionary entry.
+    </p>
       <!-- ======================================== -->
     <h3 id="turtlegroup">
       Turtle-related
@@ -155,6 +160,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#untie">untie</a>
       <a href="#uphill">uphill</a>
       <a href="#uphill">uphill4</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="patchgroup">
       Patch-related
@@ -194,6 +200,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#stop-inspecting">stop-inspecting</a>
       <a href="#subject">subject</a>
       <a href="#turtles-here">turtles-here</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="linkgroup">
       Link-related
@@ -260,6 +267,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#tie">tie</a>
       <a href="#undirected-link-breed">undirected-link-breed</a>
       <a href="#untie">untie</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="agentsetgroup">
       <a>Agentset</a>
@@ -309,6 +317,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#with">with</a>
       <a href="#with-max">with-max</a>
       <a href="#with-min">with-min</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="colorgroup">
       Color
@@ -328,6 +337,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#scale-color">scale-color</a>
       <a href="#shade-of">shade-of?</a>
       <a href="#wrap-color">wrap-color</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="controlgroup">
       Control flow and logic
@@ -363,6 +373,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#with-local-randomness">with-local-randomness</a>
       <a href="#without-interruption">without-interruption</a>
       <a href="#xor">xor</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="anonproceduresgroup">
       Anonymous Procedures
@@ -379,6 +390,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#run">run</a>
       <a href="#run">runresult</a>
       <a href="#sort-by">sort-by</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="worldgroup">
       World
@@ -409,6 +421,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#ticks">ticks</a>
       <a href="#world-dim">world-width</a>
       <a href="#world-dim">world-height</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="perspectivegroup">
       Perspective
@@ -422,6 +435,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#subject">subject</a>
       <a href="#watch">watch</a>
       <a href="#watch-me">watch-me</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="hubnetgroup">
       <a>HubNet</a>
@@ -450,6 +464,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#hubnet-send-message">hubnet-send-message</a>
       <a href="#hubnet-send-override">hubnet-send-override</a>
       <a href="#hubnet-send-watch">hubnet-send-watch</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="iogroup">
       Input/output
@@ -491,6 +506,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#user-one-of">user-one-of</a>
       <a href="#user-yes-or-no">user-yes-or-no?</a>
       <a href="#write">write</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="fileiogroup">
       File
@@ -513,6 +529,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#user-directory">user-directory</a>
       <a href="#user-file">user-file</a>
       <a href="#user-new-file">user-new-file</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="listsgroup">
       List
@@ -557,6 +574,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#sort-on">sort-on</a>
       <a href="#subliststring">sublist</a>
       <a href="#up-to-n-of">up-to-n-of</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="stringgroup">
       String
@@ -581,6 +599,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#reverse">reverse</a>
       <a href="#subliststring">substring</a>
       <a href="#word">word</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="mathematicalgroup">
       Mathematical
@@ -625,6 +644,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#sum">sum</a>
       <a href="#tan">tan</a>
       <a href="#variance">variance</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="plottinggroup">
       Plotting
@@ -661,6 +681,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#set-plot--range">set-plot-y-range</a>
       <a href="#setup-plots">setup-plots</a>
       <a href="#update-plots">update-plots</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="behaviorspacegroup">
       BehaviorSpace
@@ -668,6 +689,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
     <p>
       <a href="#behaviorspace-experiment-name">behaviorspace-experiment-name</a>
       <a href="#behaviorspace-run-number">behaviorspace-run-number</a>
+    </p>
       <!-- ======================================== -->
     <h3 id="systemgroup">
       System
@@ -675,6 +697,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
     <p>
       <a href="#netlogo-version">netlogo-version</a>
       <a href="#netlogo-web">netlogo-web?</a>
+    </p>
       <!-- ======================================== -->
        <!-- ======================================== -->
        <!-- ======================================== -->
@@ -699,6 +722,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#who">who</a>
       <a href="#xcor">xcor</a>
       <a href="#ycor">ycor</a>
+      </p>
       <!-- ======================================== -->
       <h3 id="patch-variables">
         <a>Patches</a>
@@ -709,6 +733,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#plabel-color">plabel-color</a>
       <a href="#pcor">pxcor</a>
       <a href="#pcor">pycor</a>
+      </p>
       <!-- ======================================== -->
       <h3 id="link-variables">
         <a>Links</a>
@@ -724,12 +749,14 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#shape">shape</a>
       <a href="#thickness">thickness</a>
       <a href="#tie-mode">tie-mode</a>
+      </p>
       <!-- ======================================== -->
       <h3 id="other-variables">
         <a>Other</a>
       </h3>
       <p>
       <a href="#arrow">-&gt;</a>
+      </p>
       <!-- ======================================== -->
       <!-- ======================================== -->
       <!-- ======================================== -->
@@ -750,75 +777,78 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#to-report">to-report</a>
       <a href="#turtles-own">turtles-own</a>
       <a href="#undirected-link-breed">undirected-link-breed</a>
+    </p>
       <!-- ======================================== -->
        <!-- ======================================== -->
        <!-- ======================================== -->
     <h2 id="Constants">
       <a>Constants</a>
     </h2><!-- ======================================== -->
-    <div>
-      <div class="dict_entry" id="mathconstants" data-constants="e pi">
-        <h3>
-          Mathematical Constants
-        </h3>
-        <p>
-        <b id="num-e"><a>e</a></b> = 2.718281828459045
-        <br>
-        <b id="pi"><a>pi</a></b> = 3.141592653589793
-      </div><!-- ======================================== -->
-      <div class="dict_entry" id="boolconstants" data-constants="false true">
-        <h3>
-          <a>Boolean Constants</a>
-        </h3>
-        <p id="false true">
-        <b><a>false</a></b>
-        <br>
-        <b><a>true</a></b>
-      </div><!-- ======================================== -->
-      <div class="dict_entry" id="colorconstants" data-constants="black gray white red orange brown yellow green lime turquoise cyan sky blue violet magenta pink">
-        <h3>
-          <a>Color Constants</a>
-        </h3>
-        <p>
-        <b>black</b> = 0
-        <br>
-        <b>gray</b> = 5
-        <br>
-        <b>white</b> = 9.9
-        <br>
-        <b>red</b> = 15
-        <br>
-        <b>orange</b> = 25
-        <br>
-        <b>brown</b> = 35
-        <br>
-        <b>yellow</b> = 45
-        <br>
-        <b>green</b> = 55
-        <br>
-        <b>lime</b> = 65
-        <br>
-        <b>turquoise</b> = 75
-        <br>
-        <b>cyan</b> = 85
-        <br>
-        <b>sky</b> = 95
-        <br>
-        <b>blue</b> = 105
-        <br>
-        <b>violet</b> = 115
-        <br>
-        <b>magenta</b> = 125
-        <br>
-        <b>pink</b> = 135
-        <p>
-        See the <a href="programming.html#colors">Colors</a> section of the
-        Programming Guide for more details.
-      </div><!-- ======================================== -->
-      <!-- ======================================== -->
-      <!-- ======================================== -->
-      <!-- ======================================== -->
-    </div>
+		<div class="dict_entry" id="mathconstants" data-constants="e pi">
+			<h3>
+				Mathematical Constants
+			</h3>
+			<p>
+			<b id="num-e"><a>e</a></b> = 2.718281828459045
+			<br>
+			<b id="pi"><a>pi</a></b> = 3.141592653589793
+			</p>
+		</div><!-- ======================================== -->
+		<div class="dict_entry" id="boolconstants" data-constants="false true">
+			<h3>
+				<a>Boolean Constants</a>
+			</h3>
+			<p id="false_true">
+			<b><a>false</a></b>
+			<br>
+			<b><a>true</a></b>
+			</p>
+		</div><!-- ======================================== -->
+		<div class="dict_entry" id="colorconstants" data-constants="black gray white red orange brown yellow green lime turquoise cyan sky blue violet magenta pink">
+			<h3>
+				<a>Color Constants</a>
+			</h3>
+			<p>
+			<b>black</b> = 0
+			<br>
+			<b>gray</b> = 5
+			<br>
+			<b>white</b> = 9.9
+			<br>
+			<b>red</b> = 15
+			<br>
+			<b>orange</b> = 25
+			<br>
+			<b>brown</b> = 35
+			<br>
+			<b>yellow</b> = 45
+			<br>
+			<b>green</b> = 55
+			<br>
+			<b>lime</b> = 65
+			<br>
+			<b>turquoise</b> = 75
+			<br>
+			<b>cyan</b> = 85
+			<br>
+			<b>sky</b> = 95
+			<br>
+			<b>blue</b> = 105
+			<br>
+			<b>violet</b> = 115
+			<br>
+			<b>magenta</b> = 125
+			<br>
+			<b>pink</b> = 135
+			</p>
+			<p>
+			See the <a href="programming.html#colors">Colors</a> section of the
+			Programming Guide for more details.
+			</p>
+		</div><!-- ======================================== -->
+		<!-- ======================================== -->
+		<!-- ======================================== -->
+		<!-- ======================================== -->
     <h2 id="A">
       <a>A</a>
     </h2><!-- ======================================== -->
@@ -832,6 +862,7 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       </h4>
       <p>
         Reports the absolute value of <i>number</i>.
+      </p>
       <pre>
 show abs -7
 =&gt; 7
@@ -850,6 +881,7 @@ show abs 5
         Reports the arc cosine (inverse cosine) of the given number. The
         input must be in the range -1 to 1. The result is in degrees, and
         lies in the range 0 to 180.
+      </p>
       </div>
     <div class="dict_entry" id="all">
       <h3>
@@ -862,17 +894,20 @@ show abs 5
         Reports true if all of the agents in the agentset report true for
         the given reporter. Otherwise reports false as soon as a
         counterexample is found.
+      </p>
       <p>
         If the agentset is empty, reports true.
       <p>
         The reporter must report a boolean value for every agent (either
         true or false), otherwise an error occurs.
+      </p>
       <pre>
 if all? turtles [color = red]
   [ show &quot;every turtle is red!&quot; ]
 </pre>
       <p>
         See also <a href="#any">any?</a>.
+      </p>
       </div>
     <div class="dict_entry" id="and">
       <h3>
@@ -884,9 +919,11 @@ if all? turtles [color = red]
       <p>
         Reports true if both <i>condition1</i> and <i>condition2</i> are
         true.
+      </p>
       <p>
         Note that if <i>condition1</i> is false, then <i>condition2</i>
         will not be run (since it can't affect the result).
+      </p>
       <pre>
 if (pxcor &gt; 0) and (pycor &gt; 0)
   [ set pcolor blue ]  ;; the upper-right quadrant of
@@ -902,9 +939,11 @@ if (pxcor &gt; 0) and (pycor &gt; 0)
       </h4>
       <p>
         Reports true if the given agentset is non-empty, false otherwise.
+      </p>
       <p>
         Equivalent to &quot;count <i>agentset</i> &gt; 0&quot;, but more
         efficient (and arguably more readable).
+      </p>
       <pre>
 if any? turtles with [color = red]
   [ show &quot;at least one turtle is red!&quot; ]
@@ -913,8 +952,10 @@ if any? turtles with [color = red]
         Note: nobody is not an agentset. You only get nobody back in
         situations where you were expecting a single agent, not a whole
         agentset. If any? gets nobody as input, an error results.
+      </p>
       <p>
         See also <a href="#all">all?</a>, <a href="#nobody">nobody</a>.
+      </p>
       </div>
     <div class="dict_entry" id="approximate-hsb">
       <h3>
@@ -927,12 +968,15 @@ if any? turtles with [color = red]
         Reports a number in the range 0 to 140, not including 140 itself,
         that represents the given color, specified in the HSB spectrum, in
         NetLogo's color space.
+      </p>
       <p>
         The first value (hue) should be in the range of 0 to 360, the second
         and third (saturation and brightness) in the range between 0 and 100.
+      </p>
       <p>
         The color reported may be only an approximation, since the NetLogo
         color space does not include all possible colors.
+      </p>
       <pre>
 show approximate-hsb 0 0 0
 =&gt; 0  ;; (black)
@@ -941,6 +985,7 @@ show approximate-hsb 180 57.143 76.863
 </pre>
       <p>
         See also <a href="#extract-hsb">extract-hsb</a>, <a href="#approximate-rgb">approximate-rgb</a>, <a href="#extract-rgb">extract-rgb</a>.
+      </p>
       </div>
     <div class="dict_entry" id="approximate-rgb">
       <h3>
@@ -953,13 +998,16 @@ show approximate-hsb 180 57.143 76.863
         Reports a number in the range 0 to 140, not including 140 itself,
         that represents the given color, specified in the RGB spectrum, in
         NetLogo's color space.
+      </p>
       <p>
         All three inputs should be in the range 0 to 255.
+      </p>
       <p>
         The color reported may be only an approximation, since the NetLogo
         color space does not include all possible colors. (See <a href="#approximate-hsb">approximate-hsb</a> for a description of what
         parts of the HSB color space NetLogo colors cover; this is
         difficult to characterize in RGB terms.)
+      </p>
       <pre>
 show approximate-rgb 0 0 0
 =&gt; 0  ;; black
@@ -968,6 +1016,7 @@ show approximate-rgb 0 255 255
 </pre>
       <p>
         See also <a href="#extract-rgb">extract-rgb</a>, <a href="#approximate-hsb">approximate-hsb</a>, and <a href="#extract-hsb">extract-hsb</a>.
+      </p>
       </div>
     <div class="dict_entry" id="Symbols">
       <h3>
@@ -989,18 +1038,22 @@ show approximate-rgb 0 255 255
         operators&quot; (going between the two inputs, as in standard
         mathematical use). NetLogo correctly supports order of operations
         for infix operators.
+      </p>
       <p>
         The operators work as follows: + is addition, * is multiplication,
         - is subtraction, / is division, ^ is exponentiation, &lt; is less
         than, &gt; is greater than, = is equal to, != is not equal to,
         &lt;= is less than or equal, &gt;= is greater than or equal.
+      </p>
       <p>
         Note that the subtraction operator (-) always takes two inputs
         unless you put parentheses around it, in which case it can take one
         input. For example, to take the negative of x, write (- x), with
         the parentheses.
+      </p>
       <p>
         All of the comparison operators also work on strings.
+      </p>
       <p>
         All of the comparison operators work on agents. Turtles are
         compared by who number. Patches are compared top to bottom left to
@@ -1011,13 +1064,16 @@ show approximate-rgb 0 255 255
         breeds of links unbreeded links will come before breeded links of
         the same end points and breeded links will be sorted in the order
         they are declared in the Code tab.
+      </p>
       <p>
         Agentsets can be tested for equality or inequality. Two agentsets
         are equal if they are the same type (turtle or patch) and contain
         the same agents.
+      </p>
       <p>
         If you are not sure how NetLogo will interpret your code, you
         should add parentheses.
+      </p>
       <pre>
 show 5 * 6 + 6 / 3
 =&gt; 32
@@ -1030,6 +1086,7 @@ show 5 * (6 + 6) / 3
         For instance, the array, matrix, and table objects returned by their
         respective extensions may be compared for equality / inequality.
         Extension objects may not be tested using &lt;, &gt;, &lt;=, or &gt;=.
+      </p>
     </div>
     <div class="dict_entry" id="asin">
       <h3>
@@ -1042,6 +1099,7 @@ show 5 * (6 + 6) / 3
         Reports the arc sine (inverse sine) of the given number. The input
         must be in the range -1 to 1. The result is in degrees, and lies in
         the range -90 to 90.
+      </p>
       </div>
     <div class="dict_entry" id="ask">
       <h3>
@@ -1057,6 +1115,7 @@ show 5 * (6 + 6) / 3
         used with an agentset each agent will take its turn in a random
         order.  See <a href="programming.html#agentsets">Agentsets</a>
         for more information.
+      </p>
       <pre>
 ask turtles [ fd 1 ]
   ;; all turtles move forward one step
@@ -1071,9 +1130,11 @@ ask turtle 4 [ rt 90 ]
         or all patches ask all patches, which is a common mistake to make
         if you're not careful about which agents will run the code you
         are writing.
+      </p>
       <p>
         Note: Only the agents that are in the agentset <i>at the time the
         ask begins</i> run the commands.
+      </p>
       </div>
     <div class="dict_entry" id="ask-concurrent">
       <h3>
@@ -1085,16 +1146,20 @@ ask turtle 4 [ rt 90 ]
       <p>
         This primitive exists only for backwards compatibility. We
         don't recommend using it new models.
+      </p>
       <p>
         The agents in the given agentset run the given commands, using a
         turn-taking mechanism to produce simulated concurrency. See the
         <a href="programming.html#ask-concurrent">Ask-Concurrent</a>
         section of the Programming Guide for details on how this works.
+      </p>
       <p>
         Note: Only the agents that are in the agentset <i>at the time the
         ask begins</i> run the commands.
+      </p>
       <p>
         See also <a href="#without-interruption">without-interruption</a>.
+      </p>
       </div>
     <div class="dict_entry" id="at-points">
       <h3>
@@ -1108,14 +1173,17 @@ ask turtle 4 [ rt 90 ]
         agents on the patches at the given coordinates (relative to this
         agent). The coordinates are specified as a list of two-item lists,
         where the two items are the x and y offsets.
+      </p>
       <p>
         If the caller is the observer, then the points are measured
         relative to the origin, in other words, the points are taken as
         absolute patch coordinates.
+      </p>
       <p>
         If the caller is a turtle, the points are measured relative to the
         turtle's exact location, and not from the center of the patch
         under the turtle.
+      </p>
       <pre>
 ask turtles at-points [[2 4] [1 2] [10 15]]
   [ fd 1 ]  ;; only the turtles on the patches at the
@@ -1133,6 +1201,7 @@ ask turtles at-points [[2 4] [1 2] [10 15]]
       <p>
         Converts x and y offsets to a turtle heading in degrees (from 0 to
         360).
+      </p>
       <p>
         Note that this version of atan is designed to conform to the
         geometry of the NetLogo world, where a heading of 0 is straight up,
@@ -1140,9 +1209,11 @@ ask turtles at-points [[2 4] [1 2] [10 15]]
         (Normally in geometry an angle of 0 is right, 90 is up, and so on,
         counterclockwise around the circle, and atan would be defined
         accordingly.)
+      </p>
       <p>
         When y is 0: if x is positive, it reports 90; if x is negative, it
         reports 270; if x is zero, you get an error.
+      </p>
       <pre>
 show atan 1 -1
 =&gt; 135
@@ -1154,10 +1225,12 @@ crt 1 [ set heading 30  fd 1  print atan xcor ycor ]
       <p>
         In the final example, note that the result of <code>atan</code> equals
         the turtle's heading.
+      </p>
       <p>
         If you ever need to convert a turtle heading (obtained with atan or
         otherwise) to a normal mathematical angle, the following should be
         helpful:
+      </p>
       <pre>
 to-report heading-to-angle [ h ]
   report (90 - h) mod 360
@@ -1174,6 +1247,7 @@ end
       <p>
         Reports true if auto-plotting is on for the current plot, false
         otherwise.
+      </p>
       </div>
     <div class="dict_entry" id="auto-plot-status">
       <h3>
@@ -1191,6 +1265,7 @@ end
         exceeds these boundaries. It is useful when wanting to show all
         plotted values in the current plot, regardless of the current plot
         ranges.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="B">
@@ -1209,17 +1284,21 @@ end
       <p>
         The turtle moves backward by <i>number</i> steps. (If <i>number</i>
         is negative, the turtle moves forward.)
+      </p>
       <p>
         Turtles using this primitive can move a maximum of one unit per
         time increment. So <code>bk 0.5</code> and <code>bk 1</code> both take one
         unit of time, but <code>bk 3</code> takes three.
+      </p>
       <p>
         If the turtle cannot move backward <i>number</i> steps because it
         is not permitted by the current topology the turtle will complete
         as many steps of 1 as it can and stop.
+      </p>
       <p>
         See also <a href="#forward">forward</a>, <a href="#jump">jump</a>,
         <a href="#can-move">can-move?</a>.
+      </p>
       </div>
     <div class="dict_entry" id="base-colors">
       <h3>
@@ -1230,6 +1309,7 @@ end
       </h4>
       <p>
         Reports a list of the 14 basic NetLogo hues.
+      </p>
       <pre>
 print base-colors
 =&gt; [5 15 25 35 45 55 65 75 85 95 105 115 125 135]
@@ -1250,8 +1330,10 @@ ask turtles [ set color one-of remove gray base-colors ]
         Emits a beep. Note that the beep sounds immediately, so several
         beep commands in close succession may produce only one audible
         sound.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 beep                       ;; emits one beep
 repeat 3 [ beep ]          ;; emits 3 beeps at once,
@@ -1261,6 +1343,7 @@ repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
 </pre>
       <p>
         When running headless, this command has no effect.
+      </p>
       </div>
     <div class="dict_entry" id="behaviorspace-experiment-name">
       <h3>
@@ -1271,8 +1354,10 @@ repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
       </h4>
       <p>
         Reports the current experiment name in the current experiment.
+      </p>
       <p>
         If no BehaviorSpace experiment is running, reports &quot;&quot;.
+      </p>
       </div>
     <div class="dict_entry" id="behaviorspace-run-number">
       <h3>
@@ -1284,8 +1369,10 @@ repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
       <p>
         Reports the current run number in the current BehaviorSpace
         experiment, starting at 1.
+      </p>
       <p>
         If no BehaviorSpace experiment is running, reports 0.
+      </p>
       </div>
     <div class="dict_entry" id="both-ends">
       <h3>
@@ -1297,6 +1384,7 @@ repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
       </h4>
       <p>
         Reports the agentset of the 2 nodes connected by this link.
+      </p>
       <pre>
 crt 2
 ask turtle 0 [ create-link-with turtle 1 ]
@@ -1319,14 +1407,18 @@ ask link 0 1 [
         (For turtles or links that do not have any particular breed, this
         is the <a href="#turtles">turtles</a> agentset of all turtles or
         the <a href="#links">links</a> agentset of all links respectively.)
+      </p>
       <p>
         You can set this variable to change a turtle or link's breed.
         (When a turtle changes breeds, its shape is reset to the default
         shape for that breed. See <a href="#set-default-shape">set-default-shape</a>.)
+      </p>
       <p>
         See also <a href="#breed">breed</a>, <a href="#directed-link-breed">directed-link-breed</a>, <a href="#undirected-link-breed">undirected-link-breed</a>
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 breed [cats cat]
 breed [dogs dog]
@@ -1354,8 +1446,10 @@ if breed = roads [ set color gray ]
         any procedure definitions. It defines a breed. The first input
         defines the name of the agentset associated with the breed. The
         second input defines the name of a single member of the breed.
+      </p>
       <p>
         Any turtle of the given breed:
+      </p>
       <ul>
         <li>is part of the agentset named by the breed name
         <li>has its breed built-in variable set to that agentset
@@ -1363,6 +1457,7 @@ if breed = roads [ set color gray ]
       <p>
         Most often, the agentset is used in conjunction with ask to give
         commands to only the turtles of a particular breed.
+      </p>
       <pre>
 breed [mice mouse]
 breed [frogs frog]
@@ -1385,6 +1480,7 @@ show turtle 51
 </pre>
       <p>
         See also <a href="#globals">globals</a>, <a href="#patches-own">patches-own</a>, <a href="#turtles-own">turtles-own</a>, <a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>, <a href="#create-turtles">create-<i>&lt;breeds&gt;</i></a>, <a href="#turtles-at"><i>&lt;breeds&gt;</i>-at</a>, <a href="#turtles-here"><i>&lt;breeds&gt;</i>-here</a>.
+      </p>
       </div>
     <div class="dict_entry" id="but-first-and-last">
       <h3>
@@ -1405,9 +1501,11 @@ show turtle 51
         When used on a list, but-first reports all of the list items of
         <i>list</i> except the first, and but-last reports all of the list
         items of <i>list</i> except the last.
+      </p>
       <p>
         On strings, but-first and but-last report a shorter string omitting
         the first or last character of the original string.
+      </p>
       <pre>
 ;; mylist is [2 4 6 5 8 12]
 set mylist but-first mylist
@@ -1437,8 +1535,10 @@ show but-last &quot;string&quot;
         Reports true if this turtle can move <i>distance</i> in the
         direction it is facing without violating the topology; reports
         false otherwise.
+      </p>
       <p>
         It is equivalent to:
+      </p>
       <pre>
 patch-ahead <i>distance</i> != nobody
 </pre>
@@ -1455,9 +1555,11 @@ patch-ahead <i>distance</i> != nobody
         <i>commands1</i>, NetLogo won't stop and alert the user that an
         error occurred. It will suppress the error and run <i>commands2</i>
         instead.
+      </p>
       <p>
         The error-message reporter can be used in <i>commands2</i> to find
         out what error was suppressed in <i>commands1</i>. See <a href="#error-message">error-message</a>.
+      </p>
       <pre>
 carefully [ print one-of [1 2 3] ] [ print error-message ]
 =&gt; 3
@@ -1475,6 +1577,7 @@ observer&gt; carefully [ print one-of [] ] [ print error-message ]
       <p>
         Reports the smallest integer greater than or equal to
         <i>number</i>.
+      </p>
       <pre>
 show ceiling 4.5
 =&gt; 5
@@ -1484,6 +1587,7 @@ show ceiling -4.5
       <p>
         See also <a href="#floor">floor</a>, <a href="#round">round</a>,
         <a href="#precision">precision</a>.
+      </p>
       </div>
     </div>
     <div class="dict_entry" id="clear-all">
@@ -1499,6 +1603,7 @@ show ceiling -4.5
         Combines the effects of clear-globals, clear-ticks,
         clear-turtles, clear-patches, clear-drawing, clear-all-plots, and
         clear-output.
+      </p>
       </div>
     <div class="dict_entry" id="clear-all-plots">
       <h3>
@@ -1510,6 +1615,7 @@ show ceiling -4.5
       </h4>
       <p>
         Clears every plot in the model. See <a href="#clear-plot">clear-plot</a> for more information.
+      </p>
       </div>
     <div class="dict_entry" id="clear-drawing">
       <h3>
@@ -1522,6 +1628,7 @@ show ceiling -4.5
       </h4>
       <p>
         Clears all lines and stamps drawn by turtles.
+      </p>
       </div>
     <div class="dict_entry" id="clear-globals">
       <h3>
@@ -1533,6 +1640,7 @@ show ceiling -4.5
       </h4>
       <p>
         Sets all code-defined global variables (i.e., those defined inside of <code>globals [ ... ]</code>) to 0.  Global variables defined by widgets are not affected by this primitive.
+      </p>
       </div>
     <div class="dict_entry" id="clear-links">
       <h3>
@@ -1544,8 +1652,10 @@ show ceiling -4.5
       </h4>
       <p>
         Kills all links.
+      </p>
       <p>
         See also <a href="#die">die</a>.
+      </p>
       </div>
     <div class="dict_entry" id="clear-output">
       <h3>
@@ -1558,6 +1668,7 @@ show ceiling -4.5
       <p>
         Clears all text from the model's output area, if it has one.
         Otherwise does nothing.
+      </p>
       </div>
     <div class="dict_entry" id="clear-patches">
       <h3>
@@ -1571,6 +1682,7 @@ show ceiling -4.5
       <p>
         Clears the patches by resetting all patch variables to their
         default initial values, including setting their color to black.
+      </p>
       </div>
     <div class="dict_entry" id="clear-plot">
       <h3>
@@ -1589,6 +1701,7 @@ show ceiling -4.5
         deleting all temporary pens, that is to say if there are no
         permanent plot pens, a default plot pen will be created with the
         following initial settings:
+      </p>
       <ul>
         <li>Pen: down
         <li>Color: black
@@ -1598,6 +1711,7 @@ show ceiling -4.5
         </ul>
       <p>
         See also <a href="#clear-all-plots">clear-all-plots</a>.
+      </p>
       </div>
     <div class="dict_entry" id="clear-ticks">
       <h3>
@@ -1609,14 +1723,17 @@ show ceiling -4.5
       </h4>
       <p>
         Clears the tick counter.
+      </p>
       <p>
         Does not set the counter to zero. After this command runs, the tick
         counter has no value. Attempting to access or update it is an error
         until <a href="#reset-ticks">reset-ticks</a> is called. This is
         useful if you want to set the model to a "pre-setup" state with some
         forever buttons disabled.
+      </p>
       <p>
         See also <a href="#reset-ticks">reset-ticks</a>.
+      </p>
       </div>
     <div class="dict_entry" id="clear-turtles">
       <h3>
@@ -1629,11 +1746,14 @@ show ceiling -4.5
       </h4>
       <p>
         Kills all turtles.
+      </p>
       <p>
         Also resets the who numbering, so the next turtle created will be
         turtle 0.
+      </p>
       <p>
         See also <a href="#die">die</a>.
+      </p>
       </div>
     <div class="dict_entry" id="color">
       <h3>
@@ -1650,8 +1770,10 @@ show ceiling -4.5
         color (a single number), or an RGB color (a list of 3 numbers). See
         details in the <a href="programming.html#colors">Colors section</a>
         of the Programming Guide.
+      </p>
       <p>
         See also <a href="#pcolor">pcolor</a>.
+      </p>
       </div>
     <div class="dict_entry" id="cos">
       <h3>
@@ -1663,6 +1785,7 @@ show ceiling -4.5
       <p>
         Reports the cosine of the given angle. Assumes the angle is given
         in degrees.
+      </p>
       <pre>
 show cos 180
 =&gt; -1
@@ -1677,6 +1800,7 @@ show cos 180
       </h4>
       <p>
         Reports the number of agents in the given agentset.
+      </p>
       <pre>
 show count turtles
 ;; prints the total number of turtles
@@ -1700,14 +1824,17 @@ show count patches with [pcolor = red]
         Creates <i>number</i> new turtles. New turtles start at position
         (0, 0), are created with the 14 primary colors, and have headings
         from 0 to 360, evenly spaced.
+      </p>
       <p>
         If the create-ordered-<i>&lt;breeds&gt;</i> form is used, the new
         turtles are created as members of the given breed.
+      </p>
       <p>
         If <i>commands</i> are supplied, the new turtles immediately run
         them. This is useful for giving the new turtles a different color,
         heading, or whatever. (The new turtles are created all at once then
         run one at a time, in random order.)
+      </p>
       <pre>
 cro 100 [ fd 10 ]  ;; makes an evenly spaced circle
 </pre>
@@ -1756,28 +1883,34 @@ cro 100 [ fd 10 ]  ;; makes an evenly spaced circle
       </h4>
       <p>
         Used for creating breeded and unbreeded links between turtles.
+      </p>
       <p>
         <code>create-link-with</code> creates an undirected link between the caller and
         <i>agent</i>. <code>create-link-to</code> creates a directed link from the
         caller to <i>agent</i>. <code>create-link-from</code> creates a directed link
         from <i>agent</i> to the caller.
+      </p>
       <p>
         When the plural form of the breed name is used, an <i>agentset</i>
         is expected instead of an agent and links are created between the
         caller and all agents in the agentset.
+      </p>
       <p>
         The optional command block is the set of commands each newly formed
         link runs. (The links are created all at once then run one at a
         time, in random order.)
+      </p>
       <p>
         A node cannot be linked to itself. Also, you cannot have more than
         one undirected link of the same breed between the same two nodes,
         nor can you have more than one directed link of the same breed
         going in the same direction between two nodes.
+      </p>
       <p>
         If you try to create a link where one (of the same breed) already
         exists, nothing happens. If you try to create a link from a turtle
         to itself you get a runtime error.
+      </p>
       <pre>
 to setup
   clear-all
@@ -1827,14 +1960,17 @@ end
         Creates <i>number</i> new turtles at the origin. New turtles have
         random integer headings and the color is randomly selected from the
         14 primary colors.
+      </p>
       <p>
         If the create-<i>&lt;breeds&gt;</i> form is used, the new turtles
         are created as members of the given breed.
+      </p>
       <p>
         If <i>commands</i> are supplied, the new turtles immediately run
         them. This is useful for giving the new turtles a different color,
         heading, or whatever. (The new turtles are created all at once then
         run one at a time, in random order.)
+      </p>
       <pre>
 crt 100 [ fd 10 ]     ;; makes a randomly spaced circle
 </pre>
@@ -1849,6 +1985,7 @@ end
 </pre>
       <p>
         See also <a href="#hatch">hatch</a>, <a href="#sprout">sprout</a>.
+      </p>
       </div>
     <div class="dict_entry" id="create-temporary-plot-pen">
       <h3>
@@ -1860,17 +1997,21 @@ end
       <p>
         A new temporary plot pen with the given name is created in the
         current plot and set to be the current pen.
+      </p>
       <p>
         Few models will want to use this primitive, because all temporary
         pens disappear when clear-plot or clear-all-plots are called. The
         normal way to make a pen is to make a permanent pen in the
         plot's Edit dialog.
+      </p>
       <p>
         If a pen with that name already exists in the current plot, no
         new pen is created, and the existing pen is set to the current
         pen.
+      </p>
       <p>
         The new temporary plot pen has the following initial settings:
+      </p>
       <ul>
         <li>Pen: down
         <li>Color: black
@@ -1879,9 +2020,9 @@ end
         </ul>
       <p>
         See: <a href="#clear-plot">clear-plot</a>, <a href="#clear-all-plots">clear-all-plots</a>, and <a href="#set-current-plot-pen">set-current-plot-pen</a>.
+      </p>
         <!-- ======================================== -->
       </div>
-    </div>
     <h2 id="D">
       <a>D</a>
     </h2><!-- ======================================== -->
@@ -1900,6 +2041,7 @@ end
         clock is milliseconds. (Whether you get resolution that high in
         practice may vary from system to system, depending on the
         capabilities of the underlying Java Virtual Machine.)
+      </p>
       <pre>
 show date-and-time
 =&gt; &quot;01:19:36.685 PM 19-Sep-2002&quot;
@@ -1915,6 +2057,7 @@ show date-and-time
       </h4>
       <p>
         The turtle or link dies.
+      </p>
       <pre>
 if xcor &gt; 20 [ die ]
 ;; all turtles with xcor greater than 20 die
@@ -1923,6 +2066,7 @@ ask links with [color = blue] [ die ]
 </pre>
       <p>
         A dead agent ceases to exist. The effects of this include:
+      </p>
       <ul>
         <li>The agent will not execute any further code. So if you write
         <code>ask turtles [ die print &quot;last words?&quot; ]</code>, no last
@@ -1941,6 +2085,7 @@ ask links with [color = blue] [ die ]
         </ul>
       <p>
         See also: <a href="#clear-turtles">clear-turtles</a> <a href="#clear-links">clear-links</a>
+      </p>
       </div>
     <div class="dict_entry" id="diffuse">
       <h3>
@@ -1958,10 +2103,12 @@ ask links with [color = blue] [ die ]
         conserved across the world. (If a patch has fewer than eight
         neighbors, each neighbor still gets an eighth share; the patch
         keeps any leftover shares.)
+      </p>
       <p>
         Note that this is an observer command only, even though you might
         expect it to be a patch command. (The reason is that it acts on all
         the patches at once -- patch commands act on individual patches.)
+      </p>
       <pre>
 diffuse chemical 0.5
 ;; each patch diffuses 50% of its variable
@@ -1981,6 +2128,7 @@ diffuse chemical 0.5
       <p>
         Like diffuse, but only diffuses to the four neighboring patches (to
         the north, south, east, and west), not to the diagonal neighbors.
+      </p>
       <pre>
 diffuse4 chemical 0.5
 ;; each patch diffuses 50% of its variable
@@ -2005,8 +2153,10 @@ diffuse4 chemical 0.5
         link breed. The second input defines the name of a single member of
         the breed. Directed links can be created using <a href="#create-link">create-link(s)-to</a>, and <a href="#create-link">create-link(s)-from</a>, but not
         <code>create-link(s)-with</code>
+      </p>
       <p>
         Any link of the given link breed:
+      </p>
       <ul>
         <li>is part of the agentset named by the link breed name
         <li>has its built-in variable <code>breed</code> set to that agentset
@@ -2015,6 +2165,7 @@ diffuse4 chemical 0.5
       <p>
         Most often, the agentset is used in conjunction with ask to give
         commands to only the links of a particular breed.
+      </p>
       <pre>
 directed-link-breed [streets street]
 directed-link-breed [highways highway]
@@ -2034,6 +2185,7 @@ ask turtle 0 [ show one-of my-out-links ]
 </pre>
       <p>
         See also <a href="#breed">breed</a>, <a href="#undirected-link-breed">undirected-link-breed</a>
+      </p>
       </div>
     <div class="dict_entry" id="display">
       <h3>
@@ -2046,9 +2198,11 @@ ask turtle 0 [ show one-of my-out-links ]
         Causes the view to be updated immediately. (Exception: if the user
         is using the speed slider to fast-forward the model, then the
         update may be skipped.)
+      </p>
       <p>
         Also undoes the effect of the no-display command, so that if view
         updates were suspended by that command, they will resume.
+      </p>
       <pre>
 no-display
 ask turtles [ jump 10 set color blue set size 5 ]
@@ -2063,6 +2217,7 @@ display
         updates, so that fewer total updates take place, so that models run
         faster. This command lets you force a view update, so whatever
         changes have taken place in the world are visible to the user.
+      </p>
       <pre>
 ask turtles [ set color red ]
 display
@@ -2073,8 +2228,10 @@ ask turtles [ set color blue]
       <p>
         Note that display and no-display operate independently of the
         switch in the view control strip that freezes the view.
+      </p>
       <p>
         See also <a href="#no-display">no-display</a>.
+      </p>
       </div>
     <div class="dict_entry" id="distance">
       <h3>
@@ -2086,11 +2243,13 @@ ask turtles [ set color blue]
       </h4>
       <p>
         Reports the distance from this agent to the given turtle or patch.
+      </p>
       <p>
         The distance to or a from a patch is measured from the center of
         the patch. Turtles and patches use the wrapped distance (around the
         edges of the world) if wrapping is allowed by the topology and the
         wrapped distance is shorter.
+      </p>
       <pre>
 ask turtles [ show max-one-of turtles [distance myself] ]
 ;; each turtle prints the turtle farthest from itself
@@ -2107,11 +2266,13 @@ ask turtles [ show max-one-of turtles [distance myself] ]
       <p>
         Reports the distance from this agent to the point (<i>x</i>,
         <i>y</i>).
+      </p>
       <p>
         The distance from a patch is measured from the center of the patch.
         Turtles and patches use the wrapped distance (around the edges of
         the world) if wrapping is allowed by the topology and the wrapped
         distance is shorter.
+      </p>
       <pre>
 if (distancexy 0 0) &gt; 10
   [ set color green ]
@@ -2135,12 +2296,15 @@ if (distancexy 0 0) &gt; 10
         than the current patch, the turtle stays put. If there are multiple
         patches with the same lowest value, the turtle picks one randomly.
         Non-numeric values are ignored.
+      </p>
       <p>
         downhill considers the eight neighboring patches; downhill4 only
         considers the four neighbors.
+      </p>
       <p>
         Equivalent to the following code (assumes variable values are
         numeric):
+      </p>
       <pre>
 move-to patch-here  ;; go to patch center
 let p min-one-of neighbors [<i>patch-variable</i>]  ;; or neighbors4
@@ -2152,8 +2316,10 @@ if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
       <p>
         Note that the turtle always ends up on a patch center and has a
         heading that is a multiple of 45 (downhill) or 90 (downhill4).
+      </p>
       <p>
         See also <a href="#uphill">uphill</a>, <a href="#uphill">uphill4</a>.
+      </p>
       </div>
     <div class="dict_entry" id="dxy">
       <h3>
@@ -2169,16 +2335,19 @@ if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
         Reports the x-increment or y-increment (the amount by which the
         turtle's xcor or ycor would change) if the turtle were to take
         one step forward in its current heading.
+      </p>
       <p>
         Note: dx is simply the sine of the turtle's heading, and dy is
         simply the cosine. (If this is the reverse of what you expected,
         it's because in NetLogo a heading of 0 is north and 90 is east,
         which is the reverse of how angles are usually defined in
         geometry.)
+      </p>
       <p>
         Note: In earlier versions of NetLogo, these primitives were used in
         many situations where the new <code>patch-ahead</code> primitive is now
-        more appropriate. <!-- ======================================== -->
+        more appropriate.
+      </p> <!-- ======================================== -->
       </div>
     </div>
     <h2 id="E">
@@ -2195,9 +2364,11 @@ if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
       </h4>
       <p>
         Reports true if the given list or string is empty, false otherwise.
+      </p>
       <p>
         Note: the empty list is written <code>[]</code>. The empty string is
         written <code>&quot;&quot;</code>.
+      </p>
       </div>
     <div class="dict_entry" id="end">
       <h3>
@@ -2208,6 +2379,7 @@ if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
       </h4>
       <p>
         Used to conclude a procedure. See <a href="#to">to</a> and <a href="#to-report">to-report</a>.
+      </p>
       </div>
     <div class="dict_entry" id="end1">
       <h3>
@@ -2222,6 +2394,7 @@ if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
         (turtle) of a link. For directed links this will always be the
         source for undirected links it will always be the turtle with the
         lower who number. You cannot set end1.
+      </p>
       <pre>
 crt 2
 ask turtle 0
@@ -2243,6 +2416,7 @@ ask links
         (turtle) of a link. For directed links this will always be the
         destination for undirected links it will always be the turtle with
         the higher who number. You cannot set end2.
+      </p>
       <pre>
 crt 2
 ask turtle 1
@@ -2260,11 +2434,14 @@ ask links
       </h4>
       <p>
         Causes a runtime error to occur.
+      </p>
       <p>
         The given value is converted to a string (if it isn't one
         already) and used as the error message.
+      </p>
       <p>
         See also <a href="#error-message">error-message</a>, <a href="#carefully">carefully</a>.
+      </p>
       </div>
     <div class="dict_entry" id="error-message">
       <h3>
@@ -2276,11 +2453,14 @@ ask links
       <p>
         Reports a string describing the error that was suppressed by
         carefully.
+      </p>
       <p>
         This reporter can only be used in the second block of a carefully
         command.
+      </p>
       <p>
         See also <a href="#error">error</a>, <a href="#carefully">carefully</a>.
+      </p>
       </div>
     <div class="dict_entry" id="every">
       <h3>
@@ -2293,11 +2473,13 @@ ask links
         Runs the given commands only if it's been more than
         <i>number</i> seconds since the last time this agent ran them in
         this context. Otherwise, the commands are skipped.
+      </p>
       <p>
         By itself, every doesn't make commands run over and over again.
         You need to use every inside a loop, or inside a forever button, if
         you want the commands run over and over again. every only limits
         how often the commands run.
+      </p>
       <p>
         Above, &quot;in this context&quot; means during the same ask (or
         button press or command typed in the Command Center). So it
@@ -2305,6 +2487,7 @@ ask links
         ]</code>, because when the ask finishes the turtles will all discard
         their timers for the &quot;every&quot;. The correct usage is shown
         below.
+      </p>
       <pre>
 every 0.5 [ ask turtles [ fd 1 ] ]
 ;; twice a second the turtles will move forward 1
@@ -2313,6 +2496,7 @@ every 2 [ set index index + 1 ]
 </pre>
       <p>
         See also <a href="#wait">wait</a>.
+      </p>
       </div>
     <div class="dict_entry" id="exp">
       <h3>
@@ -2323,8 +2507,10 @@ every 2 [ set index index + 1 ]
       </h4>
       <p>
         Reports the value of e raised to the <i>number</i> power.
+      </p>
       <p>
         Note: This is the same as e ^ <i>number</i>.
+      </p>
       </div>
     <div class="dict_entry" id="export-cmds">
       <h3>
@@ -2348,16 +2534,20 @@ every 2 [ set index index + 1 ]
         external file given by the string <i>filename</i>. The file is
         saved in PNG (Portable Network Graphics) format, so it is
         recommended to supply a filename ending in &quot;.png&quot;.
+      </p>
       <p>
         export-interface is similar, but for the whole interface tab.
+      </p>
       <p>
         Note that export-view still works when running NetLogo in headless
         mode, but export-interface doesn't.
+      </p>
       <p>
         export-output writes the contents of the model's output area to
         an external file given by the string <i>filename</i>. (If the model
         does not have a separate output area, the output portion of the
         Command Center is used.)
+      </p>
       <p>
         export-plot writes the x and y values of all points plotted by all
         the plot pens in the plot given by the string <i>plotname</i> to an
@@ -2366,10 +2556,12 @@ every 2 [ set index index + 1 ]
         than 0, the upper-left corner point of the bar will be exported. If
         the y value is less than 0, then the lower-left corner point of the
         bar will be exported.
+      </p>
       <p>
         export-all-plots writes every plot in the current model to an
         external file given by the string <i>filename</i>. Each plot is
         identical in format to the output of export-plot.
+      </p>
       <p>
         export-world writes the values of all variables, both built-in and
         user-defined, including all observer, turtle, and patch variables,
@@ -2378,19 +2570,23 @@ every 2 [ set index index + 1 ]
         to an external file given by the string <i>filename</i>. (The
         result file can be read back into NetLogo with the <a href="#import-world">import-world</a> primitive.) export-world does not
         save the state of open files.
+      </p>
       <p>
         export-plot, export-all-plots and export-world save files in in
         plain-text, &quot;comma-separated values&quot; (<code>.csv</code>)
         format. CSV files can be read by most popular spreadsheet and
         database programs as well as any text editor.
+      </p>
       <p>
         If you wish to export to a file in a location other than the
         model's location, you should include the full path to the file
         you wish to export. (Use the forward-slash &quot;/&quot; as the
         folder separator.)
+      </p>
       <p>
         Note that the functionality of these primitives is also available
         directly from NetLogo's File menu.
+      </p>
       <pre>
 export-world &quot;fire.csv&quot;
 ;; exports the state of the model to the file fire.csv
@@ -2406,6 +2602,7 @@ export-all-plots &quot;c:/My Documents/plots.csv&quot;
       <p>
         If the file already exists, it is overwritten. To avoid this you
         may wish to use some method of generating fresh names. Examples:
+      </p>
       <pre>
 export-world user-new-file
 export-world (word &quot;results &quot; date-and-time &quot;.csv&quot;) ;; Colon characters in the time cause errors on Windows
@@ -2423,6 +2620,7 @@ export-world (word &quot;results &quot; random-float 1.0 &quot;.csv&quot;)
         Allows the model to use primitives from the extensions with the
         given names. See the <a href="extensions.html">Extensions guide</a>
         for more information.
+      </p>
       </div>
     <div class="dict_entry" id="extract-hsb">
       <h3>
@@ -2435,11 +2633,13 @@ export-world (word &quot;results &quot; random-float 1.0 &quot;.csv&quot;)
         Reports a list of three values, the first (hue) in the range of
         0 to 360, the second and third (brightness and saturation) in
         the range of 0 to 100.
+      </p>
       <p>
         The given <i>color</i> can either be a NetLogo color in the
         range 0 to 140, not including 140 itself, or an RGB list of
         three values in the range 0 to 255 representing the levels
         of red, green, and blue.
+      </p>
       <pre>
 show extract-hsb cyan
 =&gt; [180 57.143 76.863]
@@ -2450,6 +2650,7 @@ show extract-hsb [255 0 0]
 </pre>
       <p>
         See also <a href="#approximate-hsb">approximate-hsb</a>, <a href="#approximate-rgb">approximate-rgb</a>, <a href="#extract-rgb">extract-rgb</a>.
+      </p>
       </div>
     <div class="dict_entry" id="extract-rgb">
       <h3>
@@ -2463,6 +2664,7 @@ show extract-hsb [255 0 0]
         the levels of red, green, and blue, respectively, of the given
         NetLogo <i>color</i> in the range 0 to 140, not including 140
         itself.
+      </p>
       <pre>
 show extract-rgb red
 =&gt; [215 50 41]
@@ -2471,6 +2673,7 @@ show extract-rgb cyan
 </pre>
       <p>
         See also <a href="#approximate-rgb">approximate-rgb</a>, <a href="#approximate-hsb">approximate-hsb</a>, <a href="#extract-hsb">extract-hsb</a>.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="F">
@@ -2487,13 +2690,16 @@ show extract-rgb cyan
       </h4>
       <p>
         Set the caller's heading towards <i>agent</i>.
+      </p>
       <p>
         If wrapping is allowed by the topology and the wrapped distance
         (around the edges of the world) is shorter, face will use the
         wrapped path.
+      </p>
       <p>
         If the caller and the agent are at the exact same position, the
         caller's heading won't change.
+      </p>
       </div>
     <div class="dict_entry" id="facexy">
       <h3>
@@ -2505,6 +2711,7 @@ show extract-rgb cyan
       </h4>
       <p>
         Set the caller's heading towards the point (x,y).
+      </p>
       <p>
         If wrapping is allowed by the topology and the wrapped distance
         (around the edges of the world) is shorter and wrapping is allowed,
@@ -2512,6 +2719,7 @@ show extract-rgb cyan
       <p>
         If the caller is on the point (x,y), the caller's heading
         won't change.
+      </p>
       </div>
     <div class="dict_entry" id="file-at-end">
       <h3>
@@ -2523,6 +2731,7 @@ show extract-rgb cyan
       <p>
         Reports true when there are no more characters left to read in from
         the current file (that was opened previously with <a href="#file-open">file-open</a>). Otherwise, reports false.
+      </p>
       <pre>
 file-open &quot;my-file.txt&quot;
 print file-at-end?
@@ -2534,6 +2743,7 @@ print file-at-end?
 </pre>
       <p>
         See also <a href="#file-open">file-open</a>, <a href="#file-close-all">file-close-all</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-close">
       <h3>
@@ -2544,13 +2754,17 @@ print file-at-end?
       </h4>
       <p>
         Closes a file that has been opened previously with <a href="#file-open">file-open</a>.
+      </p>
       <p>
         Note that this and file-close-all are the only ways to restart to
         the beginning of an opened file or to switch between file modes.
+      </p>
       <p>
         If no file is open, does nothing.
+      </p>
       <p>
         See also <a href="#file-close-all">file-close-all</a>, <a href="#file-open">file-open</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-close-all">
       <h3>
@@ -2562,8 +2776,10 @@ print file-at-end?
       <p>
         Closes all files (if any) that have been opened previously with
         <a href="#file-open">file-open</a>.
+      </p>
       <p>
         See also <a href="#file-close">file-close</a>, <a href="#file-open">file-open</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-delete">
       <h3>
@@ -2574,15 +2790,18 @@ print file-at-end?
       </h4>
       <p>
         Deletes the file specified as <i>string</i>
+      </p>
       <p>
         <i>string</i> must be an existing file with writable permission by
         the user. Also, the file cannot be open. Use the command <a href="#file-close">file-close</a> to close an opened file before
         deletion.
+      </p>
       <p>
         Note that the string can either be a file name or an absolute file
         path. If it is a file name, it looks in whatever the current
         directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It is defaulted
         to the model's directory.
+      </p>
       </div>
     <div class="dict_entry" id="file-exists">
       <h3>
@@ -2594,11 +2813,13 @@ print file-at-end?
       <p>
         Reports true if <i>string</i> is the name of an existing file on
         the system. Otherwise it reports false.
+      </p>
       <p>
         Note that the string can either be a file name or an absolute file
         path. If it is a file name, it looks in whatever the current
         directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It defaults to
         to the model's directory.
+      </p>
       </div>
     <div class="dict_entry" id="file-flush">
       <h3>
@@ -2612,11 +2833,13 @@ print file-at-end?
         or other output commands, the values may not be immediately written
         to disk. This improves the performance of the file output commands.
         Closing a file ensures that all output is written to disk.
+      </p>
       <p>
         Sometimes you need to ensure that data is written to disk without
         closing the file. For example, you could be using a file to
         communicate with another program on your machine and want the other
         program to be able to see the output immediately.
+      </p>
       </div>
     <div class="dict_entry" id="file-open">
       <h3>
@@ -2630,14 +2853,17 @@ print file-at-end?
         and open the file. You may then use the reporters <a href="#file-read">file-read</a>, <a href="#file-read-line">file-read-line</a>, and <a href="#file-read-characters">file-read-characters</a> to read in from
         the file, or <a href="#file-write">file-write</a>, <a href="#file-print">file-print</a>, <a href="#file-type">file-type</a>,
         or <a href="#file-show">file-show</a> to write out to the file.
+      </p>
       <p>
         Note that you can only open a file for reading or writing but not
         both. The next file i/o primitive you use after this command
         dictates which mode the file is opened in. To switch modes, you
         need to close the file using <a href="#file-close">file-close</a>.
+      </p>
       <p>
         Also, the file must already exist if opening a file in reading
         mode.
+      </p>
       <p>
         When opening a file in writing mode, all new data will be appended
         to the end of the original file. If there is no original file, a
@@ -2647,11 +2873,13 @@ print file-at-end?
         <a href="#file-delete">file-delete</a> to delete it first, perhaps
         inside a <a href="#carefully">carefully</a> if you're not sure
         whether it already exists.)
+      </p>
       <p>
         Note that the string can either be a file name or an absolute file
         path. If it is a file name, it looks in whatever the current
         directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It is defaulted
         to the model's directory.
+      </p>
       <pre>
 file-open &quot;my-file-in.txt&quot;
 print file-read-line
@@ -2664,8 +2892,10 @@ file-print &quot;Hello World&quot; ;; File is in writing mode
         Opening a file does not close previously opened files. You can use
         <code>file-open</code> to switch back and forth between multiple open
         files.
+      </p>
       <p>
         See also <a href="#file-close">file-close</a> See also <a href="#file-close-all">file-close-all</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-print">
       <h3>
@@ -2677,15 +2907,19 @@ file-print &quot;Hello World&quot; ;; File is in writing mode
       <p>
         Prints <i>value</i> to an opened file, followed by a carriage
         return.
+      </p>
       <p>
         This agent is <i>not</i> printed before the value, unlike <a href="#file-show">file-show</a>.
+      </p>
       <p>
         Note that this command is the file i/o equivalent of <a href="#print">print</a>, and <a href="#file-open">file-open</a> needs to
         be called before this command can be used.
+      </p>
       <p>
       See also <a href="#file-show">file-show</a>, <a href="#file-type">file-type</a>,
       <a href="#file-write">file-write</a>,
       and <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-read">
       <h3>
@@ -2699,17 +2933,21 @@ file-print &quot;Hello World&quot; ;; File is in writing mode
         and interpret it as if it had been typed in the Command Center. It
         reports the resulting value. The result may be a number, list,
         string, boolean, or the special value nobody.
+      </p>
       <p>
         Whitespace separates the constants. Each call to file-read will
         skip past both leading and trailing whitespace.
+      </p>
       <p>
         Note that strings need to have quotes around them. Use the command
         <a href="#file-write">file-write</a> to have quotes included.
+      </p>
       <p>
         Also note that the <a href="#file-open">file-open</a> command must
         be called before this reporter can be used, and there must be data
         remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
         of the file.
+      </p>
       <pre>
 file-open &quot;my-file.data&quot;
 print file-read + 5
@@ -2721,6 +2959,7 @@ print length file-read
 </pre>
       <p>
         See also <a href="#file-open">file-open</a> and <a href="#file-write">file-write</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-read-characters">
       <h3>
@@ -2733,14 +2972,17 @@ print length file-read
         Reports the given <i>number</i> of characters from an opened file
         as a string. If there are fewer than that many characters left, it
         will report all of the remaining characters.
+      </p>
       <p>
         Note that it will return every character including newlines and
         spaces.
+      </p>
       <p>
         Also note that the <a href="#file-open">file-open</a> command must
         be called before this reporter can be used, and there must be data
         remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
         of the file.
+      </p>
       <pre>
 file-open &quot;my-file.txt&quot;
 print file-read-characters 5
@@ -2749,6 +2991,7 @@ print file-read-characters 5
 </pre>
       <p>
         See also <a href="#file-open">file-open</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-read-line">
       <h3>
@@ -2762,11 +3005,13 @@ print file-read-characters 5
         determines the end of the file by a carriage return, an end of file
         character or both in a row. It does not return the line terminator
         characters.
+      </p>
       <p>
         Also note that the <a href="#file-open">file-open</a> command must
         be called before this reporter can be used, and there must be data
         remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
         of the file.
+      </p>
       <pre>
 file-open &quot;my-file.txt&quot;
 print file-read-line
@@ -2774,6 +3019,7 @@ print file-read-line
 </pre>
       <p>
         See also <a href="#file-open">file-open</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-show">
       <h3>
@@ -2788,13 +3034,16 @@ print file-read-line
         to help you keep track of what agents are producing which lines of
         output.) Also, all strings have their quotes included similar to
         <a href="#file-write">file-write</a>.
+      </p>
       <p>
         Note that this command is the file i/o equivalent of <a href="#show">show</a>, and <a href="#file-open">file-open</a> needs to
         be called before this command can be used.
+      </p>
       <p>
         See also <a href="#file-print">file-print</a>, <a href="#file-type">file-type</a>,
         <a href="#file-write">file-write</a>,
         and <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-type">
       <h3>
@@ -2808,14 +3057,18 @@ print file-read-line
         carriage return (unlike <a href="#file-print">file-print</a> and
         <a href="#file-show">file-show</a>). The lack of a carriage return
         allows you to print several values on the same line.
+      </p>
       <p>
         This agent is <i>not</i> printed before the value. unlike <a href="#file-show">file-show</a>.
+      </p>
       <p>
         Note that this command is the file i/o equivalent of <a href="#type">type</a>, and <a href="#file-open">file-open</a> needs to
         be called before this command can be used.
+      </p>
       <p>
         See also <a href="#file-print">file-print</a>, <a href="#file-show">file-show</a>, <a href="#file-write">file-write</a>, and
         <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="file-write">
       <h3>
@@ -2828,14 +3081,17 @@ print file-read-line
         This command will output <i>value</i>, which can be a number,
         string, list, boolean, or nobody to an opened file, <i>not</i>
         followed by a carriage return (unlike <a href="#file-print">file-print</a> and <a href="#file-show">file-show</a>).
+      </p>
       <p>
         This agent is <i>not</i> printed before the value, unlike <a href="#file-show">file-show</a>. Its output also includes quotes around
         strings and is prepended with a space. It will output the value in
         such a manner that <a href="#file-read">file-read</a> will be able
         to interpret it.
+      </p>
       <p>
         Note that this command is the file i/o equivalent of <a href="#write">write</a>, and <a href="#file-open">file-open</a> needs to
         be called before this command can be used.
+      </p>
       <pre>
 file-open &quot;locations.txt&quot;
 ask turtles
@@ -2845,6 +3101,7 @@ ask turtles
         See also <a href="#file-print">file-print</a>, <a href="#file-show">file-show</a>,
         <a href="#file-type">file-type</a>,
         and <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="filter">
       <h3>
@@ -2858,6 +3115,7 @@ ask turtles
         the reporter reports true -- in other words, the items satisfying the
         given condition. <i>reporter</i> may be an anonymous reporter or the
         name of a reporter.
+      </p>
       <pre>
 show filter is-number? [1 &quot;2&quot; 3]
 =&gt; [1 3]
@@ -2869,6 +3127,7 @@ show filter [ s -&gt; first s != &quot;t&quot; ] [&quot;hi&quot; &quot;there&quo
       <p>
         See also <a href="#map">map</a>, <a href="#reduce">reduce</a>,
         <a href="#arrow">-> (anonymous procedure)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="first">
       <h3>
@@ -2880,9 +3139,11 @@ show filter [ s -&gt; first s != &quot;t&quot; ] [&quot;hi&quot; &quot;there&quo
       </h4>
       <p>
         On a list, reports the first (0th) item in the list.
+      </p>
       <p>
         On a string, reports a one-character string containing only the
         first character of the original string.
+      </p>
       </div>
     <div class="dict_entry" id="floor">
       <h3>
@@ -2893,6 +3154,7 @@ show filter [ s -&gt; first s != &quot;t&quot; ] [&quot;hi&quot; &quot;there&quo
       </h4>
       <p>
         Reports the largest integer less than or equal to <i>number</i>.
+      </p>
       <pre>
 show floor 4.5
 =&gt; 4
@@ -2901,6 +3163,7 @@ show floor -4.5
 </pre>
       <p>
         See also <a href="#ceiling">ceiling</a>, <a href="#round">round</a>, <a href="#precision">precision</a>.
+      </p>
       </div>
     <div class="dict_entry" id="follow">
       <h3>
@@ -2913,14 +3176,17 @@ show floor -4.5
       <p>
         Similar to ride, but, in the 3D view, the observer&apos;s vantage
         point is behind and above <i>turtle</i>.
+      </p>
       <p>
         The observer may only watch or follow a single subject.
         Calling <code>follow</code> will alter the highlight created by
         prior calls to <code>watch</code> and <code>watch-me</code>, highlighting
         the followed turtle instead.
+      </p>
       <p>
         See also <a href="#follow-me">follow-me</a>, <a href="#ride">ride</a>,
         <a href="#reset-perspective">reset-perspective</a>, <a href="#watch">watch</a>, <a href="#subject">subject</a>.
+      </p>
       </div>
     <div class="dict_entry" id="follow-me">
       <h3>
@@ -2932,13 +3198,16 @@ show floor -4.5
       </h4>
       <p>
         Asks the observer to follow this turtle.
+      </p>
       <p>
         The observer may only watch or follow a single subject.
         Calling <code>follow-me</code> will remove the highlight created by
         prior calls to <code>watch</code> and <code>watch-me</code>, highlighting
         this turtle instead.
+      </p>
       <p>
         See also <a href="#follow">follow</a>.
+      </p>
       </div>
     <div class="dict_entry" id="foreach">
       <h3>
@@ -2952,6 +3221,7 @@ show floor -4.5
         With a single list, runs the command for each item of <i>list</i>.
         <i>command</i> may be the name of a command, or an anonymous command
         created with <a href="#arrow">-&gt;</a>.
+      </p>
       <pre>
 foreach [1.1 2.2 2.6] show
 =&gt; 1.1
@@ -2967,8 +3237,10 @@ foreach [1.1 2.2 2.6] [ x -&gt; show (word x &quot; -&gt; &quot; round x) ]
         from each list.
         So, they are run once for the first items, once for
         the second items, and so on. All the lists must be the same length.
+      </p>
       <p>
         Some examples make this clearer:
+      </p>
       <pre>
 (foreach [1 2 3] [2 4 6]
    [ [a b] -&gt; show word &quot;the sum is: &quot; (a + b) ])
@@ -2982,6 +3254,7 @@ foreach [1.1 2.2 2.6] [ x -&gt; show (word x &quot; -&gt; &quot; round x) ]
 </pre>
       <p>
         See also <a href="#map">map</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="forward">
       <h3>
@@ -2995,16 +3268,20 @@ foreach [1.1 2.2 2.6] [ x -&gt; show (word x &quot; -&gt; &quot; round x) ]
       <p>
         The turtle moves forward by <i>number</i> steps, one step at a
         time. (If <i>number</i> is negative, the turtle moves backward.)
+      </p>
       <p>
         <code>fd 10</code> is equivalent to <code>repeat 10 [ jump 1 ]</code>.
         <code>fd 10.5</code> is equivalent to <code>repeat 10 [ jump 1 ] jump
         0.5</code>.
+      </p>
       <p>
         If the turtle cannot move forward <i>number</i> steps because it is
         not permitted by the current topology the turtle will complete as
         many steps of 1 as it can, then stop.
+      </p>
       <p>
         See also <a href="#jump">jump</a>, <a href="#can-move">can-move?</a>.
+      </p>
       </div>
     <div class="dict_entry" id="fput">
       <h3>
@@ -3016,6 +3293,7 @@ foreach [1.1 2.2 2.6] [ x -&gt; show (word x &quot; -&gt; &quot; round x) ]
       <p>
         Adds <i>item</i> to the beginning of a list and reports the new
         list.
+      </p>
       <pre>
 ;; suppose mylist is [5 7 10]
 set mylist fput 2 mylist
@@ -3041,9 +3319,11 @@ set mylist fput 2 mylist
         new global variables. Global variables are &quot;global&quot;
         because they are accessible by all agents and can be used anywhere
         in a model.
+      </p>
       <p>
         Most often, globals is used to define variables or constants that
         need to be used in many parts of the program.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="H">
@@ -3065,15 +3345,18 @@ set mylist fput 2 mylist
         parent. (Exceptions: each new turtle will have a new <code>who</code>
         number, and it may be of a different breed than its parent if the
         <code>hatch-<i>&lt;breeds&gt;</i></code> form is used.)
+      </p>
       <p>
         The new turtles then run <i>commands</i>. You can use the commands
         to give the new turtles different colors, headings, locations, or
         whatever. (The new turtles are created all at once, then run one at
         a time, in random order.)
+      </p>
       <p>
         If the hatch-<i>&lt;breeds&gt;</i> form is used, the new turtles
         are created as members of the given breed. Otherwise, the new
         turtles are the same breed as their parent.
+      </p>
       <pre>
 hatch 1 [ lt 45 fd 1 ]
 ;; this turtle creates one new turtle,
@@ -3084,6 +3367,7 @@ hatch-sheep 1 [ set color black ]
 </pre>
       <p>
         See also <a href="#create-turtles">create-turtles</a>, <a href="#sprout">sprout</a>.
+      </p>
       </div>
     <div class="dict_entry" id="heading">
       <h3>
@@ -3098,11 +3382,14 @@ hatch-sheep 1 [ set color black ]
         turtle is facing. This is a number greater than or equal to 0 and
         less than 360. 0 is north, 90 is east, and so on. You can set this
         variable to make a turtle turn.
+      </p>
       <p>
         See also <a href="#right">right</a>, <a href="#left">left</a>,
         <a href="#dxy">dx</a>, <a href="#dxy">dy</a>.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 set heading 45      ;; turtle is now facing northeast
 set heading heading + 10 ;; same effect as &quot;rt 10&quot;
@@ -3121,11 +3408,14 @@ set heading heading + 10 ;; same effect as &quot;rt 10&quot;
         (true or false) value indicating whether the turtle or link is
         currently hidden (i.e., invisible). You can set this variable to
         make a turtle or link disappear or reappear.
+      </p>
       <p>
         See also <a href="#hide-turtle">hide-turtle</a>, <a href="#show-turtle">show-turtle</a>, <a href="#hide-link">hide-link</a>,
         <a href="#show-link">show-link</a>
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 set hidden? not hidden?
 ;; if turtle was showing, it hides, and if it was hiding,
@@ -3142,11 +3432,14 @@ set hidden? not hidden?
       </h4>
       <p>
         The link makes itself invisible.
+      </p>
       <p>
         Note: This command is equivalent to setting the link variable
         &quot;hidden?&quot; to true.
+      </p>
       <p>
         See also <a href="#show-turtle">show-link</a>.
+      </p>
       </div>
     <div class="dict_entry" id="hide-turtle">
       <h3>
@@ -3159,11 +3452,14 @@ set hidden? not hidden?
       </h4>
       <p>
         The turtle makes itself invisible.
+      </p>
       <p>
         Note: This command is equivalent to setting the turtle variable
         &quot;hidden?&quot; to true.
+      </p>
       <p>
         See also <a href="#show-turtle">show-turtle</a>.
+      </p>
       </div>
     <div class="dict_entry" id="histogram">
       <h3>
@@ -3174,15 +3470,19 @@ set hidden? not hidden?
       </h4>
       <p>
         Histograms the values in the given list
+      </p>
       <p>
         Draws a histogram showing the frequency distribution of the values
         in the list. The heights of the bars in the histogram represent the
         numbers of values in each subrange.
+      </p>
       <p>
         Before the histogram is drawn, first any previous points drawn by
         the current plot pen are removed.
+      </p>
       <p>
         Any non-numeric values in the list are ignored.
+      </p>
       <p>
         The histogram is drawn on the current plot using the current plot
         pen and pen color. Auto scaling does not affect a histogram's
@@ -3190,13 +3490,16 @@ set hidden? not hidden?
         range, and the pen interval can then be set (either directly with
         set-plot-pen-interval, or indirectly via set-histogram-num-bars) to
         control how many bars that range is split up into.
+      </p>
       <p>
         Be sure that if you want the histogram drawn with bars that the
         current pen is in bar mode (mode 1).
+      </p>
       <p>
         For histogramming purposes the plot's X range is not considered
         to include the maximum X value. Values equal to the maximum X will
         fall outside of the histogram's range.
+      </p>
       <pre>
 histogram [color] of turtles
 ;; draws a histogram showing how many turtles there are
@@ -3214,6 +3517,7 @@ histogram [color] of turtles
       <p>
         This turtle moves to the origin (0,0). Equivalent to <code>setxy 0
         0</code>.
+      </p>
       </div>
     <div class="dict_entry" id="hsb">
       <h3>
@@ -3227,8 +3531,10 @@ histogram [color] of turtles
         color. Hue, saturation, and brightness are integers in the range
         0-360, 0-100, 0-100 respectively. The RGB list contains three
         integers in the range of 0-255.
+      </p>
       <p>
         See also <a href="#rgb">rgb</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-broadcast">
       <h3>
@@ -3240,9 +3546,11 @@ histogram [color] of turtles
       <p>
         This broadcasts <i>value</i> from NetLogo to the interface element
         with the name <i>tag-name</i> on the clients.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details and instructions.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-broadcast-clear-output">
       <h3>
@@ -3253,8 +3561,10 @@ histogram [color] of turtles
       </h4>
       <p>
         This clears all messages printed to the text area on every client.
+      </p>
       <p>
         See also: <a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>, <a href="#hubnet-send-clear-output">hubnet-send-clear-output</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-broadcast-message">
       <h3>
@@ -3267,8 +3577,10 @@ histogram [color] of turtles
         This prints the value in the text area on each client. This is the
         same functionality as the &quot;Broadcast Message&quot; button in
         the HubNet Control Center.
+      </p>
       <p>
         See also: <a href="#hubnet-send-message">hubnet-send-message</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-clear-override">
       <h3>
@@ -3285,8 +3597,10 @@ histogram [color] of turtles
         specified variable for the specified agent or agentset.
         <code>hubnet-clear-overrides</code> removes all overrides from the
         specified client.
+      </p>
       <p>
         See also: <a href="#hubnet-send-override">hubnet-send-override</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-clients-list">
       <h3>
@@ -3298,6 +3612,7 @@ histogram [color] of turtles
       <p>
         Reports a list containing the names of all the clients currently
         connected to the HubNet server.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-enter-message">
       <h3>
@@ -3310,9 +3625,11 @@ histogram [color] of turtles
         Reports true if a new client just entered the simulation. Reports
         false otherwise. <a href="#hubnet-message-source">hubnet-message-source</a> will contain the
         user name of the client that just logged on.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details and instructions.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-exit-message">
       <h3>
@@ -3325,9 +3642,11 @@ histogram [color] of turtles
         Reports true if a client just exited the simulation. Reports false
         otherwise. <a href="#hubnet-message-source">hubnet-message-source</a> will contain the
         user name of the client that just logged off.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details and instructions.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-fetch-message">
       <h3>
@@ -3340,9 +3659,11 @@ histogram [color] of turtles
         If there is any new data sent by the clients, this retrieves the
         next piece of data, so that it can be accessed by <a href="#hubnet-message">hubnet-message</a>, <a href="#hubnet-message-source">hubnet-message-source</a>, and <a href="#hubnet-message-tag">hubnet-message-tag</a>. This will cause an
         error if there is no new data from the clients.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-kick-client">
       <h3>
@@ -3355,6 +3676,7 @@ histogram [color] of turtles
         Kicks the client with the given client-name. This is equivalent to
         clicking the client name in the HubNet Control Center and pressing
         the Kick button.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-kick-all-clients">
       <h3>
@@ -3367,6 +3689,7 @@ histogram [color] of turtles
         Kicks out all currently connected HubNet clients. This is
         equivalent to selecting all clients in the HubNet Control Center
         and pressing the Kick button.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-message">
       <h3>
@@ -3377,9 +3700,11 @@ histogram [color] of turtles
       </h4>
       <p>
         Reports the message retrieved by <a href="#hubnet-fetch-message">hubnet-fetch-message</a>.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-message-source">
       <h3>
@@ -3391,9 +3716,11 @@ histogram [color] of turtles
       <p>
         Reports the name of the client that sent the message retrieved by
         <a href="#hubnet-fetch-message">hubnet-fetch-message</a>.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-message-tag">
       <h3>
@@ -3407,9 +3734,11 @@ histogram [color] of turtles
         by <a href="#hubnet-fetch-message">hubnet-fetch-message</a>. The
         tag will be one of the Display Names of the interface elements in
         the client interface.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-message-waiting">
       <h3>
@@ -3421,9 +3750,11 @@ histogram [color] of turtles
       <p>
         This looks for a new message sent by the clients. It reports true
         if there is one, and false if there is not.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-reset">
       <h3>
@@ -3435,9 +3766,11 @@ histogram [color] of turtles
       <p>
         Starts up the HubNet system. HubNet must be started to use any of
         the other hubnet primitives.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-reset-perspective">
       <h3>
@@ -3449,9 +3782,11 @@ histogram [color] of turtles
       <p>
         Clears watch or follow sent directly to the client. The view
         perspective will revert to the server perspective.
+      </p>
       <p>
         See also: <a href="#hubnet-send-watch">hubnet-send-watch</a>
         <a href="#hubnet-send-follow">hubnet-send-follow</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-send">
       <h3>
@@ -3467,16 +3802,20 @@ histogram [color] of turtles
         For a <i>string</i>, this sends <i>value</i> from NetLogo to the
         tag <i>tag-name</i> on the client that has <i>string</i> for its
         user name.
+      </p>
       <p>
         For a <i>list-of-strings</i>, this sends <i>value</i> from NetLogo
         to the tag <i>tag-name</i> on all the clients that have a user name
         that is in the <i>list-of-strings</i>.
+      </p>
       <p>
         Sending a message to a non-existent client, using
         <code>hubnet-send</code>, generates a <code>hubnet-exit-message</code>.
+      </p>
       <p>
         See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
         for details.
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-send-clear-output">
       <h3>
@@ -3492,9 +3831,11 @@ histogram [color] of turtles
         This clears all messages printed to the text area on the given
         client or clients (specified in the <i>string</i> or
         <i>list-of-strings</i>.
+      </p>
       <p>
         See also: <a href="#hubnet-send-message">hubnet-send-message</a>,
         <a href="#hubnet-broadcast-clear-output">hubnet-broadcast-clear-output</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-send-follow">
       <h3>
@@ -3507,14 +3848,17 @@ histogram [color] of turtles
         Tells the client associated with <i>client-name</i> to follow
         <i>agent</i> showing a <i>radius</i> sized Moore neighborhood
         around the agent.
+      </p>
       <p>
         A client may only watch or follow a single subject.
         Calling <code>hubnet-send-follow</code> will alter the highlight created by
         prior calls to <code>hubnet-send-watch</code>, highlighting
         the followed agent instead.
+      </p>
       <p>
         See also: <a href="#hubnet-send-watch">hubnet-send-watch</a>,
         <a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-send-message">
       <h3>
@@ -3526,8 +3870,10 @@ histogram [color] of turtles
       <p>
         This prints <code>value</code> in the text area on the client specified
         by <code>string</code>.
+      </p>
       <p>
         See also: <a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-send-override">
       <h3>
@@ -3545,6 +3891,7 @@ histogram [color] of turtles
         built-in variables that affect the appearance of the agent may be
         selected. For example, you can override the color variable of a
         turtle:
+      </p>
       <pre>
 ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
 </pre>
@@ -3554,8 +3901,10 @@ ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
         the turtles are blue. This code makes the turtle associated with
         each client appear red in his or her own view but not on anyone
         else's or on the server.
+      </p>
       <p>
         See also: <a href="#hubnet-clear-override">hubnet-clear-overrides</a>
+      </p>
       </div>
     <div class="dict_entry" id="hubnet-send-watch">
       <h3>
@@ -3567,13 +3916,16 @@ ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
       <p>
         Tells the client associated with <i>client-name</i> to watch
         <i>agent</i>.
+      </p>
       <p>
         A client may only watch or follow a single subject.
         Calling <code>hubnet-send-watch</code> will undo perspective changes caused
         by prior calls to <code>hubnet-send-follow</code>.
+      </p>
       <p>
         See also: <a href="#hubnet-send-follow">hubnet-send-follow</a>,
         <a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
+      </p>
       </div>
     </div> <!-- ======================================== -->
     <h2 id="I">
@@ -3589,11 +3941,14 @@ ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
       </h4>
       <p>
         Reporter must report a boolean (true or false) value.
+      </p>
       <p>
         If <i>condition</i> reports true, runs <i>commands</i>.
+      </p>
       <p>
         The reporter may report a different value for different agents, so
         some agents may run <i>commands</i> and others don't.
+      </p>
       <pre>
 if xcor &gt; 0[ set color blue ]
 ;; turtles in the right half of the world
@@ -3601,6 +3956,7 @@ if xcor &gt; 0[ set color blue ]
 </pre>
       <p>
         See also <a href="#ifelse">ifelse</a>, <a href="#ifelse-value">ifelse-value</a>.
+      </p>
       </div>
     <div class="dict_entry" id="ifelse">
       <h3>
@@ -3612,12 +3968,15 @@ if xcor &gt; 0[ set color blue ]
       </h4>
       <p>
         The <i>reporter</i>s must report boolean (true or false) values.
+      </p>
       <p>
         For the first <i>reporter</i> that reports true, runs the <i>commands</i> that follow.
+      </p>
       <p>
         If no <i>reporter</i> reports true, runs <i>elsecommands</i> or does nothing if
         <i>elsecommands</i> is not given.  When using only one <i>reporter</i>
         you do not need to surround the entire <i>ifelse</i> primitive and its blocks in parentheses.
+      </p>
         <pre>
   ask patches
     [ ifelse pxcor &gt; 0
@@ -3629,7 +3988,8 @@ if xcor &gt; 0[ set color blue ]
       <p>
         The reporters may report a different value for different agents, so
         some agents may run different command blocks.  When using more than one <i>reporter</i> you
-        must surround the whole <i>ifelse<i> primitive and its blocks in parentheses.
+        must surround the whole <i>ifelse</i> primitive and its blocks in parentheses.
+      </p>
       <pre>
         ask patches [
           let choice random 4
@@ -3655,6 +4015,7 @@ if xcor &gt; 0[ set color blue ]
       </pre>
       <p>
         See also <a href="#if">if</a>, <a href="#ifelse-value">ifelse-value</a>.
+      </p>
       </div>
     <div class="dict_entry" id="ifelse-value">
       <h3>
@@ -3666,18 +4027,22 @@ if xcor &gt; 0[ set color blue ]
       </h4>
       <p>
         The <i>tfreporter</i>s must report boolean (true or false) values.
+      </p>
       <p>
         For the first <i>tfreporter</i> that reports true, runs the
-        <i>reporter</i> that follows and reports that result.  When using only one <i>tfreporter1<i>
+        <i>reporter</i> that follows and reports that result.  When using only one <i>tfreporter1</i>
         you do not need to surround the entire <i>ifelse-value</i> primitive and its blocks in parentheses.
+      </p>
       <p>
         If all <i>tfreporter</i>s report false, the result is the value of
         <i>elsereporter</i>.  You may leave out the <i>elsereporter</i>, but
         if all <i>tfreporter</i>s report false then a runtime error will occur.
+      </p>
       <p>
         This can be used when a conditional is needed in the context of a
         reporter, where commands (such as <a href="#ifelse">ifelse</a>) are
         not allowed.
+      </p>
       <pre>
 ask patches [
   set pcolor ifelse-value (pxcor &gt; 0) [blue] [red]
@@ -3692,7 +4057,8 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
 </pre>
       <p>
         When using more than one <i>tfreporter</i> you
-        must surround the whole <i>ifelse-value<i> primitive and its blocks in parentheses.
+        must surround the whole <i>ifelse-value</i> primitive and its blocks in parentheses.
+      </p>
       <pre>
         ask patches [
           let choice random 4
@@ -3702,8 +4068,10 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
             choice = 2 [ green ]
                        [ yellow ])
         ]
+      </pre>
       <p>
         A runtime error can occur if there is no <i>elsereporter</i>.
+      </p>
       <pre>
         ask patches [
           let x = 2
@@ -3715,6 +4083,7 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
       </pre>
       <p>
         See also <a href="#if">if</a>, <a href="#ifelse">ifelse</a>.
+      </p>
       </div>
     <div class="dict_entry" id="import-drawing">
       <h3>
@@ -3729,15 +4098,18 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
         world, while retaining the original aspect ratio of the image. The
         image is centered in the drawing. The old drawing is not cleared
         first.
+      </p>
       <p>
         Agents cannot sense the drawing, so they cannot interact with or
         process images imported by import-drawing. If you need agents to
         sense an image, use <a href="#import-pcolors">import-pcolors</a> or
         <a href="#import-pcolors-rgb">import-pcolors-rgb</a>.
+      </p>
       <p>
         The following image file formats are supported: BMP, JPG, GIF, and
         PNG. If the image format supports transparency (alpha), that
         information will be imported as well.
+      </p>
       </div>
     <div class="dict_entry" id="import-pcolors">
       <h3>
@@ -3756,16 +4128,19 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
         possible colors. (See the Color section of the Programming Guide.)
         import-pcolors may be slow for some images, particularly when you
         have many patches and a large image with many different colors.
+      </p>
       <p>
         Since import-pcolors sets the pcolor of patches, agents can sense
         the image. This is useful if agents need to analyze, process, or
         otherwise interact with the image. If you want to simply display a
         static backdrop, without color distortion, see <a href="#import-drawing">import-drawing</a>.
+      </p>
       <p>
         The following image file formats are supported: BMP, JPG, GIF, and
         PNG. If the image format supports transparency (alpha), then all
         fully transparent pixels will be ignored. (Partially transparent
         pixels will be treated as opaque.)
+      </p>
       </div>
     <div class="dict_entry" id="import-pcolors-rgb">
       <h3>
@@ -3782,11 +4157,13 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
         centered in the patch grid. Unlike <a href="#import-pcolors">import-pcolors</a> the exact colors in the
         original image are retained. The pcolor variable of all the patches
         will be an RGB list rather than an (approximated) NetLogo color.
+      </p>
       <p>
         The following image file formats are supported: BMP, JPG, GIF, and
         PNG. If the image format supports transparency (alpha), then all
         fully transparent pixels will be ignored. (Partially transparent
         pixels will be treated as opaque.)
+      </p>
       </div>
     <div class="dict_entry" id="import-world">
       <h3>
@@ -3802,12 +4179,15 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
         from an external file named by the given string. The file should be
         in the format used by the <a href="#export-cmds">export-world</a>
         primitive.
+      </p>
       <p>
         Note that the functionality of this primitive is also directly
         available from NetLogo's File menu.
+      </p>
       <p>
         When using import-world, to avoid errors, perform these steps in
         the following order:
+      </p>
       <ol>
         <li>Open the model from which you created the export file.
         <li>Press the Setup button, to get the model in a state from which
@@ -3823,6 +4203,7 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
         model's location, you may include the full path to the file you
         wish to import. See <a href="#export-cmds">export-world</a> for an
         example.
+      </p>
       </div>
     <div class="dict_entry" id="in-cone">
       <h3>
@@ -3839,12 +4220,15 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
         may range from 0 to 360 and is centered around the turtle's
         current heading. (If the angle is 360, then in-cone is equivalent
         to in-radius.)
+      </p>
       <p>
         in-cone reports an agentset that includes only those agents from
         the original agentset that fall in the cone. (This can include the
         agent itself.)
+      </p>
       <p>
         The distance to a patch is measured from the center of the patch.
+      </p>
       <pre>
 ask turtles
   [ ask patches in-cone 3 60
@@ -3868,6 +4252,7 @@ ask turtles
         to the caller or an undirected link connecting <i>turtle</i> to the
         caller. You can think of this as "is there a link I can use to get from
         <i>turtle</i> to the caller?"
+      </p>
       <pre>
 crt 2
 ask turtle 0 [
@@ -3896,6 +4281,7 @@ ask turtle 1 [
         from them to the caller as well as all turtles that have an undirected
         link connecting them with the caller. You can think of this as "all the
         turtles that can get to the caller using a link."
+      </p>
       <pre>
 crt 4
 ask turtle 0 [ create-links-to other turtles ]
@@ -3918,6 +4304,7 @@ ask turtle 1 [ ask in-link-neighbors [ set color blue ] ] ;; turtle 0 turns blue
         reports nobody. If more than one such link exists, reports a
         random one. You can think of this as "give me a link that I can use
         to travel from <i>turtle</i> to the caller."
+      </p>
       <pre>
 crt 2
 ask turtle 0 [ create-link-to turtle 1 ]
@@ -3926,6 +4313,7 @@ ask turtle 0 [ show in-link-from turtle 1 ] ;; shows nobody
 </pre>
       <p>
         See also: <a href="#out-link-to">out-link-to</a> <a href="#link-with">link-with</a>
+      </p>
       </div>
     <div class="dict_entry" id="includes">
       <h3>
@@ -3939,13 +4327,16 @@ ask turtle 0 [ show in-link-from turtle 1 ] ;; shows nobody
         suffix) to be included in this model. Included files may contain
         breed, variable, and procedure definitions. <code>__includes</code> can
         only be used once per file.
+      </p>
       <p>
         The file names must be strings, for example:
+      </p>
       <pre>
 __includes [ &quot;utils.nls&quot; ]
       </pre>
       <p>
         Or, for multiple files:
+      </p>
       <pre>
 __includes [ &quot;utils1.nls&quot; &quot;utils2.nls&quot; ]
       </pre>
@@ -3962,9 +4353,11 @@ __includes [ &quot;utils1.nls&quot; &quot;utils2.nls&quot; ]
         Reports an agentset that includes only those agents from the
         original agentset whose distance from the caller is less than or
         equal to <i>number</i>. (This can include the agent itself.)
+      </p>
       <p>
         The distance to or a from a patch is measured from the center of
         the patch.
+      </p>
       <pre>
 ask turtles
   [ ask patches in-radius 3
@@ -3985,9 +4378,11 @@ ask turtles
         On a list, inserts an item in that list. <i>index</i> is the index
         where the item will be inserted. The first item has an index of 0.
         (The 6th item in a list would have an index of 5.)
+      </p>
       <p>
         Likewise for a string, but all characters in a multiple-character <i>string2</i>
         are inserted at <i>index</i>.
+      </p>
       <pre>
 show insert-item 2 [2 7 4 5] 15
 =&gt; [2 7 15 4 5]
@@ -4006,6 +4401,7 @@ show insert-item 2 &quot;cat&quot; &quot;re&quot;
       </h4>
       <p>
         Opens an agent monitor for the given agent (turtle or patch).
+      </p>
       <pre>
 inspect patch 2 4
 ;; an agent monitor opens for that patch
@@ -4015,6 +4411,7 @@ inspect one-of sheep
 </pre>
       <p>
         See <a href="#stop-inspecting">stop-inspecting</a> and <a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>
+      </p>
     </div>
     <div class="dict_entry" id="int">
       <h3>
@@ -4026,6 +4423,7 @@ inspect one-of sheep
       <p>
         Reports the integer part of number -- any fractional part is
         discarded.
+      </p>
       <pre>
 show int 4.7
 =&gt; 4
@@ -4074,6 +4472,7 @@ show int -3.5
       </h4>
       <p>
         Reports true if <i>value</i> is of the given type, false otherwise.
+      </p>
       </div>
     <div class="dict_entry" id="item">
       <h3>
@@ -4086,12 +4485,15 @@ show int -3.5
       <p>
         On lists, reports the value of the item in the given list with the
         given index.
+      </p>
       <p>
         On strings, reports the character in the given string at the given
         index.
+      </p>
       <p>
         Note that the indices begin from 0, not 1. (The first item is item
         0, the second item is item 1, and so on.)
+      </p>
       <pre>
 ;; suppose mylist is [2 4 6 8 10]
 show item 2 mylist
@@ -4116,17 +4518,19 @@ show item 3 &quot;my-shoe&quot;
       <p>
         The turtle moves forward by <i>number</i> units all at once (rather
         than one step at a time as with the <code>forward</code> command).
+      </p>
       <p>
         If the turtle cannot jump <i>number</i> units because it is not
         permitted by the current topology the turtle does not move at all.
+      </p>
       <p>
         See also <a href="#forward">forward</a>, <a href="#can-move">can-move?</a>.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="L">
       <a>L</a>
     </h2><!-- ======================================== -->
-    <div>
     <div class="dict_entry" id="label">
       <h3>
         <a>label</a>
@@ -4140,10 +4544,13 @@ show item 3 &quot;my-shoe&quot;
         any type. The turtle or link appears in the view with the given
         value &quot;attached&quot; to it as text. You can set this variable
         to add, change, or remove a turtle or link's label.
+      </p>
       <p>
         See also <a href="#label-color">label-color</a>, <a href="#plabel">plabel</a>, <a href="#plabel-color">plabel-color</a>.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 ask turtles [ set label who ]
 ;; all the turtles now are labeled with their
@@ -4166,11 +4573,14 @@ ask turtles [ set label &quot;&quot; ]
         determines what color the turtle or link's label appears in (if
         it has a label). You can set this variable to change the color of a
         turtle or link's label.
+      </p>
       <p>
         See also <a href="#label">label</a>, <a href="#plabel">plabel</a>,
         <a href="#plabel-color">plabel-color</a>.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 ask turtles [ set label-color red ]
 ;; all the turtles now have red labels
@@ -4186,9 +4596,11 @@ ask turtles [ set label-color red ]
       </h4>
       <p>
         On a list, reports the last item in the list.
+      </p>
       <p>
         On a string, reports a one-character string containing only the
         last character of the original string.
+      </p>
       </div>
     <div class="dict_entry" id="layout-circle">
       <h3>
@@ -4203,13 +4615,16 @@ ask turtles [ set label-color red ]
         center of the world with the given radius. (If the world has an
         even size the center of the circle is rounded down to the nearest
         patch.) The turtles point outwards.
+      </p>
       <p>
         If the first input is an agentset, the turtles are arranged in
         random order.
+      </p>
       <p>
         If the first input is a list, the turtles are arranged clockwise in
         the given order, starting at the top of the circle. (Any
         non-turtles in the list are ignored.)
+      </p>
       <pre>
 ;; in random order
 layout-circle turtles 10
@@ -4230,14 +4645,17 @@ layout-circle sort-by [ [a b] -&gt; [size] of a &lt; [size] of b ] turtles 10
         Arranges the turtles in <i>turtle-set</i> connected by links in
         <i>link-set</i>, in a radial tree layout, centered around the
         <i>root-agent</i> which is moved to the center of the world view.
+      </p>
       <p>
         Only links in the <i>link-set</i> will be used to determine the
         layout. If links connect turtles that are not in <i>turtle-set</i>
         those turtles will remain stationary.
+      </p>
       <p>
         Even if the network does contain cycles, and is not a true tree
         structure, this layout will still work, although the results will
         not always be pretty.
+      </p>
       <pre>
 to make-a-tree
   set-default-shape turtles &quot;circle&quot;
@@ -4270,19 +4688,23 @@ end
         other. Turtles that are connected by links in <i>link-set</i> but
         not included in <i>turtle-set</i> are treated as anchors and are
         not moved.
+      </p>
       <p>
         <i>spring-constant</i> is a measure of the &quot;tautness&quot; of
         the spring. It is the &quot;resistance&quot; to change in their
         length. spring-constant is the force the spring would exert if
         it's length were changed by 1 unit.
+      </p>
       <p>
         spring-length is the &quot;zero-force&quot; length or the natural
         length of the springs. This is the length which all springs try to
         achieve either by pushing out their nodes or pulling them in.
+      </p>
       <p>
         repulsion-constant is a measure of repulsion between the nodes. It
         is the force that 2 nodes at a distance of 1 unit will exert on
         each other.
+      </p>
       <p>
         The repulsion effect tries to get the nodes as far as possible from
         each other, in order to avoid crowding and the spring effect tries
@@ -4290,10 +4712,12 @@ end
         they are connected to. The result is the laying out of the whole
         network in a way which highlights relationships among the nodes and
         at the same time is crowded less and is visually pleasing.
+      </p>
       <p>
         The layout algorithm is based on the Fruchterman-Reingold layout
         algorithm. More information about this algorithm can be obtained
         <a href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.13.8444" target="_blank">here</a>.
+      </p>
       <pre>
 to make-a-triangle
   set-default-shape turtles &quot;circle&quot;
@@ -4322,19 +4746,24 @@ end
         included in <i>turtle-set</i> are placed in a circle layout with
         the given <i>radius</i>. There should be at least 3 agents in this
         agentset.
+      </p>
       <p>
         The turtles in <i>turtle-set</i> are then laid out in the following
         manner: Each turtle is placed at centroid (or barycenter) of the
         polygon formed by its linked neighbors. (The centroid is like a
         2-dimensional average of the coordinates of the neighbors.)
+      </p>
       <p>
         (The purpose of the circle of &quot;anchor agents&quot; is to
         prevent all the turtles from collapsing down to one point.)
+      </p>
       <p>
         After a few iterations of this, the layout will stabilize.
+      </p>
       <p>
         This layout is named after the mathematician William Thomas Tutte,
         who proposed it as a method for graph layout.
+      </p>
       <pre>
 to make-a-tree
   set-default-shape turtles &quot;circle&quot;
@@ -4368,6 +4797,7 @@ end
       <p>
         The turtle turns left by <i>number</i> degrees. (If <i>number</i>
         is negative, it turns right.)
+      </p>
       </div>
     <div class="dict_entry" id="length">
       <h3>
@@ -4380,6 +4810,7 @@ end
       <p>
         Reports the number of items in the given list, or the number of
         characters in the given string.
+      </p>
       </div>
     <div class="dict_entry" id="let">
       <h3>
@@ -4392,10 +4823,13 @@ end
         Creates a new local variable and gives it the given value. A local
         variable is one that exists only within the enclosing block of
         commands.
+      </p>
       <p>
         If you want to change the value afterwards, use <a href="#set">set</a>.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 let prey one-of sheep-here
 if prey != nobody
@@ -4415,6 +4849,7 @@ if prey != nobody
         the turtles. If there is no such link reports <code>nobody</code>. To
         refer to breeded links you must use the singular breed form with
         the endpoints.
+      </p>
       <pre>
 ask link 0 1 [ set color green ]
 ;; unbreeded link connecting turtle 0 and turtle 1 will turn green
@@ -4423,6 +4858,7 @@ ask directed-link 0 1 [ set color red ]
 </pre>
       <p>
         See also <a href="#patch-at">patch-at</a>.
+      </p>
       </div>
     <div class="dict_entry" id="link-heading">
       <h3>
@@ -4436,12 +4872,14 @@ ask directed-link 0 1 [ set color red ]
         Reports the heading in degrees (at least 0, less than 360) from
         <code>end1</code> to <code>end2</code> of the link. Throws a runtime error
         if the endpoints are at the same location.
+      </p>
       <pre>
 ask link 0 1 [ print link-heading ]
 ;; prints [[towards other-end] of end1] of link 0 1
 </pre>
       <p>
         See also <a href="#link-length">link-length</a>
+      </p>
       </div>
     <div class="dict_entry" id="link-length">
       <h3>
@@ -4453,12 +4891,14 @@ ask link 0 1 [ print link-heading ]
       </h4>
       <p>
         Reports the distance between the endpoints of the link.
+      </p>
       <pre>
 ask link 0 1 [ print link-length ]
 ;; prints [[distance other-end] of end1] of link 0 1
 </pre>
       <p>
         See also <a href="#link-heading">link-heading</a>
+      </p>
       </div>
     <div class="dict_entry" id="link-set">
       <h3>
@@ -4472,12 +4912,14 @@ ask link 0 1 [ print link-length ]
         Reports an agentset containing all of the links anywhere in any of
         the inputs. The inputs may be individual links, link agentsets,
         nobody, or lists (or nested lists) containing any of the above.
+      </p>
       <pre>
 link-set self
 link-set [my-links] of nodes with [color = red]
 </pre>
       <p>
         See also <a href="#turtle-set">turtle-set</a>, <a href="#patch-set">patch-set</a>.
+      </p>
       </div>
     <div class="dict_entry" id="link-shapes">
       <h3>
@@ -4489,9 +4931,11 @@ link-set [my-links] of nodes with [color = red]
       <p>
         Reports a list of strings containing all of the link shapes in the
         model.
+      </p>
       <p>
         New shapes can be created, or imported from other models, in the
         <a href="shapes.html">Link Shapes Editor</a>.
+      </p>
       <pre>
 show link-shapes
 =&gt; [&quot;default&quot;]
@@ -4506,6 +4950,7 @@ show link-shapes
       </h4>
       <p>
         Reports the agentset consisting of all links. This is a special agentset that can grow as links are added to the world, see <a href="programming.html#special-agentsets">the programming guide for more info</a>.
+      </p>
       <pre>
 show count links
 ;; prints the number of links
@@ -4524,10 +4969,12 @@ show count links
         <i>&lt;breeds&gt;</i>-own, turtles-own, and patches-own keywords,
         can only be used at the beginning of a program, before any function
         definitions. It defines the variables belonging to each link.
+      </p>
       <p>
         If you specify a breed instead of &quot;links&quot;, only links of
         that breed have the listed variables. (More than one link breed may
         list the same variable.)
+      </p>
       <pre>
 undirected-link-breed [sidewalks sidewalk]
 directed-link-breed [streets street]
@@ -4546,6 +4993,7 @@ streets-own [cars bikes]
         <p>
           Reports a list containing the given items. The items can be of
           any type, produced by any kind of reporter.
+        </p>
         <pre>
 show list (random 10) (random 10)
 =&gt; [4 9]  ;; or similar list
@@ -4565,8 +5013,10 @@ show (list (random 10) 1 2 3 (random 10))
         <p>
           Reports the natural logarithm of <i>number</i>, that is, the
           logarithm to the base e (2.71828...).
+        </p>
         <p>
           See also <a href="#num-e">e</a>, <a href="#log">log</a>.
+        </p>
         </div>
       <div class="dict_entry" id="log">
         <h3>
@@ -4577,12 +5027,14 @@ show (list (random 10) 1 2 3 (random 10))
         </h4>
         <p>
           Reports the logarithm of <i>number</i> in base <i>base</i>.
+        </p>
         <pre>
 show log 64 2
 =&gt; 6
 </pre>
         <p>
           See also <a href="#ln">ln</a>.
+        </p>
         </div>
       <div class="dict_entry" id="loop">
         <h3>
@@ -4595,6 +5047,7 @@ show log 64 2
           Repeats the commands forever, or until the enclosing procedure
           exits through use of the <a href="#stop">stop</a> or
           <a href="#report">report</a> commands.
+        </p>
           <pre>to move-to-world-edge  ;; turtle procedure
   loop [
     if not can-move? 1 [ stop ]
@@ -4603,11 +5056,13 @@ show log 64 2
 end</pre>
         <p>In this example, <code>stop</code> exits not just the loop,
            but the entire procedure.
+        </p>
         <p>
           Note: in many circumstances, it is more appropriate to use
           a forever button to repeat something indefinitely.  See
           <a href="programming.html#buttons">Buttons</a> in the
           Programming Guide.
+        </p>
         </div>
       <div class="dict_entry" id="lput">
         <h3>
@@ -4618,6 +5073,7 @@ end</pre>
         </h4>
         <p>
           Adds <i>value</i> to the end of a list and reports the new list.
+        </p>
         <pre>
 ;; suppose mylist is [2 7 10 &quot;Bob&quot;]
 set mylist lput 42 mylist
@@ -4641,6 +5097,7 @@ set mylist lput 42 mylist
           With a single <i>list</i>, the given reporter is run for each item in
           the list, and a list of the results is collected and reported.
           <i>reporter</i> may be an anonymous reporter or the name of a reporter.
+        </p>
         <pre>
 show map round [1.1 2.2 2.7]
 =&gt; [1 2 3]
@@ -4652,8 +5109,10 @@ show map [ i -&gt; i * i ] [1 2 3]
           items from each list. So, it is run once for the first items,
           once for the second items, and so on. All the lists must be the
           same length.
+        </p>
         <p>
           Some examples make this clearer:
+        </p>
         <pre>
 show (map + [1 2 3] [2 4 6])
 =&gt; [3 6 9]
@@ -4662,6 +5121,7 @@ show (map [ [a b c] -&gt; a + b = c ] [1 2 3] [2 4 6] [3 5 9])
 </pre>
         <p>
         See also <a href="#foreach">foreach</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>.
+        </p>
         </div>
       <div class="dict_entry" id="max">
         <h3>
@@ -4673,6 +5133,7 @@ show (map [ [a b c] -&gt; a + b = c ] [1 2 3] [2 4 6] [3 5 9])
         <p>
           Reports the maximum number value in the list. It ignores other
           types of items.
+        </p>
         <pre>
 show max [xcor] of turtles
 ;; prints the x coordinate of the turtle which is
@@ -4698,6 +5159,7 @@ show max (list a b c)
           with that value then agents with the second highest value are
           found, and so on. At the end, if there is a tie that would make
           the resulting agentset too large, the tie is broken randomly.
+        </p>
         <pre>
 ;; assume the world is 11 x 11
 show max-n-of 5 patches [pxcor]
@@ -4708,6 +5170,7 @@ show max-n-of 5 patches with [pycor = 0] [pxcor]
 </pre>
         <p>
           See also <a href="#max-one-of">max-one-of</a>, <a href="#with-max">with-max</a>.
+        </p>
         </div>
       <div class="dict_entry" id="max-one-of">
         <h3>
@@ -4721,12 +5184,14 @@ show max-n-of 5 patches with [pycor = 0] [pxcor]
           the given reporter. If there is a tie this command reports one
           random agent with the highest value. If you want all such agents,
           use with-max instead.
+        </p>
         <pre>
 show max-one-of patches [count turtles-here]
 <br>;; prints the first patch with the most turtles on it
 </pre>
         <p>
           See also <a href="#max-n-of">max-n-of</a>, <a href="#with-max">with-max</a>.
+        </p>
         </div>
       <div class="dict_entry" id="max-pcor">
         <h3>
@@ -4741,13 +5206,16 @@ show max-one-of patches [count turtles-here]
           These reporters give the maximum x-coordinate and maximum
           y-coordinate, (respectively) for patches, which determines the
           size of the world.
+        </p>
         <p>
           Unlike in older versions of NetLogo the origin does not have to
           be at the center of the world. However, the maximum x- and y-
           coordinates must be greater than or equal to zero.
+        </p>
         <p>
           Note: You can set the size of the world only by editing the view
           -- these are reporters which cannot be set.
+        </p>
         <pre>
 crt 100 [ setxy random-float max-pxcor
                 random-float max-pycor ]
@@ -4756,6 +5224,7 @@ crt 100 [ setxy random-float max-pxcor
 </pre>
         <p>
           See also <a href="#min-pcor">min-pxcor</a>, <a href="#min-pcor">min-pycor</a>, <a href="#world-dim">world-width</a>, and <a href="#world-dim">world-height</a>
+        </p>
         </div>
       <div class="dict_entry" id="mean">
         <h3>
@@ -4768,6 +5237,7 @@ crt 100 [ setxy random-float max-pxcor
           Reports the statistical mean of the numeric items in the given
           list. Errors on non-numeric items. The mean is the average, i.e.,
           the sum of the items divided by the total number of items.
+        </p>
         <pre>
 show mean [xcor] of turtles
 ;; prints the average of all the turtles' x coordinates
@@ -4786,6 +5256,7 @@ show mean [xcor] of turtles
           would be in the middle if all the items were arranged in order.
           (If two items would be in the middle, the median is the average
           of the two.)
+        </p>
         <pre>
 show median [xcor] of turtles
 ;; prints the median of all the turtles' x coordinates
@@ -4803,13 +5274,16 @@ show median [xcor] of turtles
         <p>
           For a list, reports true if the given value appears in the given
           list, otherwise reports false.
+        </p>
         <p>
           For a string, reports true or false depending on whether
           <i>string1</i> appears anywhere inside <i>string2</i> as a
           substring.
+        </p>
         <p>
           For an agentset, reports true if the given agent is appears in
           the given agentset, otherwise reports false.
+        </p>
         <pre>
 show member? 2 [1 2 3]
 =&gt; true
@@ -4824,6 +5298,7 @@ show member? turtle 0 patches
 </pre>
         <p>
           See also <a href="#position">position</a>.
+        </p>
         </div>
       <div class="dict_entry" id="min">
         <h3>
@@ -4835,6 +5310,7 @@ show member? turtle 0 patches
         <p>
           Reports the minimum number value in the list. It ignores other
           types of items.
+        </p>
         <pre>
 show min [xcor] of turtles
 ;; prints the lowest x-coordinate of all the turtles
@@ -4859,6 +5335,7 @@ show min (list a b c)
           that value then the agents with the second lowest value are
           found, and so on. At the end, if there is a tie that would make
           the resulting agentset too large, the tie is broken randomly.
+        </p>
         <pre>
 ;; assume the world is 11 x 11
 show min-n-of 5 patches [pxcor]
@@ -4869,6 +5346,7 @@ show min-n-of 5 patches with [pycor = 0] [pxcor]
 </pre>
         <p>
           See also <a href="#min-one-of">min-one-of</a>, <a href="#with-min">with-min</a>.
+        </p>
         </div>
       <div class="dict_entry" id="min-one-of">
         <h3>
@@ -4882,6 +5360,7 @@ show min-n-of 5 patches with [pycor = 0] [pxcor]
           value for the given reporter. If there is a tie, this command
           reports one random agent that meets the condition. If you want
           all such agents use with-min instead.
+        </p>
         <pre>
 show min-one-of turtles [xcor + ycor]
 ;; reports the first turtle with the smallest sum of
@@ -4889,6 +5368,7 @@ show min-one-of turtles [xcor + ycor]
 </pre>
         <p>
           See also <a href="#with-min">with-min</a>, <a href="#min-n-of">min-n-of</a>.
+        </p>
         </div>
       <div class="dict_entry" id="min-pcor">
         <h3>
@@ -4903,13 +5383,16 @@ show min-one-of turtles [xcor + ycor]
           These reporters give the minimum x-coordinate and minimum
           y-coordinate, (respectively) for patches, which determines the
           size of the world.
+        </p>
         <p>
           Unlike in older versions of NetLogo the origin does not have to
           be at the center of the world. However, the minimum x- and y-
           coordinates must be less than or equal to zero.
+        </p>
         <p>
           Note: You can set the size of the world only by editing the view
           -- these are reporters which cannot be set.
+        </p>
         <pre>
 crt 100 [ setxy random-float min-pxcor
                 random-float min-pycor ]
@@ -4918,6 +5401,7 @@ crt 100 [ setxy random-float min-pxcor
 </pre>
         <p>
           See also <a href="#max-pcor">max-pxcor</a>, <a href="#max-pcor">max-pycor</a>, <a href="#world-dim">world-width</a>, and <a href="#world-dim">world-height</a>
+        </p>
         </div>
       <div class="dict_entry" id="mod">
         <h3>
@@ -4930,12 +5414,14 @@ crt 100 [ setxy random-float min-pxcor
           Reports <i>number1</i> modulo <i>number2</i>: that is, the
           residue of <i>number1</i> (mod <i>number2</i>). mod is is
           equivalent to the following NetLogo code:
+        </p>
         <pre>
 <i>number1</i> - (floor (<i>number1</i> / <i>number2</i>)) * <i>number2</i>
 </pre>
         <p>
           Note that mod is &quot;infix&quot;, that is, it comes between its
           two inputs.
+        </p>
         <pre>
 show 62 mod 5
 =&gt; 2
@@ -4946,6 +5432,7 @@ show -8 mod 3
           See also <a href="#remainder">remainder</a>. mod and remainder
           behave the same for positive numbers, but differently for
           negative numbers.
+        </p>
         </div>
       <div class="dict_entry" id="modes">
         <h3>
@@ -4956,10 +5443,13 @@ show -8 mod 3
         </h4>
         <p>
           Reports a list of the most common item or items in <i>list</i>.
+        </p>
         <p>
           The input list may contain any NetLogo values.
+        </p>
         <p>
           If the input is an empty list, reports an empty list.
+        </p>
         <pre>
 show modes [1 2 2 3 4]
 =&gt; [2]
@@ -4981,9 +5471,11 @@ show modes [pxcor] of turtles
         </h4>
         <p>
           Reports true if the mouse button is down, false otherwise.
+        </p>
         <p>
           Note: If the mouse pointer is outside of the current view ,
           mouse-down? will always report false.
+        </p>
         </div>
       <div class="dict_entry" id="mouse-inside">
         <h3>
@@ -4995,6 +5487,7 @@ show modes [pxcor] of turtles
         <p>
           Reports true if the mouse pointer is inside the current view,
           false otherwise.
+        </p>
         </div>
       <div class="dict_entry" id="mouse-cor">
         <h3>
@@ -5010,9 +5503,11 @@ show modes [pxcor] of turtles
           value is in terms of turtle coordinates, so it might not be an
           integer. If you want patch coordinates, use <code>round
           mouse-xcor</code> and <code>round mouse-ycor</code>.
+        </p>
         <p>
           Note: If the mouse is outside of the 2D view, reports the value
           from the last time it was inside.
+        </p>
         <pre>
 ;; to make the mouse &quot;draw&quot; in red:
 if mouse-down?
@@ -5030,9 +5525,11 @@ if mouse-down?
         <p>
           The turtle sets its x and y coordinates to be the same as the
           given agent's.
+        </p>
         <p>
           (If that agent is a patch, the effect is to move the turtle to
           the center of that patch.)
+        </p>
         <pre>
 move-to turtle 5
 ;; turtle moves to same point as turtle 5
@@ -5045,8 +5542,10 @@ move-to max-one-of turtles [size]
           Note that the turtle's heading is unaltered. You may want to
           use the <a href="#face">face</a> command first to orient the
           turtle in the direction of motion.
+        </p>
         <p>
           See also <a href="#setxy">setxy</a>.
+        </p>
         </div>
       <div class="dict_entry" id="my-links">
         <h3>
@@ -5066,6 +5565,7 @@ move-to max-one-of turtles [size]
           of this primitive, as it works well for either directed or
           undirected networks (since it excludes directed, incoming
           links).
+        </p>
         <pre>
 crt 5
 ask turtle 0
@@ -5098,6 +5598,7 @@ end
           other nodes to the caller as well as all undirected links
           connected to the caller. You can think of this as "all links
           that you can use to travel <i>to</i> this node".
+        </p>
         <pre>
 crt 5
 ask turtle 0
@@ -5126,6 +5627,7 @@ ask turtle 1
           caller to other nodes as well as undirected links connected to the
           caller. You can think of this as "all links you can use to travel
           <i>from</i> this node".
+        </p>
         <pre>
 crt 5
 ask turtle 0
@@ -5152,17 +5654,21 @@ ask turtle 1
           &quot;self&quot; is simple; it means &quot;me&quot;.
           &quot;myself&quot; means &quot;the turtle, patch or link who asked me
           to do what I'm doing right now.&quot;
+        </p>
         <p>
           When an agent has been asked to run some code, using myself in
           that code reports the agent (turtle, patch or link) that did the
           asking.
+        </p>
         <p>
           myself is most often used in conjunction with <code>of</code> to read
           or set variables in the asking agent.
+        </p>
         <p>
           myself can be used within blocks of code not just in the ask
           command, but also hatch, sprout, of, with, all?, with-min,
           with-max, min-one-of, max-one-of, min-n-of, max-n-of.
+        </p>
         <pre>
 ask turtles
   [ ask patches in-radius 3
@@ -5172,8 +5678,10 @@ ask turtles
         <p>
           See the &quot;Myself Example&quot; code example for more
           examples.
+        </p>
         <p>
           See also <a href="#self">self</a>.
+        </p>
         </div><!-- ======================================== -->
       </div>
       <h2 id="N">
@@ -5191,14 +5699,17 @@ ask turtles
         <p>
           From an agentset, reports an agentset of size <i>size</i>
           randomly chosen from the input set, with no repeats.
+        </p>
         <p>
           From a list, reports a list of size <i>size</i> randomly chosen
           from the input set, with no repeats. The items in the result
           appear in the same order that they appeared in the input list.
           (If you want them in random order, use shuffle on the result.)
+        </p>
         <p>
           It is an error for <i>size</i> to be greater than the size of the
           input.
+        </p>
         <pre>
 ask n-of 50 patches [ set pcolor green ]
 ;; 50 randomly chosen patches turn green
@@ -5207,6 +5718,7 @@ ask n-of 50 patches [ set pcolor green ]
           See also <a href="#one-of">one-of</a> and <a href="#up-to-n-of">up-to-n-of</a>,
           a version that does not error with a <i>size</i> greater than
           the size of the input.
+        </p>
         </div>
       <div class="dict_entry" id="n-values">
         <h3>
@@ -5219,9 +5731,11 @@ ask n-of 50 patches [ set pcolor green ]
           Reports a list of length <i>size</i> containing values computed
           by repeatedly running the reporter. <i>reporter</i> may be an anonymous
           reporter or the name of a reporter.
+        </p>
         <p>
           If the reporter accepts inputs, the input will be the number of the
           item currently being computed, starting from zero.
+        </p>
         <pre>
 show n-values 5 [1]
 =&gt; [1 1 1 1 1]
@@ -5234,6 +5748,7 @@ show n-values 5 [ x -&gt; x * x ]
 </pre>
         <p>
         See also <a href="#reduce">reduce</a>, <a href="#filter">filter</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>, <a href="#range">range</a>.
+        </p>
         </div>
       <div class="dict_entry" id="neighbors">
         <h3>
@@ -5248,6 +5763,7 @@ show n-values 5 [ x -&gt; x * x ]
         <p>
           Reports an agentset containing the 8 surrounding patches
           (neighbors) or 4 surrounding patches (neighbors4).
+        </p>
         <pre>
 show sum [count turtles-here] of neighbors
   ;; prints the total number of turtles on the eight
@@ -5272,6 +5788,7 @@ ask neighbors4 [ set pcolor red ]
           Reports the agentset of all turtles found at the other end of
           any links (undirected or directed, incoming or outgoing)
           connected to this turtle.
+        </p>
         <pre>
 crt 3
 ask turtle 0
@@ -5299,6 +5816,7 @@ end
         <p>
           Reports true if there is a link (either directed or undirected,
           incoming or outgoing) between <i>turtle</i> and the caller.
+        </p>
         <pre>
 crt 2
 ask turtle 0
@@ -5322,6 +5840,7 @@ ask turtle 1
       <p>
         Reports a string containing the version number of the NetLogo you
         are running.
+      </p>
       <pre>
 show netlogo-version
 =&gt; &quot;{{version}}&quot;
@@ -5336,6 +5855,7 @@ show netlogo-version
       </h4>
       <p>
         Reports true if the model is running in NetLogo Web.
+      </p>
       </div>
     <div class="dict_entry" id="new-seed">
       <h3>
@@ -5346,17 +5866,21 @@ show netlogo-version
       </h4>
       <p>
         Reports a number suitable for seeding the random number generator.
+      </p>
       <p>
         The numbers reported by new-seed are based on the current date and
         time in milliseconds and lie in the generator's usable range of
         seeds, -2147483648 to 2147483647.
+      </p>
       <p>
         new-seed never reports the same number twice in succession, even
         across parallel BehaviorSpace runs. (This
         is accomplished by waiting a millisecond if the seed for the
         current millisecond was already used.)
+      </p>
       <p>
         See also <a href="#random-seed">random-seed</a>.
+      </p>
       </div>
     <div class="dict_entry" id="no-display">
       <h3>
@@ -5368,21 +5892,26 @@ show netlogo-version
       <p>
         Turns off all updates to the current view until the display command
         is issued. This has two major uses.
+      </p>
       <p>
         One, you can control when the user sees view updates. You might
         want to change lots of things on the view behind the user's
         back, so to speak, then make them visible to the user all at once.
+      </p>
       <p>
         Two, your model will run faster when view updating is off, so if
         you're in a hurry, this command will let you get results
         faster. (Note that normally you don't need to use no-display
         for this, since you can also use the on/off switch in view control
         strip to freeze the view.)
+      </p>
       <p>
         Note that display and no-display operate independently of the
         switch in the view control strip that freezes the view.
+      </p>
       <p>
         See also <a href="#display">display</a>.
+      </p>
       </div>
     <div class="dict_entry" id="nobody">
       <h3>
@@ -5395,11 +5924,13 @@ show netlogo-version
         This is a special value which some primitives such as turtle,
         one-of, max-one-of, etc. report to indicate that no agent was
         found. Also, when a turtle dies, it becomes equal to nobody.
+      </p>
       <p>
         Note: Empty agentsets are not equal to nobody. If you want to test
         for an empty agentset, use <a href="#any">any?</a>. You only get
         nobody back in situations where you were expecting a single agent,
         not a whole agentset.
+      </p>
       <pre>
 set target one-of other turtles-here
 if target != nobody
@@ -5415,6 +5946,7 @@ if target != nobody
       </h4>
       <p>
         Reports an empty link agentset.
+      </p>
     </div>
     <div class="dict_entry" id="no-patches">
       <h3>
@@ -5425,6 +5957,7 @@ if target != nobody
       </h4>
       <p>
         Reports an empty patch agentset.
+      </p>
     </div>
     <div class="dict_entry" id="not">
       <h3>
@@ -5435,6 +5968,7 @@ if target != nobody
       </h4>
       <p>
         Reports true if <i>boolean</i> is false, otherwise reports false.
+      </p>
       <pre>
 if not any? turtles [ crt 10 ]
 </pre>
@@ -5448,6 +5982,7 @@ if not any? turtles [ crt 10 ]
       </h4>
       <p>
         Reports an empty turtle agentset.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="O">
@@ -5465,6 +6000,7 @@ if not any? turtles [ crt 10 ]
       <p>
         For an agent, reports the value of the reporter for that agent
         (turtle or patch).
+      </p>
       <pre>
 show [pxcor] of patch 3 5
 ;; prints 3
@@ -5479,6 +6015,7 @@ show [count turtles in-radius 3] of patch 0 0
       <p>
         For an agentset, reports a list that contains the value of the
         reporter for each agent in the agentset (in random order).
+      </p>
       <pre>
 crt 4
 show sort [who] of turtles
@@ -5498,9 +6035,11 @@ show sort [who * who] of turtles
       <p>
         From an agentset, reports a random agent. If the agentset is empty,
         reports <a href="#nobody">nobody</a>.
+      </p>
       <p>
         From a list, reports a random list item. It is an error for the
         list to be empty.
+      </p>
       <pre>
 ask one-of patches [ set pcolor green ]
 ;; a random patch turns green
@@ -5515,6 +6054,7 @@ show one-of mylist
 </pre>
       <p>
         See also <a href="#n-of">n-of</a>, <a href="#up-to-n-of">up-to-n-of</a>.
+      </p>
       </div>
     <div class="dict_entry" id="or">
       <h3>
@@ -5526,9 +6066,11 @@ show one-of mylist
       <p>
         Reports true if either <i>boolean1</i> or <i>boolean2</i>, or both,
         is true.
+      </p>
       <p>
         Note that if <i>condition1</i> is true, then <i>condition2</i> will
         not be run (since it can't affect the result).
+      </p>
       <pre>
 if (pxcor &gt; 0) or (pycor &gt; 0) [ set pcolor red ]
 ;; patches turn red except in lower-left quadrant
@@ -5545,6 +6087,7 @@ if (pxcor &gt; 0) or (pycor &gt; 0) [ set pcolor red ]
       <p>
         Reports an agentset which is the same as the input agentset but
         omits this agent.
+      </p>
       <pre>
 show count turtles-here
 =&gt; 10
@@ -5563,12 +6106,15 @@ show count other turtles-here
       <p>
         If run by a turtle, reports the turtle at the other end of the
         asking link.
+      </p>
       <p>
         If run by a link, reports the turtle at the end of the link that
         isn't the asking turtle.
+      </p>
       <p>
         These definitions are difficult to understand in the abstract, but
         the following examples should help:
+      </p>
       <pre>
 ask turtle 0 [ create-link-with turtle 1 ]
 ask turtle 0 [ ask link 0 1 [ show other-end ] ] ;; prints turtle 1
@@ -5578,6 +6124,7 @@ ask link 0 1 [ ask turtle 0 [ show other-end ] ] ;; prints turtle 1
       <p>
         As these examples hopefully make plain, the &quot;other&quot; end
         is the end that is neither asking nor being asked.
+      </p>
       </div>
     <div class="dict_entry" id="out-link-neighbor">
       <h3>
@@ -5594,6 +6141,7 @@ ask link 0 1 [ ask turtle 0 [ show other-end ] ] ;; prints turtle 1
         <i>turtle</i> or if there is an undirected link connecting the caller
         with <i>turtle</i>. You can think of this as "can I get from the caller
         to <i>turtle</i> using a link?"
+      </p>
       <pre>
 crt 2
 ask turtle 0 [
@@ -5621,6 +6169,7 @@ ask turtle 1 [
         Reports the agentset of all the turtles that have directed links
         from the caller, or undirected links with the caller. You can think
         of this as "who can I get to from the caller using a link?"
+      </p>
       <pre>
 crt 4
 ask turtle 0
@@ -5652,6 +6201,7 @@ end
         reports nobody. If more than one such link exists, reports a
         random one. You can think of this as "give me a link that I can use
         to travel from the caller to <i>turtle</i>."
+      </p>
       <pre>
 crt 2
 ask turtle 0 [
@@ -5665,6 +6215,7 @@ ask turtle 1
 </pre>
       <p>
         See also: <a href="#in-link-from">in-link-from</a> <a href="#link-with">link-with</a>
+      </p>
       </div>
     <div class="dict_entry" id="output-cmds">
       <h3>
@@ -5685,6 +6236,7 @@ ask turtle 1
         the model's output area, instead of in the Command Center. (If
         the model does not have a separate output area, then the Command
         Center is used.) See also <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="P">
@@ -5702,14 +6254,17 @@ ask turtle 1
         Given the x and y coordinates of a point, reports the patch
         containing that point. (The coordinates are absolute coordinates;
         they are not computed relative to this agent, as with patch-at.)
+      </p>
       <p>
         If x and y are integers, the point is the center of a patch. If x
         or y is not an integer, rounding to the nearest integer is used to
         determine which patch contains the point.
+      </p>
       <p>
         If wrapping is allowed by the topology, the given coordinates will
         be wrapped to be within the world. If wrapping is not allowed and
         the given coordinates are outside the world, reports nobody.
+      </p>
       <pre>
 ask patch 3 -4 [ set pcolor green ]
 ;; patch with pxcor of 3 and pycor of -4 turns green
@@ -5723,6 +6278,7 @@ show patch 18 19
 </pre>
       <p>
         See also <a href="#patch-at">patch-at</a>.
+      </p>
       </div>
     <div class="dict_entry" id="patch-ahead">
       <h3>
@@ -5737,6 +6293,7 @@ show patch 18 19
         &quot;ahead&quot; of this turtle, that is, along the turtle's
         current heading. Reports nobody if the patch does not exist because
         it is outside the world.
+      </p>
       <pre>
 ask patch-ahead 1 [ set pcolor green ]
 ;; turns the patch 1 in front of this turtle
@@ -5745,6 +6302,7 @@ ask patch-ahead 1 [ set pcolor green ]
 </pre>
       <p>
         See also <a href="#patch-at">patch-at</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
+      </p>
       </div>
     <div class="dict_entry" id="patch-at">
       <h3>
@@ -5757,9 +6315,11 @@ ask patch-ahead 1 [ set pcolor green ]
       <p>
         Reports the patch at (dx, dy) from the caller, that is, the patch
         containing the point dx east and dy patches north of this agent.
+      </p>
       <p>
         Reports nobody if there is no such patch because that point is
         beyond a non-wrapping world boundary.
+      </p>
       <pre>
 ask patch-at 1 -1 [ set pcolor green ]
 ;; if caller is a turtle or patch, turns the
@@ -5767,6 +6327,7 @@ ask patch-at 1 -1 [ set pcolor green ]
 </pre>
       <p>
         See also <a href="#patch">patch</a>, <a href="#patch-ahead">patch-ahead</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
+      </p>
       </div>
     <div class="dict_entry" id="patch-at-heading-and-distance">
       <h3>
@@ -5783,12 +6344,14 @@ ask patch-at 1 -1 [ set pcolor green ]
         patch-right-and-ahead, this turtle's current heading is not
         taken into account.) Reports nobody if the patch does not exist
         because it is outside the world.
+      </p>
       <pre>
 ask patch-at-heading-and-distance -90 1 [ set pcolor green ]
 ;; turns the patch 1 to the west of this patch green
 </pre>
       <p>
         See also <a href="#patch">patch</a>, <a href="#patch-at">patch-at</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>.
+      </p>
       </div>
     <div class="dict_entry" id="patch-here">
       <h3>
@@ -5800,9 +6363,11 @@ ask patch-at-heading-and-distance -90 1 [ set pcolor green ]
       </h4>
       <p>
         patch-here reports the patch under the turtle.
+      </p>
       <p>
         Note that this reporter isn't available to a patch because a
         patch can just say &quot;self&quot;.
+      </p>
       </div>
     <div class="dict_entry" id="patch-lr-and-ahead">
       <h3>
@@ -5819,10 +6384,12 @@ ask patch-at-heading-and-distance -90 1 [ set pcolor green ]
         turtle, in the direction turned left or right the given angle (in
         degrees) from the turtle's current heading. Reports nobody if
         the patch does not exist because it is outside the world.
+      </p>
       <p>
         (If you want to find a patch in a given absolute heading, rather
         than one relative to the current turtle's heading, use
         patch-at-heading-and-distance instead.)
+      </p>
       <pre>
 ask patch-right-and-ahead 30 1 [ set pcolor green ]
 ;; this turtle &quot;looks&quot; 30 degrees right of its
@@ -5832,6 +6399,7 @@ ask patch-right-and-ahead 30 1 [ set pcolor green ]
 </pre>
       <p>
         See also <a href="#patch">patch</a>, <a href="#patch-at">patch-at</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
+      </p>
       </div>
     <div class="dict_entry" id="patch-set">
       <h3>
@@ -5846,6 +6414,7 @@ ask patch-right-and-ahead 30 1 [ set pcolor green ]
         of the inputs. The inputs may be individual patches, patch
         agentsets, nobody, or lists (or nested lists) containing any of the
         above.
+      </p>
       <pre>
 patch-set self
 patch-set patch-here
@@ -5858,6 +6427,7 @@ patch-set [neighbors] of turtles
 </pre>
       <p>
         See also <a href="#turtle-set">turtle-set</a>, <a href="#link-set">link-set</a>.
+      </p>
       </div>
     <div class="dict_entry" id="patch-size">
       <h3>
@@ -5869,8 +6439,10 @@ patch-set [neighbors] of turtles
       <p>
         Reports the size of the patches in the view in pixels. The size is
         typically an integer, but may also be a floating point number.
+      </p>
       <p>
         See also <a href="#set-patch-size">set-patch-size</a>.
+      </p>
       </div>
     <div class="dict_entry" id="patches">
       <h3>
@@ -5881,6 +6453,7 @@ patch-set [neighbors] of turtles
       </h4>
       <p>
         Reports the agentset consisting of all patches.
+      </p>
       </div>
     <div class="dict_entry" id="patches-own">
       <h3>
@@ -5894,15 +6467,19 @@ patch-set [neighbors] of turtles
         and turtles-own keywords, can only be used at the beginning of a
         program, before any function definitions. It defines the variables
         that all patches can use.
+      </p>
       <p>
         All patches will then have the given variables and be able to use
         them.
+      </p>
       <p>
         All patch variables can also be directly accessed by any turtle
         standing on the patch.
+      </p>
       <p>
         See also <a href="#globals">globals</a>, <a href="#turtles-own">turtles-own</a>, <a href="#breed">breed</a>,
         <a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>.
+      </p>
       </div>
     <div class="dict_entry" id="pcolor">
       <h3>
@@ -5915,14 +6492,17 @@ patch-set [neighbors] of turtles
       <p>
         This is a built-in patch variable. It holds the color of the patch.
         You can set this variable to make the patch change color.
+      </p>
       <p>
         All patch variables can be directly accessed by any turtle standing
         on the patch. Color can be represented either as a NetLogo color (a
         single number) or an RGB color (a list of 3 numbers). See details
         in the <a href="programming.html#colors">Colors section</a> of the
         Programming Guide.
+      </p>
       <p>
         See also <a href="#color">color</a>.
+      </p>
       </div>
     <div class="dict_entry" id="pen-switch-status">
       <h3>
@@ -5944,16 +6524,20 @@ patch-set [neighbors] of turtles
         neither. The lines will always be displayed on top of the patches
         and below the turtles. To change the color of the pen set the color
         of the turtle using <code>set color</code>.
+      </p>
       <p>
         Note: When a turtle's pen is down, all movement commands cause
         lines to be drawn, including jump, setxy, and move-to.
+      </p>
       <p>
         Note: These commands are equivalent to setting the turtle variable
         &quot;pen-mode&quot; to &quot;down&quot; , &quot;up&quot;, and
         &quot;erase&quot;.
+      </p>
       <p>
         Note: On Windows drawing and erasing a line might not erase every
         pixel.
+      </p>
       </div>
     <div class="dict_entry" id="pen-mode">
       <h3>
@@ -5967,6 +6551,7 @@ patch-set [neighbors] of turtles
         turtle's pen. You set the variable to draw lines, erase lines
         or stop either of these actions. Possible values are
         &quot;up&quot;, &quot;down&quot;, and &quot;erase&quot;.
+      </p>
       </div>
     <div class="dict_entry" id="pen-size">
       <h3>
@@ -5979,6 +6564,7 @@ patch-set [neighbors] of turtles
         This is a built-in turtle variable. It holds the width of the line,
         in pixels, that the turtle will draw (or erase) when the pen is
         down (or erasing).
+      </p>
       </div>
     <div class="dict_entry" id="plabel">
       <h3>
@@ -5993,11 +6579,14 @@ patch-set [neighbors] of turtles
         The patch appears in the view with the given value
         &quot;attached&quot; to it as text. You can set this variable to
         add, change, or remove a patch's label.
+      </p>
       <p>
         All patch variables can be directly accessed by any turtle standing
         on the patch.
+      </p>
       <p>
         See also <a href="#plabel-color">plabel-color</a>, <a href="#label">label</a>, <a href="#label-color">label-color</a>.
+      </p>
       </div>
     <div class="dict_entry" id="plabel-color">
       <h3>
@@ -6012,12 +6601,15 @@ patch-set [neighbors] of turtles
         or equal to 0 and less than 140. This number determines what color
         the patch's label appears in (if it has a label). You can set
         this variable to change the color of a patch's label.
+      </p>
       <p>
         All patch variables can be directly accessed by any turtle standing
         on the patch.
+      </p>
       <p>
         See also <a href="#plabel">plabel</a>, <a href="#label">label</a>,
         <a href="#label-color">label-color</a>.
+      </p>
       </div>
     <div class="dict_entry" id="plot">
       <h3>
@@ -6031,6 +6623,7 @@ patch-set [neighbors] of turtles
         plots a point at the updated x-value and a y-value of
         <i>number</i>. (The first time the command is used on a plot, the
         point plotted has an x-value of 0.)
+      </p>
       </div>
     <div class="dict_entry" id="plot-name">
       <h3>
@@ -6041,6 +6634,7 @@ patch-set [neighbors] of turtles
       </h4>
       <p>
         Reports the name of the current plot (a string)
+      </p>
       </div>
     <div class="dict_entry" id="plot-pen-exists">
       <h3>
@@ -6052,6 +6646,7 @@ patch-set [neighbors] of turtles
       <p>
         Reports true if a plot pen with the given name is defined in the
         current plot. Otherwise reports false.
+      </p>
       </div>
     <div class="dict_entry" id="plot-pen-switch-status">
       <h3>
@@ -6065,6 +6660,7 @@ patch-set [neighbors] of turtles
       <p>
         Puts down (or up) the current plot-pen, so that it draws (or
         doesn't). (By default, all pens are down initially.)
+      </p>
       </div>
     <div class="dict_entry" id="plot-pen-reset">
       <h3>
@@ -6078,6 +6674,7 @@ patch-set [neighbors] of turtles
         (0,0), and puts it down. If the pen is a permanent pen, the color,
         mode, and interval are reset to the default values from the plot
         Edit dialog.
+      </p>
       </div>
     <div class="dict_entry" id="plotxy">
       <h3>
@@ -6090,6 +6687,7 @@ patch-set [neighbors] of turtles
         Moves the current plot pen to the point with coordinates
         (<i>number1</i>, <i>number2</i>). If the pen is down, a line, bar,
         or point will be drawn (depending on the pen's mode).
+      </p>
       </div>
     <div class="dict_entry" id="plot-cor-max-or-min">
       <h3>
@@ -6107,10 +6705,12 @@ patch-set [neighbors] of turtles
       <p>
         Reports the minimum or maximum value on the x or y axis of the
         current plot.
+      </p>
       <p>
         These values can be set with the commands set-plot-x-range and
         set-plot-y-range. (Their default values are set from the plot Edit
         dialog.)
+      </p>
       </div>
     <div class="dict_entry" id="position">
       <h3>
@@ -6123,12 +6723,15 @@ patch-set [neighbors] of turtles
       <p>
         On a list, reports the first position of <i>item</i> in
         <i>list</i>, or false if it does not appear.
+      </p>
       <p>
         On strings, reports the position of the first appearance
         <i>string1</i> as a substring of <i>string2</i>, or false if it
         does not appear.
+      </p>
       <p>
         Note: The positions are numbered beginning with 0, not with 1.
+      </p>
       <pre>
 ;; suppose mylist is [2 7 4 7 &quot;Bob&quot;]
 show position 7 mylist
@@ -6140,6 +6743,7 @@ show position &quot;in&quot; &quot;string&quot;
 </pre>
       <p>
         See also <a href="#member">member?</a>.
+      </p>
       </div>
     <div class="dict_entry" id="precision">
       <h3>
@@ -6150,9 +6754,11 @@ show position &quot;in&quot; &quot;string&quot;
       </h4>
       <p>
         Reports <i>number</i> rounded to <i>places</i> decimal places.
+      </p>
       <p>
         If <i>places</i> is negative, the rounding takes place to the left
         of the decimal point.
+      </p>
       <pre>
 show precision 1.23456789 3
 =&gt; 1.235
@@ -6161,6 +6767,7 @@ show precision 3834 -3
 </pre>
       <p>
         See also <a href="#round">round</a>, <a href="#ceiling">ceiling</a>, <a href="#floor">floor</a>.
+      </p>
       </div>
     <div class="dict_entry" id="print">
       <h3>
@@ -6172,12 +6779,15 @@ show precision 3834 -3
       <p>
         Prints <i>value</i> in the Command Center, followed by a carriage
         return.
+      </p>
       <p>
         This agent is <i>not</i> printed before the value, unlike <a href="#show">show</a>.
+      </p>
       <p>
         See also <a href="#show">show</a>, <a href="#type">type</a>,
         <a href="#write">write</a>, <a href="#output-cmds">output-print</a>, and
         <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="pcor">
       <h3>
@@ -6193,14 +6803,18 @@ show precision 3834 -3
         These are built-in patch variables. They hold the x and y
         coordinate of the patch. They are always integers. You cannot set
         these variables, because patches don't move.
+      </p>
       <p>
         pxcor is greater than or equal to min-pxcor and less than or equal
         to max-pxcor; similarly for pycor and min-pycor and max-pycor.
+      </p>
       <p>
         All patch variables can be directly accessed by any turtle standing
         on the patch.
+      </p>
       <p>
         See also <a href="#xcor">xcor</a>, <a href="#ycor">ycor</a>.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="R">
@@ -6217,16 +6831,20 @@ show precision 3834 -3
       <p>
         If <i>number</i> is positive, reports a random integer greater than
         or equal to 0, but strictly less than <i>number</i>.
+      </p>
       <p>
         If <i>number</i> is negative, reports a random integer less than or
         equal to 0, but strictly greater than <i>number</i>.
+      </p>
       <p>
         If <i>number</i> is zero, the result is always 0 as well.
+      </p>
       <p>
         Note: In versions of NetLogo prior to version 2.0, this primitive
         reported a floating point number if given a non-integer input. This
         is no longer the case. If you want a floating point answer, you
         must now use <a href="#random-float">random-float</a> instead.
+      </p>
       <pre>
 show random 3
 ;; prints 0, 1,  or 2
@@ -6237,6 +6855,7 @@ show random 3.5
 </pre>
       <p>
         See also <a href="#random-float">random-float</a>.
+      </p>
       </div>
     <div class="dict_entry" id="random-float">
       <h3>
@@ -6249,12 +6868,15 @@ show random 3.5
         If <i>number</i> is positive, reports a random floating point
         number greater than or equal to 0 but strictly less than
         <i>number</i>.
+      </p>
       <p>
         If <i>number</i> is negative, reports a random floating point
         number less than or equal to 0, but strictly greater than
         <i>number</i>.
+      </p>
       <p>
         If <i>number</i> is zero, the result is always 0.
+      </p>
       <pre>
 show random-float 3
 ;; prints a number at least 0 but less than 3,
@@ -6282,21 +6904,26 @@ show random-float 2.5
         <i>mean</i> and, in the case of the normal distribution, the
         <i>standard-deviation</i>. (The standard deviation may not be
         negative.)
+      </p>
       <p>
         random-exponential reports an exponentially distributed random
         floating point number. It is equivalent to <code>(- <i>mean</i>) * ln
         random-float 1.0</code>.
+      </p>
       <p>
         random-gamma reports a gamma-distributed random floating point
         number as controlled by the floating point alpha and lambda
         parameters. Both inputs must be greater than zero. (Note: for
         results with a given mean and variance, use inputs as follows:
         alpha = mean * mean / variance; lambda = 1 / (variance / mean).)
+      </p>
       <p>
         random-normal reports a normally distributed random floating point
         number.
+      </p>
       <p>
         random-poisson reports a Poisson-distributed random integer.
+      </p>
       <pre>
 show random-exponential 2
 ;; prints an exponentially distributed random floating
@@ -6322,6 +6949,7 @@ show random-poisson 3.4
       <p>
         Reports a random integer ranging from min-pxcor (or -y) to
         max-pxcor (or -y) inclusive.
+      </p>
       <pre>
 ask turtles [
   ;; move each turtle to the center of a random patch
@@ -6330,6 +6958,7 @@ ask turtles [
 </pre>
       <p>
         See also <a href="#random-cor">random-xcor</a>, <a href="#random-cor">random-ycor</a>.
+      </p>
       </div>
     <div class="dict_entry" id="random-seed">
       <h3>
@@ -6344,9 +6973,11 @@ ask turtles [
         2147483647; note that this is smaller than the full range of
         integers supported by NetLogo (-9007199254740992 to
         9007199254740992).
+      </p>
       <p>
         See the <a href="programming.html#random-numbers">Random Numbers</a>
         section of the Programming Guide for more details.
+      </p>
       <pre>
 random-seed 47822
 show random 100
@@ -6372,10 +7003,12 @@ show random 100
       <p>
         Reports a random floating point number from the allowable range of
         turtle coordinates along the given axis, x or y.
+      </p>
       <p>
         Turtle coordinates range from min-pxcor - 0.5 (inclusive) to
         max-pxcor + 0.5 (exclusive) horizontally; vertically, substitute -y
         for -x.
+      </p>
       <pre>
 ask turtles [
   ;; move each turtle to a random point
@@ -6384,6 +7017,7 @@ ask turtles [
 </pre>
       <p>
         See also <a href="#random-pcor">random-pxcor</a>, <a href="#random-pcor">random-pycor</a>.
+      </p>
       </div>
     <div class="dict_entry" id="range">
       <h3>
@@ -6398,6 +7032,7 @@ ask turtles [
         Generates a list of numbers, starting at <i>start</i>, ending before
         <i>stop</i>, counting by <i>step</i>. <i>start</i> defaults to 0 and
         <i>step</i> defaults to 1.
+      </p>
         <pre>
 show range 5
 =&gt; [0 1 2 3 4]
@@ -6410,6 +7045,7 @@ show (range 10 0 -1)
 </pre>
       <p>
       See also <a href="#n-values">n-values</a>
+      </p>
     </div>
     <div class="dict_entry" id="read-from-string">
       <h3>
@@ -6423,9 +7059,11 @@ show (range 10 0 -1)
         Center, and reports the resulting value. The result may be a
         number, list, string, or boolean value, or the special value
         &quot;nobody&quot;.
+      </p>
       <p>
         Useful in conjunction with the <a href="#user-input">user-input</a>
         primitive for converting the user's input into usable form.
+      </p>
       <pre>
 show read-from-string &quot;3&quot; + read-from-string &quot;5&quot;
 =&gt; 8
@@ -6451,14 +7089,17 @@ crt read-from-string user-input &quot;Make how many turtles?&quot;
         <i>list</i> has a single item, that item is reported. It is an
         error to reduce an empty list. <i>reporter</i> may be an anonymous
         reporter or the name of a reporter.
+      </p>
       <p>
         The first input passed to the reporter is the result so far, and the
         second input is the next item in the list.
+      </p>
       <p>
         Since it can be difficult to develop an intuition about what
         <code>reduce</code> does, here are some simple examples which, while
         not useful in themselves, may give you a better understanding of
         this primitive:
+      </p>
       <pre>
 show reduce + [1 2 3]
 =&gt; 6
@@ -6477,6 +7118,7 @@ show reduce [ [result-so-far next-item] -&gt; fput next-item result-so-far ] (fp
 </pre>
       <p>
         Here are some more useful examples:
+      </p>
       <pre>
 ;; find the longest string in a list
 to-report longest-string [strings]
@@ -6508,6 +7150,7 @@ show evaluate-polynomial [3 2 1] 4
 </pre>
       <p>
       See also <a href="#filter">filter</a>, <a href="#arrow">-&gt; (anonymous procedure</a>.
+      </p>
     </div>
     <div class="dict_entry" id="remainder">
       <h3>
@@ -6519,6 +7162,7 @@ show evaluate-polynomial [3 2 1] 4
       <p>
         Reports the remainder when <i>number1</i> is divided by
         <i>number2</i>. This is equivalent to the following NetLogo code:
+      </p>
       <pre>
 <i>number1</i> - (int (<i>number1</i> / <i>number2</i>)) * <i>number2</i>
 </pre>
@@ -6531,6 +7175,7 @@ show remainder -8 3
       <p>
         See also <a href="#mod">mod</a>. mod and remainder behave the same
         for positive numbers, but differently for negative numbers.
+      </p>
       </div>
     <div class="dict_entry" id="remove">
       <h3>
@@ -6543,9 +7188,11 @@ show remainder -8 3
       <p>
         For a list, reports a copy of <i>list</i> with all instances of
         <i>item</i> removed.
+      </p>
       <p>
         For strings, reports a copy of <i>string2</i> with all the
         appearances of <i>string1</i> as a substring removed.
+      </p>
       <pre>
 set mylist [2 7 4 7 &quot;Bob&quot;]
 set mylist remove 7 mylist
@@ -6564,6 +7211,7 @@ show remove &quot;to&quot; &quot;phototonic&quot;
       <p>
         Reports a copy of <i>list</i> with all duplicate items removed. The
         first of each item remains in place.
+      </p>
       <pre>
 set mylist [2 7 4 7 &quot;Bob&quot; 7]
 set mylist remove-duplicates mylist
@@ -6581,12 +7229,15 @@ set mylist remove-duplicates mylist
       <p>
         For a list, reports a copy of <i>list</i> with the item at the
         given index removed.
+      </p>
       <p>
         For strings, reports a copy of <i>string</i> with the character at
         the given index removed.
+      </p>
       <p>
         Note that the indices begin from 0, not 1. (The first item is item
         0, the second item is item 1, and so on.)
+      </p>
       <pre>
 set mylist [2 7 4 7 &quot;Bob&quot;]
 set mylist remove-item 2 mylist
@@ -6604,6 +7255,7 @@ show remove-item 2 &quot;string&quot;
       </h4>
       <p>
         Runs <i>commands</i> <i>number</i> times.
+      </p>
       <pre>
 
  pd repeat 36 [ fd 1 rt 10 ]
@@ -6624,9 +7276,11 @@ show remove-item 2 &quot;string&quot;
         of the item to be replaced, starting with 0. (The 6th item in a
         list would have an index of 5.) Note that &quot;replace-item&quot;
         is used in conjunction with &quot;set&quot; to change a list.
+      </p>
       <p>
         Likewise for a string, but the given character of <i>string1</i>
         removed and the contents of <i>string2</i> spliced in instead.
+      </p>
       <pre>
 show replace-item 2 [2 7 4 5] 15
 =&gt; [2 7 15 5]
@@ -6645,6 +7299,7 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
         Immediately exits from the current to-report procedure and reports
         <i>value</i> as the result of that procedure. report and to-report
         are always used in conjunction with each other. See <a href="#to-report">to-report</a> for a discussion of how to use them.
+      </p>
       </div>
     <div class="dict_entry" id="reset-perspective">
       <h3>
@@ -6659,9 +7314,11 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
         patches). (If it wasn't watching, following, or riding anybody,
         nothing happens.) In the 3D view, the observer also returns to its
         default position (above the origin, looking straight down).
+      </p>
       <p>
         See also <a href="#follow">follow</a>, <a href="#ride">ride</a>,
         <a href="#watch">watch</a>.
+      </p>
       </div>
     <div class="dict_entry" id="reset-ticks">
       <h3>
@@ -6674,10 +7331,13 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
       <p>
         Resets the tick counter to zero, sets up all plots, then updates
         all plots (so that the initial state of the world is plotted).
+      </p>
       <p>
         Normally <code>reset-ticks</code> goes at the end of a setup procedure.
+      </p>
       <p>
         See also <a href="#clear-ticks">clear-ticks</a>, <a href="#tick">tick</a>, <a href="#ticks">ticks</a>, <a href="#tick-advance">tick-advance</a>, <a href="#setup-plots">setup-plots</a>, <a href="#update-plots">update-plots</a>.
+      </p>
       </div>
     <div class="dict_entry" id="reset-timer">
       <h3>
@@ -6688,10 +7348,12 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
       </h4>
       <p>
         Resets the timer to zero seconds. See also <a href="#timer">timer</a>.
+      </p>
       <p>
         Note that the timer is different from the tick counter. The timer
         measures elapsed real time in seconds; the tick counter measures
         elapsed model time in ticks.
+      </p>
       </div>
     <div class="dict_entry" id="resize-world">
       <h3>
@@ -6703,17 +7365,21 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
       </h4>
       <p>
         Changes the size of the patch grid.
+      </p>
       <p>
         If the given patch grid coordinates are different than the ones
         in use, all turtles and links die, and the existing patch grid is
         discarded and new patches created. Otherwise, existing turtles
         and links will live if the grid coordinates are unchanged.
+      </p>
       <p>
         Retaining references to old patches or patch sets is inadvisable
         and may subsequently cause runtime errors or other unexpected
         behavior.
+      </p>
       <p>
         See also <a href="#set-patch-size">set-patch-size</a>.
+      </p>
       </div>
     <div class="dict_entry" id="reverse">
       <h3>
@@ -6725,6 +7391,7 @@ show replace-item 1 &quot;cat&quot; &quot;are&quot;
       </h4>
       <p>
         Reports a reversed copy of the given list or string.
+      </p>
       <pre>
 show mylist
 ;; mylist is [2 7 4 &quot;Bob&quot;]
@@ -6744,8 +7411,10 @@ show reverse &quot;live&quot;
       <p>
         Reports a RGB list when given three numbers describing an RGB
         color. The numbers are range checked to be between 0 and 255.
+      </p>
       <p>
         See also <a href="#hsb">hsb</a>
+      </p>
       </div>
     <div class="dict_entry" id="ride">
       <h3>
@@ -6757,19 +7426,23 @@ show reverse &quot;live&quot;
       </h4>
       <p>
         Set the perspective to <i>turtle</i>.
+      </p>
       <p>
         Every time <i>turtle</i> moves the observer also moves. Thus, in
         the 2D View the turtle will stay at the center of the view. In the
         3D view it is as if looking through the eyes of the turtle. If the
         turtle dies, the perspective resets to the default.
+      </p>
       <p>
         The observer may only watch or follow a single subject.
         Calling <code>ride</code> will remove the highlight created by
         prior calls to <code>watch</code> and <code>watch-me</code>,
         highlighting the ridden turtle instead.
+      </p>
       <p>
         See also <a href="#reset-perspective">reset-perspective</a>,
         <a href="#watch">watch</a>, <a href="#follow">follow</a>, <a href="#subject">subject</a>.
+      </p>
       </div>
     <div class="dict_entry" id="ride-me">
       <h3>
@@ -6781,13 +7454,16 @@ show reverse &quot;live&quot;
       </h4>
       <p>
         Asks the observer to ride this turtle.
+      </p>
       <p>
         The observer may only watch or follow a single subject.
         Calling <code>ride-me</code> will remove the highlight created by
         prior calls to <code>watch</code> and <code>watch-me</code>,
         highlighting this turtle instead.
+      </p>
       <p>
         See also <a href="#ride">ride</a>.
+      </p>
       </div>
     <div class="dict_entry" id="right">
       <h3>
@@ -6801,6 +7477,7 @@ show reverse &quot;live&quot;
       <p>
         The turtle turns right by <i>number</i> degrees. (If <i>number</i>
         is negative, it turns left.)
+      </p>
       </div>
     <div class="dict_entry" id="round">
       <h3>
@@ -6811,9 +7488,11 @@ show reverse &quot;live&quot;
       </h4>
       <p>
         Reports the integer nearest to <i>number</i>.
+      </p>
       <p>
         If the decimal portion of <i>number</i> is exactly .5, the number
         is rounded in the <b>positive</b> direction.
+      </p>
       <p>
         Note that rounding in the positive direction is not always how
         rounding is done in other software programs. (In particular, it
@@ -6826,6 +7505,7 @@ show reverse &quot;live&quot;
         considered to be in one patch or the other, so the turtle is
         considered to be in the patch whose pxcor is -4, because we round
         towards the positive numbers.
+      </p>
       <pre>
 show round 4.2
 =&gt; 4
@@ -6836,6 +7516,7 @@ show round -4.5
 </pre>
       <p>
         See also <a href="#precision">precision</a>, <a href="#ceiling">ceiling</a>, <a href="#floor">floor</a>.
+      </p>
       </div>
     <div class="dict_entry" id="run">
       <h3>
@@ -6853,9 +7534,11 @@ show round -4.5
       <p>
         The <code>run</code> form expects the name of a command, an anonymous command,
         or a string containing commands. This agent then runs them.
+      </p>
       <p>
         The <code>runresult</code> form expects the name of a reporter, an anonymous reporter,
         or a string containing a reporter. This agent runs it and reports the result.
+      </p>
       <p>
         Note that you can't use <code>run</code> to define or redefine
         procedures. If you care about performance, note that the code must
@@ -6864,17 +7547,21 @@ show round -4.5
         string over and over is much faster than running different strings.
         The first run, though, will be many times slower than
         running the same code directly, or in an anonymous command.
+      </p>
       <p>
         Anonymous procedures are recommended over strings whenever possible.
         (An example of when you must use strings is if you accept pieces
         of code from the user of your model.)
+      </p>
       <p>
         Anonymous procedures may freely read and/or set local variables
         and procedure inputs. Trying to do the same with strings may
         or may not work and should not be relied on.
+      </p>
       <p>
         When using anonymous procedures, you can provide them with inputs,
         if you surround the entire call with parentheses. For example:
+      </p>
       <pre>
 (run [ [turtle-count step-count] -&gt; crt turtle-count [ fd step-count ] ] 10 5)
 ;; creates 10 turtles and move them forward 5 steps
@@ -6884,6 +7571,7 @@ show (runresult [ [a b] -&gt; a + b ] 10 5)
 </pre>
         <p>
         See also <a href="#foreach">foreach</a>, <a href="#arrow">-> (anonymous procedure)</a>.
+        </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="S">
@@ -6900,19 +7588,24 @@ show (runresult [ [a b] -&gt; a + b ] 10 5)
       <p>
         Reports a shade of <i>color</i> proportional to the value of
         <i>number</i>.
+      </p>
       <p>
         If <i>range1</i> is less than <i>range2</i>, then the larger the
         number, the lighter the shade of <i>color</i>. But if <i>range2</i>
         is less than <i>range1</i>, the color scaling is inverted.
+      </p>
       <p>
         If <i>number</i> is less than <i>range1</i>, then the darkest shade
         of <i>color</i> is chosen.
+      </p>
       <p>
         If <i>number</i> is greater than <i>range2</i>, then the lightest
         shade of <i>color</i> is chosen.
+      </p>
       <p>
         Note: for <i>color</i> shade is irrelevant, e.g. green and green +
         2 are equivalent, and the same spectrum of colors will be used.
+      </p>
       <pre>
 ask turtles [ set color scale-color red age 0 50 ]
 ;; colors each turtle a shade of red proportional
@@ -6929,16 +7622,20 @@ ask turtles [ set color scale-color red age 0 50 ]
       </h4>
       <p>
         Reports this turtle, patch, or link.
+      </p>
       <p>
         &quot;self&quot; and &quot;myself&quot; are very different.
         &quot;self&quot; is simple; it means &quot;me&quot;.
         &quot;myself&quot; means &quot;the agent who asked me to do what
         I'm doing right now.&quot;
+      </p>
       <p>
         Note that it is always redundant to write <code>[foo] of self</code>.
         This is always equivalent to simply writing <code>foo</code>.
+      </p>
       <p>
         See also <a href="#myself">myself</a>.
+      </p>
       </div>
     <div class="dict_entry" id="semicolon">
       <h3>
@@ -6952,9 +7649,11 @@ ask turtles [ set color scale-color red age 0 50 ]
         for adding &quot;comments&quot; to your code -- text that explains
         the code to human readers. Extra semicolons can be added for visual
         effect.
+      </p>
       <p>
         NetLogo's Edit menu has items that let you comment or uncomment
         whole sections of code.
+      </p>
       </div>
     <div class="dict_entry" id="sentence">
       <h3>
@@ -6969,6 +7668,7 @@ ask turtles [ set color scale-color red age 0 50 ]
         Makes a list out of the values. If any value is a list, its items
         are included in the result directly, rather than being included as
         a sublist. Examples make this clearer:
+      </p>
       <pre>
 show sentence 1 2
 =&gt; [1 2]
@@ -6993,8 +7693,10 @@ show (sentence [1 2] 3 [4 5] (3 + 3) 7)
       </h4>
       <p>
         Sets <i>variable</i> to the given value.
+      </p>
       <p>
         Variable can be any of the following:
+      </p>
       <ul>
         <li>A global variable declared using &quot;globals&quot;
         <li>The global variable associated with a slider, switch, chooser,
@@ -7015,16 +7717,20 @@ show (sentence [1 2] 3 [4 5] (3 + 3) 7)
       </h4>
       <p>
         Sets the current directory that is used by the primitives <a href="#file-delete">file-delete</a>, <a href="#file-exists">file-exists?</a>, and <a href="#file-open">file-open</a>.
+      </p>
       <p>
         The current directory is not used if the above commands are given
         an absolute file path. This is defaulted to the user's home
         directory for new models, and is changed to the model's
         directory when a model is opened.
+      </p>
       <p>
         Note that in Windows file paths the backslash needs to be escaped
         within a string by using another backslash &quot;C:\\&quot;
+      </p>
       <p>
         The change is temporary and is not saved with the model.
+      </p>
       <pre>
 set-current-directory &quot;C:\\NetLogo&quot;
 ;; Assume it is a Windows Machine
@@ -7042,6 +7748,7 @@ file-open &quot;my-file.txt&quot;
       <p>
         Sets the current plot to the plot with the given name (a string).
         Subsequent plotting commands will affect the current plot.
+      </p>
       </div>
     <div class="dict_entry" id="set-current-plot-pen">
       <h3>
@@ -7054,6 +7761,7 @@ file-open &quot;my-file.txt&quot;
         The current plot's current pen is set to the pen named
         <i>penname</i> (a string). If no such pen exists in the current
         plot, a runtime error occurs.
+      </p>
       </div>
     <div class="dict_entry" id="set-default-shape">
       <h3>
@@ -7069,20 +7777,25 @@ file-open &quot;my-file.txt&quot;
         Specifies a default initial shape for all turtles or links, or for
         a particular breed of turtles or links. When a turtle or link is
         created, or it changes breeds, it shape is set to the given shape.
+      </p>
       <p>
         This command doesn't affect existing agents, only agents you
         create afterwards.
+      </p>
       <p>
         The given breed must be either turtles, links, or the name of a
         breed. The given string must be the name of a currently defined
         shape.
+      </p>
       <p>
         In new models, the default shape for all turtles is
         &quot;default&quot;.
+      </p>
       <p>
         Note that specifying a default shape does not prevent you from
         changing an agent's shape later. Agents don't have to be
         stuck with their breed's default shape.
+      </p>
       <pre>
 create-turtles 1 ;; new turtle's shape is &quot;default&quot;
 create-cats 1    ;; new turtle's shape is &quot;default&quot;
@@ -7100,6 +7813,7 @@ ask cats [ set breed dogs ]
 </pre>
       <p>
         See also <a href="#shape">shape</a>.
+      </p>
       </div>
     <div class="dict_entry" id="set-histogram-num-bars">
       <h3>
@@ -7112,8 +7826,10 @@ ask cats [ set breed dogs ]
         Set the current plot pen's plot interval so that, given the
         current x range for the plot, there would be <i>number</i> number
         of bars drawn if the histogram command is called.
+      </p>
       <p>
         See also <a href="#histogram">histogram</a>.
+      </p>
       </div>
     <div class="dict_entry" id="set-line-thickness">
       <h3>
@@ -7126,16 +7842,21 @@ ask cats [ set breed dogs ]
       <p>
         Specifies the thickness of lines and outlined elements in the
         turtle's shape.
+      </p>
       <p>
         The default value is 0. This always produces lines one pixel thick.
+      </p>
       <p>
         Non-zero values are interpreted as thickness in patches. A
         thickness of 1, for example, produces lines which appear one patch
         thick. (It's common to use a smaller value such as 0.5 or 0.2.)
+      </p>
       <p>
         Lines are always at least one pixel thick.
+      </p>
       <p>
         This command is experimental and may change in later releases.
+      </p>
       </div>
     <div class="dict_entry" id="set-patch-size">
       <h3>
@@ -7148,8 +7869,10 @@ ask cats [ set breed dogs ]
       <p>
         Sets the size of the patches of the view in pixels. The size is
         typically an integer, but may also be a floating point number.
+      </p>
       <p>
         See also <a href="#patch-size">patch-size</a>, <a href="#resize-world">resize-world</a>.
+      </p>
       </div>
     <div class="dict_entry" id="set-plot-background-color">
       <h3>
@@ -7164,6 +7887,7 @@ ask cats [ set breed dogs ]
         See the <a href="programming.html#colors">Colors</a> section of the programming guide for more details.
         This change is temporary and is not saved with the model. When the
         plot is cleared, the background color will revert to white.
+      </p>
       <p>
         <b>Note:</b> Plot backgrounds do not support transparency.
         If a list is used to set the color, the alpha component will be ignored.
@@ -7177,6 +7901,7 @@ ask cats [ set breed dogs ]
       </h4>
       <p>
         Sets the color of the current plot pen to <i>color</i>.
+      </p>
       </div>
     <div class="dict_entry" id="set-plot-pen-interval">
       <h3>
@@ -7189,6 +7914,7 @@ ask cats [ set breed dogs ]
         Tells the current plot pen to move a distance of <i>number</i> in
         the x direction during each use of the plot command. (The plot pen
         interval also affects the behavior of the histogram command.)
+      </p>
       </div>
     <div class="dict_entry" id="set-plot-pen-mode">
       <h3>
@@ -7200,6 +7926,7 @@ ask cats [ set breed dogs ]
       <p>
         Sets the mode the current plot pen draws in to <i>number</i>. The
         allowed plot pen modes are:
+      </p>
       <ul>
         <li>0 (line mode) the plot pen draws a line connecting two points
         together.
@@ -7211,6 +7938,7 @@ ask cats [ set breed dogs ]
         </ul>
       <p>
         The default mode for new pens is 0 (line mode).
+      </p>
       </div>
     <div class="dict_entry" id="setup-plots">
       <h3>
@@ -7222,15 +7950,19 @@ ask cats [ set breed dogs ]
       <p>
         For each plot, runs that plot's setup commands, including the
         setup code for any pens in the plot.
+      </p>
       <p>
         <a href="#reset-ticks">reset-ticks</a> has the same effect, so in
         models that use the tick counter, this primitive is not normally
         used.
+      </p>
       <p>
         See the <a href="programming.html#plotting">Plotting section</a> of
         the Programming Guide for more details.
+      </p>
       <p>
         See also <a href="#update-plots">update-plots</a>.
+      </p>
       </div>
     <div class="dict_entry" id="set-plot--range">
       <h3>
@@ -7244,10 +7976,12 @@ ask cats [ set breed dogs ]
       <p>
         Sets the minimum and maximum values of the x or y axis of the
         current plot.
+      </p>
       <p>
         The change is temporary and is not saved with the model. When the
         plot is cleared, the ranges will revert to their default values as
         set in the plot's Edit dialog.
+      </p>
       </div>
     <div class="dict_entry" id="setxy">
       <h3>
@@ -7260,9 +7994,11 @@ ask cats [ set breed dogs ]
       <p>
         The turtle sets its x-coordinate to <i>x</i> and its y-coordinate
         to <i>y</i>.
+      </p>
       <p>
         Equivalent to <code>set xcor x set ycor y</code>, except it happens in
         one time step instead of two.
+      </p>
       <p>
         If <i>x</i> or <i>y</i> is outside the world, NetLogo will throw a
         runtime error, unless wrapping is turned on in the relevant
@@ -7271,6 +8007,7 @@ ask cats [ set breed dogs ]
         <code>max-pxcor = 16</code>, <code>min-pycor = -16</code> and <code>max-pycor
         = 16</code>, asking a turtle to <code>setxy 17 17</code> will move it to
         the center of patch (-16, -16).
+      </p>
       <pre>
 setxy 0 0
 ;; turtle moves to the middle of the center patch
@@ -7281,6 +8018,7 @@ setxy random-pxcor random-pycor
 </pre>
       <p>
         See also <a href="#move-to">move-to</a>.
+      </p>
       </div>
     <div class="dict_entry" id="shade-of">
       <h3>
@@ -7292,6 +8030,7 @@ setxy random-pxcor random-pycor
       <p>
         Reports true if both colors are shades of one another, false
         otherwise.
+      </p>
       <pre>
 show shade-of? blue red
 =&gt; false
@@ -7316,8 +8055,10 @@ show shade-of? gray white
         this variable to change the shape. New turtles and links have the
         shape &quot;default&quot; unless the a different shape has been
         specified using <a href="#set-default-shape">set-default-shape</a>.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 ask turtles [ set shape &quot;wolf&quot; ]
 ;; assumes you have made a &quot;wolf&quot;
@@ -7329,6 +8070,7 @@ ask links [ set shape &quot;link 1&quot; ]
       <p>
         See also <a href="#set-default-shape">set-default-shape</a>,
         <a href="#shapes">shapes</a>.
+      </p>
       </div>
     <div class="dict_entry" id="shapes">
       <h3>
@@ -7340,9 +8082,11 @@ ask links [ set shape &quot;link 1&quot; ]
       <p>
         Reports a list of strings containing all of the turtle shapes in
         the model.
+      </p>
       <p>
         New shapes can be created, or imported from the shapes library or
         from other models, in the <a href="shapes.html">Shapes Editor</a>.
+      </p>
       <pre>
 show shapes
 =&gt; [&quot;default&quot; &quot;airplane&quot; &quot;arrow&quot; &quot;box&quot; &quot;bug&quot; ...
@@ -7361,10 +8105,12 @@ ask turtles [ set shape one-of shapes ]
         and followed by a carriage return. (This agent is included to help
         you keep track of what agents are producing which lines of output.)
         Also, all strings have their quotes included similar to <a href="#write">write</a>.
+      </p>
       <p>
         See also <a href="#print">print</a>, <a href="#type">type</a>,
         <a href="#write">write</a>, <a href="#output-cmds">output-show</a>,
         and <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="show-turtle">
       <h3>
@@ -7377,11 +8123,14 @@ ask turtles [ set shape one-of shapes ]
       </h4>
       <p>
         The turtle becomes visible again.
+      </p>
       <p>
         Note: This command is equivalent to setting the turtle variable
         &quot;hidden?&quot; to false.
+      </p>
       <p>
         See also <a href="#hide-turtle">hide-turtle</a>.
+      </p>
       </div>
     <div class="dict_entry" id="show-link">
       <h3>
@@ -7393,11 +8142,14 @@ ask turtles [ set shape one-of shapes ]
       </h4>
       <p>
         The link becomes visible again.
+      </p>
       <p>
         Note: This command is equivalent to setting the link variable
         &quot;hidden?&quot; to false.
+      </p>
       <p>
         See also <a href="#hide-link">hide-link</a>.
+      </p>
       </div>
     <div class="dict_entry" id="shuffle">
       <h3>
@@ -7409,6 +8161,7 @@ ask turtles [ set shape one-of shapes ]
       <p>
         Reports a new list containing the same items as the input list, but
         in randomized order.
+      </p>
       <pre>
 show shuffle [1 2 3 4 5]
 =&gt; [5 2 4 1 3]
@@ -7426,6 +8179,7 @@ show shuffle [1 2 3 4 5]
       <p>
         Reports the sine of the given angle. Assumes angle is given in
         degrees.
+      </p>
       <pre>
 show sin 270
 =&gt; -1
@@ -7444,6 +8198,7 @@ show sin 270
         turtle's apparent size. The default size is 1, which means that
         the turtle is the same size as a patch. You can set this variable
         to change a turtle's size.
+      </p>
       </div>
     <div class="dict_entry" id="sort">
       <h3>
@@ -7455,17 +8210,21 @@ show sin 270
       </h4>
       <p>
         Reports a sorted list of numbers, strings, or agents.
+      </p>
       <p>
         If the input contains no numbers, strings, or agents, the result is
         the empty list.
+      </p>
       <p>
         If the input contains at least one number, the numbers in the list
         are sorted in ascending order and a new list reported; non-numbers
         are ignored.
+      </p>
       <p>
         Or, if the input contains at least one string, the strings in the
         list are sorted in ascending order and a new list reported;
         non-strings are ignored.
+      </p>
       <p>
         Or, if the input is an agentset or a list containing at least one
         agent, a sorted list of agents (never an agentset) is reported;
@@ -7473,6 +8232,7 @@ show sin 270
         &lt; operator uses. (Patches are sorted with the top left-most patch first
         and the bottom right-most patch last, turtles are sorted by <code>who</code>
         number).
+      </p>
       <pre>
 show sort [3 1 4 2]
 =&gt; [1 2 3 4]
@@ -7502,6 +8262,7 @@ show sort (list [1 2 3] turtles) ; lists and agentsets are not included if they 
 </pre>
       <p>
         See also <a href="#sort-by">sort-by</a>, <a href="#sort-on">sort-on</a>.
+      </p>
       </div>
     <div class="dict_entry" id="sort-by">
       <h3>
@@ -7516,17 +8277,21 @@ show sort (list [1 2 3] turtles) ; lists and agentsets are not included if they 
         items as the input list, in a sorted order defined by the boolean
         reporter. <i>reporter</i> may be an anonymous reporter or
         the name of a reporter.
+      </p>
       <p>
       The two inputs to <i>reporter</i> are the values being compared.
         The reporter should report true if the first argument comes strictly before
         the second in the desired sort order, and false otherwise.
+      </p>
       <p>
         If the input is an agentset or a list of agents, reports a list
         (never an agentset) of agents.
+      </p>
       <p>
         If the input is a list, the sort is stable, that is, the order of
         items considered equal by the reporter is not disturbed. If the
         input is an agentset, ties are broken randomly.
+      </p>
       <pre>
 show sort-by &lt; [3 1 4 2]
 =&gt; [1 2 3 4]
@@ -7537,6 +8302,7 @@ show sort-by [ [string1 string2] -&gt; length string1 &lt; length string2 ] [&qu
 </pre>
       <p>
       See also <a href="#sort">sort</a>, <a href="#sort-on">sort-on</a>, <a href="#arrow">-> (anonymous procedure)</a>.
+      </p>
       </div>
     <div class="dict_entry" id="sort-on">
       <h3>
@@ -7548,9 +8314,11 @@ show sort-by [ [string1 string2] -&gt; length string1 &lt; length string2 ] [&qu
       <p>
         Reports a list of agents, sorted according to each agent's
         value for <i>reporter</i>. Ties are broken randomly.
+      </p>
       <p>
         The values must be all numbers, all strings, or all agents of the
         same type.
+      </p>
       <pre>
 crt 3
 show sort-on [who] turtles
@@ -7564,6 +8332,7 @@ foreach sort-on [size] turtles
 </pre>
       <p>
         See also <a href="#sort">sort</a>, <a href="#sort-by">sort-by</a>.
+      </p>
       </div>
     <div class="dict_entry" id="sprout">
       <h3>
@@ -7581,9 +8350,11 @@ foreach sort-on [size] turtles
         <i>commands</i>. This is useful for giving the new turtles
         different colors, headings, or whatever. (The new turtles are
         created all at once then run one at a time, in random order.)
+      </p>
       <p>
         If the sprout-<i>&lt;breeds&gt;</i> form is used, the new turtles
         are created as members of the given breed.
+      </p>
       <pre>
 sprout 5
 sprout-wolves 10
@@ -7592,6 +8363,7 @@ sprout-sheep 1 [ set color black ]
 </pre>
       <p>
         See also <a href="#create-turtles">create-turtles</a>, <a href="#hatch">hatch</a>.
+      </p>
       </div>
     <div class="dict_entry" id="sqrt">
       <h3>
@@ -7602,6 +8374,7 @@ sprout-sheep 1 [ set color black ]
       </h4>
       <p>
         Reports the square root of <i>number</i>.
+      </p>
       </div>
     <div class="dict_entry" id="stamp">
       <h3>
@@ -7614,9 +8387,11 @@ sprout-sheep 1 [ set color black ]
       <p>
         This turtle or link leaves an image of its shape in the drawing at
         its current location.
+      </p>
       <p>
         Note: The shapes made by stamp may not be pixel-for-pixel identical
         from computer to computer.
+      </p>
       </div>
     <div class="dict_entry" id="stamp-erase">
       <h3>
@@ -7629,9 +8404,11 @@ sprout-sheep 1 [ set color black ]
       <p>
         This turtle or link removes any pixels below it in the drawing
         inside the bounds of its shape.
+      </p>
       <p>
         Note: The shapes made by stamp-erase may not be pixel-for-pixel
         identical from computer to computer.
+      </p>
       </div>
     <div class="dict_entry" id="standard-deviation">
       <h3>
@@ -7643,10 +8420,12 @@ sprout-sheep 1 [ set color black ]
       <p>
         Reports the sample standard deviation of a <i>list</i> of numbers.
         Ignores other types of items.
+      </p>
       <p>
         (Note that this estimates the standard deviation for a
         <i>sample</i>, rather than for a whole <i>population</i>, using
         Bessel's correction.)
+      </p>
       <pre>
 show standard-deviation [1 2 3 4 5 6]
 =&gt; 1.8708286933869707
@@ -7666,6 +8445,7 @@ show standard-deviation [energy] of turtles
       <p>
         User-defined procedure which, if it exists, will be called when a
         model is first loaded in the NetLogo application.
+      </p>
       <pre>
 to startup
   setup
@@ -7674,6 +8454,7 @@ end
       <p>
         <code>startup</code> does not run when a model is run headless from the
         command line, or by parallel BehaviorSpace.
+      </p>
       </div>
     <div class="dict_entry" id="stop">
       <h3>
@@ -7686,6 +8467,7 @@ end
         This agent exits immediately from the enclosing procedure, ask, or
         ask-like construct (e.g. crt, hatch, sprout). Only the enclosing
         procedure or construct stops, not all execution for the agent.
+      </p>
       <pre>
 if not any? turtles [ stop ]
 ;; exits if there are no more turtles
@@ -7694,10 +8476,12 @@ if not any? turtles [ stop ]
         Note: <code>stop</code> can also be used to stop a forever button. See
         <a href="programming.html#buttons">Buttons</a> in the
         Programming Guide for details.
+      </p>
       <p>
         <code>stop</code> can also be used to stop a BehaviorSpace model run. If the go
         commands directly call a procedure, then when that procedure calls <i>stop</i>,
         the run ends.
+      </p>
       </div>
     <div class="dict_entry" id="stop-inspecting">
       <h3>
@@ -7710,6 +8494,7 @@ if not any? turtles [ stop ]
         Closes the agent monitor for the given agent (turtle or patch).
         In the case that no agent monitor is open, <code>stop-inspecting</code> does
         nothing.
+      </p>
       <pre>
 stop-inspecting patch 2 4
 ;; the agent monitor for that patch closes
@@ -7718,6 +8503,7 @@ ask sheep [ stop-inspecting self ]
 </pre>
       <p>
         See <a href="#inspect">inspect</a> and <a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>.
+      </p>
     </div>
     <div class="dict_entry" id="stop-inspecting-dead-agents">
       <h3>
@@ -7729,6 +8515,7 @@ ask sheep [ stop-inspecting self ]
       <p>
         Closes all agent monitors for dead agents.
         See <a href="#inspect">inspect</a> and <a href="#stop-inspecting">stop-inspecting</a>.
+      </p>
     </div>
     <div class="dict_entry" id="subject">
       <h3>
@@ -7740,9 +8527,11 @@ ask sheep [ stop-inspecting self ]
       <p>
         Reports the turtle (or patch) that the observer is currently
         watching, following, or riding. Reports <a href="#nobody">nobody</a> if there is no such turtle (or patch).
+      </p>
       <p>
         See also <a href="#watch">watch</a>, <a href="#follow">follow</a>,
         <a href="#ride">ride</a>.
+      </p>
       </div>
     <div class="dict_entry" id="subliststring">
       <h3>
@@ -7756,8 +8545,10 @@ ask sheep [ stop-inspecting self ]
       <p>
         Reports just a section of the given list or string, ranging between
         the first position (inclusive) and the second position (exclusive).
+      </p>
       <p>
         Note: The positions are numbered beginning with 0, not with 1.
+      </p>
       <pre>
 show sublist [99 88 77 66] 1 3
 =&gt; [88 77]
@@ -7778,12 +8569,14 @@ show substring &quot;apartment&quot; 1 5
         rotated to produce heading1. A positive answer means a clockwise
         rotation, a negative answer counterclockwise. The result is always
         in the range -180 to 180, but is never exactly -180.
+      </p>
       <p>
         Note that simply subtracting the two headings using the - (minus)
         operator wouldn't work. Just subtracting corresponds to always
         rotating clockwise from heading2 to heading1; but sometimes the
         counterclockwise rotation is shorter. For example, the difference
         between 5 degrees and 355 degrees is 10 degrees, not -350 degrees.
+      </p>
       <pre>
 show subtract-headings 80 60
 =&gt; 20
@@ -7808,6 +8601,7 @@ show subtract-headings 0 180
       </h4>
       <p>
         Reports the sum of the items in the list.
+      </p>
       <pre>
 show sum [energy] of turtles
 ;; prints the total of the variable &quot;energy&quot;
@@ -7829,6 +8623,7 @@ show sum [energy] of turtles
       <p>
         Reports the tangent of the given angle. Assumes the angle is given
         in degrees.
+      </p>
       </div>
     <div class="dict_entry" id="thickness">
       <h3>
@@ -7844,6 +8639,7 @@ show sum [energy] of turtles
         default thickness is 0, which means that regardless of patch-size
         the links will always appear 1 pixel wide. You can set this
         variable to change a link's thickness.
+      </p>
       </div>
     <div class="dict_entry" id="tick">
       <h3>
@@ -7855,13 +8651,17 @@ show sum [energy] of turtles
       </h4>
       <p>
         Advances the tick counter by one and updates all plots.
+      </p>
       <p>
         If the tick counter has not been started yet with
         <code>reset-ticks</code>, an error results.
+      </p>
       <p>
         Normally <code>tick</code> goes at the end of a go procedure.
+      </p>
       <p>
         See also <a href="#ticks">ticks</a>, <a href="#tick-advance">tick-advance</a>, <a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>, <a href="#update-plots">update-plots</a>.
+      </p>
       </div>
     <div class="dict_entry" id="tick-advance">
       <h3>
@@ -7875,20 +8675,25 @@ show sum [energy] of turtles
         Advances the tick counter by <i>number</i>. The input may be an
         integer or a floating point number. (Some models divide ticks more
         finely than by ones.) The input may not be negative.
+      </p>
       <p>
         When using <a href="programming.html#view-updates">tick-based view
         updates</a>, the view is normally updated every 1.0 ticks, so using
         <code>tick-advance</code> with a number less then 1.0 may not always
         trigger an update. If you want to make sure that the view is
         updated, you can use the <code>display</code> command.
+      </p>
       <p>
         If the tick counter has not been started yet with
         <code>reset-ticks</code>, an error results.
+      </p>
       <p>
         Does not update plots.
+      </p>
       <p>
         See also <a href="#tick">tick</a>, <a href="#ticks">ticks</a>,
         <a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>.
+      </p>
       </div>
     <div class="dict_entry" id="ticks">
       <h3>
@@ -7900,16 +8705,20 @@ show sum [energy] of turtles
       <p>
         Reports the current value of the tick counter. The result is always
         a number and never negative.
+      </p>
       <p>
         If the tick counter has not been started yet with
         <code>reset-ticks</code>, an error results.
+      </p>
       <p>
         Most models use the <code>tick</code> command to advance the tick
         counter, in which case <code>ticks</code> will always report an
         integer. If the <code>tick-advance</code> command is used, then
         <code>ticks</code> may report a floating point number.
+      </p>
       <p>
         See also <a href="#tick">tick</a>, <a href="#tick-advance">tick-advance</a>, <a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>.
+      </p>
       </div>
     <div class="dict_entry" id="tie">
       <h3>
@@ -7928,17 +8737,21 @@ show sum [energy] of turtles
         turtles can be considered <i>root turtles</i> and <i>leaf
         turtles</i>. Movement or change in heading of either turtle affects
         the location and heading of the other turtle.
+      </p>
       <p>
         When the root turtle moves, the leaf turtles moves the same
         distance, in the same direction. The heading of the leaf turtle is
         not affected. This works with forward, jump, and setting the xcor
         or ycor of the root turtle.
+      </p>
       <p>
         When the root turtle turns right or left, the leaf turtle is
         rotated around the root turtle the same amount. The heading of the
         leaf turtle is also changed by the same amount.
+      </p>
       <p>
         If the link dies, the tie relation is removed.
+      </p>
       <pre>
       crt 2 [ fd 3 ]
       ;; creates a link and ties turtle 1 to turtle 0
@@ -7946,6 +8759,7 @@ show sum [energy] of turtles
 </pre>
       <p>
         See also <a href="#untie">untie</a>
+      </p>
       </div>
     <div class="dict_entry" id="tie-mode">
       <h3>
@@ -7961,8 +8775,10 @@ show sum [energy] of turtles
         mode of the link. You can also set tie-mode to &quot;free&quot; to
         create a non-rigid joint between two turtles (see the <a href="programming.html#tie">Tie section</a> of the Programming Guide for
         details). By default links are not tied.
+      </p>
       <p>
         See also: <a href="#tie">tie</a>, <a href="#untie">untie</a>
+      </p>
       </div>
     <div class="dict_entry" id="timer">
       <h3>
@@ -7977,12 +8793,15 @@ show sum [energy] of turtles
         (Whether you get resolution that high in practice may vary from
         system to system, depending on the capabilities of the underlying
         Java Virtual Machine.)
+      </p>
       <p>
         See also <a href="#reset-timer">reset-timer</a>.
+      </p>
       <p>
         Note that the timer is different from the tick counter. The timer
         measures elapsed real time in seconds; the tick counter measures
         elapsed model time in ticks.
+      </p>
       </div>
     <div class="dict_entry" id="to">
       <h3>
@@ -7994,6 +8813,7 @@ show sum [energy] of turtles
       </h4>
       <p>
         Used to begin a command procedure.
+      </p>
       <pre>
 to setup
   clear-all
@@ -8015,9 +8835,11 @@ end
       </h4>
       <p>
         Used to begin a reporter procedure.
+      </p>
       <p>
         The body of the procedure should use <code>report</code> to report a
         value for the procedure. See <a href="#report">report</a>.
+      </p>
       <pre>
 to-report average [a b]
   report (a + b) / 2
@@ -8044,19 +8866,23 @@ end
       </h4>
       <p>
         Reports the heading from this agent to the given agent.
+      </p>
       <p>
         If wrapping is allowed by the topology and the wrapped distance
         (around the edges of the world) is shorter, towards will use the
         wrapped path.
+      </p>
       <p>
         Note: asking for the heading from an agent to itself, or an agent
         on the same location, will cause a runtime error.
+      </p>
       <pre>
 set heading towards turtle 1
 ;; same as &quot;face turtle 1&quot;
 </pre>
       <p>
         See also <a href="#face">face</a>.
+      </p>
       </div>
     <div class="dict_entry" id="towardsxy">
       <h3>
@@ -8069,15 +8895,19 @@ set heading towards turtle 1
       <p>
         Reports the heading from the turtle or patch towards the point
         (<i>x</i>,<i>y</i>).
+      </p>
       <p>
         If wrapping is allowed by the topology and the wrapped distance
         (around the edges of the world) is shorter, towardsxy will use the
         wrapped path.
+      </p>
       <p>
         Note: asking for the heading to the point the agent is already
         standing on will cause a runtime error.
+      </p>
       <p>
         See also <a href="#facexy">facexy</a>.
+      </p>
       </div>
     <div class="dict_entry" id="turtle">
       <h3>
@@ -8090,6 +8920,7 @@ set heading towards turtle 1
       <p>
         Reports the turtle with the given who number, or <a href="#nobody">nobody</a> if there is no such turtle. For breeded
         turtles you may also use the single breed form to refer to them.
+      </p>
       <pre>
 ask turtle 5 [ set color red ]
 ;; turtle with who number 5 turns red
@@ -8108,6 +8939,7 @@ ask turtle 5 [ set color red ]
         of the inputs. The inputs may be individual turtles, turtle
         agentsets, nobody, or lists (or nested lists) containing any of the
         above.
+      </p>
       <pre>
 turtle-set self
 (turtle-set self turtles-on neighbors)
@@ -8116,6 +8948,7 @@ turtle-set self
 </pre>
       <p>
         See also <a href="#patch-set">patch-set</a>, <a href="#link-set">link-set</a>.
+      </p>
       </div>
     <div class="dict_entry" id="turtles">
       <h3>
@@ -8126,6 +8959,7 @@ turtle-set self
       </h4>
       <p>
         Reports the agentset consisting of all turtles. This is a special agentset that can grow as turtles are added to the world, see <a href="programming.html#special-agentsets">the programming guide for more info</a>.
+      </p>
       <pre>
 show count turtles
 ;; prints the number of turtles
@@ -8144,6 +8978,7 @@ show count turtles
         Reports an agentset containing the turtles on the patch (dx, dy)
         from the caller. (The result may include the caller itself if the
         caller is a turtle.)
+      </p>
       <pre>
 create-turtles 5 [ setxy 2 3 ]
 show count [turtles-at 1 1] of patch 1 2
@@ -8152,6 +8987,7 @@ show count [turtles-at 1 1] of patch 1 2
       <p>
         If the name of a breed is substituted for &quot;turtles&quot;, then
         only turtles of that breed are included.
+      </p>
       </div>
     <div class="dict_entry" id="turtles-here">
       <h3>
@@ -8165,6 +9001,7 @@ show count [turtles-at 1 1] of patch 1 2
       <p>
         Reports an agentset containing all the turtles on the caller's
         patch (including the caller itself if it's a turtle).
+      </p>
       <pre>
 crt 10
 ask turtle 0 [ show count turtles-here ]
@@ -8173,6 +9010,7 @@ ask turtle 0 [ show count turtles-here ]
       <p>
         If the name of a breed is substituted for &quot;turtles&quot;, then
         only turtles of that breed are included.
+      </p>
       <pre>
 breed [cats cat]
 breed [dogs dog]
@@ -8197,6 +9035,7 @@ ask dogs [ show count cats-here ]
         Reports an agentset containing all the turtles that are on the
         given patch or patches, or standing on the same patch as the given
         turtle or turtles.
+      </p>
       <pre>
 ask turtles [
   if not any? turtles-on patch-ahead 1
@@ -8211,6 +9050,7 @@ ask turtles [
       <p>
         If the name of a breed is substituted for &quot;turtles&quot;, then
         only turtles of that breed are included.
+      </p>
       </div>
     <div class="dict_entry" id="turtles-own">
       <h3>
@@ -8225,10 +9065,12 @@ ask turtles [
         <i>&lt;breeds&gt;</i>-own, and patches-own keywords, can only be
         used at the beginning of a program, before any function
         definitions. It defines the variables belonging to each turtle.
+      </p>
       <p>
         If you specify a breed instead of &quot;turtles&quot;, only turtles
         of that breed have the listed variables. (More than one turtle
         breed may list the same variable.)
+      </p>
       <pre>
 breed [cats cat ]
 breed [dogs dog]
@@ -8241,6 +9083,7 @@ dogs-own [hair puppies]
       <p>
         See also <a href="#globals">globals</a>, <a href="#patches-own">patches-own</a>, <a href="#breed">breed</a>,
         <a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>.
+      </p>
       </div>
     <div class="dict_entry" id="type">
       <h3>
@@ -8253,8 +9096,10 @@ dogs-own [hair puppies]
         Prints <i>value</i> in the Command Center, <i>not</i> followed by a
         carriage return (unlike <a href="#print">print</a> and <a href="#show">show</a>). The lack of a carriage return allows you to
         print several values on the same line.
+      </p>
       <p>
         This agent is <i>not</i> printed before the value. unlike <a href="#show">show</a>.
+      </p>
       <pre>
 type 3 type &quot; &quot; print 4
 =&gt; 3 4
@@ -8263,6 +9108,7 @@ type 3 type &quot; &quot; print 4
         See also <a href="#print">print</a>, <a href="#show">show</a>,
         <a href="#write">write</a>, <a href="#output-cmds">output-type</a>, and
         <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="U">
@@ -8284,8 +9130,10 @@ type 3 type &quot; &quot; print 4
         The first input defines the name of the agentset associated with
         the link breed. The second input defines the name of a single
         member of the breed.
+      </p>
       <p>
         Any link of the given link breed:
+      </p>
       <ul>
         <li>is part of the agentset named by the link breed name
         <li>has its built-in variable <code>breed</code> set to that agentset
@@ -8294,6 +9142,7 @@ type 3 type &quot; &quot; print 4
       <p>
         Most often, the agentset is used in conjunction with ask to give
         commands to only the links of a particular breed.
+      </p>
       <pre>
 undirected-link-breed [streets street]
 undirected-link-breed [highways highway]
@@ -8309,6 +9158,7 @@ ask turtle 0 [ show sort my-links ]
 </pre>
       <p>
         See also <a href="#breed">breed</a>, <a href="#directed-link-breed">directed-link-breed</a>
+      </p>
       </div>
     <div class="dict_entry" id="untie">
       <h3>
@@ -8323,11 +9173,14 @@ ask turtle 0 [ show sort my-links ]
         previously tied together. If the link is an undirected link, then
         it will untie <i>end1</i> from <i>end2</i> as well. It does
         <b>not</b> remove the link between the two turtles.
+      </p>
       <p>
         See also <a href="#tie">tie</a>
+      </p>
       <p>
         See the <a href="programming.html#tie">Tie</a> section of the
         Programming Guide for more details.
+      </p>
       </div>
       <div class="dict_entry" id="up-to-n-of">
         <h3>
@@ -8342,6 +9195,7 @@ ask turtle 0 [ show sort my-links ]
           randomly chosen from the input set, with no repeats.  If the
           input does not have enough agents to satisfy the <i>size</i>,
           reports the entire agentset.
+        </p>
         <p>
           From a list, reports a list of size <i>size</i> randomly chosen
           from the input set, with no repeats. The items in the result
@@ -8349,6 +9203,7 @@ ask turtle 0 [ show sort my-links ]
           (If you want them in random order, use shuffle on the result.)
           If the input does not have enough items to satisfy the
           <i>size</i>, reports the entire list.
+        </p>
         <pre>
           ask up-to-n-of 50 patches [ set pcolor green ]
           ;; 50 randomly chosen patches turn green
@@ -8356,6 +9211,7 @@ ask turtle 0 [ show sort my-links ]
         </pre>
         <p>
           See also <a href="#n-of">n-of</a>, <a href="#one-of">one-of</a>.
+        </p>
         </div>
     <div class="dict_entry" id="update-plots">
       <h3>
@@ -8367,15 +9223,19 @@ ask turtle 0 [ show sort my-links ]
       <p>
         For each plot, runs that plot's update commands, including the
         update code for any pens in the plot.
+      </p>
       <p>
         <a href="#tick">tick</a> has the same effect, so in models that use
         the tick counter, this primitive is not normally used. Models that
         use fractional ticks may need <code>update-plots</code>, since <a href="#tick-advance">tick-advance</a> does not update the plots.
+      </p>
       <p>
         See the <a href="programming.html#plotting">Plotting section</a> of
         the Programming Guide for more details.
+      </p>
       <p>
         See also <a href="#setup-plots">setup-plots</a>.
+      </p>
       </div>
     <div class="dict_entry" id="uphill">
       <h3>
@@ -8393,12 +9253,15 @@ ask turtle 0 [ show sort my-links ]
         value than the current patch, the turtle stays put. If there are
         multiple patches with the same highest value, the turtle picks one
         randomly. Non-numeric values are ignored.
+      </p>
       <p>
         uphill considers the eight neighboring patches; uphill4 only
         considers the four neighbors.
+      </p>
       <p>
         Equivalent to the following code (assumes variable values are
         numeric):
+      </p>
       <pre>
 move-to patch-here  ;; go to patch center
 let p max-one-of neighbors [<i>patch-variable</i>]  ;; or neighbors4
@@ -8410,8 +9273,10 @@ if [<i>patch-variable</i>] of p &gt; <i>patch-variable</i> [
       <p>
         Note that the turtle always ends up on a patch center and has a
         heading that is a multiple of 45 (uphill) or 90 (uphill4).
+      </p>
       <p>
         See also <a href="#downhill">downhill</a>, <a href="#downhill">downhill4</a>.
+      </p>
       </div>
     <div class="dict_entry" id="user-directory">
       <h3>
@@ -8423,9 +9288,11 @@ if [<i>patch-variable</i>] of p &gt; <i>patch-variable</i> [
       <p>
         Opens a dialog that allows the user to choose an existing directory
         on the system.
+      </p>
       <p>
         It reports a string with the absolute path or false if the user
         cancels.
+      </p>
       <pre>
 set-current-directory user-directory
 ;; Assumes the user will choose a directory
@@ -8441,9 +9308,11 @@ set-current-directory user-directory
       <p>
         Opens a dialog that allows the user to choose an existing file on
         the system.
+      </p>
       <p>
         It reports a string with the absolute file path or false if the
         user cancels.
+      </p>
       <pre>
 file-open user-file
 ;; Assumes the user will choose a file
@@ -8460,6 +9329,7 @@ file-open user-file
         Opens a dialog that allows the user to choose a location and name
         of a new file to be created. It reports a string with the absolute
         file path or false if the user cancels.
+      </p>
       <pre>
 file-open user-new-file
 ;; Assumes the user will choose a file
@@ -8468,11 +9338,13 @@ file-open user-new-file
         Note that this reporter doesn't actually create the file;
         normally you would create the file using <code>file-open</code>, as in
         the example.
+      </p>
       <p>
         If the user chooses an existing file, they will be asked if they
         wish to replace it or not, but the reporter itself doesn't
         cause the file to be replaced. To do that you would use
         <code>file-delete</code>.
+      </p>
       </div>
     <div class="dict_entry" id="user-input">
       <h3>
@@ -8484,14 +9356,17 @@ file-open user-new-file
       <p>
         Reports the string that a user types into an entry field in a
         dialog with title <i>value</i>.
+      </p>
       <p>
         <i>value</i> may be of any type, but is typically a string.
+      </p>
       <pre>
 show user-input &quot;What is your name?&quot;
 </pre>
       <p>
         See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
         Programming Guide for additional details.
+      </p>
     </div>
     <div class="dict_entry" id="user-message">
       <h3>
@@ -8502,17 +9377,21 @@ show user-input &quot;What is your name?&quot;
       </h4>
       <p>
         Opens a dialog with <i>value</i> displayed as the message to the user.
+      </p>
       <p>
         <i>value</i> may be of any type, but is typically a string.
+      </p>
         <pre>
 user-message (word &quot;There are &quot; count turtles &quot; turtles.&quot;)
 </pre>
         <p>
         Note that if a user closes the <code>user-message</code> dialog
         with the &quot;X&quot; in the corner, the behavior will be the same as if they had clicked &quot;OK&quot;.
+        </p>
         <p>
         See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
         Programming Guide for additional details.
+        </p>
     </div>
     <div class="dict_entry" id="user-one-of">
       <h3>
@@ -8525,10 +9404,13 @@ user-message (word &quot;There are &quot; count turtles &quot; turtles.&quot;)
         Opens a dialog with <i>value</i> displayed as the message and
         <i>list-of-choices</i> displayed as a popup menu for the user to
         select from.
+      </p>
       <p>
         Reports the item in <i>list-of-choices</i> selected by the user.
+      </p>
       <p>
         <i>value</i> may be of any type, but is typically a string.
+      </p>
       <pre>
 if &quot;yes&quot; = user-one-of &quot;Set up the model?&quot; [&quot;yes&quot; &quot;no&quot;]
   [ setup ]
@@ -8536,6 +9418,7 @@ if &quot;yes&quot; = user-one-of &quot;Set up the model?&quot; [&quot;yes&quot; 
         <p>
         See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
         Programming Guide for additional details.
+        </p>
     </div>
     <div class="dict_entry" id="user-yes-or-no">
       <h3>
@@ -8547,8 +9430,10 @@ if &quot;yes&quot; = user-one-of &quot;Set up the model?&quot; [&quot;yes&quot; 
       <p>
         Reports true or false based on the user's response to
         <i>value</i>.
+      </p>
       <p>
         <i>value</i> may be of any type, but is typically a string.
+      </p>
       <pre>
 if user-yes-or-no? &quot;Set up the model?&quot;
   [ setup ]
@@ -8556,6 +9441,7 @@ if user-yes-or-no? &quot;Set up the model?&quot;
         <p>
         See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
         Programming Guide for additional details.
+        </p>
     </div><!-- ======================================== -->
   </div>
     <h2 id="V">
@@ -8572,14 +9458,17 @@ if user-yes-or-no? &quot;Set up the model?&quot;
       <p>
         Reports the sample variance of a <i>list</i> of numbers. Ignores
         other types of items.
+      </p>
       <p>
         (Note that this computes an unbiased estimate of the variance for a
         <i>sample</i>, rather than for a whole <i>population</i>, using
         Bessel's correction.)
+      </p>
       <p>
         The sample variance is the sum of the squares of the deviations of
         the numbers from their mean, divided by one less than the number of
         numbers in the list.
+      </p>
       <pre>
 show variance [2 7 4 3 5]
 =&gt; 3.7
@@ -8602,14 +9491,17 @@ show variance [2 7 4 3 5]
         you can specify fractions of seconds.) Note that you can't
         expect complete precision; the agent will never wait less than the
         given amount, but might wait slightly more.
+      </p>
       <pre>
 repeat 10 [ fd 1 wait 0.5 ]
 </pre>
       <p>
         While the agent is waiting, no other agents can do anything.
         Everything stops until the agent is done.
+      </p>
       <p>
         See also <a href="#every">every</a>.
+      </p>
       </div>
     <div class="dict_entry" id="watch">
       <h3>
@@ -8622,14 +9514,17 @@ repeat 10 [ fd 1 wait 0.5 ]
       <p>
         Puts a spotlight on <i>agent</i>. In the 3D view the observer will
         also turn to face the subject.
+      </p>
       <p>
         The observer may only watch or follow a single subject.
         Calling <code>watch</code> will undo perspective changes caused
         by prior calls to <code>follow</code>, <code>follow-me</code>,
         <code>ride</code>, and <code>ride-me</code>.
+      </p>
       <p>
         See also <a href="#follow">follow</a>, <a href="#subject">subject</a>, <a href="#reset-perspective">reset-perspective</a>,
         <a href="#ride">ride</a>, <a href="#ride-me">ride-me</a>, <a href="#watch-me">watch-me</a>.
+      </p>
       </div>
     <div class="dict_entry" id="watch-me">
       <h3>
@@ -8641,14 +9536,17 @@ repeat 10 [ fd 1 wait 0.5 ]
       </h4>
       <p>
         Asks the observer to watch this agent.
+      </p>
       <p>
         The observer may only watch or follow a single subject.
         Calling <code>watch</code> will undo perspective changes caused
         by prior calls to <code>follow</code>, <code>follow-me</code>,
         <code>ride</code>, and <code>ride-me</code>.
+      </p>
       <p>
         See also <a href="#follow">follow</a>, <a href="#subject">subject</a>, <a href="#reset-perspective">reset-perspective</a>,
         <a href="#ride">ride</a>, <a href="#ride-me">ride-me</a>, <a href="#watch">watch</a>.
+      </p>
       </div>
     <div class="dict_entry" id="while">
       <h3>
@@ -8660,10 +9558,12 @@ repeat 10 [ fd 1 wait 0.5 ]
       <p>
         If <i>reporter</i> reports false, exit the loop. Otherwise run
         <i>commands</i> and repeat.
+      </p>
       <p>
         The reporter may have different values for different agents, so
         some agents may run <i>commands</i> a different number of times
         than other agents.
+      </p>
       <pre>
 while [any? other turtles-here]
   [ fd 1 ]
@@ -8684,12 +9584,15 @@ while [any? other turtles-here]
         &quot;who number&quot; or ID number, an integer greater than or
         equal to zero. You cannot set this variable; a turtle's who
         number never changes.
+      </p>
       <p>
         Who numbers start at 0. A dead turtle's number will not be
         reassigned to a new turtle until you use the <a href="#clear-turtles">clear-turtles</a> or <a href="#clear-all">clear-all</a> commands, at which time who numbering
         starts over again at 0.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 show [who] of turtles with [color = red]
 ;; prints a list of the who numbers of all red turtles
@@ -8704,9 +9607,11 @@ crt 100
       <p>
         You can use the turtle reporter to retrieve a turtle with a given
         who number. See also <a href="#turtle">turtle</a>.
+      </p>
       <p>
         Note that who numbers aren't breed-specific. No two turtles can
         have the same who number, even if they are different breeds:
+      </p>
       <pre>
 clear-turtles
 create-frogs 1
@@ -8720,6 +9625,7 @@ ask turtles [ print who ]
         Even though we only have one mouse, it is <code>mouse 1</code> not
         <code>mouse 0</code>, because the who number 0 was already taken by the
         frog.
+      </p>
       </div>
     <div class="dict_entry" id="with">
       <h3>
@@ -8734,6 +9640,7 @@ ask turtles [ print who ]
         boolean reporter. Reports a new agentset containing only those
         agents that reported true -- in other words, the agents satisfying
         the given condition.
+      </p>
       <pre>
 show count patches with [pcolor = red]
 ;; prints the number of red patches
@@ -8753,6 +9660,7 @@ show count patches with [pcolor = red]
         Reports a link between <i>turtle</i> and the caller (directed or
         undirected, incoming or outgoing). If no link exists then it reports
         nobody. If more than one such link exists, reports a random one.
+      </p>
       <pre>
 crt 2
 ask turtle 0 [
@@ -8762,6 +9670,7 @@ ask turtle 0 [
 </pre>
       <p>
         See also: <a href="#in-link-from">in-link-from</a>, <a href="#out-link-to">out-link-to</a>
+      </p>
       </div>
     <div class="dict_entry" id="with-max">
       <h3>
@@ -8775,12 +9684,14 @@ ask turtle 0 [
         &quot;turtles&quot; or &quot;patches&quot;). On the right, a
         reporter. Reports a new agentset containing all agents reporting
         the maximum value of the given reporter.
+      </p>
       <pre>
 show count patches with-max [pxcor]
 ;; prints the number of patches on the right edge
 </pre>
       <p>
         See also <a href="#max-one-of">max-one-of</a>, <a href="#max-n-of">max-n-of</a>.
+      </p>
       </div>
     <div class="dict_entry" id="with-min">
       <h3>
@@ -8794,12 +9705,14 @@ show count patches with-max [pxcor]
         &quot;turtles&quot; or &quot;patches&quot;). On the right, a
         reporter. Reports a new agentset containing only those agents that
         have the minimum value of the given reporter.
+      </p>
       <pre>
 show count patches with-min [pycor]
 ;; prints the number of patches on the bottom edge
 </pre>
       <p>
         See also <a href="#min-one-of">min-one-of</a>, <a href="#min-n-of">min-n-of</a>.
+      </p>
       </div>
     <div class="dict_entry" id="with-local-randomness">
       <h3>
@@ -8812,8 +9725,10 @@ show count patches with-min [pycor]
         The commands are run without affecting subsequent random events.
         This is useful for performing extra operations (such as output)
         without changing the outcome of a model.
+      </p>
       <p>
         Example:
+      </p>
       <pre>
 ;; Run #1:
 random-seed 50 setup repeat 10 [ go ]
@@ -8825,15 +9740,18 @@ repeat 10 [ go ]
       <p>
         Since <code>one-of</code> is used inside
         <code>with-local-randomness</code>, both runs will be identical.
+      </p>
       <p>
         Specifically how it works is, the state of the random number
         generator is remembered before the commands run, then restored
         afterwards. (If you want to run the commands with a fresh random
         state instead of the same random state that will be restored later,
         you can begin the commands with <code>random-seed new-seed</code>.)
+      </p>
       <p>
         The following example demonstrates that the random number generator
         state is the same both before the commands run and afterwards.
+      </p>
       <pre>
 random-seed 10
 with-local-randomness [ print n-values 10 [random 10] ]
@@ -8852,16 +9770,20 @@ print n-values 10 [random 10]
       <p>
         This primitive exists only for backwards compatibility. We
         don't recommend using it in new models.
+      </p>
       <p>
         The agent runs all the commands in the block without allowing other
         agents using <code>ask-concurrent</code> to &quot;interrupt&quot;. That
         is, other agents are put &quot;on hold&quot; and do not run any
         commands until the commands in the block are finished.
+      </p>
       <p>
         Note: This command is only useful in conjunction with
         <code>ask-concurrent</code>.
+      </p>
       <p>
         See also <a href="#ask-concurrent">ask-concurrent</a>.
+      </p>
       </div>
     <div class="dict_entry" id="word">
       <h3>
@@ -8874,6 +9796,7 @@ print n-values 10 [random 10]
       <p>
         Concatenates the inputs together and reports the result as a
         string.
+      </p>
       <pre>
 show word &quot;tur&quot; &quot;tle&quot;
 =&gt; &quot;turtle&quot;
@@ -8902,12 +9825,15 @@ show (word &quot;a&quot; &quot;b&quot; &quot;c&quot; 1 23)
       <p>
         These reporters give the total width and height of the NetLogo
         world.
+      </p>
       <p>
         The width equals max-pxcor - min-pxcor + 1 and the height equals
         max-pycor - min-pycor + 1.
+      </p>
       <p>
         See also <a href="#max-pcor">max-pxcor</a>, <a href="#max-pcor">max-pycor</a>, <a href="#min-pcor">min-pxcor</a>, and
         <a href="#min-pcor">min-pycor</a>
+      </p>
       </div>
     <div class="dict_entry" id="wrap-color">
       <h3>
@@ -8921,12 +9847,14 @@ show (word &quot;a&quot; &quot;b&quot; &quot;c&quot; 1 23)
         range of 0 to 140 (not including 140 itself). If it is not,
         wrap-color &quot;wraps&quot; the numeric input to the 0 to 140
         range.
+      </p>
       <p>
         The wrapping is done by repeatedly adding or subtracting 140 from
         the given number until it is in the 0 to 140 range. (This is the
         same wrapping that is done automatically if you assign an
         out-of-range number to the color turtle variable or pcolor patch
         variable.)
+      </p>
       <pre>
 show wrap-color 150
 =&gt; 10
@@ -8946,9 +9874,11 @@ show wrap-color -10
         string, list, boolean, or nobody to the Command Center, <i>not</i>
         followed by a carriage return (unlike <a href="#print">print</a>
         and <a href="#show">show</a>).
+      </p>
       <p>
         This agent is <i>not</i> printed before the value, unlike <a href="#show">show</a>. Its output also includes quotes around strings
         and is prepended with a space.
+      </p>
       <pre>
 write &quot;hello world&quot;
 =&gt;  &quot;hello world&quot;
@@ -8957,6 +9887,7 @@ write &quot;hello world&quot;
         See also <a href="#print">print</a>, <a href="#show">show</a>,
         <a href="#type">type</a>, <a href="#output-cmds">output-write</a>,
         and <a href="programming.html#output">Output (programming guide)</a>.
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2 id="X">
@@ -8975,12 +9906,15 @@ write &quot;hello world&quot;
         This is a built-in turtle variable. It holds the current x
         coordinate of the turtle. You can set this variable to change the
         turtle's location.
+      </p>
       <p>
         This variable is always greater than or equal to (min-pxcor - 0.5)
         and strictly less than (max-pxcor + 0.5).
+      </p>
       <p>
         See also <a href="#setxy">setxy</a>, <a href="#ycor">ycor</a>,
         <a href="#pcor">pxcor</a>, <a href="#pcor">pycor</a>,
+      </p>
       </div>
     <div class="dict_entry" id="xor">
       <h3>
@@ -8992,6 +9926,7 @@ write &quot;hello world&quot;
       <p>
         Reports true if either <i>boolean1</i> or <i>boolean2</i> is true,
         but not when both are true.
+      </p>
       <pre>
 if (pxcor &gt; 0) xor (pycor &gt; 0)
   [ set pcolor blue ]
@@ -9015,12 +9950,15 @@ if (pxcor &gt; 0) xor (pycor &gt; 0)
         This is a built-in turtle variable. It holds the current y
         coordinate of the turtle. You can set this variable to change the
         turtle's location.
+      </p>
       <p>
         This variable is always greater than or equal to (min-pycor - 0.5)
         and strictly less than (max-pycor + 0.5).
+      </p>
       <p>
         See also <a href="#setxy">setxy</a>, <a href="#xcor">xcor</a>,
         <a href="#pcor">pxcor</a>, <a href="#pcor">pycor</a>,
+      </p>
       </div><!-- ======================================== -->
     </div>
     <h2>
@@ -9042,13 +9980,18 @@ if (pxcor &gt; 0) xor (pycor &gt; 0)
         The variable names in <i>args</i> have the same restrictions
         as variable names of commands and reporters. In addition, they must not match the name of
         any let or procedure variable in their procedure.
+        </p>
         <p>
         Anonymous procedures are commonly used with the primitives
         <a href="#foreach">foreach</a>, <a href="#map">map</a>, <a href="#reduce">reduce</a>,
         <a href="#filter">filter</a>, <a href="#sort-by">sort-by</a>, and <a href="#n-values">n-values</a>. See
         those entries for example usage.
+        </p>
         <p>
         See the <a href="programming.html#anonymous-procedures">Anonymous Procedures section</a> of the
         Programming Guide for details.
+        </p>
       </div>
     </div>
+</body>
+</html>

--- a/autogen/docs/dictionary.html.mustache
+++ b/autogen/docs/dictionary.html.mustache
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+<!DOCTYPE html>
 <html lang="en">
 <head>
 <title>

--- a/autogen/docs/dictionary.html.mustache
+++ b/autogen/docs/dictionary.html.mustache
@@ -1,797 +1,797 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<title>
-  NetLogo {{version}} User Manual: NetLogo Dictionary
-</title>
-<link rel="stylesheet" href="netlogo.css" type="text/css">
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<style>
-p  { margin-left: 1.5em ; }
-h3 { font-size: 115% ; }
-h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
-</style>
-</head>
-<body>
-<h1>
-  NetLogo Dictionary
-</h1>
-<div class="version">
-  NetLogo {{version}} User Manual
-</div>
-    <div class="centertext">
-      <div class="block">
-        <div class="smallfont centertext tocborder inlineblock">
-          Alphabetical:
-          <span class="bold">
-            <a href="#A">A</a>
-            <a href="#B">B</a>
-            <a href="#C">C</a>
-            <a href="#D">D</a>
-            <a href="#E">E</a>
-            <a href="#F">F</a>
-            <a href="#G">G</a>
-            <a href="#H">H</a>
-            <a href="#I">I</a>
-            <a href="#J">J</a>
-            <!--<a href="#K">K</a>-->
-            <a href="#L">L</a>
-            <a href="#M">M</a>
-            <a href="#N">N</a>
-            <a href="#O">O</a>
-            <a href="#P">P</a>
-            <!--<a href="#Q">Q</a>-->
-            <a href="#R">R</a>
-            <a href="#S">S</a>
-            <a href="#T">T</a>
-            <a href="#U">U</a>
-            <a href="#V">V</a>
-            <a href="#W">W</a>
-            <a href="#X">X</a>
-            <a href="#Y">Y</a>
-            <!--<a href="#Z">Z</a>-->
-            <a href="#ops">-></a>
-          </span>
-        </div>
-      </div>
-      <div class="block">
-        <div class="smallfont centertext tocborder inlineblock">
-          Categories: <a href="#turtlegroup">Turtle</a> - <a href="#patchgroup">Patch</a> - <a href="#linkgroup">Links</a>
-          - <a href="#agentsetgroup">Agentset</a> - <a href="#colorgroup">Color</a>
-          - <a href="#anonproceduresgroup">Anonymous Procedures</a> - <a href="#controlgroup">Control/Logic</a> - <a href="#worldgroup">World</a>
-          <br>
-          <a href="#perspectivegroup">Perspective</a> -
-          <a href="#iogroup">Input/Output</a> - <a href="#fileiogroup">File</a> - <a href="#listsgroup">List</a> -
-          <a href="#stringgroup">String</a> - <a href="#mathematicalgroup">Math</a> - <a href="#plottinggroup">Plotting</a>
-          - <a href="#systemgroup">System</a> - <a href="#hubnetgroup">HubNet</a>
-        </div>
-      </div>
-      <div class="block">
-        <div class="smallfont centertext tocborder inlineblock">
-          Special: <a href="#builtinvariables">Variables</a> - <a href="#Keywords">Keywords</a> - <a href="#Constants">Constants</a>
-        </div>
-      </div>
-    </div>
-    <h2>
-      Categories
-    </h2>
-    <p>
-      This is an approximate grouping. Remember that a turtle-related
-      primitive might still be used by patches or the observer, and vice
-      versa. To see which agents (turtles, patches, links, observer) can
-      actually run a primitive, consult its dictionary entry.
-    </p>
-      <!-- ======================================== -->
-    <h3 id="turtlegroup">
-      Turtle-related
-    </h3>
-    <p>
-      <a href="#back">back</a> (<a href="#back">bk</a>)
-      <a href="#turtles-at"><i>&lt;breeds&gt;</i>-at</a>
-      <a href="#turtles-here"><i>&lt;breeds&gt;</i>-here</a>
-      <a href="#turtles-on"><i>&lt;breeds&gt;</i>-on</a>
-      <a href="#can-move">can-move?</a>
-      <a href="#clear-turtles">clear-turtles</a> (<a href="#clear-turtles">ct</a>)
-      <a href="#create-turtles">create-<i>&lt;breeds&gt;</i></a>
-      <a href="#create-ordered-turtles">create-ordered-<i>&lt;breeds&gt;</i></a>
-      <a href="#create-ordered-turtles">create-ordered-turtles</a> (<a href="#create-ordered-turtles">cro</a>)
-      <a href="#create-turtles">create-turtles</a> (<a href="#create-turtles">crt</a>)
-      <a href="#die">die</a>
-      <a href="#distance">distance</a>
-      <a href="#distancexy">distancexy</a>
-      <a href="#downhill">downhill</a>
-      <a href="#downhill">downhill4</a>
-      <a href="#dxy">dx</a>
-      <a href="#dxy">dy</a>
-      <a href="#face">face</a>
-      <a href="#facexy">facexy</a>
-      <a href="#forward">forward</a> (<a href="#forward">fd</a>)
-      <a href="#hatch">hatch</a>
-      <a href="#hatch">hatch-<i>&lt;breeds&gt;</i></a>
-      <a href="#hide-turtle">hide-turtle</a> (<a href="#hide-turtle">ht</a>)
-      <a href="#home">home</a>
-      <a href="#inspect">inspect</a>
-      <a href="#is-of-type">is-<i>&lt;breed&gt;</i>?</a>
-      <a href="#is-of-type">is-turtle?</a>
-      <a href="#jump">jump</a>
-      <a href="#layout-circle">layout-circle</a>
-      <a href="#left">left</a> (<a href="#left">lt</a>)
-      <a href="#move-to">move-to</a>
-      <a href="#myself">myself</a>
-      <a href="#nobody">nobody</a>
-      <a href="#no-turtles">no-turtles</a>
-      <a href="#of">of</a>
-      <a href="#other">other</a>
-      <a href="#patch-ahead">patch-ahead</a>
-      <a href="#patch-at">patch-at</a>
-      <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>
-      <a href="#patch-here">patch-here</a>
-      <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>
-      <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>
-      <a href="#pen-switch-status">pen-down</a>  (<a href="#pen-switch-status">pd</a>)
-      <a href="#pen-switch-status">pen-erase</a> (<a href="#pen-switch-status">pe</a>)
-      <a href="#pen-switch-status">pen-up</a>    (<a href="#pen-switch-status">pu</a>)
-      <a href="#random-cor">random-xcor</a>
-      <a href="#random-cor">random-ycor</a>
-      <a href="#right">right</a> (<a href="#right">rt</a>)
-      <a href="#self">self</a>
-      <a href="#set-default-shape">set-default-shape</a>
-      <a href="#set-line-thickness">__set-line-thickness</a>
-      <a href="#setxy">setxy</a>
-      <a href="#shapes">shapes</a>
-      <a href="#show-turtle">show-turtle</a> (<a href="#show-turtle">st</a>)
-      <a href="#sprout">sprout</a>
-      <a href="#sprout">sprout-<i>&lt;breeds&gt;</i></a>
-      <a href="#stamp">stamp</a>
-      <a href="#stamp-erase">stamp-erase</a>
-      <a href="#stop-inspecting">stop-inspecting</a>
-      <a href="#subject">subject</a>
-      <a href="#subtract-headings">subtract-headings</a>
-      <a href="#tie">tie</a>
-      <a href="#towards">towards</a>
-      <a href="#towardsxy">towardsxy</a>
-      <a href="#turtle">turtle</a>
-      <a href="#turtle-set">turtle-set</a>
-      <a href="#turtles">turtles</a>
-      <a href="#turtles-at">turtles-at</a>
-      <a href="#turtles-here">turtles-here</a>
-      <a href="#turtles-on">turtles-on</a>
-      <a href="#turtles-own">turtles-own</a>
-      <a href="#untie">untie</a>
-      <a href="#uphill">uphill</a>
-      <a href="#uphill">uphill4</a>
-    </p>
-      <!-- ======================================== -->
-    <h3 id="patchgroup">
-      Patch-related
-    </h3>
-    <p>
-      <a href="#clear-patches">clear-patches</a> (<a href="#clear-patches">cp</a>)
-      <a href="#diffuse">diffuse</a>
-      <a href="#diffuse4">diffuse4</a>
-      <a href="#distance">distance</a>
-      <a href="#distancexy">distancexy</a>
-      <a href="#import-pcolors">import-pcolors</a>
-      <a href="#import-pcolors-rgb">import-pcolors-rgb</a>
-      <a href="#inspect">inspect</a>
-      <a href="#is-of-type">is-patch?</a>
-      <a href="#myself">myself</a>
-      <a href="#neighbors">neighbors</a>
-      <a href="#neighbors">neighbors4</a>
-      <a href="#nobody">nobody</a>
-      <a href="#no-patches">no-patches</a>
-      <a href="#of">of</a>
-      <a href="#other">other</a>
-      <a href="#patch">patch</a>
-      <a href="#patch-at">patch-at</a>
-      <a href="#patch-ahead">patch-ahead</a>
-      <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>
-      <a href="#patch-here">patch-here</a>
-      <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>
-      <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>
-      <a href="#patch-set">patch-set</a>
-      <a href="#patches">patches</a>
-      <a href="#patches-own">patches-own</a>
-      <a href="#random-pcor">random-pxcor</a>
-      <a href="#random-pcor">random-pycor</a>
-      <a href="#self">self</a>
-      <a href="#sprout">sprout</a>
-      <a href="#sprout">sprout-<i>&lt;breeds&gt;</i></a>
-      <a href="#stop-inspecting">stop-inspecting</a>
-      <a href="#subject">subject</a>
-      <a href="#turtles-here">turtles-here</a>
-    </p>
-      <!-- ======================================== -->
-    <h3 id="linkgroup">
-      Link-related
-    </h3>
-    <p>
-      <a href="#both-ends">both-ends</a>
-      <a href="#clear-links">clear-links</a>
-      <a href="#create-link">create-&lt;breed&gt;-from</a>
-      <a href="#create-link">create-&lt;breeds&gt;-from</a>
-      <a href="#create-link">create-&lt;breed&gt;-to</a>
-      <a href="#create-link">create-&lt;breeds&gt;-to</a>
-      <a href="#create-link">create-&lt;breed&gt;-with</a>
-      <a href="#create-link">create-&lt;breeds&gt;-with</a>
-      <a href="#create-link">create-link-from</a>
-      <a href="#create-link">create-links-from</a>
-      <a href="#create-link">create-link-to</a>
-      <a href="#create-link">create-links-to</a>
-      <a href="#create-link">create-link-with</a>
-      <a href="#create-link">create-links-with</a>
-      <a href="#die">die</a>
-      <a href="#directed-link-breed">directed-link-breed</a>
-      <a href="#hide-link">hide-link</a>
-      <a href="#in-link-neighbor">in-&lt;breed&gt;-neighbor?</a>
-      <a href="#in-link-neighbors">in-&lt;breed&gt;-neighbors</a>
-      <a href="#in-link-from">in-&lt;breed&gt;-from</a>
-      <a href="#in-link-neighbor">in-link-neighbor?</a>
-      <a href="#in-link-neighbors">in-link-neighbors</a>
-      <a href="#in-link-from">in-link-from</a>
-      <a href="#is-of-type">is-directed-link?</a>
-      <a href="#is-of-type">is-link?</a>
-      <a href="#is-of-type">is-link-set?</a>
-      <a href="#is-of-type">is-<i>&lt;link-breed&gt;</i>?</a>
-      <a href="#is-of-type">is-undirected-link?</a>
-      <a href="#layout-radial">layout-radial</a>
-      <a href="#layout-spring">layout-spring</a>
-      <a href="#layout-tutte">layout-tutte</a>
-      <a href="#link-neighbor">&lt;breed&gt;-neighbor?</a>
-      <a href="#link-neighbors">&lt;breed&gt;-neighbors</a>
-      <a href="#link-with">&lt;breed&gt;-with</a>
-      <a href="#link-heading">link-heading</a>
-      <a href="#link-length">link-length</a>
-      <a href="#link-neighbor">link-neighbor?</a>
-      <a href="#link">link</a>
-      <a href="#links">links</a>
-      <a href="#links-own">links-own</a>
-      <a href="#links-own">&lt;link-breeds&gt;-own</a>
-      <a href="#link-neighbors">link-neighbors</a>
-      <a href="#link-with">link-with</a>
-      <a href="#my-links">my-&lt;breeds&gt;</a>
-      <a href="#my-in-links">my-in-&lt;breeds&gt;</a>
-      <a href="#my-in-links">my-in-links</a>
-      <a href="#my-links">my-links</a>
-      <a href="#my-out-links">my-out-&lt;breeds&gt;</a>
-      <a href="#my-out-links">my-out-links</a>
-      <a href="#no-links">no-links</a>
-      <a href="#other-end">other-end</a>
-      <a href="#out-link-neighbor">out-&lt;breed&gt;-neighbor?</a>
-      <a href="#out-link-neighbors">out-&lt;breed&gt;-neighbors</a>
-      <a href="#out-link-to">out-&lt;breed&gt;-to</a>
-      <a href="#out-link-neighbor">out-link-neighbor?</a>
-      <a href="#out-link-neighbors">out-link-neighbors</a>
-      <a href="#out-link-to">out-link-to</a>
-      <a href="#show-link">show-link</a>
-      <a href="#tie">tie</a>
-      <a href="#undirected-link-breed">undirected-link-breed</a>
-      <a href="#untie">untie</a>
-    </p>
-      <!-- ======================================== -->
-    <h3 id="agentsetgroup">
-      <a>Agentset</a>
-    </h3>
-    <p>
-      <a href="#all">all?</a>
-      <a href="#any">any?</a>
-      <a href="#ask">ask</a>
-      <a href="#ask-concurrent">ask-concurrent</a>
-      <a href="#at-points">at-points</a>
-      <a href="#turtles-at"><i>&lt;breeds&gt;</i>-at</a>
-      <a href="#turtles-here"><i>&lt;breeds&gt;</i>-here</a>
-      <a href="#turtles-on"><i>&lt;breeds&gt;</i>-on</a>
-      <a href="#count">count</a>
-      <a href="#in-cone">in-cone</a>
-      <a href="#in-radius">in-radius</a>
-      <a href="#is-of-type">is-agent?</a>
-      <a href="#is-of-type">is-agentset?</a>
-      <a href="#is-of-type">is-patch-set?</a>
-      <a href="#is-of-type">is-turtle-set?</a>
-      <a href="#link-set">link-set</a>
-      <a href="#max-n-of">max-n-of</a>
-      <a href="#max-one-of">max-one-of</a>
-      <a href="#member">member?</a>
-      <a href="#min-n-of">min-n-of</a>
-      <a href="#min-one-of">min-one-of</a>
-      <a href="#n-of">n-of</a>
-      <a href="#neighbors">neighbors</a>
-      <a href="#neighbors">neighbors4</a>
-      <a href="#no-links">no-links</a>
-      <a href="#no-patches">no-patches</a>
-      <a href="#no-turtles">no-turtles</a>
-      <a href="#of">of</a>
-      <a href="#one-of">one-of</a>
-      <a href="#other">other</a>
-      <a href="#patch-set">patch-set</a>
-      <a href="#patches">patches</a>
-      <a href="#sort">sort</a>
-      <a href="#sort-by">sort-by</a>
-      <a href="#sort-on">sort-on</a>
-      <a href="#turtle-set">turtle-set</a>
-      <a href="#turtles">turtles</a>
-      <a href="#turtles-at">turtles-at</a>
-      <a href="#turtles-here">turtles-here</a>
-      <a href="#turtles-on">turtles-on</a>
-      <a href="#up-to-n-of">up-to-n-of</a>
-      <a href="#with">with</a>
-      <a href="#with-max">with-max</a>
-      <a href="#with-min">with-min</a>
-    </p>
-      <!-- ======================================== -->
-    <h3 id="colorgroup">
-      Color
-    </h3>
-    <p>
-      <a href="#approximate-hsb">approximate-hsb</a>
-      <a href="#approximate-rgb">approximate-rgb</a>
-      <a href="#base-colors">base-colors</a>
-      <a href="#color">color</a>
-      <a href="#extract-hsb">extract-hsb</a>
-      <a href="#extract-rgb">extract-rgb</a>
-      <a href="#hsb">hsb</a>
-      <a href="#import-pcolors">import-pcolors</a>
-      <a href="#import-pcolors-rgb">import-pcolors-rgb</a>
-      <a href="#pcolor">pcolor</a>
-      <a href="#rgb">rgb</a>
-      <a href="#scale-color">scale-color</a>
-      <a href="#shade-of">shade-of?</a>
-      <a href="#wrap-color">wrap-color</a>
-    </p>
-      <!-- ======================================== -->
-    <h3 id="controlgroup">
-      Control flow and logic
-    </h3>
-    <p>
-      <a href="#and">and</a>
-      <a href="#ask">ask</a>
-      <a href="#ask-concurrent">ask-concurrent</a>
-      <a href="#carefully">carefully</a>
-      <a href="#end">end</a>
-      <a href="#error">error</a>
-      <a href="#error-message">error-message</a>
-      <a href="#every">every</a>
-      <a href="#if">if</a>
-      <a href="#ifelse">ifelse</a>
-      <a href="#ifelse-value">ifelse-value</a>
-      <a href="#let">let</a>
-      <a href="#loop">loop</a>
-      <a href="#not">not</a>
-      <a href="#or">or</a>
-      <a href="#repeat">repeat</a>
-      <a href="#report">report</a>
-      <a href="#run">run</a>
-      <a href="#run">runresult</a>
-      <a href="#semicolon">; (semicolon)</a>
-      <a href="#set">set</a>
-      <a href="#stop">stop</a>
-      <a href="#startup">startup</a>
-      <a href="#to">to</a>
-      <a href="#to-report">to-report</a>
-      <a href="#wait">wait</a>
-      <a href="#while">while</a>
-      <a href="#with-local-randomness">with-local-randomness</a>
-      <a href="#without-interruption">without-interruption</a>
-      <a href="#xor">xor</a>
-    </p>
-      <!-- ======================================== -->
-    <h3 id="anonproceduresgroup">
-      Anonymous Procedures
-    </h3>
-    <p>
-      <a href="#arrow">-&gt; (anonymous procedure)</a>
-      <a href="#filter">filter</a>
-      <a href="#foreach">foreach</a>
-      <a href="#is-of-type">is-anonymous-command?</a>
-      <a href="#is-of-type">is-anonymous-reporter?</a>
-      <a href="#map">map</a>
-      <a href="#n-values">n-values</a>
-      <a href="#reduce">reduce</a>
-      <a href="#run">run</a>
-      <a href="#run">runresult</a>
-      <a href="#sort-by">sort-by</a>
-    </p>
-      <!-- ======================================== -->
-    <h3 id="worldgroup">
-      World
-    </h3>
-    <p>
-      <a href="#clear-all">clear-all</a> (<a href="#clear-all">ca</a>)
-      <a href="#clear-drawing">clear-drawing</a> (<a href="#clear-drawing">cd</a>)
-      <a href="#clear-globals">clear-globals</a>
-      <a href="#clear-patches">clear-patches</a> (<a href="#clear-patches">cp</a>)
-      <a href="#clear-ticks">clear-ticks</a>
-      <a href="#clear-turtles">clear-turtles</a> (<a href="#clear-turtles">ct</a>)
-      <a href="#display">display</a>
-      <a href="#import-drawing">import-drawing</a>
-      <a href="#import-pcolors">import-pcolors</a>
-      <a href="#import-pcolors-rgb">import-pcolors-rgb</a>
-      <a href="#no-display">no-display</a>
-      <a href="#max-pcor">max-pxcor</a>
-      <a href="#max-pcor">max-pycor</a>
-      <a href="#min-pcor">min-pxcor</a>
-      <a href="#min-pcor">min-pycor</a>
-      <a href="#patch-size">patch-size</a>
-      <a href="#reset-ticks">reset-ticks</a>
-      <a href="#resize-world">resize-world</a>
-      <a href="#set-patch-size">set-patch-size</a>
-      <a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>
-      <a href="#tick">tick</a>
-      <a href="#tick-advance">tick-advance</a>
-      <a href="#ticks">ticks</a>
-      <a href="#world-dim">world-width</a>
-      <a href="#world-dim">world-height</a>
-    </p>
-      <!-- ======================================== -->
-    <h3 id="perspectivegroup">
-      Perspective
-    </h3>
-    <p>
-      <a href="#follow">follow</a>
-      <a href="#follow-me">follow-me</a>
-      <a href="#reset-perspective">reset-perspective</a> (<a href="#reset-perspective">rp</a>)
-      <a href="#ride">ride</a>
-      <a href="#ride-me">ride-me</a>
-      <a href="#subject">subject</a>
-      <a href="#watch">watch</a>
-      <a href="#watch-me">watch-me</a>
-    </p>
-      <!-- ======================================== -->
-    <h3 id="hubnetgroup">
-      <a>HubNet</a>
-    </h3>
-    <p>
-      <a href="#hubnet-broadcast">hubnet-broadcast</a>
-      <a href="#hubnet-broadcast-clear-output">hubnet-broadcast-clear-output</a>
-      <a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>
-      <a href="#hubnet-clear-override">hubnet-clear-override</a>
-      <a href="#hubnet-clear-override">hubnet-clear-overrides</a>
-      <a href="#hubnet-clients-list">hubnet-clients-list</a>
-      <a href="#hubnet-enter-message">hubnet-enter-message?</a>
-      <a href="#hubnet-exit-message">hubnet-exit-message?</a>
-      <a href="#hubnet-kick-all-clients">hubnet-kick-all-clients</a>
-      <a href="#hubnet-kick-client">hubnet-kick-client</a>
-      <a href="#hubnet-fetch-message">hubnet-fetch-message</a>
-      <a href="#hubnet-message">hubnet-message</a>
-      <a href="#hubnet-message-source">hubnet-message-source</a>
-      <a href="#hubnet-message-tag">hubnet-message-tag</a>
-      <a href="#hubnet-message-waiting">hubnet-message-waiting?</a>
-      <a href="#hubnet-reset">hubnet-reset</a>
-      <a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
-      <a href="#hubnet-send">hubnet-send</a>
-      <a href="#hubnet-send-clear-output">hubnet-send-clear-output</a>
-      <a href="#hubnet-send-follow">hubnet-send-follow</a>
-      <a href="#hubnet-send-message">hubnet-send-message</a>
-      <a href="#hubnet-send-override">hubnet-send-override</a>
-      <a href="#hubnet-send-watch">hubnet-send-watch</a>
-    </p>
-      <!-- ======================================== -->
-    <h3 id="iogroup">
-      Input/output
-    </h3>
-    <p>
-      <a href="#beep">beep</a>
-      <a href="#clear-output">clear-output</a>
-      <a href="#date-and-time">date-and-time</a>
-      <a href="#export-cmds">export-view</a>
-      <a href="#export-cmds">export-interface</a>
-      <a href="#export-cmds">export-output</a>
-      <a href="#export-cmds">export-plot</a>
-      <a href="#export-cmds">export-all-plots</a>
-      <a href="#export-cmds">export-world</a>
-      <a href="#import-drawing">import-drawing</a>
-      <a href="#import-pcolors">import-pcolors</a>
-      <a href="#import-pcolors-rgb">import-pcolors-rgb</a>
-      <a href="#import-world">import-world</a>
-      <a href="#mouse-down">mouse-down?</a>
-      <a href="#mouse-inside">mouse-inside?</a>
-      <a href="#mouse-cor">mouse-xcor</a>
-      <a href="#mouse-cor">mouse-ycor</a>
-      <a href="#output-cmds">output-print</a>
-      <a href="#output-cmds">output-show</a>
-      <a href="#output-cmds">output-type</a>
-      <a href="#output-cmds">output-write</a>
-      <a href="#print">print</a>
-      <a href="#read-from-string">read-from-string</a>
-      <a href="#reset-timer">reset-timer</a>
-      <a href="#set-current-directory">set-current-directory</a>
-      <a href="#show">show</a>
-      <a href="#timer">timer</a>
-      <a href="#type">type</a>
-      <a href="#user-directory">user-directory</a>
-      <a href="#user-file">user-file</a>
-      <a href="#user-new-file">user-new-file</a>
-      <a href="#user-input">user-input</a>
-      <a href="#user-message">user-message</a>
-      <a href="#user-one-of">user-one-of</a>
-      <a href="#user-yes-or-no">user-yes-or-no?</a>
-      <a href="#write">write</a>
-    </p>
-      <!-- ======================================== -->
-    <h3 id="fileiogroup">
-      File
-    </h3>
-    <p>
-      <a href="#file-at-end">file-at-end?</a>
-      <a href="#file-close">file-close</a>
-      <a href="#file-close-all">file-close-all</a>
-      <a href="#file-delete">file-delete</a>
-      <a href="#file-exists">file-exists?</a>
-      <a href="#file-flush">file-flush</a>
-      <a href="#file-open">file-open</a>
-      <a href="#file-print">file-print</a>
-      <a href="#file-read">file-read</a>
-      <a href="#file-read-characters">file-read-characters</a>
-      <a href="#file-read-line">file-read-line</a>
-      <a href="#file-show">file-show</a>
-      <a href="#file-type">file-type</a>
-      <a href="#file-write">file-write</a>
-      <a href="#user-directory">user-directory</a>
-      <a href="#user-file">user-file</a>
-      <a href="#user-new-file">user-new-file</a>
-    </p>
-      <!-- ======================================== -->
-    <h3 id="listsgroup">
-      List
-    </h3>
-    <p>
-      <a href="#but-first-and-last">but-first</a>
-      <a href="#but-first-and-last">but-last</a>
-      <a href="#empty">empty?</a>
-      <a href="#filter">filter</a>
-      <a href="#first">first</a>
-      <a href="#foreach">foreach</a>
-      <a href="#fput">fput</a>
-      <a href="#histogram">histogram</a>
-      <a href="#insert-item">insert-item</a>
-      <a href="#is-of-type">is-list?</a>
-      <a href="#item">item</a>
-      <a href="#last">last</a>
-      <a href="#length">length</a>
-      <a href="#list">list</a>
-      <a href="#lput">lput</a>
-      <a href="#map">map</a>
-      <a href="#max">max</a>
-      <a href="#member">member?</a>
-      <a href="#min">min</a>
-      <a href="#modes">modes</a>
-      <a href="#n-of">n-of</a>
-      <a href="#n-values">n-values</a>
-      <a href="#of">of</a>
-      <a href="#position">position</a>
-      <a href="#one-of">one-of</a>
-      <a href="#range">range</a>
-      <a href="#reduce">reduce</a>
-      <a href="#remove">remove</a>
-      <a href="#remove-duplicates">remove-duplicates</a>
-      <a href="#remove-item">remove-item</a>
-      <a href="#replace-item">replace-item</a>
-      <a href="#reverse">reverse</a>
-      <a href="#sentence">sentence</a>
-      <a href="#shuffle">shuffle</a>
-      <a href="#sort">sort</a>
-      <a href="#sort-by">sort-by</a>
-      <a href="#sort-on">sort-on</a>
-      <a href="#subliststring">sublist</a>
-      <a href="#up-to-n-of">up-to-n-of</a>
-    </p>
-      <!-- ======================================== -->
-    <h3 id="stringgroup">
-      String
-    </h3>
-    <p>
-      <a href="#Symbols">Operators (&lt;, &gt;, =, !=, &lt;=, &gt;=)</a>
-      <a href="#but-first-and-last">but-first</a>
-      <a href="#but-first-and-last">but-last</a>
-      <a href="#empty">empty?</a>
-      <a href="#first">first</a>
-      <a href="#insert-item">insert-item</a>
-      <a href="#is-of-type">is-string?</a>
-      <a href="#item">item</a>
-      <a href="#last">last</a>
-      <a href="#length">length</a>
-      <a href="#member">member?</a>
-      <a href="#position">position</a>
-      <a href="#remove">remove</a>
-      <a href="#remove-item">remove-item</a>
-      <a href="#read-from-string">read-from-string</a>
-      <a href="#replace-item">replace-item</a>
-      <a href="#reverse">reverse</a>
-      <a href="#subliststring">substring</a>
-      <a href="#word">word</a>
-    </p>
-      <!-- ======================================== -->
-    <h3 id="mathematicalgroup">
-      Mathematical
-    </h3>
-    <p>
-      <a href="#Symbols">Arithmetic Operators (+, *, -, /, ^, &lt;, &gt;, =, !=, &lt;=, &gt;=)</a>
-      <a href="#abs">abs</a>
-      <a href="#acos">acos</a>
-      <a href="#asin">asin</a>
-      <a href="#atan">atan</a>
-      <a href="#ceiling">ceiling</a>
-      <a href="#cos">cos</a>
-      <a href="#num-e">e</a>
-      <a href="#exp">exp</a>
-      <a href="#floor">floor</a>
-      <a href="#int">int</a>
-      <a href="#is-of-type">is-number?</a>
-      <a href="#ln">ln</a>
-      <a href="#log">log</a>
-      <a href="#max">max</a>
-      <a href="#mean">mean</a>
-      <a href="#median">median</a>
-      <a href="#min">min</a>
-      <a href="#mod">mod</a>
-      <a href="#modes">modes</a>
-      <a href="#new-seed">new-seed</a>
-      <a href="#pi">pi</a>
-      <a href="#precision">precision</a>
-      <a href="#random">random</a>
-      <a href="#random-reporters">random-exponential</a>
-      <a href="#random-float">random-float</a>
-      <a href="#random-reporters">random-gamma</a>
-      <a href="#random-reporters">random-normal</a>
-      <a href="#random-reporters">random-poisson</a>
-      <a href="#random-seed">random-seed</a>
-      <a href="#remainder">remainder</a>
-      <a href="#round">round</a>
-      <a href="#sin">sin</a>
-      <a href="#sqrt">sqrt</a>
-      <a href="#standard-deviation">standard-deviation</a>
-      <a href="#subtract-headings">subtract-headings</a>
-      <a href="#sum">sum</a>
-      <a href="#tan">tan</a>
-      <a href="#variance">variance</a>
-    </p>
-      <!-- ======================================== -->
-    <h3 id="plottinggroup">
-      Plotting
-    </h3>
-    <p>
-      <a href="#autoplot">autoplot?</a>
-      <a href="#auto-plot-status">auto-plot-off</a>
-      <a href="#auto-plot-status">auto-plot-on</a>
-      <a href="#clear-all-plots">clear-all-plots</a>
-      <a href="#clear-plot">clear-plot</a>
-      <a href="#create-temporary-plot-pen">create-temporary-plot-pen</a>
-      <a href="#export-cmds">export-plot</a>
-      <a href="#export-cmds">export-all-plots</a>
-      <a href="#histogram">histogram</a>
-      <a href="#plot">plot</a>
-      <a href="#plot-name">plot-name</a>
-      <a href="#plot-pen-exists">plot-pen-exists?</a>
-      <a href="#plot-pen-switch-status">plot-pen-down</a>
-      <a href="#plot-pen-reset">plot-pen-reset</a>
-      <a href="#plot-pen-switch-status">plot-pen-up</a>
-      <a href="#plot-cor-max-or-min">plot-x-max</a>
-      <a href="#plot-cor-max-or-min">plot-x-min</a>
-      <a href="#plot-cor-max-or-min">plot-y-max</a>
-      <a href="#plot-cor-max-or-min">plot-y-min</a>
-      <a href="#plotxy">plotxy</a>
-      <a href="#set-current-plot">set-current-plot</a>
-      <a href="#set-current-plot-pen">set-current-plot-pen</a>
-      <a href="#set-histogram-num-bars">set-histogram-num-bars</a>
-      <a href="#set-plot-background-color">set-plot-background-color</a>
-      <a href="#set-plot-pen-color">set-plot-pen-color</a>
-      <a href="#set-plot-pen-interval">set-plot-pen-interval</a>
-      <a href="#set-plot-pen-mode">set-plot-pen-mode</a>
-      <a href="#set-plot--range">set-plot-x-range</a>
-      <a href="#set-plot--range">set-plot-y-range</a>
-      <a href="#setup-plots">setup-plots</a>
-      <a href="#update-plots">update-plots</a>
-    </p>
-      <!-- ======================================== -->
-    <h3 id="behaviorspacegroup">
-      BehaviorSpace
-    </h3>
-    <p>
-      <a href="#behaviorspace-experiment-name">behaviorspace-experiment-name</a>
-      <a href="#behaviorspace-run-number">behaviorspace-run-number</a>
-    </p>
-      <!-- ======================================== -->
-    <h3 id="systemgroup">
-      System
-    </h3>
-    <p>
-      <a href="#netlogo-version">netlogo-version</a>
-      <a href="#netlogo-web">netlogo-web?</a>
-    </p>
-      <!-- ======================================== -->
-       <!-- ======================================== -->
-       <!-- ======================================== -->
-    <h2 id="builtinvariables">
-      <a>Built-In Variables</a>
-    </h2><!-- ======================================== -->
-    <div>
-      <h3 id="turtle-variables">
-        <a>Turtles</a>
-      </h3>
-      <p>
-      <a href="#breedvar">breed</a>
-      <a href="#color">color</a>
-      <a href="#heading">heading</a>
-      <a href="#hidden">hidden?</a>
-      <a href="#label">label</a>
-      <a href="#label-color">label-color</a>
-      <a href="#pen-mode">pen-mode</a>
-      <a href="#pen-size">pen-size</a>
-      <a href="#shape">shape</a>
-      <a href="#size">size</a>
-      <a href="#who">who</a>
-      <a href="#xcor">xcor</a>
-      <a href="#ycor">ycor</a>
-      </p>
-      <!-- ======================================== -->
-      <h3 id="patch-variables">
-        <a>Patches</a>
-      </h3>
-      <p>
-      <a href="#pcolor">pcolor</a>
-      <a href="#plabel">plabel</a>
-      <a href="#plabel-color">plabel-color</a>
-      <a href="#pcor">pxcor</a>
-      <a href="#pcor">pycor</a>
-      </p>
-      <!-- ======================================== -->
-      <h3 id="link-variables">
-        <a>Links</a>
-      </h3>
-      <p>
-      <a href="#breed">breed</a>
-      <a href="#color">color</a>
-      <a href="#end1">end1</a>
-      <a href="#end2">end2</a>
-      <a href="#hidden">hidden?</a>
-      <a href="#label">label</a>
-      <a href="#label-color">label-color</a>
-      <a href="#shape">shape</a>
-      <a href="#thickness">thickness</a>
-      <a href="#tie-mode">tie-mode</a>
-      </p>
-      <!-- ======================================== -->
-      <h3 id="other-variables">
-        <a>Other</a>
-      </h3>
-      <p>
-      <a href="#arrow">-&gt;</a>
-      </p>
-      <!-- ======================================== -->
-      <!-- ======================================== -->
-      <!-- ======================================== -->
-    </div>
-    <h2 id="Keywords">
-      <a>Keywords</a>
-    </h2>
-    <p>
-      <a href="#breed">breed</a>
-      <a href="#directed-link-breed">directed-link-breed</a>
-      <a href="#end">end</a>
-      <a href="#extensions">extensions</a>
-      <a href="#globals">globals</a>
-      <a href="#includes">__includes</a>
-      <a href="#links-own">links-own</a>
-      <a href="#patches-own">patches-own</a>
-      <a href="#to">to</a>
-      <a href="#to-report">to-report</a>
-      <a href="#turtles-own">turtles-own</a>
-      <a href="#undirected-link-breed">undirected-link-breed</a>
-    </p>
-      <!-- ======================================== -->
-       <!-- ======================================== -->
-       <!-- ======================================== -->
-    <h2 id="Constants">
-      <a>Constants</a>
-    </h2><!-- ======================================== -->
+	<head>
+		<title>
+			NetLogo {{version}} User Manual: NetLogo Dictionary
+		</title>
+		<link rel="stylesheet" href="netlogo.css" type="text/css"/>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+		<style>
+			p  { margin-left: 1.5em ; }
+			h3 { font-size: 115% ; }
+			h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
+		</style>
+	</head>
+	<body>
+		<h1>
+			NetLogo Dictionary
+		</h1>
+		<div class="version">
+			NetLogo {{version}} User Manual
+		</div>
+		<div class="centertext">
+			<div class="block">
+				<div class="smallfont centertext tocborder inlineblock">
+					Alphabetical:
+					<span class="bold">
+						<a href="#A">A</a>
+						<a href="#B">B</a>
+						<a href="#C">C</a>
+						<a href="#D">D</a>
+						<a href="#E">E</a>
+						<a href="#F">F</a>
+						<a href="#G">G</a>
+						<a href="#H">H</a>
+						<a href="#I">I</a>
+						<a href="#J">J</a>
+						<!--<a href="#K">K</a>-->
+						<a href="#L">L</a>
+						<a href="#M">M</a>
+						<a href="#N">N</a>
+						<a href="#O">O</a>
+						<a href="#P">P</a>
+						<!--<a href="#Q">Q</a>-->
+						<a href="#R">R</a>
+						<a href="#S">S</a>
+						<a href="#T">T</a>
+						<a href="#U">U</a>
+						<a href="#V">V</a>
+						<a href="#W">W</a>
+						<a href="#X">X</a>
+						<a href="#Y">Y</a>
+						<!--<a href="#Z">Z</a>-->
+						<a href="#ops">-></a>
+					</span>
+				</div>
+			</div>
+			<div class="block">
+				<div class="smallfont centertext tocborder inlineblock">
+					Categories: <a href="#turtlegroup">Turtle</a> - <a href="#patchgroup">Patch</a> - <a href="#linkgroup">Links</a>
+					- <a href="#agentsetgroup">Agentset</a> - <a href="#colorgroup">Color</a>
+					- <a href="#anonproceduresgroup">Anonymous Procedures</a> - <a href="#controlgroup">Control/Logic</a> - <a href="#worldgroup">World</a>
+					<br/>
+					<a href="#perspectivegroup">Perspective</a> -
+					<a href="#iogroup">Input/Output</a> - <a href="#fileiogroup">File</a> - <a href="#listsgroup">List</a> -
+					<a href="#stringgroup">String</a> - <a href="#mathematicalgroup">Math</a> - <a href="#plottinggroup">Plotting</a>
+					- <a href="#systemgroup">System</a> - <a href="#hubnetgroup">HubNet</a>
+				</div>
+			</div>
+			<div class="block">
+				<div class="smallfont centertext tocborder inlineblock">
+					Special: <a href="#builtinvariables">Variables</a> - <a href="#Keywords">Keywords</a> - <a href="#Constants">Constants</a>
+				</div>
+			</div>
+		</div>
+		<h2>
+			Categories
+		</h2>
+		<p>
+			This is an approximate grouping. Remember that a turtle-related
+			primitive might still be used by patches or the observer, and vice
+			versa. To see which agents (turtles, patches, links, observer) can
+			actually run a primitive, consult its dictionary entry.
+		</p>
+		<!-- ======================================== -->
+		<h3 id="turtlegroup">
+			Turtle-related
+		</h3>
+		<p>
+			<a href="#back">back</a> (<a href="#back">bk</a>)
+			<a href="#turtles-at"><i>&lt;breeds&gt;</i>-at</a>
+			<a href="#turtles-here"><i>&lt;breeds&gt;</i>-here</a>
+			<a href="#turtles-on"><i>&lt;breeds&gt;</i>-on</a>
+			<a href="#can-move">can-move?</a>
+			<a href="#clear-turtles">clear-turtles</a> (<a href="#clear-turtles">ct</a>)
+			<a href="#create-turtles">create-<i>&lt;breeds&gt;</i></a>
+			<a href="#create-ordered-turtles">create-ordered-<i>&lt;breeds&gt;</i></a>
+			<a href="#create-ordered-turtles">create-ordered-turtles</a> (<a href="#create-ordered-turtles">cro</a>)
+			<a href="#create-turtles">create-turtles</a> (<a href="#create-turtles">crt</a>)
+			<a href="#die">die</a>
+			<a href="#distance">distance</a>
+			<a href="#distancexy">distancexy</a>
+			<a href="#downhill">downhill</a>
+			<a href="#downhill">downhill4</a>
+			<a href="#dxy">dx</a>
+			<a href="#dxy">dy</a>
+			<a href="#face">face</a>
+			<a href="#facexy">facexy</a>
+			<a href="#forward">forward</a> (<a href="#forward">fd</a>)
+			<a href="#hatch">hatch</a>
+			<a href="#hatch">hatch-<i>&lt;breeds&gt;</i></a>
+			<a href="#hide-turtle">hide-turtle</a> (<a href="#hide-turtle">ht</a>)
+			<a href="#home">home</a>
+			<a href="#inspect">inspect</a>
+			<a href="#is-of-type">is-<i>&lt;breed&gt;</i>?</a>
+			<a href="#is-of-type">is-turtle?</a>
+			<a href="#jump">jump</a>
+			<a href="#layout-circle">layout-circle</a>
+			<a href="#left">left</a> (<a href="#left">lt</a>)
+			<a href="#move-to">move-to</a>
+			<a href="#myself">myself</a>
+			<a href="#nobody">nobody</a>
+			<a href="#no-turtles">no-turtles</a>
+			<a href="#of">of</a>
+			<a href="#other">other</a>
+			<a href="#patch-ahead">patch-ahead</a>
+			<a href="#patch-at">patch-at</a>
+			<a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>
+			<a href="#patch-here">patch-here</a>
+			<a href="#patch-lr-and-ahead">patch-left-and-ahead</a>
+			<a href="#patch-lr-and-ahead">patch-right-and-ahead</a>
+			<a href="#pen-switch-status">pen-down</a>  (<a href="#pen-switch-status">pd</a>)
+			<a href="#pen-switch-status">pen-erase</a> (<a href="#pen-switch-status">pe</a>)
+			<a href="#pen-switch-status">pen-up</a>    (<a href="#pen-switch-status">pu</a>)
+			<a href="#random-cor">random-xcor</a>
+			<a href="#random-cor">random-ycor</a>
+			<a href="#right">right</a> (<a href="#right">rt</a>)
+			<a href="#self">self</a>
+			<a href="#set-default-shape">set-default-shape</a>
+			<a href="#set-line-thickness">__set-line-thickness</a>
+			<a href="#setxy">setxy</a>
+			<a href="#shapes">shapes</a>
+			<a href="#show-turtle">show-turtle</a> (<a href="#show-turtle">st</a>)
+			<a href="#sprout">sprout</a>
+			<a href="#sprout">sprout-<i>&lt;breeds&gt;</i></a>
+			<a href="#stamp">stamp</a>
+			<a href="#stamp-erase">stamp-erase</a>
+			<a href="#stop-inspecting">stop-inspecting</a>
+			<a href="#subject">subject</a>
+			<a href="#subtract-headings">subtract-headings</a>
+			<a href="#tie">tie</a>
+			<a href="#towards">towards</a>
+			<a href="#towardsxy">towardsxy</a>
+			<a href="#turtle">turtle</a>
+			<a href="#turtle-set">turtle-set</a>
+			<a href="#turtles">turtles</a>
+			<a href="#turtles-at">turtles-at</a>
+			<a href="#turtles-here">turtles-here</a>
+			<a href="#turtles-on">turtles-on</a>
+			<a href="#turtles-own">turtles-own</a>
+			<a href="#untie">untie</a>
+			<a href="#uphill">uphill</a>
+			<a href="#uphill">uphill4</a>
+		</p>
+		<!-- ======================================== -->
+		<h3 id="patchgroup">
+			Patch-related
+		</h3>
+		<p>
+			<a href="#clear-patches">clear-patches</a> (<a href="#clear-patches">cp</a>)
+			<a href="#diffuse">diffuse</a>
+			<a href="#diffuse4">diffuse4</a>
+			<a href="#distance">distance</a>
+			<a href="#distancexy">distancexy</a>
+			<a href="#import-pcolors">import-pcolors</a>
+			<a href="#import-pcolors-rgb">import-pcolors-rgb</a>
+			<a href="#inspect">inspect</a>
+			<a href="#is-of-type">is-patch?</a>
+			<a href="#myself">myself</a>
+			<a href="#neighbors">neighbors</a>
+			<a href="#neighbors">neighbors4</a>
+			<a href="#nobody">nobody</a>
+			<a href="#no-patches">no-patches</a>
+			<a href="#of">of</a>
+			<a href="#other">other</a>
+			<a href="#patch">patch</a>
+			<a href="#patch-at">patch-at</a>
+			<a href="#patch-ahead">patch-ahead</a>
+			<a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>
+			<a href="#patch-here">patch-here</a>
+			<a href="#patch-lr-and-ahead">patch-left-and-ahead</a>
+			<a href="#patch-lr-and-ahead">patch-right-and-ahead</a>
+			<a href="#patch-set">patch-set</a>
+			<a href="#patches">patches</a>
+			<a href="#patches-own">patches-own</a>
+			<a href="#random-pcor">random-pxcor</a>
+			<a href="#random-pcor">random-pycor</a>
+			<a href="#self">self</a>
+			<a href="#sprout">sprout</a>
+			<a href="#sprout">sprout-<i>&lt;breeds&gt;</i></a>
+			<a href="#stop-inspecting">stop-inspecting</a>
+			<a href="#subject">subject</a>
+			<a href="#turtles-here">turtles-here</a>
+		</p>
+		<!-- ======================================== -->
+		<h3 id="linkgroup">
+			Link-related
+		</h3>
+		<p>
+			<a href="#both-ends">both-ends</a>
+			<a href="#clear-links">clear-links</a>
+			<a href="#create-link">create-&lt;breed&gt;-from</a>
+			<a href="#create-link">create-&lt;breeds&gt;-from</a>
+			<a href="#create-link">create-&lt;breed&gt;-to</a>
+			<a href="#create-link">create-&lt;breeds&gt;-to</a>
+			<a href="#create-link">create-&lt;breed&gt;-with</a>
+			<a href="#create-link">create-&lt;breeds&gt;-with</a>
+			<a href="#create-link">create-link-from</a>
+			<a href="#create-link">create-links-from</a>
+			<a href="#create-link">create-link-to</a>
+			<a href="#create-link">create-links-to</a>
+			<a href="#create-link">create-link-with</a>
+			<a href="#create-link">create-links-with</a>
+			<a href="#die">die</a>
+			<a href="#directed-link-breed">directed-link-breed</a>
+			<a href="#hide-link">hide-link</a>
+			<a href="#in-link-neighbor">in-&lt;breed&gt;-neighbor?</a>
+			<a href="#in-link-neighbors">in-&lt;breed&gt;-neighbors</a>
+			<a href="#in-link-from">in-&lt;breed&gt;-from</a>
+			<a href="#in-link-neighbor">in-link-neighbor?</a>
+			<a href="#in-link-neighbors">in-link-neighbors</a>
+			<a href="#in-link-from">in-link-from</a>
+			<a href="#is-of-type">is-directed-link?</a>
+			<a href="#is-of-type">is-link?</a>
+			<a href="#is-of-type">is-link-set?</a>
+			<a href="#is-of-type">is-<i>&lt;link-breed&gt;</i>?</a>
+			<a href="#is-of-type">is-undirected-link?</a>
+			<a href="#layout-radial">layout-radial</a>
+			<a href="#layout-spring">layout-spring</a>
+			<a href="#layout-tutte">layout-tutte</a>
+			<a href="#link-neighbor">&lt;breed&gt;-neighbor?</a>
+			<a href="#link-neighbors">&lt;breed&gt;-neighbors</a>
+			<a href="#link-with">&lt;breed&gt;-with</a>
+			<a href="#link-heading">link-heading</a>
+			<a href="#link-length">link-length</a>
+			<a href="#link-neighbor">link-neighbor?</a>
+			<a href="#link">link</a>
+			<a href="#links">links</a>
+			<a href="#links-own">links-own</a>
+			<a href="#links-own">&lt;link-breeds&gt;-own</a>
+			<a href="#link-neighbors">link-neighbors</a>
+			<a href="#link-with">link-with</a>
+			<a href="#my-links">my-&lt;breeds&gt;</a>
+			<a href="#my-in-links">my-in-&lt;breeds&gt;</a>
+			<a href="#my-in-links">my-in-links</a>
+			<a href="#my-links">my-links</a>
+			<a href="#my-out-links">my-out-&lt;breeds&gt;</a>
+			<a href="#my-out-links">my-out-links</a>
+			<a href="#no-links">no-links</a>
+			<a href="#other-end">other-end</a>
+			<a href="#out-link-neighbor">out-&lt;breed&gt;-neighbor?</a>
+			<a href="#out-link-neighbors">out-&lt;breed&gt;-neighbors</a>
+			<a href="#out-link-to">out-&lt;breed&gt;-to</a>
+			<a href="#out-link-neighbor">out-link-neighbor?</a>
+			<a href="#out-link-neighbors">out-link-neighbors</a>
+			<a href="#out-link-to">out-link-to</a>
+			<a href="#show-link">show-link</a>
+			<a href="#tie">tie</a>
+			<a href="#undirected-link-breed">undirected-link-breed</a>
+			<a href="#untie">untie</a>
+		</p>
+		<!-- ======================================== -->
+		<h3 id="agentsetgroup">
+			<a>Agentset</a>
+		</h3>
+		<p>
+			<a href="#all">all?</a>
+			<a href="#any">any?</a>
+			<a href="#ask">ask</a>
+			<a href="#ask-concurrent">ask-concurrent</a>
+			<a href="#at-points">at-points</a>
+			<a href="#turtles-at"><i>&lt;breeds&gt;</i>-at</a>
+			<a href="#turtles-here"><i>&lt;breeds&gt;</i>-here</a>
+			<a href="#turtles-on"><i>&lt;breeds&gt;</i>-on</a>
+			<a href="#count">count</a>
+			<a href="#in-cone">in-cone</a>
+			<a href="#in-radius">in-radius</a>
+			<a href="#is-of-type">is-agent?</a>
+			<a href="#is-of-type">is-agentset?</a>
+			<a href="#is-of-type">is-patch-set?</a>
+			<a href="#is-of-type">is-turtle-set?</a>
+			<a href="#link-set">link-set</a>
+			<a href="#max-n-of">max-n-of</a>
+			<a href="#max-one-of">max-one-of</a>
+			<a href="#member">member?</a>
+			<a href="#min-n-of">min-n-of</a>
+			<a href="#min-one-of">min-one-of</a>
+			<a href="#n-of">n-of</a>
+			<a href="#neighbors">neighbors</a>
+			<a href="#neighbors">neighbors4</a>
+			<a href="#no-links">no-links</a>
+			<a href="#no-patches">no-patches</a>
+			<a href="#no-turtles">no-turtles</a>
+			<a href="#of">of</a>
+			<a href="#one-of">one-of</a>
+			<a href="#other">other</a>
+			<a href="#patch-set">patch-set</a>
+			<a href="#patches">patches</a>
+			<a href="#sort">sort</a>
+			<a href="#sort-by">sort-by</a>
+			<a href="#sort-on">sort-on</a>
+			<a href="#turtle-set">turtle-set</a>
+			<a href="#turtles">turtles</a>
+			<a href="#turtles-at">turtles-at</a>
+			<a href="#turtles-here">turtles-here</a>
+			<a href="#turtles-on">turtles-on</a>
+			<a href="#up-to-n-of">up-to-n-of</a>
+			<a href="#with">with</a>
+			<a href="#with-max">with-max</a>
+			<a href="#with-min">with-min</a>
+		</p>
+		<!-- ======================================== -->
+		<h3 id="colorgroup">
+			Color
+		</h3>
+		<p>
+			<a href="#approximate-hsb">approximate-hsb</a>
+			<a href="#approximate-rgb">approximate-rgb</a>
+			<a href="#base-colors">base-colors</a>
+			<a href="#color">color</a>
+			<a href="#extract-hsb">extract-hsb</a>
+			<a href="#extract-rgb">extract-rgb</a>
+			<a href="#hsb">hsb</a>
+			<a href="#import-pcolors">import-pcolors</a>
+			<a href="#import-pcolors-rgb">import-pcolors-rgb</a>
+			<a href="#pcolor">pcolor</a>
+			<a href="#rgb">rgb</a>
+			<a href="#scale-color">scale-color</a>
+			<a href="#shade-of">shade-of?</a>
+			<a href="#wrap-color">wrap-color</a>
+		</p>
+		<!-- ======================================== -->
+		<h3 id="controlgroup">
+			Control flow and logic
+		</h3>
+		<p>
+			<a href="#and">and</a>
+			<a href="#ask">ask</a>
+			<a href="#ask-concurrent">ask-concurrent</a>
+			<a href="#carefully">carefully</a>
+			<a href="#end">end</a>
+			<a href="#error">error</a>
+			<a href="#error-message">error-message</a>
+			<a href="#every">every</a>
+			<a href="#if">if</a>
+			<a href="#ifelse">ifelse</a>
+			<a href="#ifelse-value">ifelse-value</a>
+			<a href="#let">let</a>
+			<a href="#loop">loop</a>
+			<a href="#not">not</a>
+			<a href="#or">or</a>
+			<a href="#repeat">repeat</a>
+			<a href="#report">report</a>
+			<a href="#run">run</a>
+			<a href="#run">runresult</a>
+			<a href="#semicolon">; (semicolon)</a>
+			<a href="#set">set</a>
+			<a href="#stop">stop</a>
+			<a href="#startup">startup</a>
+			<a href="#to">to</a>
+			<a href="#to-report">to-report</a>
+			<a href="#wait">wait</a>
+			<a href="#while">while</a>
+			<a href="#with-local-randomness">with-local-randomness</a>
+			<a href="#without-interruption">without-interruption</a>
+			<a href="#xor">xor</a>
+		</p>
+		<!-- ======================================== -->
+		<h3 id="anonproceduresgroup">
+			Anonymous Procedures
+		</h3>
+		<p>
+			<a href="#arrow">-&gt; (anonymous procedure)</a>
+			<a href="#filter">filter</a>
+			<a href="#foreach">foreach</a>
+			<a href="#is-of-type">is-anonymous-command?</a>
+			<a href="#is-of-type">is-anonymous-reporter?</a>
+			<a href="#map">map</a>
+			<a href="#n-values">n-values</a>
+			<a href="#reduce">reduce</a>
+			<a href="#run">run</a>
+			<a href="#run">runresult</a>
+			<a href="#sort-by">sort-by</a>
+		</p>
+		<!-- ======================================== -->
+		<h3 id="worldgroup">
+			World
+		</h3>
+		<p>
+			<a href="#clear-all">clear-all</a> (<a href="#clear-all">ca</a>)
+			<a href="#clear-drawing">clear-drawing</a> (<a href="#clear-drawing">cd</a>)
+			<a href="#clear-globals">clear-globals</a>
+			<a href="#clear-patches">clear-patches</a> (<a href="#clear-patches">cp</a>)
+			<a href="#clear-ticks">clear-ticks</a>
+			<a href="#clear-turtles">clear-turtles</a> (<a href="#clear-turtles">ct</a>)
+			<a href="#display">display</a>
+			<a href="#import-drawing">import-drawing</a>
+			<a href="#import-pcolors">import-pcolors</a>
+			<a href="#import-pcolors-rgb">import-pcolors-rgb</a>
+			<a href="#no-display">no-display</a>
+			<a href="#max-pcor">max-pxcor</a>
+			<a href="#max-pcor">max-pycor</a>
+			<a href="#min-pcor">min-pxcor</a>
+			<a href="#min-pcor">min-pycor</a>
+			<a href="#patch-size">patch-size</a>
+			<a href="#reset-ticks">reset-ticks</a>
+			<a href="#resize-world">resize-world</a>
+			<a href="#set-patch-size">set-patch-size</a>
+			<a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>
+			<a href="#tick">tick</a>
+			<a href="#tick-advance">tick-advance</a>
+			<a href="#ticks">ticks</a>
+			<a href="#world-dim">world-width</a>
+			<a href="#world-dim">world-height</a>
+		</p>
+		<!-- ======================================== -->
+		<h3 id="perspectivegroup">
+			Perspective
+		</h3>
+		<p>
+			<a href="#follow">follow</a>
+			<a href="#follow-me">follow-me</a>
+			<a href="#reset-perspective">reset-perspective</a> (<a href="#reset-perspective">rp</a>)
+			<a href="#ride">ride</a>
+			<a href="#ride-me">ride-me</a>
+			<a href="#subject">subject</a>
+			<a href="#watch">watch</a>
+			<a href="#watch-me">watch-me</a>
+		</p>
+		<!-- ======================================== -->
+		<h3 id="hubnetgroup">
+			<a>HubNet</a>
+		</h3>
+		<p>
+			<a href="#hubnet-broadcast">hubnet-broadcast</a>
+			<a href="#hubnet-broadcast-clear-output">hubnet-broadcast-clear-output</a>
+			<a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>
+			<a href="#hubnet-clear-override">hubnet-clear-override</a>
+			<a href="#hubnet-clear-override">hubnet-clear-overrides</a>
+			<a href="#hubnet-clients-list">hubnet-clients-list</a>
+			<a href="#hubnet-enter-message">hubnet-enter-message?</a>
+			<a href="#hubnet-exit-message">hubnet-exit-message?</a>
+			<a href="#hubnet-kick-all-clients">hubnet-kick-all-clients</a>
+			<a href="#hubnet-kick-client">hubnet-kick-client</a>
+			<a href="#hubnet-fetch-message">hubnet-fetch-message</a>
+			<a href="#hubnet-message">hubnet-message</a>
+			<a href="#hubnet-message-source">hubnet-message-source</a>
+			<a href="#hubnet-message-tag">hubnet-message-tag</a>
+			<a href="#hubnet-message-waiting">hubnet-message-waiting?</a>
+			<a href="#hubnet-reset">hubnet-reset</a>
+			<a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
+			<a href="#hubnet-send">hubnet-send</a>
+			<a href="#hubnet-send-clear-output">hubnet-send-clear-output</a>
+			<a href="#hubnet-send-follow">hubnet-send-follow</a>
+			<a href="#hubnet-send-message">hubnet-send-message</a>
+			<a href="#hubnet-send-override">hubnet-send-override</a>
+			<a href="#hubnet-send-watch">hubnet-send-watch</a>
+		</p>
+		<!-- ======================================== -->
+		<h3 id="iogroup">
+			Input/output
+		</h3>
+		<p>
+			<a href="#beep">beep</a>
+			<a href="#clear-output">clear-output</a>
+			<a href="#date-and-time">date-and-time</a>
+			<a href="#export-cmds">export-view</a>
+			<a href="#export-cmds">export-interface</a>
+			<a href="#export-cmds">export-output</a>
+			<a href="#export-cmds">export-plot</a>
+			<a href="#export-cmds">export-all-plots</a>
+			<a href="#export-cmds">export-world</a>
+			<a href="#import-drawing">import-drawing</a>
+			<a href="#import-pcolors">import-pcolors</a>
+			<a href="#import-pcolors-rgb">import-pcolors-rgb</a>
+			<a href="#import-world">import-world</a>
+			<a href="#mouse-down">mouse-down?</a>
+			<a href="#mouse-inside">mouse-inside?</a>
+			<a href="#mouse-cor">mouse-xcor</a>
+			<a href="#mouse-cor">mouse-ycor</a>
+			<a href="#output-cmds">output-print</a>
+			<a href="#output-cmds">output-show</a>
+			<a href="#output-cmds">output-type</a>
+			<a href="#output-cmds">output-write</a>
+			<a href="#print">print</a>
+			<a href="#read-from-string">read-from-string</a>
+			<a href="#reset-timer">reset-timer</a>
+			<a href="#set-current-directory">set-current-directory</a>
+			<a href="#show">show</a>
+			<a href="#timer">timer</a>
+			<a href="#type">type</a>
+			<a href="#user-directory">user-directory</a>
+			<a href="#user-file">user-file</a>
+			<a href="#user-new-file">user-new-file</a>
+			<a href="#user-input">user-input</a>
+			<a href="#user-message">user-message</a>
+			<a href="#user-one-of">user-one-of</a>
+			<a href="#user-yes-or-no">user-yes-or-no?</a>
+			<a href="#write">write</a>
+		</p>
+		<!-- ======================================== -->
+		<h3 id="fileiogroup">
+			File
+		</h3>
+		<p>
+			<a href="#file-at-end">file-at-end?</a>
+			<a href="#file-close">file-close</a>
+			<a href="#file-close-all">file-close-all</a>
+			<a href="#file-delete">file-delete</a>
+			<a href="#file-exists">file-exists?</a>
+			<a href="#file-flush">file-flush</a>
+			<a href="#file-open">file-open</a>
+			<a href="#file-print">file-print</a>
+			<a href="#file-read">file-read</a>
+			<a href="#file-read-characters">file-read-characters</a>
+			<a href="#file-read-line">file-read-line</a>
+			<a href="#file-show">file-show</a>
+			<a href="#file-type">file-type</a>
+			<a href="#file-write">file-write</a>
+			<a href="#user-directory">user-directory</a>
+			<a href="#user-file">user-file</a>
+			<a href="#user-new-file">user-new-file</a>
+		</p>
+		<!-- ======================================== -->
+		<h3 id="listsgroup">
+			List
+		</h3>
+		<p>
+			<a href="#but-first-and-last">but-first</a>
+			<a href="#but-first-and-last">but-last</a>
+			<a href="#empty">empty?</a>
+			<a href="#filter">filter</a>
+			<a href="#first">first</a>
+			<a href="#foreach">foreach</a>
+			<a href="#fput">fput</a>
+			<a href="#histogram">histogram</a>
+			<a href="#insert-item">insert-item</a>
+			<a href="#is-of-type">is-list?</a>
+			<a href="#item">item</a>
+			<a href="#last">last</a>
+			<a href="#length">length</a>
+			<a href="#list">list</a>
+			<a href="#lput">lput</a>
+			<a href="#map">map</a>
+			<a href="#max">max</a>
+			<a href="#member">member?</a>
+			<a href="#min">min</a>
+			<a href="#modes">modes</a>
+			<a href="#n-of">n-of</a>
+			<a href="#n-values">n-values</a>
+			<a href="#of">of</a>
+			<a href="#position">position</a>
+			<a href="#one-of">one-of</a>
+			<a href="#range">range</a>
+			<a href="#reduce">reduce</a>
+			<a href="#remove">remove</a>
+			<a href="#remove-duplicates">remove-duplicates</a>
+			<a href="#remove-item">remove-item</a>
+			<a href="#replace-item">replace-item</a>
+			<a href="#reverse">reverse</a>
+			<a href="#sentence">sentence</a>
+			<a href="#shuffle">shuffle</a>
+			<a href="#sort">sort</a>
+			<a href="#sort-by">sort-by</a>
+			<a href="#sort-on">sort-on</a>
+			<a href="#subliststring">sublist</a>
+			<a href="#up-to-n-of">up-to-n-of</a>
+		</p>
+		<!-- ======================================== -->
+		<h3 id="stringgroup">
+			String
+		</h3>
+		<p>
+			<a href="#Symbols">Operators (&lt;, &gt;, =, !=, &lt;=, &gt;=)</a>
+			<a href="#but-first-and-last">but-first</a>
+			<a href="#but-first-and-last">but-last</a>
+			<a href="#empty">empty?</a>
+			<a href="#first">first</a>
+			<a href="#insert-item">insert-item</a>
+			<a href="#is-of-type">is-string?</a>
+			<a href="#item">item</a>
+			<a href="#last">last</a>
+			<a href="#length">length</a>
+			<a href="#member">member?</a>
+			<a href="#position">position</a>
+			<a href="#remove">remove</a>
+			<a href="#remove-item">remove-item</a>
+			<a href="#read-from-string">read-from-string</a>
+			<a href="#replace-item">replace-item</a>
+			<a href="#reverse">reverse</a>
+			<a href="#subliststring">substring</a>
+			<a href="#word">word</a>
+		</p>
+		<!-- ======================================== -->
+		<h3 id="mathematicalgroup">
+			Mathematical
+		</h3>
+		<p>
+			<a href="#Symbols">Arithmetic Operators (+, *, -, /, ^, &lt;, &gt;, =, !=, &lt;=, &gt;=)</a>
+			<a href="#abs">abs</a>
+			<a href="#acos">acos</a>
+			<a href="#asin">asin</a>
+			<a href="#atan">atan</a>
+			<a href="#ceiling">ceiling</a>
+			<a href="#cos">cos</a>
+			<a href="#num-e">e</a>
+			<a href="#exp">exp</a>
+			<a href="#floor">floor</a>
+			<a href="#int">int</a>
+			<a href="#is-of-type">is-number?</a>
+			<a href="#ln">ln</a>
+			<a href="#log">log</a>
+			<a href="#max">max</a>
+			<a href="#mean">mean</a>
+			<a href="#median">median</a>
+			<a href="#min">min</a>
+			<a href="#mod">mod</a>
+			<a href="#modes">modes</a>
+			<a href="#new-seed">new-seed</a>
+			<a href="#pi">pi</a>
+			<a href="#precision">precision</a>
+			<a href="#random">random</a>
+			<a href="#random-reporters">random-exponential</a>
+			<a href="#random-float">random-float</a>
+			<a href="#random-reporters">random-gamma</a>
+			<a href="#random-reporters">random-normal</a>
+			<a href="#random-reporters">random-poisson</a>
+			<a href="#random-seed">random-seed</a>
+			<a href="#remainder">remainder</a>
+			<a href="#round">round</a>
+			<a href="#sin">sin</a>
+			<a href="#sqrt">sqrt</a>
+			<a href="#standard-deviation">standard-deviation</a>
+			<a href="#subtract-headings">subtract-headings</a>
+			<a href="#sum">sum</a>
+			<a href="#tan">tan</a>
+			<a href="#variance">variance</a>
+		</p>
+		<!-- ======================================== -->
+		<h3 id="plottinggroup">
+			Plotting
+		</h3>
+		<p>
+			<a href="#autoplot">autoplot?</a>
+			<a href="#auto-plot-status">auto-plot-off</a>
+			<a href="#auto-plot-status">auto-plot-on</a>
+			<a href="#clear-all-plots">clear-all-plots</a>
+			<a href="#clear-plot">clear-plot</a>
+			<a href="#create-temporary-plot-pen">create-temporary-plot-pen</a>
+			<a href="#export-cmds">export-plot</a>
+			<a href="#export-cmds">export-all-plots</a>
+			<a href="#histogram">histogram</a>
+			<a href="#plot">plot</a>
+			<a href="#plot-name">plot-name</a>
+			<a href="#plot-pen-exists">plot-pen-exists?</a>
+			<a href="#plot-pen-switch-status">plot-pen-down</a>
+			<a href="#plot-pen-reset">plot-pen-reset</a>
+			<a href="#plot-pen-switch-status">plot-pen-up</a>
+			<a href="#plot-cor-max-or-min">plot-x-max</a>
+			<a href="#plot-cor-max-or-min">plot-x-min</a>
+			<a href="#plot-cor-max-or-min">plot-y-max</a>
+			<a href="#plot-cor-max-or-min">plot-y-min</a>
+			<a href="#plotxy">plotxy</a>
+			<a href="#set-current-plot">set-current-plot</a>
+			<a href="#set-current-plot-pen">set-current-plot-pen</a>
+			<a href="#set-histogram-num-bars">set-histogram-num-bars</a>
+			<a href="#set-plot-background-color">set-plot-background-color</a>
+			<a href="#set-plot-pen-color">set-plot-pen-color</a>
+			<a href="#set-plot-pen-interval">set-plot-pen-interval</a>
+			<a href="#set-plot-pen-mode">set-plot-pen-mode</a>
+			<a href="#set-plot--range">set-plot-x-range</a>
+			<a href="#set-plot--range">set-plot-y-range</a>
+			<a href="#setup-plots">setup-plots</a>
+			<a href="#update-plots">update-plots</a>
+		</p>
+		<!-- ======================================== -->
+		<h3 id="behaviorspacegroup">
+			BehaviorSpace
+		</h3>
+		<p>
+			<a href="#behaviorspace-experiment-name">behaviorspace-experiment-name</a>
+			<a href="#behaviorspace-run-number">behaviorspace-run-number</a>
+		</p>
+		<!-- ======================================== -->
+		<h3 id="systemgroup">
+			System
+		</h3>
+		<p>
+			<a href="#netlogo-version">netlogo-version</a>
+			<a href="#netlogo-web">netlogo-web?</a>
+		</p>
+		<!-- ======================================== -->
+		<!-- ======================================== -->
+		<!-- ======================================== -->
+		<h2 id="builtinvariables">
+			<a>Built-In Variables</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<h3 id="turtle-variables">
+				<a>Turtles</a>
+			</h3>
+			<p>
+				<a href="#breedvar">breed</a>
+				<a href="#color">color</a>
+				<a href="#heading">heading</a>
+				<a href="#hidden">hidden?</a>
+				<a href="#label">label</a>
+				<a href="#label-color">label-color</a>
+				<a href="#pen-mode">pen-mode</a>
+				<a href="#pen-size">pen-size</a>
+				<a href="#shape">shape</a>
+				<a href="#size">size</a>
+				<a href="#who">who</a>
+				<a href="#xcor">xcor</a>
+				<a href="#ycor">ycor</a>
+			</p>
+			<!-- ======================================== -->
+			<h3 id="patch-variables">
+				<a>Patches</a>
+			</h3>
+			<p>
+				<a href="#pcolor">pcolor</a>
+				<a href="#plabel">plabel</a>
+				<a href="#plabel-color">plabel-color</a>
+				<a href="#pcor">pxcor</a>
+				<a href="#pcor">pycor</a>
+			</p>
+			<!-- ======================================== -->
+			<h3 id="link-variables">
+				<a>Links</a>
+			</h3>
+			<p>
+				<a href="#breed">breed</a>
+				<a href="#color">color</a>
+				<a href="#end1">end1</a>
+				<a href="#end2">end2</a>
+				<a href="#hidden">hidden?</a>
+				<a href="#label">label</a>
+				<a href="#label-color">label-color</a>
+				<a href="#shape">shape</a>
+				<a href="#thickness">thickness</a>
+				<a href="#tie-mode">tie-mode</a>
+			</p>
+			<!-- ======================================== -->
+			<h3 id="other-variables">
+				<a>Other</a>
+			</h3>
+			<p>
+				<a href="#arrow">-&gt;</a>
+			</p>
+			<!-- ======================================== -->
+			<!-- ======================================== -->
+			<!-- ======================================== -->
+		</div>
+		<h2 id="Keywords">
+			<a>Keywords</a>
+		</h2>
+		<p>
+			<a href="#breed">breed</a>
+			<a href="#directed-link-breed">directed-link-breed</a>
+			<a href="#end">end</a>
+			<a href="#extensions">extensions</a>
+			<a href="#globals">globals</a>
+			<a href="#includes">__includes</a>
+			<a href="#links-own">links-own</a>
+			<a href="#patches-own">patches-own</a>
+			<a href="#to">to</a>
+			<a href="#to-report">to-report</a>
+			<a href="#turtles-own">turtles-own</a>
+			<a href="#undirected-link-breed">undirected-link-breed</a>
+		</p>
+		<!-- ======================================== -->
+		<!-- ======================================== -->
+		<!-- ======================================== -->
+		<h2 id="Constants">
+			<a>Constants</a>
+		</h2><!-- ======================================== -->
 		<div class="dict_entry" id="mathconstants" data-constants="e pi">
 			<h3>
 				Mathematical Constants
 			</h3>
 			<p>
-			<b id="num-e"><a>e</a></b> = 2.718281828459045
-			<br>
-			<b id="pi"><a>pi</a></b> = 3.141592653589793
+				<b id="num-e"><a>e</a></b> = 2.718281828459045
+				<br/>
+				<b id="pi"><a>pi</a></b> = 3.141592653589793
 			</p>
 		</div><!-- ======================================== -->
 		<div class="dict_entry" id="boolconstants" data-constants="false true">
@@ -799,9 +799,9 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
 				<a>Boolean Constants</a>
 			</h3>
 			<p id="false_true">
-			<b><a>false</a></b>
-			<br>
-			<b><a>true</a></b>
+				<b><a>false</a></b>
+				<br/>
+				<b><a>true</a></b>
 			</p>
 		</div><!-- ======================================== -->
 		<div class="dict_entry" id="colorconstants" data-constants="black gray white red orange brown yellow green lime turquoise cyan sky blue violet magenta pink">
@@ -809,9189 +809,9200 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
 				<a>Color Constants</a>
 			</h3>
 			<p>
-			<b>black</b> = 0
-			<br>
-			<b>gray</b> = 5
-			<br>
-			<b>white</b> = 9.9
-			<br>
-			<b>red</b> = 15
-			<br>
-			<b>orange</b> = 25
-			<br>
-			<b>brown</b> = 35
-			<br>
-			<b>yellow</b> = 45
-			<br>
-			<b>green</b> = 55
-			<br>
-			<b>lime</b> = 65
-			<br>
-			<b>turquoise</b> = 75
-			<br>
-			<b>cyan</b> = 85
-			<br>
-			<b>sky</b> = 95
-			<br>
-			<b>blue</b> = 105
-			<br>
-			<b>violet</b> = 115
-			<br>
-			<b>magenta</b> = 125
-			<br>
-			<b>pink</b> = 135
+				<b>black</b> = 0
+				<br/>
+				<b>gray</b> = 5
+				<br/>
+				<b>white</b> = 9.9
+				<br/>
+				<b>red</b> = 15
+				<br/>
+				<b>orange</b> = 25
+				<br/>
+				<b>brown</b> = 35
+				<br/>
+				<b>yellow</b> = 45
+				<br/>
+				<b>green</b> = 55
+				<br/>
+				<b>lime</b> = 65
+				<br/>
+				<b>turquoise</b> = 75
+				<br/>
+				<b>cyan</b> = 85
+				<br/>
+				<b>sky</b> = 95
+				<br/>
+				<b>blue</b> = 105
+				<br/>
+				<b>violet</b> = 115
+				<br/>
+				<b>magenta</b> = 125
+				<br/>
+				<b>pink</b> = 135
 			</p>
 			<p>
-			See the <a href="programming.html#colors">Colors</a> section of the
-			Programming Guide for more details.
+				See the <a href="programming.html#colors">Colors</a> section of the
+				Programming Guide for more details.
 			</p>
 		</div><!-- ======================================== -->
 		<!-- ======================================== -->
 		<!-- ======================================== -->
 		<!-- ======================================== -->
-    <h2 id="A">
-      <a>A</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="abs">
-      <h3>
-        <a>abs<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">abs <i>number</i></span>
-      </h4>
-      <p>
-        Reports the absolute value of <i>number</i>.
-      </p>
-      <pre>
-show abs -7
-=&gt; 7
-show abs 5
-=&gt; 5
-</pre>
-    </div>
-    <div class="dict_entry" id="acos">
-      <h3>
-        <a>acos<span class="since">1.3</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">acos <i>number</i></span>
-      </h4>
-      <p>
-        Reports the arc cosine (inverse cosine) of the given number. The
-        input must be in the range -1 to 1. The result is in degrees, and
-        lies in the range 0 to 180.
-      </p>
-      </div>
-    <div class="dict_entry" id="all">
-      <h3>
-        <a>all?<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">all? <i>agentset</i> [<i>reporter</i>]</span>
-      </h4>
-      <p>
-        Reports true if all of the agents in the agentset report true for
-        the given reporter. Otherwise reports false as soon as a
-        counterexample is found.
-      </p>
-      <p>
-        If the agentset is empty, reports true.
-      <p>
-        The reporter must report a boolean value for every agent (either
-        true or false), otherwise an error occurs.
-      </p>
-      <pre>
-if all? turtles [color = red]
-  [ show &quot;every turtle is red!&quot; ]
-</pre>
-      <p>
-        See also <a href="#any">any?</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="and">
-      <h3>
-        <a>and<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example"><i>condition1</i> and <i>condition2</i></span>
-      </h4>
-      <p>
-        Reports true if both <i>condition1</i> and <i>condition2</i> are
-        true.
-      </p>
-      <p>
-        Note that if <i>condition1</i> is false, then <i>condition2</i>
-        will not be run (since it can't affect the result).
-      </p>
-      <pre>
-if (pxcor &gt; 0) and (pycor &gt; 0)
-  [ set pcolor blue ]  ;; the upper-right quadrant of
-                       ;; patches turn blue
-</pre>
-    </div>
-    <div class="dict_entry" id="any">
-      <h3>
-        <a>any?<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">any? <i>agentset</i></span>
-      </h4>
-      <p>
-        Reports true if the given agentset is non-empty, false otherwise.
-      </p>
-      <p>
-        Equivalent to &quot;count <i>agentset</i> &gt; 0&quot;, but more
-        efficient (and arguably more readable).
-      </p>
-      <pre>
-if any? turtles with [color = red]
-  [ show &quot;at least one turtle is red!&quot; ]
-</pre>
-      <p>
-        Note: nobody is not an agentset. You only get nobody back in
-        situations where you were expecting a single agent, not a whole
-        agentset. If any? gets nobody as input, an error results.
-      </p>
-      <p>
-        See also <a href="#all">all?</a>, <a href="#nobody">nobody</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="approximate-hsb">
-      <h3>
-        <a>approximate-hsb<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">approximate-hsb <i>hue saturation brightness</i></span>
-      </h4>
-      <p>
-        Reports a number in the range 0 to 140, not including 140 itself,
-        that represents the given color, specified in the HSB spectrum, in
-        NetLogo's color space.
-      </p>
-      <p>
-        The first value (hue) should be in the range of 0 to 360, the second
-        and third (saturation and brightness) in the range between 0 and 100.
-      </p>
-      <p>
-        The color reported may be only an approximation, since the NetLogo
-        color space does not include all possible colors.
-      </p>
-      <pre>
-show approximate-hsb 0 0 0
-=&gt; 0  ;; (black)
-show approximate-hsb 180 57.143 76.863
-=&gt; 85 ;; (cyan)
-</pre>
-      <p>
-        See also <a href="#extract-hsb">extract-hsb</a>, <a href="#approximate-rgb">approximate-rgb</a>, <a href="#extract-rgb">extract-rgb</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="approximate-rgb">
-      <h3>
-        <a>approximate-rgb<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">approximate-rgb <i>red green blue</i></span>
-      </h4>
-      <p>
-        Reports a number in the range 0 to 140, not including 140 itself,
-        that represents the given color, specified in the RGB spectrum, in
-        NetLogo's color space.
-      </p>
-      <p>
-        All three inputs should be in the range 0 to 255.
-      </p>
-      <p>
-        The color reported may be only an approximation, since the NetLogo
-        color space does not include all possible colors. (See <a href="#approximate-hsb">approximate-hsb</a> for a description of what
-        parts of the HSB color space NetLogo colors cover; this is
-        difficult to characterize in RGB terms.)
-      </p>
-      <pre>
-show approximate-rgb 0 0 0
-=&gt; 0  ;; black
-show approximate-rgb 0 255 255
-=&gt; 85.2 ;; cyan
-</pre>
-      <p>
-        See also <a href="#extract-rgb">extract-rgb</a>, <a href="#approximate-hsb">approximate-hsb</a>, and <a href="#extract-hsb">extract-hsb</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="Symbols">
-      <h3>
-        <a>Arithmetic Operators</a>
-        <a>+<span class="since">1.0</span></a>
-        <a>*<span class="since">1.0</span></a>
-        <a>-<span class="since">1.0</span></a>
-        <a>/<span class="since">1.0</span></a>
-        <a>^<span class="since">1.0</span></a>
-        <a>&lt;<span class="since">1.0</span></a>
-        <a>&gt;<span class="since">1.0</span></a>
-        <a>=<span class="since">1.0</span></a>
-        <a>!=<span class="since">1.0</span></a>
-        <a>&lt;=<span class="since">1.0</span></a>
-        <a>&gt;=<span class="since">1.0</span></a>
-      </h3>
-      <p>
-        All of these operators take two inputs, and all act as &quot;infix
-        operators&quot; (going between the two inputs, as in standard
-        mathematical use). NetLogo correctly supports order of operations
-        for infix operators.
-      </p>
-      <p>
-        The operators work as follows: + is addition, * is multiplication,
-        - is subtraction, / is division, ^ is exponentiation, &lt; is less
-        than, &gt; is greater than, = is equal to, != is not equal to,
-        &lt;= is less than or equal, &gt;= is greater than or equal.
-      </p>
-      <p>
-        Note that the subtraction operator (-) always takes two inputs
-        unless you put parentheses around it, in which case it can take one
-        input. For example, to take the negative of x, write (- x), with
-        the parentheses.
-      </p>
-      <p>
-        All of the comparison operators also work on strings.
-      </p>
-      <p>
-        All of the comparison operators work on agents. Turtles are
-        compared by who number. Patches are compared top to bottom left to
-        right, so patch 0 10 is less than patch 0 9 and patch 9 0 is less
-        than patch 10 0. Links are ordered by end points and in case of a
-        tie by breed. So link 0 9 is before link 1 10 as the end1 is
-        smaller, and link 0 8 is less than link 0 9. If there are multiple
-        breeds of links unbreeded links will come before breeded links of
-        the same end points and breeded links will be sorted in the order
-        they are declared in the Code tab.
-      </p>
-      <p>
-        Agentsets can be tested for equality or inequality. Two agentsets
-        are equal if they are the same type (turtle or patch) and contain
-        the same agents.
-      </p>
-      <p>
-        If you are not sure how NetLogo will interpret your code, you
-        should add parentheses.
-      </p>
-      <pre>
-show 5 * 6 + 6 / 3
-=&gt; 32
-show 5 * (6 + 6) / 3
-=&gt; 20
-</pre>
-      <p>
-        Many extension objects may be tested for equality and inequality
-        using = and !=.
-        For instance, the array, matrix, and table objects returned by their
-        respective extensions may be compared for equality / inequality.
-        Extension objects may not be tested using &lt;, &gt;, &lt;=, or &gt;=.
-      </p>
-    </div>
-    <div class="dict_entry" id="asin">
-      <h3>
-        <a>asin<span class="since">1.3</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">asin <i>number</i></span>
-      </h4>
-      <p>
-        Reports the arc sine (inverse sine) of the given number. The input
-        must be in the range -1 to 1. The result is in degrees, and lies in
-        the range -90 to 90.
-      </p>
-      </div>
-    <div class="dict_entry" id="ask">
-      <h3>
-        <a>ask<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">ask <i>agentset</i> [<i>commands</i>]</span>
-        <span class="prim_example">ask <i>agent</i> [<i>commands</i>]</span>
-      </h4>
-      <p>
-        The specified agent or agentset runs the given commands.  Because
-        agentset members are always read in a random order, when ask is
-        used with an agentset each agent will take its turn in a random
-        order.  See <a href="programming.html#agentsets">Agentsets</a>
-        for more information.
-      </p>
-      <pre>
-ask turtles [ fd 1 ]
-  ;; all turtles move forward one step
-ask patches [ set pcolor red ]
-  ;; all patches turn red
-ask turtle 4 [ rt 90 ]
-  ;; only the turtle with id 4 turns right
-</pre>
-      <p>
-        Note: only the observer can ask all turtles or all patches. This
-        prevents you from inadvertently having all turtles ask all turtles
-        or all patches ask all patches, which is a common mistake to make
-        if you're not careful about which agents will run the code you
-        are writing.
-      </p>
-      <p>
-        Note: Only the agents that are in the agentset <i>at the time the
-        ask begins</i> run the commands.
-      </p>
-      </div>
-    <div class="dict_entry" id="ask-concurrent">
-      <h3>
-        <a>ask-concurrent<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">ask-concurrent <i>agentset</i> [<i>commands</i>]</span>
-      </h4>
-      <p>
-        This primitive exists only for backwards compatibility. We
-        don't recommend using it new models.
-      </p>
-      <p>
-        The agents in the given agentset run the given commands, using a
-        turn-taking mechanism to produce simulated concurrency. See the
-        <a href="programming.html#ask-concurrent">Ask-Concurrent</a>
-        section of the Programming Guide for details on how this works.
-      </p>
-      <p>
-        Note: Only the agents that are in the agentset <i>at the time the
-        ask begins</i> run the commands.
-      </p>
-      <p>
-        See also <a href="#without-interruption">without-interruption</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="at-points">
-      <h3>
-        <a>at-points<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example"><i>agentset</i> at-points [[<i>x1 y1</i>] [<i>x2 y2</i>] ...]</span>
-      </h4>
-      <p>
-        Reports a subset of the given agentset that includes only the
-        agents on the patches at the given coordinates (relative to this
-        agent). The coordinates are specified as a list of two-item lists,
-        where the two items are the x and y offsets.
-      </p>
-      <p>
-        If the caller is the observer, then the points are measured
-        relative to the origin, in other words, the points are taken as
-        absolute patch coordinates.
-      </p>
-      <p>
-        If the caller is a turtle, the points are measured relative to the
-        turtle's exact location, and not from the center of the patch
-        under the turtle.
-      </p>
-      <pre>
-ask turtles at-points [[2 4] [1 2] [10 15]]
-  [ fd 1 ]  ;; only the turtles on the patches at the
-            ;; coordinates (2,4), (1,2) and (10,15),
-            ;; relative to the caller, move
-</pre>
-    </div>
-    <div class="dict_entry" id="atan">
-      <h3>
-        <a>atan<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">atan <i>x y</i></span>
-      </h4>
-      <p>
-        Converts x and y offsets to a turtle heading in degrees (from 0 to
-        360).
-      </p>
-      <p>
-        Note that this version of atan is designed to conform to the
-        geometry of the NetLogo world, where a heading of 0 is straight up,
-        90 is to the right, and so on clockwise around the circle.
-        (Normally in geometry an angle of 0 is right, 90 is up, and so on,
-        counterclockwise around the circle, and atan would be defined
-        accordingly.)
-      </p>
-      <p>
-        When y is 0: if x is positive, it reports 90; if x is negative, it
-        reports 270; if x is zero, you get an error.
-      </p>
-      <pre>
-show atan 1 -1
-=&gt; 135
-show atan -1 1
-=&gt; 315
-crt 1 [ set heading 30  fd 1  print atan xcor ycor ]
-=&gt; 30
-</pre>
-      <p>
-        In the final example, note that the result of <code>atan</code> equals
-        the turtle's heading.
-      </p>
-      <p>
-        If you ever need to convert a turtle heading (obtained with atan or
-        otherwise) to a normal mathematical angle, the following should be
-        helpful:
-      </p>
-      <pre>
-to-report heading-to-angle [ h ]
-  report (90 - h) mod 360
-end
-</pre>
-    </div>
-    <div class="dict_entry" id="autoplot">
-      <h3>
-        <a>autoplot?<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">autoplot?</span>
-      </h4>
-      <p>
-        Reports true if auto-plotting is on for the current plot, false
-        otherwise.
-      </p>
-      </div>
-    <div class="dict_entry" id="auto-plot-status">
-      <h3>
-        <a>auto-plot-off<span class="since">1.0</span></a>
-        <a>auto-plot-on<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">auto-plot-off</span>
-        <span class="prim_example">auto-plot-on</span>
-      </h4>
-      <p>
-        This pair of commands is used to control the NetLogo feature of
-        auto-plotting in the current plot. Auto-plotting will automatically
-        update the x and y axes of the plot whenever the current pen
-        exceeds these boundaries. It is useful when wanting to show all
-        plotted values in the current plot, regardless of the current plot
-        ranges.
-      </p>
-      </div><!-- ======================================== -->
-    </div>
-    <h2 id="B">
-      <a>B</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="back">
-      <h3>
-        <a>back<span class="since">1.0</span></a>
-        <a>bk<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">back <i>number</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        The turtle moves backward by <i>number</i> steps. (If <i>number</i>
-        is negative, the turtle moves forward.)
-      </p>
-      <p>
-        Turtles using this primitive can move a maximum of one unit per
-        time increment. So <code>bk 0.5</code> and <code>bk 1</code> both take one
-        unit of time, but <code>bk 3</code> takes three.
-      </p>
-      <p>
-        If the turtle cannot move backward <i>number</i> steps because it
-        is not permitted by the current topology the turtle will complete
-        as many steps of 1 as it can and stop.
-      </p>
-      <p>
-        See also <a href="#forward">forward</a>, <a href="#jump">jump</a>,
-        <a href="#can-move">can-move?</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="base-colors">
-      <h3>
-        <a>base-colors<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">base-colors</span>
-      </h4>
-      <p>
-        Reports a list of the 14 basic NetLogo hues.
-      </p>
-      <pre>
-print base-colors
-=&gt; [5 15 25 35 45 55 65 75 85 95 105 115 125 135]
-ask turtles [ set color one-of base-colors ]
-;; each turtle turns a random base color
-ask turtles [ set color one-of remove gray base-colors ]
-;; each turtle turns a random base color except for gray
-</pre>
-    </div>
-    <div class="dict_entry" id="beep">
-      <h3>
-        <a>beep<span class="since">2.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">beep</span>
-      </h4>
-      <p>
-        Emits a beep. Note that the beep sounds immediately, so several
-        beep commands in close succession may produce only one audible
-        sound.
-      </p>
-      <p>
-        Example:
-      </p>
-      <pre>
-beep                       ;; emits one beep
-repeat 3 [ beep ]          ;; emits 3 beeps at once,
-                           ;; so you only hear one sound
-repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
-                           ;; separated by 1/10th of a second
-</pre>
-      <p>
-        When running headless, this command has no effect.
-      </p>
-      </div>
-    <div class="dict_entry" id="behaviorspace-experiment-name">
-      <h3>
-        <a>behaviorspace-experiment-name<span class="since">5.2</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">behaviorspace-experiment-name</span>
-      </h4>
-      <p>
-        Reports the current experiment name in the current experiment.
-      </p>
-      <p>
-        If no BehaviorSpace experiment is running, reports &quot;&quot;.
-      </p>
-      </div>
-    <div class="dict_entry" id="behaviorspace-run-number">
-      <h3>
-        <a>behaviorspace-run-number<span class="since">4.1.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">behaviorspace-run-number</span>
-      </h4>
-      <p>
-        Reports the current run number in the current BehaviorSpace
-        experiment, starting at 1.
-      </p>
-      <p>
-        If no BehaviorSpace experiment is running, reports 0.
-      </p>
-      </div>
-    <div class="dict_entry" id="both-ends">
-      <h3>
-        <a>both-ends<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">both-ends</span>
-        <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        Reports the agentset of the 2 nodes connected by this link.
-      </p>
-      <pre>
-crt 2
-ask turtle 0 [ create-link-with turtle 1 ]
-ask link 0 1 [
-  ask both-ends [ set color red ] ;; turtles 0 and 1 both turn red
-]
-</pre>
-    </div>
-    <div class="dict_entry" id="breedvar">
-      <h3>
-        <a>breed</a>
-      </h3>
-      <h4>
-        <span class="prim_example">breed</span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        This is a built-in turtle and link variable. It holds the agentset
-        of all turtles or links of the same breed as this turtle or link.
-        (For turtles or links that do not have any particular breed, this
-        is the <a href="#turtles">turtles</a> agentset of all turtles or
-        the <a href="#links">links</a> agentset of all links respectively.)
-      </p>
-      <p>
-        You can set this variable to change a turtle or link's breed.
-        (When a turtle changes breeds, its shape is reset to the default
-        shape for that breed. See <a href="#set-default-shape">set-default-shape</a>.)
-      </p>
-      <p>
-        See also <a href="#breed">breed</a>, <a href="#directed-link-breed">directed-link-breed</a>, <a href="#undirected-link-breed">undirected-link-breed</a>
-      </p>
-      <p>
-        Example:
-      </p>
-      <pre>
-breed [cats cat]
-breed [dogs dog]
-;; turtle code:
-if breed = cats [ show &quot;meow!&quot; ]
-set breed dogs
-show &quot;woof!&quot;
-</pre>
-      <pre>
-directed-link-breed [ roads road ]
-;; link code
-if breed = roads [ set color gray ]
-</pre>
-    </div>
-    <div class="dict_entry" id="breed">
-      <h3>
-        <a>breed</a>
-      </h3>
-      <h4>
-        <span class="prim_example">breed [<i>&lt;breeds&gt;</i> <i>&lt;breed&gt;</i>]</span>
-      </h4>
-      <p>
-        This keyword, like the globals, turtles-own, and patches-own
-        keywords, can only be used at the beginning of the Code tab, before
-        any procedure definitions. It defines a breed. The first input
-        defines the name of the agentset associated with the breed. The
-        second input defines the name of a single member of the breed.
-      </p>
-      <p>
-        Any turtle of the given breed:
-      </p>
-      <ul>
-        <li>is part of the agentset named by the breed name
-        <li>has its breed built-in variable set to that agentset
-        </ul>
-      <p>
-        Most often, the agentset is used in conjunction with ask to give
-        commands to only the turtles of a particular breed.
-      </p>
-      <pre>
-breed [mice mouse]
-breed [frogs frog]
-to setup
-  clear-all
-  create-mice 50
-  ask mice [ set color white ]
-  create-frogs 50
-  ask frogs [ set color green ]
-  show [breed] of one-of mice    ;; prints mice
-  show [breed] of one-of frogs   ;; prints frogs
-end
+		<h2 id="A">
+			<a>A</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="abs">
+				<h3>
+					<a>abs<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">abs <i>number</i></span>
+				</h4>
+				<p>
+					Reports the absolute value of <i>number</i>.
+				</p>
+				<pre>
+					show abs -7
+					=&gt; 7
+					show abs 5
+					=&gt; 5
+				</pre>
+			</div>
+			<div class="dict_entry" id="acos">
+				<h3>
+					<a>acos<span class="since">1.3</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">acos <i>number</i></span>
+				</h4>
+				<p>
+					Reports the arc cosine (inverse cosine) of the given number. The
+					input must be in the range -1 to 1. The result is in degrees, and
+					lies in the range 0 to 180.
+				</p>
+			</div>
+			<div class="dict_entry" id="all">
+				<h3>
+					<a>all?<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">all? <i>agentset</i> [<i>reporter</i>]</span>
+				</h4>
+				<p>
+					Reports true if all of the agents in the agentset report true for
+					the given reporter. Otherwise reports false as soon as a
+					counterexample is found.
+				</p>
+				<p>
+					If the agentset is empty, reports true.
+				</p>
+				<p>
+					The reporter must report a boolean value for every agent (either
+					true or false), otherwise an error occurs.
+				</p>
+				<pre>
+					if all? turtles [color = red]
+					[ show &quot;every turtle is red!&quot; ]
+				</pre>
+				<p>
+					See also <a href="#any">any?</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="and">
+				<h3>
+					<a>and<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example"><i>condition1</i> and <i>condition2</i></span>
+				</h4>
+				<p>
+					Reports true if both <i>condition1</i> and <i>condition2</i> are
+					true.
+				</p>
+				<p>
+					Note that if <i>condition1</i> is false, then <i>condition2</i>
+					will not be run (since it can't affect the result).
+				</p>
+				<pre>
+					if (pxcor &gt; 0) and (pycor &gt; 0)
+					[ set pcolor blue ]  ;; the upper-right quadrant of
+					;; patches turn blue
+				</pre>
+			</div>
+			<div class="dict_entry" id="any">
+				<h3>
+					<a>any?<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">any? <i>agentset</i></span>
+				</h4>
+				<p>
+					Reports true if the given agentset is non-empty, false otherwise.
+				</p>
+				<p>
+					Equivalent to &quot;count <i>agentset</i> &gt; 0&quot;, but more
+					efficient (and arguably more readable).
+				</p>
+				<pre>
+					if any? turtles with [color = red]
+					[ show &quot;at least one turtle is red!&quot; ]
+				</pre>
+				<p>
+					Note: nobody is not an agentset. You only get nobody back in
+					situations where you were expecting a single agent, not a whole
+					agentset. If any? gets nobody as input, an error results.
+				</p>
+				<p>
+					See also <a href="#all">all?</a>, <a href="#nobody">nobody</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="approximate-hsb">
+				<h3>
+					<a>approximate-hsb<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">approximate-hsb <i>hue saturation brightness</i></span>
+				</h4>
+				<p>
+					Reports a number in the range 0 to 140, not including 140 itself,
+					that represents the given color, specified in the HSB spectrum, in
+					NetLogo's color space.
+				</p>
+				<p>
+					The first value (hue) should be in the range of 0 to 360, the second
+					and third (saturation and brightness) in the range between 0 and 100.
+				</p>
+				<p>
+					The color reported may be only an approximation, since the NetLogo
+					color space does not include all possible colors.
+				</p>
+				<pre>
+					show approximate-hsb 0 0 0
+					=&gt; 0  ;; (black)
+					show approximate-hsb 180 57.143 76.863
+					=&gt; 85 ;; (cyan)
+				</pre>
+				<p>
+					See also <a href="#extract-hsb">extract-hsb</a>, <a href="#approximate-rgb">approximate-rgb</a>, <a href="#extract-rgb">extract-rgb</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="approximate-rgb">
+				<h3>
+					<a>approximate-rgb<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">approximate-rgb <i>red green blue</i></span>
+				</h4>
+				<p>
+					Reports a number in the range 0 to 140, not including 140 itself,
+					that represents the given color, specified in the RGB spectrum, in
+					NetLogo's color space.
+				</p>
+				<p>
+					All three inputs should be in the range 0 to 255.
+				</p>
+				<p>
+					The color reported may be only an approximation, since the NetLogo
+					color space does not include all possible colors. (See <a href="#approximate-hsb">approximate-hsb</a> for a description of what
+					parts of the HSB color space NetLogo colors cover; this is
+					difficult to characterize in RGB terms.)
+				</p>
+				<pre>
+					show approximate-rgb 0 0 0
+					=&gt; 0  ;; black
+					show approximate-rgb 0 255 255
+					=&gt; 85.2 ;; cyan
+				</pre>
+				<p>
+					See also <a href="#extract-rgb">extract-rgb</a>, <a href="#approximate-hsb">approximate-hsb</a>, and <a href="#extract-hsb">extract-hsb</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="Symbols">
+				<h3>
+					<a>Arithmetic Operators</a>
+					<a>+<span class="since">1.0</span></a>
+					<a>*<span class="since">1.0</span></a>
+					<a>-<span class="since">1.0</span></a>
+					<a>/<span class="since">1.0</span></a>
+					<a>^<span class="since">1.0</span></a>
+					<a>&lt;<span class="since">1.0</span></a>
+					<a>&gt;<span class="since">1.0</span></a>
+					<a>=<span class="since">1.0</span></a>
+					<a>!=<span class="since">1.0</span></a>
+					<a>&lt;=<span class="since">1.0</span></a>
+					<a>&gt;=<span class="since">1.0</span></a>
+				</h3>
+				<p>
+					All of these operators take two inputs, and all act as &quot;infix
+					operators&quot; (going between the two inputs, as in standard
+					mathematical use). NetLogo correctly supports order of operations
+					for infix operators.
+				</p>
+				<p>
+					The operators work as follows: + is addition, * is multiplication,
+					- is subtraction, / is division, ^ is exponentiation, &lt; is less
+					than, &gt; is greater than, = is equal to, != is not equal to,
+					&lt;= is less than or equal, &gt;= is greater than or equal.
+				</p>
+				<p>
+					Note that the subtraction operator (-) always takes two inputs
+					unless you put parentheses around it, in which case it can take one
+					input. For example, to take the negative of x, write (- x), with
+					the parentheses.
+				</p>
+				<p>
+					All of the comparison operators also work on strings.
+				</p>
+				<p>
+					All of the comparison operators work on agents. Turtles are
+					compared by who number. Patches are compared top to bottom left to
+					right, so patch 0 10 is less than patch 0 9 and patch 9 0 is less
+					than patch 10 0. Links are ordered by end points and in case of a
+					tie by breed. So link 0 9 is before link 1 10 as the end1 is
+					smaller, and link 0 8 is less than link 0 9. If there are multiple
+					breeds of links unbreeded links will come before breeded links of
+					the same end points and breeded links will be sorted in the order
+					they are declared in the Code tab.
+				</p>
+				<p>
+					Agentsets can be tested for equality or inequality. Two agentsets
+					are equal if they are the same type (turtle or patch) and contain
+					the same agents.
+				</p>
+				<p>
+					If you are not sure how NetLogo will interpret your code, you
+					should add parentheses.
+				</p>
+				<pre>
+					show 5 * 6 + 6 / 3
+					=&gt; 32
+					show 5 * (6 + 6) / 3
+					=&gt; 20
+				</pre>
+				<p>
+					Many extension objects may be tested for equality and inequality
+					using = and !=.
+					For instance, the array, matrix, and table objects returned by their
+					respective extensions may be compared for equality / inequality.
+					Extension objects may not be tested using &lt;, &gt;, &lt;=, or &gt;=.
+				</p>
+			</div>
+			<div class="dict_entry" id="asin">
+				<h3>
+					<a>asin<span class="since">1.3</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">asin <i>number</i></span>
+				</h4>
+				<p>
+					Reports the arc sine (inverse sine) of the given number. The input
+					must be in the range -1 to 1. The result is in degrees, and lies in
+					the range -90 to 90.
+				</p>
+			</div>
+			<div class="dict_entry" id="ask">
+				<h3>
+					<a>ask<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">ask <i>agentset</i> [<i>commands</i>]</span>
+					<span class="prim_example">ask <i>agent</i> [<i>commands</i>]</span>
+				</h4>
+				<p>
+					The specified agent or agentset runs the given commands.  Because
+					agentset members are always read in a random order, when ask is
+					used with an agentset each agent will take its turn in a random
+					order.  See <a href="programming.html#agentsets">Agentsets</a>
+					for more information.
+				</p>
+				<pre>
+					ask turtles [ fd 1 ]
+					;; all turtles move forward one step
+					ask patches [ set pcolor red ]
+					;; all patches turn red
+					ask turtle 4 [ rt 90 ]
+					;; only the turtle with id 4 turns right
+				</pre>
+				<p>
+					Note: only the observer can ask all turtles or all patches. This
+					prevents you from inadvertently having all turtles ask all turtles
+					or all patches ask all patches, which is a common mistake to make
+					if you're not careful about which agents will run the code you
+					are writing.
+				</p>
+				<p>
+					Note: Only the agents that are in the agentset <i>at the time the
+						ask begins</i> run the commands.
+				</p>
+			</div>
+			<div class="dict_entry" id="ask-concurrent">
+				<h3>
+					<a>ask-concurrent<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">ask-concurrent <i>agentset</i> [<i>commands</i>]</span>
+				</h4>
+				<p>
+					This primitive exists only for backwards compatibility. We
+					don't recommend using it new models.
+				</p>
+				<p>
+					The agents in the given agentset run the given commands, using a
+					turn-taking mechanism to produce simulated concurrency. See the
+					<a href="programming.html#ask-concurrent">Ask-Concurrent</a>
+					section of the Programming Guide for details on how this works.
+				</p>
+				<p>
+					Note: Only the agents that are in the agentset <i>at the time the
+						ask begins</i> run the commands.
+				</p>
+				<p>
+					See also <a href="#without-interruption">without-interruption</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="at-points">
+				<h3>
+					<a>at-points<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example"><i>agentset</i> at-points [[<i>x1 y1</i>] [<i>x2 y2</i>] ...]</span>
+				</h4>
+				<p>
+					Reports a subset of the given agentset that includes only the
+					agents on the patches at the given coordinates (relative to this
+					agent). The coordinates are specified as a list of two-item lists,
+					where the two items are the x and y offsets.
+				</p>
+				<p>
+					If the caller is the observer, then the points are measured
+					relative to the origin, in other words, the points are taken as
+					absolute patch coordinates.
+				</p>
+				<p>
+					If the caller is a turtle, the points are measured relative to the
+					turtle's exact location, and not from the center of the patch
+					under the turtle.
+				</p>
+				<pre>
+					ask turtles at-points [[2 4] [1 2] [10 15]]
+					[ fd 1 ]  ;; only the turtles on the patches at the
+					;; coordinates (2,4), (1,2) and (10,15),
+					;; relative to the caller, move
+				</pre>
+			</div>
+			<div class="dict_entry" id="atan">
+				<h3>
+					<a>atan<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">atan <i>x y</i></span>
+				</h4>
+				<p>
+					Converts x and y offsets to a turtle heading in degrees (from 0 to
+					360).
+				</p>
+				<p>
+					Note that this version of atan is designed to conform to the
+					geometry of the NetLogo world, where a heading of 0 is straight up,
+					90 is to the right, and so on clockwise around the circle.
+					(Normally in geometry an angle of 0 is right, 90 is up, and so on,
+					counterclockwise around the circle, and atan would be defined
+					accordingly.)
+				</p>
+				<p>
+					When y is 0: if x is positive, it reports 90; if x is negative, it
+					reports 270; if x is zero, you get an error.
+				</p>
+				<pre>
+					show atan 1 -1
+					=&gt; 135
+					show atan -1 1
+					=&gt; 315
+					crt 1 [ set heading 30  fd 1  print atan xcor ycor ]
+					=&gt; 30
+				</pre>
+				<p>
+					In the final example, note that the result of <code>atan</code> equals
+					the turtle's heading.
+				</p>
+				<p>
+					If you ever need to convert a turtle heading (obtained with atan or
+					otherwise) to a normal mathematical angle, the following should be
+					helpful:
+				</p>
+				<pre>
+					to-report heading-to-angle [ h ]
+					report (90 - h) mod 360
+					end
+				</pre>
+			</div>
+			<div class="dict_entry" id="autoplot">
+				<h3>
+					<a>autoplot?<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">autoplot?</span>
+				</h4>
+				<p>
+					Reports true if auto-plotting is on for the current plot, false
+					otherwise.
+				</p>
+			</div>
+			<div class="dict_entry" id="auto-plot-status">
+				<h3>
+					<a>auto-plot-off<span class="since">1.0</span></a>
+					<a>auto-plot-on<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">auto-plot-off</span>
+					<span class="prim_example">auto-plot-on</span>
+				</h4>
+				<p>
+					This pair of commands is used to control the NetLogo feature of
+					auto-plotting in the current plot. Auto-plotting will automatically
+					update the x and y axes of the plot whenever the current pen
+					exceeds these boundaries. It is useful when wanting to show all
+					plotted values in the current plot, regardless of the current plot
+					ranges.
+				</p>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="B">
+			<a>B</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="back">
+				<h3>
+					<a>back<span class="since">1.0</span></a>
+					<a>bk<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">back <i>number</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					The turtle moves backward by <i>number</i> steps. (If <i>number</i>
+					is negative, the turtle moves forward.)
+				</p>
+				<p>
+					Turtles using this primitive can move a maximum of one unit per
+					time increment. So <code>bk 0.5</code> and <code>bk 1</code> both take one
+					unit of time, but <code>bk 3</code> takes three.
+				</p>
+				<p>
+					If the turtle cannot move backward <i>number</i> steps because it
+					is not permitted by the current topology the turtle will complete
+					as many steps of 1 as it can and stop.
+				</p>
+				<p>
+					See also <a href="#forward">forward</a>, <a href="#jump">jump</a>,
+					<a href="#can-move">can-move?</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="base-colors">
+				<h3>
+					<a>base-colors<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">base-colors</span>
+				</h4>
+				<p>
+					Reports a list of the 14 basic NetLogo hues.
+				</p>
+				<pre>
+					print base-colors
+					=&gt; [5 15 25 35 45 55 65 75 85 95 105 115 125 135]
+					ask turtles [ set color one-of base-colors ]
+					;; each turtle turns a random base color
+					ask turtles [ set color one-of remove gray base-colors ]
+					;; each turtle turns a random base color except for gray
+				</pre>
+			</div>
+			<div class="dict_entry" id="beep">
+				<h3>
+					<a>beep<span class="since">2.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">beep</span>
+				</h4>
+				<p>
+					Emits a beep. Note that the beep sounds immediately, so several
+					beep commands in close succession may produce only one audible
+					sound.
+				</p>
+				<p>
+					Example:
+				</p>
+				<pre>
+					beep                       ;; emits one beep
+					repeat 3 [ beep ]          ;; emits 3 beeps at once,
+					;; so you only hear one sound
+					repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
+					;; separated by 1/10th of a second
+				</pre>
+				<p>
+					When running headless, this command has no effect.
+				</p>
+			</div>
+			<div class="dict_entry" id="behaviorspace-experiment-name">
+				<h3>
+					<a>behaviorspace-experiment-name<span class="since">5.2</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">behaviorspace-experiment-name</span>
+				</h4>
+				<p>
+					Reports the current experiment name in the current experiment.
+				</p>
+				<p>
+					If no BehaviorSpace experiment is running, reports &quot;&quot;.
+				</p>
+			</div>
+			<div class="dict_entry" id="behaviorspace-run-number">
+				<h3>
+					<a>behaviorspace-run-number<span class="since">4.1.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">behaviorspace-run-number</span>
+				</h4>
+				<p>
+					Reports the current run number in the current BehaviorSpace
+					experiment, starting at 1.
+				</p>
+				<p>
+					If no BehaviorSpace experiment is running, reports 0.
+				</p>
+			</div>
+			<div class="dict_entry" id="both-ends">
+				<h3>
+					<a>both-ends<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">both-ends</span>
+					<img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					Reports the agentset of the 2 nodes connected by this link.
+				</p>
+				<pre>
+					crt 2
+					ask turtle 0 [ create-link-with turtle 1 ]
+					ask link 0 1 [
+					ask both-ends [ set color red ] ;; turtles 0 and 1 both turn red
+					]
+				</pre>
+			</div>
+			<div class="dict_entry" id="breedvar">
+				<h3>
+					<a>breed</a>
+				</h3>
+				<h4>
+					<span class="prim_example">breed</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					This is a built-in turtle and link variable. It holds the agentset
+					of all turtles or links of the same breed as this turtle or link.
+					(For turtles or links that do not have any particular breed, this
+					is the <a href="#turtles">turtles</a> agentset of all turtles or
+					the <a href="#links">links</a> agentset of all links respectively.)
+				</p>
+				<p>
+					You can set this variable to change a turtle or link's breed.
+					(When a turtle changes breeds, its shape is reset to the default
+					shape for that breed. See <a href="#set-default-shape">set-default-shape</a>.)
+				</p>
+				<p>
+					See also <a href="#breed">breed</a>, <a href="#directed-link-breed">directed-link-breed</a>, <a href="#undirected-link-breed">undirected-link-breed</a>
+				</p>
+				<p>
+					Example:
+				</p>
+				<pre>
+					breed [cats cat]
+					breed [dogs dog]
+					;; turtle code:
+					if breed = cats [ show &quot;meow!&quot; ]
+					set breed dogs
+					show &quot;woof!&quot;
+				</pre>
+				<pre>
+					directed-link-breed [ roads road ]
+					;; link code
+					if breed = roads [ set color gray ]
+				</pre>
+			</div>
+			<div class="dict_entry" id="breed">
+				<h3>
+					<a>breed</a>
+				</h3>
+				<h4>
+					<span class="prim_example">breed [<i>&lt;breeds&gt;</i> <i>&lt;breed&gt;</i>]</span>
+				</h4>
+				<p>
+					This keyword, like the globals, turtles-own, and patches-own
+					keywords, can only be used at the beginning of the Code tab, before
+					any procedure definitions. It defines a breed. The first input
+					defines the name of the agentset associated with the breed. The
+					second input defines the name of a single member of the breed.
+				</p>
+				<p>
+					Any turtle of the given breed:
+				</p>
+				<ul>
+					<li>is part of the agentset named by the breed name</li>
+					<li>has its breed built-in variable set to that agentset</li>
+				</ul>
+				<p>
+					Most often, the agentset is used in conjunction with ask to give
+					commands to only the turtles of a particular breed.
+				</p>
+				<pre>
+					breed [mice mouse]
+					breed [frogs frog]
+					to setup
+					clear-all
+					create-mice 50
+					ask mice [ set color white ]
+					create-frogs 50
+					ask frogs [ set color green ]
+					show [breed] of one-of mice    ;; prints mice
+					show [breed] of one-of frogs   ;; prints frogs
+					end
 
-show mouse 1
-;; prints (mouse 1)
-show frog 51
-;; prints (frog 51)
-show turtle 51
-;; prints (frog 51)
-</pre>
-      <p>
-        See also <a href="#globals">globals</a>, <a href="#patches-own">patches-own</a>, <a href="#turtles-own">turtles-own</a>, <a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>, <a href="#create-turtles">create-<i>&lt;breeds&gt;</i></a>, <a href="#turtles-at"><i>&lt;breeds&gt;</i>-at</a>, <a href="#turtles-here"><i>&lt;breeds&gt;</i>-here</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="but-first-and-last">
-      <h3>
-        <a>but-first<span class="since">1.0</span></a>
-        <a>butfirst<span class="since">1.0</span></a>
-        <a>bf<span class="since">1.0</span></a>
-        <a>but-last<span class="since">1.0</span></a>
-        <a>butlast<span class="since">1.0</span></a>
-        <a>bl<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">but-first <i>list</i></span>
-        <span class="prim_example">but-first <i>string</i></span>
-        <span class="prim_example">but-last <i>list</i></span>
-        <span class="prim_example">but-last <i>string</i></span>
-      </h4>
-      <p>
-        When used on a list, but-first reports all of the list items of
-        <i>list</i> except the first, and but-last reports all of the list
-        items of <i>list</i> except the last.
-      </p>
-      <p>
-        On strings, but-first and but-last report a shorter string omitting
-        the first or last character of the original string.
-      </p>
-      <pre>
-;; mylist is [2 4 6 5 8 12]
-set mylist but-first mylist
-;; mylist is now [4 6 5 8 12]
-set mylist but-last mylist
-;; mylist is now [4 6 5 8]
-show but-first &quot;string&quot;
-;; prints &quot;tring&quot;
-show but-last &quot;string&quot;
-;; prints &quot;strin&quot;
-</pre><!-- ======================================== -->
-    </div>
-  </div>
-    <h2 id="C">
-      <a>C</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="can-move">
-      <h3>
-        <a>can-move?<span class="since">3.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">can-move? <i>distance</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Reports true if this turtle can move <i>distance</i> in the
-        direction it is facing without violating the topology; reports
-        false otherwise.
-      </p>
-      <p>
-        It is equivalent to:
-      </p>
-      <pre>
-patch-ahead <i>distance</i> != nobody
-</pre>
-    </div>
-    <div class="dict_entry" id="carefully">
-      <h3>
-        <a>carefully<span class="since">2.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">carefully [ <i>commands1</i> ] [ <i>commands2</i> ]</span>
-      </h4>
-      <p>
-        Runs <i>commands1</i>. If a runtime error occurs inside
-        <i>commands1</i>, NetLogo won't stop and alert the user that an
-        error occurred. It will suppress the error and run <i>commands2</i>
-        instead.
-      </p>
-      <p>
-        The error-message reporter can be used in <i>commands2</i> to find
-        out what error was suppressed in <i>commands1</i>. See <a href="#error-message">error-message</a>.
-      </p>
-      <pre>
-carefully [ print one-of [1 2 3] ] [ print error-message ]
-=&gt; 3
-observer&gt; carefully [ print one-of [] ] [ print error-message ]
-=&gt; ONE-OF got an empty list as input.
-</pre>
-    </div>
-    <div class="dict_entry" id="ceiling">
-      <h3>
-        <a>ceiling<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">ceiling <i>number</i></span>
-      </h4>
-      <p>
-        Reports the smallest integer greater than or equal to
-        <i>number</i>.
-      </p>
-      <pre>
-show ceiling 4.5
-=&gt; 5
-show ceiling -4.5
-=&gt; -4
-</pre>
-      <p>
-        See also <a href="#floor">floor</a>, <a href="#round">round</a>,
-        <a href="#precision">precision</a>.
-      </p>
-      </div>
-    </div>
-    <div class="dict_entry" id="clear-all">
-      <h3>
-        <a>clear-all<span class="since">1.0</span></a>
-        <a>ca<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">clear-all</span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Combines the effects of clear-globals, clear-ticks,
-        clear-turtles, clear-patches, clear-drawing, clear-all-plots, and
-        clear-output.
-      </p>
-      </div>
-    <div class="dict_entry" id="clear-all-plots">
-      <h3>
-        <a>clear-all-plots<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">clear-all-plots</span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Clears every plot in the model. See <a href="#clear-plot">clear-plot</a> for more information.
-      </p>
-      </div>
-    <div class="dict_entry" id="clear-drawing">
-      <h3>
-        <a>clear-drawing<span class="since">3.0</span></a>
-        <a>cd<span class="since">3.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">clear-drawing</span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Clears all lines and stamps drawn by turtles.
-      </p>
-      </div>
-    <div class="dict_entry" id="clear-globals">
-      <h3>
-        <a>clear-globals<span class="since">5.2</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">clear-globals</span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Sets all code-defined global variables (i.e., those defined inside of <code>globals [ ... ]</code>) to 0.  Global variables defined by widgets are not affected by this primitive.
-      </p>
-      </div>
-    <div class="dict_entry" id="clear-links">
-      <h3>
-        <a>clear-links<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">clear-links</span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Kills all links.
-      </p>
-      <p>
-        See also <a href="#die">die</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="clear-output">
-      <h3>
-        <a>clear-output<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">clear-output</span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Clears all text from the model's output area, if it has one.
-        Otherwise does nothing.
-      </p>
-      </div>
-    <div class="dict_entry" id="clear-patches">
-      <h3>
-        <a>clear-patches<span class="since">1.0</span></a>
-        <a>cp<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">clear-patches</span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Clears the patches by resetting all patch variables to their
-        default initial values, including setting their color to black.
-      </p>
-      </div>
-    <div class="dict_entry" id="clear-plot">
-      <h3>
-        <a>clear-plot</a>
-      </h3>
-      <h4>
-        <span class="prim_example">clear-plot</span>
-      </h4>
-      <p>
-        In the current plot only, resets all plot pens, deletes all
-        temporary plot pens, resets the plot to its default values (for x
-        range, y range, etc.), and resets all permanent plot pens to their
-        default values. The default values for the plot and for the
-        permanent plot pens are set in the plot Edit dialog, which is
-        displayed when you edit the plot. If there are no plot pens after
-        deleting all temporary pens, that is to say if there are no
-        permanent plot pens, a default plot pen will be created with the
-        following initial settings:
-      </p>
-      <ul>
-        <li>Pen: down
-        <li>Color: black
-        <li>Mode: 0 (line mode)
-        <li>Name: &quot;default&quot;
-        <li>Interval: 1
-        </ul>
-      <p>
-        See also <a href="#clear-all-plots">clear-all-plots</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="clear-ticks">
-      <h3>
-        <a>clear-ticks<span class="since">5.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">clear-ticks</span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Clears the tick counter.
-      </p>
-      <p>
-        Does not set the counter to zero. After this command runs, the tick
-        counter has no value. Attempting to access or update it is an error
-        until <a href="#reset-ticks">reset-ticks</a> is called. This is
-        useful if you want to set the model to a "pre-setup" state with some
-        forever buttons disabled.
-      </p>
-      <p>
-        See also <a href="#reset-ticks">reset-ticks</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="clear-turtles">
-      <h3>
-        <a>clear-turtles<span class="since">1.0</span></a>
-        <a>ct<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">clear-turtles</span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Kills all turtles.
-      </p>
-      <p>
-        Also resets the who numbering, so the next turtle created will be
-        turtle 0.
-      </p>
-      <p>
-        See also <a href="#die">die</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="color">
-      <h3>
-        <a>color</a>
-      </h3>
-      <h4>
-        <span class="prim_example">color</span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        This is a built-in turtle or link variable. It holds the color of
-        the turtle or link. You can set this variable to make the turtle or
-        link change color. Color can be represented either as a NetLogo
-        color (a single number), or an RGB color (a list of 3 numbers). See
-        details in the <a href="programming.html#colors">Colors section</a>
-        of the Programming Guide.
-      </p>
-      <p>
-        See also <a href="#pcolor">pcolor</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="cos">
-      <h3>
-        <a>cos<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">cos <i>number</i></span>
-      </h4>
-      <p>
-        Reports the cosine of the given angle. Assumes the angle is given
-        in degrees.
-      </p>
-      <pre>
-show cos 180
-=&gt; -1
-</pre>
-    </div>
-    <div class="dict_entry" id="count">
-      <h3>
-        <a>count<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">count <i>agentset</i></span>
-      </h4>
-      <p>
-        Reports the number of agents in the given agentset.
-      </p>
-      <pre>
-show count turtles
-;; prints the total number of turtles
-show count patches with [pcolor = red]
-;; prints the total number of red patches
-</pre>
-    </div>
-    <div class="dict_entry" id="create-ordered-turtles">
-      <h3>
-        <a>create-ordered-turtles<span class="since">4.0</span></a>
-        <a>cro<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">create-ordered-turtles <i>number</i></span>
-        <span class="prim_example">create-ordered-turtles <i>number</i> [ <i>commands</i> ]</span>
-        <span class="prim_example">create-ordered<i>&lt;breeds&gt;</i> <i>number</i></span>
-        <span class="prim_example">create-ordered<i>&lt;breeds&gt;</i> <i>number</i> [ <i>commands</i> ]</span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Creates <i>number</i> new turtles. New turtles start at position
-        (0, 0), are created with the 14 primary colors, and have headings
-        from 0 to 360, evenly spaced.
-      </p>
-      <p>
-        If the create-ordered-<i>&lt;breeds&gt;</i> form is used, the new
-        turtles are created as members of the given breed.
-      </p>
-      <p>
-        If <i>commands</i> are supplied, the new turtles immediately run
-        them. This is useful for giving the new turtles a different color,
-        heading, or whatever. (The new turtles are created all at once then
-        run one at a time, in random order.)
-      </p>
-      <pre>
-cro 100 [ fd 10 ]  ;; makes an evenly spaced circle
-</pre>
-    </div>
-    <div class="dict_entry" id="create-link">
-      <h3>
-        <a>create-&lt;breed&gt;-to</a>
-        <a>create-&lt;breeds&gt;-to</a>
-        <a>create-&lt;breed&gt;-from</a>
-        <a>create-&lt;breeds&gt;-from</a>
-        <a>create-&lt;breed&gt;-with</a>
-        <a>create-&lt;breeds&gt;-with</a>
-        <a>create-link-to<span class="since">4.0</span></a>
-        <a>create-links-to<span class="since">4.0</span></a>
-        <a>create-link-from<span class="since">4.0</span></a>
-        <a>create-links-from<span class="since">4.0</span></a>
-        <a>create-link-with<span class="since">4.0</span></a>
-        <a>create-links-with<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">create-&lt;breed&gt;-to <i>turtle</i></span>
-        <span class="prim_example">create-&lt;breed&gt;-to <i>turtle</i> [ <i>commands</i> ]</span>
-        <span class="prim_example">create-&lt;breed&gt;-from <i>turtle</i></span>
-        <span class="prim_example">create-&lt;breed&gt;-from <i>turtle</i> [ <i>commands</i> ]</span>
-        <span class="prim_example">create-&lt;breed&gt;-with <i>turtle</i></span>
-        <span class="prim_example">create-&lt;breed&gt;-with <i>turtle</i> [ <i>commands</i> ]</span>
-        <span class="prim_example">create-&lt;breeds&gt;-to <i>turtleset</i></span>
-        <span class="prim_example">create-&lt;breeds&gt;-to <i>turtleset</i> [ <i>commands</i> ]</span>
-        <span class="prim_example">create-&lt;breeds&gt;-from <i>turtleset</i></span>
-        <span class="prim_example">create-&lt;breeds&gt;-from <i>turtleset</i> [ <i>commands</i> ]</span>
-        <span class="prim_example">create-&lt;breeds&gt;-with <i>turtleset</i></span>
-        <span class="prim_example">create-&lt;breeds&gt;-with <i>turtleset</i> [ <i>commands</i> ]</span>
-        <span class="prim_example">create-link-to <i>turtle</i></span>
-        <span class="prim_example">create-link-to <i>turtle</i> [ <i>commands</i> ]</span>
-        <span class="prim_example">create-link-from <i>turtle</i></span>
-        <span class="prim_example">create-link-from <i>turtle</i> [ <i>commands</i> ]</span>
-        <span class="prim_example">create-link-with <i>turtle</i></span>
-        <span class="prim_example">create-link-with <i>turtle</i> [ <i>commands</i> ]</span>
-        <span class="prim_example">create-links-to <i>turtleset</i></span>
-        <span class="prim_example">create-links-to <i>turtleset</i> [ <i>commands</i> ]</span>
-        <span class="prim_example">create-links-from <i>turtleset</i></span>
-        <span class="prim_example">create-links-from <i>turtleset</i> [ <i>commands</i> ]</span>
-        <span class="prim_example">create-links-with <i>turtleset</i></span>
-        <span class="prim_example">create-links-with <i>turtleset</i> [ <i>commands</i> ]</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Used for creating breeded and unbreeded links between turtles.
-      </p>
-      <p>
-        <code>create-link-with</code> creates an undirected link between the caller and
-        <i>agent</i>. <code>create-link-to</code> creates a directed link from the
-        caller to <i>agent</i>. <code>create-link-from</code> creates a directed link
-        from <i>agent</i> to the caller.
-      </p>
-      <p>
-        When the plural form of the breed name is used, an <i>agentset</i>
-        is expected instead of an agent and links are created between the
-        caller and all agents in the agentset.
-      </p>
-      <p>
-        The optional command block is the set of commands each newly formed
-        link runs. (The links are created all at once then run one at a
-        time, in random order.)
-      </p>
-      <p>
-        A node cannot be linked to itself. Also, you cannot have more than
-        one undirected link of the same breed between the same two nodes,
-        nor can you have more than one directed link of the same breed
-        going in the same direction between two nodes.
-      </p>
-      <p>
-        If you try to create a link where one (of the same breed) already
-        exists, nothing happens. If you try to create a link from a turtle
-        to itself you get a runtime error.
-      </p>
-      <pre>
-to setup
-  clear-all
-  create-turtles 5
-  ;; turtle 1 creates links with all other turtles
-  ;; the link between the turtle and itself is ignored
-  ask turtle 0 [ create-links-with other turtles ]
-  show count links ;; shows 4
-  ;; this does nothing since the link already exists
-  ask turtle 0 [ create-link-with turtle 1 ]
-  show count links ;; shows 4 since the previous link already existed
-  ask turtle 2 [ create-link-with turtle 1 ]
-  show count links ;; shows 5
-end
-</pre>
-      <pre>
-directed-link-breed [red-links red-link]
-undirected-link-breed [blue-links blue-link]
+					show mouse 1
+					;; prints (mouse 1)
+					show frog 51
+					;; prints (frog 51)
+					show turtle 51
+					;; prints (frog 51)
+				</pre>
+				<p>
+					See also <a href="#globals">globals</a>, <a href="#patches-own">patches-own</a>, <a href="#turtles-own">turtles-own</a>, <a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>, <a href="#create-turtles">create-<i>&lt;breeds&gt;</i></a>, <a href="#turtles-at"><i>&lt;breeds&gt;</i>-at</a>, <a href="#turtles-here"><i>&lt;breeds&gt;</i>-here</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="but-first-and-last">
+				<h3>
+					<a>but-first<span class="since">1.0</span></a>
+					<a>butfirst<span class="since">1.0</span></a>
+					<a>bf<span class="since">1.0</span></a>
+					<a>but-last<span class="since">1.0</span></a>
+					<a>butlast<span class="since">1.0</span></a>
+					<a>bl<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">but-first <i>list</i></span>
+					<span class="prim_example">but-first <i>string</i></span>
+					<span class="prim_example">but-last <i>list</i></span>
+					<span class="prim_example">but-last <i>string</i></span>
+				</h4>
+				<p>
+					When used on a list, but-first reports all of the list items of
+					<i>list</i> except the first, and but-last reports all of the list
+					items of <i>list</i> except the last.
+				</p>
+				<p>
+					On strings, but-first and but-last report a shorter string omitting
+					the first or last character of the original string.
+				</p>
+				<pre>
+					;; mylist is [2 4 6 5 8 12]
+					set mylist but-first mylist
+					;; mylist is now [4 6 5 8 12]
+					set mylist but-last mylist
+					;; mylist is now [4 6 5 8]
+					show but-first &quot;string&quot;
+					;; prints &quot;tring&quot;
+					show but-last &quot;string&quot;
+					;; prints &quot;strin&quot;
+				</pre><!-- ======================================== -->
+			</div>
+		</div>
+		<h2 id="C">
+			<a>C</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="can-move">
+				<h3>
+					<a>can-move?<span class="since">3.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">can-move? <i>distance</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Reports true if this turtle can move <i>distance</i> in the
+					direction it is facing without violating the topology; reports
+					false otherwise.
+				</p>
+				<p>
+					It is equivalent to:
+				</p>
+				<pre>
+					patch-ahead <i>distance</i> != nobody
+				</pre>
+			</div>
+			<div class="dict_entry" id="carefully">
+				<h3>
+					<a>carefully<span class="since">2.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">carefully [ <i>commands1</i> ] [ <i>commands2</i> ]</span>
+				</h4>
+				<p>
+					Runs <i>commands1</i>. If a runtime error occurs inside
+					<i>commands1</i>, NetLogo won't stop and alert the user that an
+					error occurred. It will suppress the error and run <i>commands2</i>
+					instead.
+				</p>
+				<p>
+					The error-message reporter can be used in <i>commands2</i> to find
+					out what error was suppressed in <i>commands1</i>. See <a href="#error-message">error-message</a>.
+				</p>
+				<pre>
+					carefully [ print one-of [1 2 3] ] [ print error-message ]
+					=&gt; 3
+					observer&gt; carefully [ print one-of [] ] [ print error-message ]
+					=&gt; ONE-OF got an empty list as input.
+				</pre>
+			</div>
+			<div class="dict_entry" id="ceiling">
+				<h3>
+					<a>ceiling<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">ceiling <i>number</i></span>
+				</h4>
+				<p>
+					Reports the smallest integer greater than or equal to
+					<i>number</i>.
+				</p>
+				<pre>
+					show ceiling 4.5
+					=&gt; 5
+					show ceiling -4.5
+					=&gt; -4
+				</pre>
+				<p>
+					See also <a href="#floor">floor</a>, <a href="#round">round</a>,
+					<a href="#precision">precision</a>.
+				</p>
+			</div>
+		</div>
+		<div class="dict_entry" id="clear-all">
+			<h3>
+				<a>clear-all<span class="since">1.0</span></a>
+				<a>ca<span class="since">1.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">clear-all</span>
+				<img alt="Observer Command" src="images/observer.gif"/>
+			</h4>
+			<p>
+				Combines the effects of clear-globals, clear-ticks,
+				clear-turtles, clear-patches, clear-drawing, clear-all-plots, and
+				clear-output.
+			</p>
+		</div>
+		<div class="dict_entry" id="clear-all-plots">
+			<h3>
+				<a>clear-all-plots<span class="since">1.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">clear-all-plots</span>
+				<img alt="Observer Command" src="images/observer.gif"/>
+			</h4>
+			<p>
+				Clears every plot in the model. See <a href="#clear-plot">clear-plot</a> for more information.
+			</p>
+		</div>
+		<div class="dict_entry" id="clear-drawing">
+			<h3>
+				<a>clear-drawing<span class="since">3.0</span></a>
+				<a>cd<span class="since">3.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">clear-drawing</span>
+				<img alt="Observer Command" src="images/observer.gif"/>
+			</h4>
+			<p>
+				Clears all lines and stamps drawn by turtles.
+			</p>
+		</div>
+		<div class="dict_entry" id="clear-globals">
+			<h3>
+				<a>clear-globals<span class="since">5.2</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">clear-globals</span>
+				<img alt="Observer Command" src="images/observer.gif"/>
+			</h4>
+			<p>
+				Sets all code-defined global variables (i.e., those defined inside of <code>globals [ ... ]</code>) to 0.  Global variables defined by widgets are not affected by this primitive.
+			</p>
+		</div>
+		<div class="dict_entry" id="clear-links">
+			<h3>
+				<a>clear-links<span class="since">4.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">clear-links</span>
+				<img alt="Observer Command" src="images/observer.gif"/>
+			</h4>
+			<p>
+				Kills all links.
+			</p>
+			<p>
+				See also <a href="#die">die</a>.
+			</p>
+		</div>
+		<div class="dict_entry" id="clear-output">
+			<h3>
+				<a>clear-output<span class="since">1.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">clear-output</span>
+				<img alt="Observer Command" src="images/observer.gif"/>
+			</h4>
+			<p>
+				Clears all text from the model's output area, if it has one.
+				Otherwise does nothing.
+			</p>
+		</div>
+		<div class="dict_entry" id="clear-patches">
+			<h3>
+				<a>clear-patches<span class="since">1.0</span></a>
+				<a>cp<span class="since">1.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">clear-patches</span>
+				<img alt="Observer Command" src="images/observer.gif"/>
+			</h4>
+			<p>
+				Clears the patches by resetting all patch variables to their
+				default initial values, including setting their color to black.
+			</p>
+		</div>
+		<div class="dict_entry" id="clear-plot">
+			<h3>
+				<a>clear-plot</a>
+			</h3>
+			<h4>
+				<span class="prim_example">clear-plot</span>
+			</h4>
+			<p>
+				In the current plot only, resets all plot pens, deletes all
+				temporary plot pens, resets the plot to its default values (for x
+				range, y range, etc.), and resets all permanent plot pens to their
+				default values. The default values for the plot and for the
+				permanent plot pens are set in the plot Edit dialog, which is
+				displayed when you edit the plot. If there are no plot pens after
+				deleting all temporary pens, that is to say if there are no
+				permanent plot pens, a default plot pen will be created with the
+				following initial settings:
+			</p>
+			<ul>
+				<li>Pen: down</li>
+				<li>Color: black</li>
+				<li>Mode: 0 (line mode)</li>
+				<li>Name: &quot;default&quot;</li>
+				<li>Interval: 1</li>
+			</ul>
+			<p>
+				See also <a href="#clear-all-plots">clear-all-plots</a>.
+			</p>
+		</div>
+		<div class="dict_entry" id="clear-ticks">
+			<h3>
+				<a>clear-ticks<span class="since">5.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">clear-ticks</span>
+				<img alt="Observer Command" src="images/observer.gif"/>
+			</h4>
+			<p>
+				Clears the tick counter.
+			</p>
+			<p>
+				Does not set the counter to zero. After this command runs, the tick
+				counter has no value. Attempting to access or update it is an error
+				until <a href="#reset-ticks">reset-ticks</a> is called. This is
+				useful if you want to set the model to a "pre-setup" state with some
+				forever buttons disabled.
+			</p>
+			<p>
+				See also <a href="#reset-ticks">reset-ticks</a>.
+			</p>
+		</div>
+		<div class="dict_entry" id="clear-turtles">
+			<h3>
+				<a>clear-turtles<span class="since">1.0</span></a>
+				<a>ct<span class="since">1.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">clear-turtles</span>
+				<img alt="Observer Command" src="images/observer.gif"/>
+			</h4>
+			<p>
+				Kills all turtles.
+			</p>
+			<p>
+				Also resets the who numbering, so the next turtle created will be
+				turtle 0.
+			</p>
+			<p>
+				See also <a href="#die">die</a>.
+			</p>
+		</div>
+		<div class="dict_entry" id="color">
+			<h3>
+				<a>color</a>
+			</h3>
+			<h4>
+				<span class="prim_example">color</span>
+				<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+			</h4>
+			<p>
+				This is a built-in turtle or link variable. It holds the color of
+				the turtle or link. You can set this variable to make the turtle or
+				link change color. Color can be represented either as a NetLogo
+				color (a single number), or an RGB color (a list of 3 numbers). See
+				details in the <a href="programming.html#colors">Colors section</a>
+				of the Programming Guide.
+			</p>
+			<p>
+				See also <a href="#pcolor">pcolor</a>.
+			</p>
+		</div>
+		<div class="dict_entry" id="cos">
+			<h3>
+				<a>cos<span class="since">1.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">cos <i>number</i></span>
+			</h4>
+			<p>
+				Reports the cosine of the given angle. Assumes the angle is given
+				in degrees.
+			</p>
+			<pre>
+				show cos 180
+				=&gt; -1
+			</pre>
+		</div>
+		<div class="dict_entry" id="count">
+			<h3>
+				<a>count<span class="since">1.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">count <i>agentset</i></span>
+			</h4>
+			<p>
+				Reports the number of agents in the given agentset.
+			</p>
+			<pre>
+				show count turtles
+				;; prints the total number of turtles
+				show count patches with [pcolor = red]
+				;; prints the total number of red patches
+			</pre>
+		</div>
+		<div class="dict_entry" id="create-ordered-turtles">
+			<h3>
+				<a>create-ordered-turtles<span class="since">4.0</span></a>
+				<a>cro<span class="since">4.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">create-ordered-turtles <i>number</i></span>
+				<span class="prim_example">create-ordered-turtles <i>number</i> [ <i>commands</i> ]</span>
+				<span class="prim_example">create-ordered<i>&lt;breeds&gt;</i> <i>number</i></span>
+				<span class="prim_example">create-ordered<i>&lt;breeds&gt;</i> <i>number</i> [ <i>commands</i> ]</span>
+				<img alt="Observer Command" src="images/observer.gif"/>
+			</h4>
+			<p>
+				Creates <i>number</i> new turtles. New turtles start at position
+				(0, 0), are created with the 14 primary colors, and have headings
+				from 0 to 360, evenly spaced.
+			</p>
+			<p>
+				If the create-ordered-<i>&lt;breeds&gt;</i> form is used, the new
+				turtles are created as members of the given breed.
+			</p>
+			<p>
+				If <i>commands</i> are supplied, the new turtles immediately run
+				them. This is useful for giving the new turtles a different color,
+				heading, or whatever. (The new turtles are created all at once then
+				run one at a time, in random order.)
+			</p>
+			<pre>
+				cro 100 [ fd 10 ]  ;; makes an evenly spaced circle
+			</pre>
+		</div>
+		<div class="dict_entry" id="create-link">
+			<h3>
+				<a>create-&lt;breed&gt;-to</a>
+				<a>create-&lt;breeds&gt;-to</a>
+				<a>create-&lt;breed&gt;-from</a>
+				<a>create-&lt;breeds&gt;-from</a>
+				<a>create-&lt;breed&gt;-with</a>
+				<a>create-&lt;breeds&gt;-with</a>
+				<a>create-link-to<span class="since">4.0</span></a>
+				<a>create-links-to<span class="since">4.0</span></a>
+				<a>create-link-from<span class="since">4.0</span></a>
+				<a>create-links-from<span class="since">4.0</span></a>
+				<a>create-link-with<span class="since">4.0</span></a>
+				<a>create-links-with<span class="since">4.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">create-&lt;breed&gt;-to <i>turtle</i></span>
+				<span class="prim_example">create-&lt;breed&gt;-to <i>turtle</i> [ <i>commands</i> ]</span>
+				<span class="prim_example">create-&lt;breed&gt;-from <i>turtle</i></span>
+				<span class="prim_example">create-&lt;breed&gt;-from <i>turtle</i> [ <i>commands</i> ]</span>
+				<span class="prim_example">create-&lt;breed&gt;-with <i>turtle</i></span>
+				<span class="prim_example">create-&lt;breed&gt;-with <i>turtle</i> [ <i>commands</i> ]</span>
+				<span class="prim_example">create-&lt;breeds&gt;-to <i>turtleset</i></span>
+				<span class="prim_example">create-&lt;breeds&gt;-to <i>turtleset</i> [ <i>commands</i> ]</span>
+				<span class="prim_example">create-&lt;breeds&gt;-from <i>turtleset</i></span>
+				<span class="prim_example">create-&lt;breeds&gt;-from <i>turtleset</i> [ <i>commands</i> ]</span>
+				<span class="prim_example">create-&lt;breeds&gt;-with <i>turtleset</i></span>
+				<span class="prim_example">create-&lt;breeds&gt;-with <i>turtleset</i> [ <i>commands</i> ]</span>
+				<span class="prim_example">create-link-to <i>turtle</i></span>
+				<span class="prim_example">create-link-to <i>turtle</i> [ <i>commands</i> ]</span>
+				<span class="prim_example">create-link-from <i>turtle</i></span>
+				<span class="prim_example">create-link-from <i>turtle</i> [ <i>commands</i> ]</span>
+				<span class="prim_example">create-link-with <i>turtle</i></span>
+				<span class="prim_example">create-link-with <i>turtle</i> [ <i>commands</i> ]</span>
+				<span class="prim_example">create-links-to <i>turtleset</i></span>
+				<span class="prim_example">create-links-to <i>turtleset</i> [ <i>commands</i> ]</span>
+				<span class="prim_example">create-links-from <i>turtleset</i></span>
+				<span class="prim_example">create-links-from <i>turtleset</i> [ <i>commands</i> ]</span>
+				<span class="prim_example">create-links-with <i>turtleset</i></span>
+				<span class="prim_example">create-links-with <i>turtleset</i> [ <i>commands</i> ]</span>
+				<img alt="Turtle Command" src="images/turtle.gif"/>
+			</h4>
+			<p>
+				Used for creating breeded and unbreeded links between turtles.
+			</p>
+			<p>
+				<code>create-link-with</code> creates an undirected link between the caller and
+				<i>agent</i>. <code>create-link-to</code> creates a directed link from the
+				caller to <i>agent</i>. <code>create-link-from</code> creates a directed link
+				from <i>agent</i> to the caller.
+			</p>
+			<p>
+				When the plural form of the breed name is used, an <i>agentset</i>
+				is expected instead of an agent and links are created between the
+				caller and all agents in the agentset.
+			</p>
+			<p>
+				The optional command block is the set of commands each newly formed
+				link runs. (The links are created all at once then run one at a
+				time, in random order.)
+			</p>
+			<p>
+				A node cannot be linked to itself. Also, you cannot have more than
+				one undirected link of the same breed between the same two nodes,
+				nor can you have more than one directed link of the same breed
+				going in the same direction between two nodes.
+			</p>
+			<p>
+				If you try to create a link where one (of the same breed) already
+				exists, nothing happens. If you try to create a link from a turtle
+				to itself you get a runtime error.
+			</p>
+			<pre>
+				to setup
+				clear-all
+				create-turtles 5
+				;; turtle 1 creates links with all other turtles
+				;; the link between the turtle and itself is ignored
+				ask turtle 0 [ create-links-with other turtles ]
+				show count links ;; shows 4
+				;; this does nothing since the link already exists
+				ask turtle 0 [ create-link-with turtle 1 ]
+				show count links ;; shows 4 since the previous link already existed
+				ask turtle 2 [ create-link-with turtle 1 ]
+				show count links ;; shows 5
+				end
+			</pre>
+			<pre>
+				directed-link-breed [red-links red-link]
+				undirected-link-breed [blue-links blue-link]
 
-to setup
-  clear-all
-  create-turtles 5
-  ;; create links in both directions between turtle 0
-  ;; and all other turtles
-  ask turtle 0 [ create-red-links-to other turtles ]
-  ask turtle 0 [ create-red-links-from other turtles ]
-  show count links ;; shows 8
-  ;; now create undirected links between turtle 0 and other turtles
-  ask turtle 0 [ create-blue-links-with other turtles ]
-  show count links ;; shows 12
-end
-</pre>
-    </div>
-    <div class="dict_entry" id="create-turtles">
-      <h3>
-        <a>create-turtles<span class="since">1.0</span></a>
-        <a>crt<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">create-turtles <i>number</i></span>
-        <span class="prim_example">create-turtles <i>number</i> [ <i>commands</i> ]</span>
-        <span class="prim_example">create-<i>&lt;breeds&gt;</i> <i>number</i></span>
-        <span class="prim_example">create-<i>&lt;breeds&gt;</i> <i>number</i> [ <i>commands</i> ]</span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Creates <i>number</i> new turtles at the origin. New turtles have
-        random integer headings and the color is randomly selected from the
-        14 primary colors.
-      </p>
-      <p>
-        If the create-<i>&lt;breeds&gt;</i> form is used, the new turtles
-        are created as members of the given breed.
-      </p>
-      <p>
-        If <i>commands</i> are supplied, the new turtles immediately run
-        them. This is useful for giving the new turtles a different color,
-        heading, or whatever. (The new turtles are created all at once then
-        run one at a time, in random order.)
-      </p>
-      <pre>
-crt 100 [ fd 10 ]     ;; makes a randomly spaced circle
-</pre>
-      <pre>
-breed [canaries canary]
-breed [snakes snake]
-to setup
-  clear-all
-  create-canaries 50 [ set color yellow ]
-  create-snakes 50 [ set color green ]
-end
-</pre>
-      <p>
-        See also <a href="#hatch">hatch</a>, <a href="#sprout">sprout</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="create-temporary-plot-pen">
-      <h3>
-        <a>create-temporary-plot-pen<span class="since">1.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">create-temporary-plot-pen <i>string</i></span>
-      </h4>
-      <p>
-        A new temporary plot pen with the given name is created in the
-        current plot and set to be the current pen.
-      </p>
-      <p>
-        Few models will want to use this primitive, because all temporary
-        pens disappear when clear-plot or clear-all-plots are called. The
-        normal way to make a pen is to make a permanent pen in the
-        plot's Edit dialog.
-      </p>
-      <p>
-        If a pen with that name already exists in the current plot, no
-        new pen is created, and the existing pen is set to the current
-        pen.
-      </p>
-      <p>
-        The new temporary plot pen has the following initial settings:
-      </p>
-      <ul>
-        <li>Pen: down
-        <li>Color: black
-        <li>Mode: 0 (line mode)
-        <li>Interval: 1
-        </ul>
-      <p>
-        See: <a href="#clear-plot">clear-plot</a>, <a href="#clear-all-plots">clear-all-plots</a>, and <a href="#set-current-plot-pen">set-current-plot-pen</a>.
-      </p>
-        <!-- ======================================== -->
-      </div>
-    <h2 id="D">
-      <a>D</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="date-and-time">
-      <h3>
-        <a>date-and-time<span class="since">3.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">date-and-time</span>
-      </h4>
-      <p>
-        Reports a string containing the current date and time. The format
-        is shown below. All fields are fixed width, so they are always at
-        the same locations in the string. The potential resolution of the
-        clock is milliseconds. (Whether you get resolution that high in
-        practice may vary from system to system, depending on the
-        capabilities of the underlying Java Virtual Machine.)
-      </p>
-      <pre>
-show date-and-time
-=&gt; &quot;01:19:36.685 PM 19-Sep-2002&quot;
-</pre>
-    </div>
-    <div class="dict_entry" id="die">
-      <h3>
-        <a>die<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">die</span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        The turtle or link dies.
-      </p>
-      <pre>
-if xcor &gt; 20 [ die ]
-;; all turtles with xcor greater than 20 die
-ask links with [color = blue] [ die ]
-;; all the blue links will die
-</pre>
-      <p>
-        A dead agent ceases to exist. The effects of this include:
-      </p>
-      <ul>
-        <li>The agent will not execute any further code. So if you write
-        <code>ask turtles [ die print &quot;last words?&quot; ]</code>, no last
-        words will be printed, because the turtles are already dead before
-        they have a chance to print anything.
-        <li>The agent will disappear from any agentsets it was in, reducing
-        the size of those agentsets by one.
-        <li>Any variable that was storing the agent will now instead have
-        <code>nobody</code> in it. So for example <code>let x one-of turtles ask
-        x [ die ] print x</code> prints <code>nobody</code>.
-        <li>If the dead agent was a turtle, every link connected to it also
-        dies.
-        <li>If the observer was watching or following the agent, the
-        observer's perspective resets, as if <code>reset-perspective</code>
-        had been run.
-        </ul>
-      <p>
-        See also: <a href="#clear-turtles">clear-turtles</a> <a href="#clear-links">clear-links</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="diffuse">
-      <h3>
-        <a>diffuse<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">diffuse <i>patch-variable</i> <i>number</i></span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Tells each patch to give equal shares of (<i>number</i> * 100)
-        percent of the value of <i>patch-variable</i> to its eight
-        neighboring patches. <i>number</i> should be between 0 and 1.
-        Regardless of topology the sum of <i>patch-variable</i> will be
-        conserved across the world. (If a patch has fewer than eight
-        neighbors, each neighbor still gets an eighth share; the patch
-        keeps any leftover shares.)
-      </p>
-      <p>
-        Note that this is an observer command only, even though you might
-        expect it to be a patch command. (The reason is that it acts on all
-        the patches at once -- patch commands act on individual patches.)
-      </p>
-      <pre>
-diffuse chemical 0.5
-;; each patch diffuses 50% of its variable
-;; chemical to its neighboring 8 patches. Thus,
-;; each patch gets 1/8 of 50% of the chemical
-;; from each neighboring patch.)
-</pre>
-    </div>
-    <div class="dict_entry" id="diffuse4">
-      <h3>
-        <a>diffuse4<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">diffuse4 <i>patch-variable</i> <i>number</i></span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Like diffuse, but only diffuses to the four neighboring patches (to
-        the north, south, east, and west), not to the diagonal neighbors.
-      </p>
-      <pre>
-diffuse4 chemical 0.5
-;; each patch diffuses 50% of its variable
-;; chemical to its neighboring 4 patches. Thus,
-;; each patch gets 1/4 of 50% of the chemical
-;; from each neighboring patch.)
-</pre>
-    </div>
-    <div class="dict_entry" id="directed-link-breed">
-      <h3>
-        <a>directed-link-breed</a>
-      </h3>
-      <h4>
-        <span class="prim_example">directed-link-breed [<i>&lt;link-breeds&gt;</i> <i>&lt;link-breed&gt;</i>]</span>
-      </h4>
-      <p>
-        This keyword, like the globals and breeds keywords, can only be
-        used at the beginning of the Code tab, before any procedure
-        definitions. It defines a directed link breed. Links of a
-        particular breed are always all directed or all undirected The
-        first input defines the name of the agentset associated with the
-        link breed. The second input defines the name of a single member of
-        the breed. Directed links can be created using <a href="#create-link">create-link(s)-to</a>, and <a href="#create-link">create-link(s)-from</a>, but not
-        <code>create-link(s)-with</code>
-      </p>
-      <p>
-        Any link of the given link breed:
-      </p>
-      <ul>
-        <li>is part of the agentset named by the link breed name
-        <li>has its built-in variable <code>breed</code> set to that agentset
-        <li>is directed or undirected as declared by the keyword
-        </ul>
-      <p>
-        Most often, the agentset is used in conjunction with ask to give
-        commands to only the links of a particular breed.
-      </p>
-      <pre>
-directed-link-breed [streets street]
-directed-link-breed [highways highway]
-to setup
-  clear-all
-  crt 2
-  ;; create a link from turtle 0 to turtle 1
-  ask turtle 0 [ create-street-to turtle 1 ]
-  ;; create a link from turtle 1 to turtle 0
-  ask turtle 0 [ create-highway-from turtle 1 ]
-end
+				to setup
+				clear-all
+				create-turtles 5
+				;; create links in both directions between turtle 0
+				;; and all other turtles
+				ask turtle 0 [ create-red-links-to other turtles ]
+				ask turtle 0 [ create-red-links-from other turtles ]
+				show count links ;; shows 8
+				;; now create undirected links between turtle 0 and other turtles
+				ask turtle 0 [ create-blue-links-with other turtles ]
+				show count links ;; shows 12
+				end
+			</pre>
+		</div>
+		<div class="dict_entry" id="create-turtles">
+			<h3>
+				<a>create-turtles<span class="since">1.0</span></a>
+				<a>crt<span class="since">1.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">create-turtles <i>number</i></span>
+				<span class="prim_example">create-turtles <i>number</i> [ <i>commands</i> ]</span>
+				<span class="prim_example">create-<i>&lt;breeds&gt;</i> <i>number</i></span>
+				<span class="prim_example">create-<i>&lt;breeds&gt;</i> <i>number</i> [ <i>commands</i> ]</span>
+				<img alt="Observer Command" src="images/observer.gif"/>
+			</h4>
+			<p>
+				Creates <i>number</i> new turtles at the origin. New turtles have
+				random integer headings and the color is randomly selected from the
+				14 primary colors.
+			</p>
+			<p>
+				If the create-<i>&lt;breeds&gt;</i> form is used, the new turtles
+				are created as members of the given breed.
+			</p>
+			<p>
+				If <i>commands</i> are supplied, the new turtles immediately run
+				them. This is useful for giving the new turtles a different color,
+				heading, or whatever. (The new turtles are created all at once then
+				run one at a time, in random order.)
+			</p>
+			<pre>
+				crt 100 [ fd 10 ]     ;; makes a randomly spaced circle
+			</pre>
+			<pre>
+				breed [canaries canary]
+				breed [snakes snake]
+				to setup
+				clear-all
+				create-canaries 50 [ set color yellow ]
+				create-snakes 50 [ set color green ]
+				end
+			</pre>
+			<p>
+				See also <a href="#hatch">hatch</a>, <a href="#sprout">sprout</a>.
+			</p>
+		</div>
+		<div class="dict_entry" id="create-temporary-plot-pen">
+			<h3>
+				<a>create-temporary-plot-pen<span class="since">1.1</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">create-temporary-plot-pen <i>string</i></span>
+			</h4>
+			<p>
+				A new temporary plot pen with the given name is created in the
+				current plot and set to be the current pen.
+			</p>
+			<p>
+				Few models will want to use this primitive, because all temporary
+				pens disappear when clear-plot or clear-all-plots are called. The
+				normal way to make a pen is to make a permanent pen in the
+				plot's Edit dialog.
+			</p>
+			<p>
+				If a pen with that name already exists in the current plot, no
+				new pen is created, and the existing pen is set to the current
+				pen.
+			</p>
+			<p>
+				The new temporary plot pen has the following initial settings:
+			</p>
+			<ul>
+				<li>Pen: down</li>
+				<li>Color: black</li>
+				<li>Mode: 0 (line mode)</li>
+				<li>Interval: 1</li>
+			</ul>
+			<p>
+				See: <a href="#clear-plot">clear-plot</a>, <a href="#clear-all-plots">clear-all-plots</a>, and <a href="#set-current-plot-pen">set-current-plot-pen</a>.
+			</p>
+			<!-- ======================================== -->
+		</div>
+		<h2 id="D">
+			<a>D</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="date-and-time">
+				<h3>
+					<a>date-and-time<span class="since">3.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">date-and-time</span>
+				</h4>
+				<p>
+					Reports a string containing the current date and time. The format
+					is shown below. All fields are fixed width, so they are always at
+					the same locations in the string. The potential resolution of the
+					clock is milliseconds. (Whether you get resolution that high in
+					practice may vary from system to system, depending on the
+					capabilities of the underlying Java Virtual Machine.)
+				</p>
+				<pre>
+					show date-and-time
+					=&gt; &quot;01:19:36.685 PM 19-Sep-2002&quot;
+				</pre>
+			</div>
+			<div class="dict_entry" id="die">
+				<h3>
+					<a>die<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">die</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					The turtle or link dies.
+				</p>
+				<pre>
+					if xcor &gt; 20 [ die ]
+					;; all turtles with xcor greater than 20 die
+					ask links with [color = blue] [ die ]
+					;; all the blue links will die
+				</pre>
+				<p>
+					A dead agent ceases to exist. The effects of this include:
+				</p>
+				<ul>
+					<li>The agent will not execute any further code. So if you write
+						<code>ask turtles [ die print &quot;last words?&quot; ]</code>, no last
+						words will be printed, because the turtles are already dead before
+						they have a chance to print anything.
+					</li>
+					<li>The agent will disappear from any agentsets it was in, reducing
+						the size of those agentsets by one.
+					</li>
+					<li>Any variable that was storing the agent will now instead have
+						<code>nobody</code> in it. So for example <code>let x one-of turtles ask
+							x [ die ] print x</code> prints <code>nobody</code>.
+					</li>
+					<li>If the dead agent was a turtle, every link connected to it also
+						dies.
+					</li>
+					<li>If the observer was watching or following the agent, the
+						observer's perspective resets, as if <code>reset-perspective</code>
+						had been run.
+					</li>
+				</ul>
+				<p>
+					See also: <a href="#clear-turtles">clear-turtles</a> <a href="#clear-links">clear-links</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="diffuse">
+				<h3>
+					<a>diffuse<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">diffuse <i>patch-variable</i> <i>number</i></span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Tells each patch to give equal shares of (<i>number</i> * 100)
+					percent of the value of <i>patch-variable</i> to its eight
+					neighboring patches. <i>number</i> should be between 0 and 1.
+					Regardless of topology the sum of <i>patch-variable</i> will be
+					conserved across the world. (If a patch has fewer than eight
+					neighbors, each neighbor still gets an eighth share; the patch
+					keeps any leftover shares.)
+				</p>
+				<p>
+					Note that this is an observer command only, even though you might
+					expect it to be a patch command. (The reason is that it acts on all
+					the patches at once -- patch commands act on individual patches.)
+				</p>
+				<pre>
+					diffuse chemical 0.5
+					;; each patch diffuses 50% of its variable
+					;; chemical to its neighboring 8 patches. Thus,
+					;; each patch gets 1/8 of 50% of the chemical
+					;; from each neighboring patch.)
+				</pre>
+			</div>
+			<div class="dict_entry" id="diffuse4">
+				<h3>
+					<a>diffuse4<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">diffuse4 <i>patch-variable</i> <i>number</i></span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Like diffuse, but only diffuses to the four neighboring patches (to
+					the north, south, east, and west), not to the diagonal neighbors.
+				</p>
+				<pre>
+					diffuse4 chemical 0.5
+					;; each patch diffuses 50% of its variable
+					;; chemical to its neighboring 4 patches. Thus,
+					;; each patch gets 1/4 of 50% of the chemical
+					;; from each neighboring patch.)
+				</pre>
+			</div>
+			<div class="dict_entry" id="directed-link-breed">
+				<h3>
+					<a>directed-link-breed</a>
+				</h3>
+				<h4>
+					<span class="prim_example">directed-link-breed [<i>&lt;link-breeds&gt;</i> <i>&lt;link-breed&gt;</i>]</span>
+				</h4>
+				<p>
+					This keyword, like the globals and breeds keywords, can only be
+					used at the beginning of the Code tab, before any procedure
+					definitions. It defines a directed link breed. Links of a
+					particular breed are always all directed or all undirected The
+					first input defines the name of the agentset associated with the
+					link breed. The second input defines the name of a single member of
+					the breed. Directed links can be created using <a href="#create-link">create-link(s)-to</a>, and <a href="#create-link">create-link(s)-from</a>, but not
+					<code>create-link(s)-with</code>
+				</p>
+				<p>
+					Any link of the given link breed:
+				</p>
+				<ul>
+					<li>is part of the agentset named by the link breed name</li>
+					<li>has its built-in variable <code>breed</code> set to that agentset</li>
+					<li>is directed or undirected as declared by the keyword</li>
+				</ul>
+				<p>
+					Most often, the agentset is used in conjunction with ask to give
+					commands to only the links of a particular breed.
+				</p>
+				<pre>
+					directed-link-breed [streets street]
+					directed-link-breed [highways highway]
+					to setup
+					clear-all
+					crt 2
+					;; create a link from turtle 0 to turtle 1
+					ask turtle 0 [ create-street-to turtle 1 ]
+					;; create a link from turtle 1 to turtle 0
+					ask turtle 0 [ create-highway-from turtle 1 ]
+					end
 
-ask turtle 0 [ show one-of my-in-links ]
-;; prints (street 0 1)
-ask turtle 0 [ show one-of my-out-links ]
-;; prints (highway 1 0)
-</pre>
-      <p>
-        See also <a href="#breed">breed</a>, <a href="#undirected-link-breed">undirected-link-breed</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="display">
-      <h3>
-        <a>display<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">display</span>
-      </h4>
-      <p>
-        Causes the view to be updated immediately. (Exception: if the user
-        is using the speed slider to fast-forward the model, then the
-        update may be skipped.)
-      </p>
-      <p>
-        Also undoes the effect of the no-display command, so that if view
-        updates were suspended by that command, they will resume.
-      </p>
-      <pre>
-no-display
-ask turtles [ jump 10 set color blue set size 5 ]
-display
-;; turtles move, change color, and grow, with none of
-;; their intermediate states visible to the user, only
-;; their final state
-</pre>
-      <p>
-        Even if no-display was not used, &quot;display&quot; can still be
-        useful, because ordinarily NetLogo is free to skip some view
-        updates, so that fewer total updates take place, so that models run
-        faster. This command lets you force a view update, so whatever
-        changes have taken place in the world are visible to the user.
-      </p>
-      <pre>
-ask turtles [ set color red ]
-display
-ask turtles [ set color blue]
-;; turtles turn red, then blue; use of &quot;display&quot; forces
-;; red turtles to appear briefly
-</pre>
-      <p>
-        Note that display and no-display operate independently of the
-        switch in the view control strip that freezes the view.
-      </p>
-      <p>
-        See also <a href="#no-display">no-display</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="distance">
-      <h3>
-        <a>distance<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">distance <i>agent</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        Reports the distance from this agent to the given turtle or patch.
-      </p>
-      <p>
-        The distance to or a from a patch is measured from the center of
-        the patch. Turtles and patches use the wrapped distance (around the
-        edges of the world) if wrapping is allowed by the topology and the
-        wrapped distance is shorter.
-      </p>
-      <pre>
-ask turtles [ show max-one-of turtles [distance myself] ]
-;; each turtle prints the turtle farthest from itself
-</pre>
-    </div>
-    <div class="dict_entry" id="distancexy">
-      <h3>
-        <a>distancexy<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">distancexy <i>x</i> <i>y</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        Reports the distance from this agent to the point (<i>x</i>,
-        <i>y</i>).
-      </p>
-      <p>
-        The distance from a patch is measured from the center of the patch.
-        Turtles and patches use the wrapped distance (around the edges of
-        the world) if wrapping is allowed by the topology and the wrapped
-        distance is shorter.
-      </p>
-      <pre>
-if (distancexy 0 0) &gt; 10
-  [ set color green ]
-;; all turtles more than 10 units from
-;; the center of the world turn green.
-</pre>
-    </div>
-    <div class="dict_entry" id="downhill">
-      <h3>
-        <a>downhill<span class="since">1.0</span></a>
-        <a>downhill4<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">downhill <i>patch-variable</i></span>
-        <span class="prim_example">downhill4 <i>patch-variable</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Moves the turtle to the neighboring patch with the lowest value for
-        <i>patch-variable</i>. If no neighboring patch has a smaller value
-        than the current patch, the turtle stays put. If there are multiple
-        patches with the same lowest value, the turtle picks one randomly.
-        Non-numeric values are ignored.
-      </p>
-      <p>
-        downhill considers the eight neighboring patches; downhill4 only
-        considers the four neighbors.
-      </p>
-      <p>
-        Equivalent to the following code (assumes variable values are
-        numeric):
-      </p>
-      <pre>
-move-to patch-here  ;; go to patch center
-let p min-one-of neighbors [<i>patch-variable</i>]  ;; or neighbors4
-if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
-  face p
-  move-to p
-]
-</pre>
-      <p>
-        Note that the turtle always ends up on a patch center and has a
-        heading that is a multiple of 45 (downhill) or 90 (downhill4).
-      </p>
-      <p>
-        See also <a href="#uphill">uphill</a>, <a href="#uphill">uphill4</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="dxy">
-      <h3>
-        <a>dx<span class="since">1.0</span></a>
-        <a>dy<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">dx</span>
-        <span class="prim_example">dy</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Reports the x-increment or y-increment (the amount by which the
-        turtle's xcor or ycor would change) if the turtle were to take
-        one step forward in its current heading.
-      </p>
-      <p>
-        Note: dx is simply the sine of the turtle's heading, and dy is
-        simply the cosine. (If this is the reverse of what you expected,
-        it's because in NetLogo a heading of 0 is north and 90 is east,
-        which is the reverse of how angles are usually defined in
-        geometry.)
-      </p>
-      <p>
-        Note: In earlier versions of NetLogo, these primitives were used in
-        many situations where the new <code>patch-ahead</code> primitive is now
-        more appropriate.
-      </p> <!-- ======================================== -->
-      </div>
-    </div>
-    <h2 id="E">
-      <a>E</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="empty">
-      <h3>
-        <a>empty?<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">empty? <i>list</i></span>
-        <span class="prim_example">empty? <i>string</i></span>
-      </h4>
-      <p>
-        Reports true if the given list or string is empty, false otherwise.
-      </p>
-      <p>
-        Note: the empty list is written <code>[]</code>. The empty string is
-        written <code>&quot;&quot;</code>.
-      </p>
-      </div>
-    <div class="dict_entry" id="end">
-      <h3>
-        <a>end</a>
-      </h3>
-      <h4>
-        <span class="prim_example">end</span>
-      </h4>
-      <p>
-        Used to conclude a procedure. See <a href="#to">to</a> and <a href="#to-report">to-report</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="end1">
-      <h3>
-        <a>end1<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">end1</span>
-        <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        This is a built-in link variable. It indicates the first endpoint
-        (turtle) of a link. For directed links this will always be the
-        source for undirected links it will always be the turtle with the
-        lower who number. You cannot set end1.
-      </p>
-      <pre>
-crt 2
-ask turtle 0
-[ create-link-to turtle 1 ]
-ask links
-[ show end1 ] ;; shows turtle 0
-</pre>
-    </div>
-    <div class="dict_entry" id="end2">
-      <h3>
-        <a>end2<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">end2</span>
-        <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        This is a built-in link variable. It indicates the second endpoint
-        (turtle) of a link. For directed links this will always be the
-        destination for undirected links it will always be the turtle with
-        the higher who number. You cannot set end2.
-      </p>
-      <pre>
-crt 2
-ask turtle 1
-[ create-link-with turtle 0 ]
-ask links
-[ show end2 ] ;; shows turtle 1
-</pre>
-    </div>
-    <div class="dict_entry" id="error">
-      <h3>
-        <a>error<span class="since">5.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">error <i>value</i></span>
-      </h4>
-      <p>
-        Causes a runtime error to occur.
-      </p>
-      <p>
-        The given value is converted to a string (if it isn't one
-        already) and used as the error message.
-      </p>
-      <p>
-        See also <a href="#error-message">error-message</a>, <a href="#carefully">carefully</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="error-message">
-      <h3>
-        <a>error-message<span class="since">2.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">error-message</span>
-      </h4>
-      <p>
-        Reports a string describing the error that was suppressed by
-        carefully.
-      </p>
-      <p>
-        This reporter can only be used in the second block of a carefully
-        command.
-      </p>
-      <p>
-        See also <a href="#error">error</a>, <a href="#carefully">carefully</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="every">
-      <h3>
-        <a>every<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">every <i>number</i> [ <i>commands</i> ]</span>
-      </h4>
-      <p>
-        Runs the given commands only if it's been more than
-        <i>number</i> seconds since the last time this agent ran them in
-        this context. Otherwise, the commands are skipped.
-      </p>
-      <p>
-        By itself, every doesn't make commands run over and over again.
-        You need to use every inside a loop, or inside a forever button, if
-        you want the commands run over and over again. every only limits
-        how often the commands run.
-      </p>
-      <p>
-        Above, &quot;in this context&quot; means during the same ask (or
-        button press or command typed in the Command Center). So it
-        doesn't make sense to write <code>ask turtles [ every 0.5 [ ... ]
-        ]</code>, because when the ask finishes the turtles will all discard
-        their timers for the &quot;every&quot;. The correct usage is shown
-        below.
-      </p>
-      <pre>
-every 0.5 [ ask turtles [ fd 1 ] ]
-;; twice a second the turtles will move forward 1
-every 2 [ set index index + 1 ]
-;; every 2 seconds index is incremented
-</pre>
-      <p>
-        See also <a href="#wait">wait</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="exp">
-      <h3>
-        <a>exp<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">exp <i>number</i></span>
-      </h4>
-      <p>
-        Reports the value of e raised to the <i>number</i> power.
-      </p>
-      <p>
-        Note: This is the same as e ^ <i>number</i>.
-      </p>
-      </div>
-    <div class="dict_entry" id="export-cmds">
-      <h3>
-        <a>export-view<span class="since">3.0</span></a>
-        <a>export-interface<span class="since">2.0</span></a>
-        <a>export-output<span class="since">1.0</span></a>
-        <a>export-plot<span class="since">1.0</span></a>
-        <a>export-all-plots<span class="since">1.2.1</span></a>
-        <a>export-world<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">export-view <i>filename</i></span>
-        <span class="prim_example">export-interface <i>filename</i></span>
-        <span class="prim_example">export-output <i>filename</i></span>
-        <span class="prim_example">export-plot <i>plotname</i> <i>filename</i></span>
-        <span class="prim_example">export-all-plots <i>filename</i></span>
-        <span class="prim_example">export-world <i>filename</i></span>
-      </h4>
-      <p>
-        export-view writes the current contents of the current view to an
-        external file given by the string <i>filename</i>. The file is
-        saved in PNG (Portable Network Graphics) format, so it is
-        recommended to supply a filename ending in &quot;.png&quot;.
-      </p>
-      <p>
-        export-interface is similar, but for the whole interface tab.
-      </p>
-      <p>
-        Note that export-view still works when running NetLogo in headless
-        mode, but export-interface doesn't.
-      </p>
-      <p>
-        export-output writes the contents of the model's output area to
-        an external file given by the string <i>filename</i>. (If the model
-        does not have a separate output area, the output portion of the
-        Command Center is used.)
-      </p>
-      <p>
-        export-plot writes the x and y values of all points plotted by all
-        the plot pens in the plot given by the string <i>plotname</i> to an
-        external file given by the string <i>filename</i>. If a pen is in
-        bar mode (mode 0) and the y value of the point plotted is greater
-        than 0, the upper-left corner point of the bar will be exported. If
-        the y value is less than 0, then the lower-left corner point of the
-        bar will be exported.
-      </p>
-      <p>
-        export-all-plots writes every plot in the current model to an
-        external file given by the string <i>filename</i>. Each plot is
-        identical in format to the output of export-plot.
-      </p>
-      <p>
-        export-world writes the values of all variables, both built-in and
-        user-defined, including all observer, turtle, and patch variables,
-        the drawing, the contents of the output area if one exists, the
-        contents of any plots and the state of the random number generator,
-        to an external file given by the string <i>filename</i>. (The
-        result file can be read back into NetLogo with the <a href="#import-world">import-world</a> primitive.) export-world does not
-        save the state of open files.
-      </p>
-      <p>
-        export-plot, export-all-plots and export-world save files in in
-        plain-text, &quot;comma-separated values&quot; (<code>.csv</code>)
-        format. CSV files can be read by most popular spreadsheet and
-        database programs as well as any text editor.
-      </p>
-      <p>
-        If you wish to export to a file in a location other than the
-        model's location, you should include the full path to the file
-        you wish to export. (Use the forward-slash &quot;/&quot; as the
-        folder separator.)
-      </p>
-      <p>
-        Note that the functionality of these primitives is also available
-        directly from NetLogo's File menu.
-      </p>
-      <pre>
-export-world &quot;fire.csv&quot;
-;; exports the state of the model to the file fire.csv
-;; located in the NetLogo folder
-export-plot &quot;Temperature&quot; &quot;c:/My Documents/plot.csv&quot;
-;; exports the plot named
-;; &quot;Temperature&quot; to the file plot.csv located in
-;; the C:\My Documents folder
-export-all-plots &quot;c:/My Documents/plots.csv&quot;
-;; exports all plots to the file plots.csv
-;; located in the C:\My Documents folder
-</pre>
-      <p>
-        If the file already exists, it is overwritten. To avoid this you
-        may wish to use some method of generating fresh names. Examples:
-      </p>
-      <pre>
-export-world user-new-file
-export-world (word &quot;results &quot; date-and-time &quot;.csv&quot;) ;; Colon characters in the time cause errors on Windows
-export-world (word &quot;results &quot; random-float 1.0 &quot;.csv&quot;)
-</pre>
-    </div>
-    <div class="dict_entry" id="extensions">
-      <h3>
-        <a>extensions</a>
-      </h3>
-      <h4>
-        <span class="prim_example">extensions [<i>name</i> ...]</span>
-      </h4>
-      <p>
-        Allows the model to use primitives from the extensions with the
-        given names. See the <a href="extensions.html">Extensions guide</a>
-        for more information.
-      </p>
-      </div>
-    <div class="dict_entry" id="extract-hsb">
-      <h3>
-        <a>extract-hsb<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">extract-hsb <i>color</i></span>
-      </h4>
-      <p>
-        Reports a list of three values, the first (hue) in the range of
-        0 to 360, the second and third (brightness and saturation) in
-        the range of 0 to 100.
-      </p>
-      <p>
-        The given <i>color</i> can either be a NetLogo color in the
-        range 0 to 140, not including 140 itself, or an RGB list of
-        three values in the range 0 to 255 representing the levels
-        of red, green, and blue.
-      </p>
-      <pre>
-show extract-hsb cyan
-=&gt; [180 57.143 76.863]
-show extract-hsb red
-=&gt; [3.103 80.93 84.314]
-show extract-hsb [255 0 0]
-=&gt; [0 100 100]
-</pre>
-      <p>
-        See also <a href="#approximate-hsb">approximate-hsb</a>, <a href="#approximate-rgb">approximate-rgb</a>, <a href="#extract-rgb">extract-rgb</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="extract-rgb">
-      <h3>
-        <a>extract-rgb<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">extract-rgb <i>color</i></span>
-      </h4>
-      <p>
-        Reports a list of three values in the range 0 to 255 representing
-        the levels of red, green, and blue, respectively, of the given
-        NetLogo <i>color</i> in the range 0 to 140, not including 140
-        itself.
-      </p>
-      <pre>
-show extract-rgb red
-=&gt; [215 50 41]
-show extract-rgb cyan
-=&gt; [84 196 196]
-</pre>
-      <p>
-        See also <a href="#approximate-rgb">approximate-rgb</a>, <a href="#approximate-hsb">approximate-hsb</a>, <a href="#extract-hsb">extract-hsb</a>.
-      </p>
-      </div><!-- ======================================== -->
-    </div>
-    <h2 id="F">
-      <a>F</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="face">
-      <h3>
-        <a>face<span class="since">3.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">face <i>agent</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Set the caller's heading towards <i>agent</i>.
-      </p>
-      <p>
-        If wrapping is allowed by the topology and the wrapped distance
-        (around the edges of the world) is shorter, face will use the
-        wrapped path.
-      </p>
-      <p>
-        If the caller and the agent are at the exact same position, the
-        caller's heading won't change.
-      </p>
-      </div>
-    <div class="dict_entry" id="facexy">
-      <h3>
-        <a>facexy<span class="since">3.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">facexy <i>x</i> <i>y</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Set the caller's heading towards the point (x,y).
-      </p>
-      <p>
-        If wrapping is allowed by the topology and the wrapped distance
-        (around the edges of the world) is shorter and wrapping is allowed,
-        facexy will use the wrapped path.
-      <p>
-        If the caller is on the point (x,y), the caller's heading
-        won't change.
-      </p>
-      </div>
-    <div class="dict_entry" id="file-at-end">
-      <h3>
-        <a>file-at-end?<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">file-at-end?</span>
-      </h4>
-      <p>
-        Reports true when there are no more characters left to read in from
-        the current file (that was opened previously with <a href="#file-open">file-open</a>). Otherwise, reports false.
-      </p>
-      <pre>
-file-open &quot;my-file.txt&quot;
-print file-at-end?
-=&gt; false ;; Can still read in more characters
-print file-read-line
-=&gt; This is the last line in file
-print file-at-end?
-=&gt; true ;; We reached the end of the file
-</pre>
-      <p>
-        See also <a href="#file-open">file-open</a>, <a href="#file-close-all">file-close-all</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="file-close">
-      <h3>
-        <a>file-close<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">file-close</span>
-      </h4>
-      <p>
-        Closes a file that has been opened previously with <a href="#file-open">file-open</a>.
-      </p>
-      <p>
-        Note that this and file-close-all are the only ways to restart to
-        the beginning of an opened file or to switch between file modes.
-      </p>
-      <p>
-        If no file is open, does nothing.
-      </p>
-      <p>
-        See also <a href="#file-close-all">file-close-all</a>, <a href="#file-open">file-open</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="file-close-all">
-      <h3>
-        <a>file-close-all<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">file-close-all</span>
-      </h4>
-      <p>
-        Closes all files (if any) that have been opened previously with
-        <a href="#file-open">file-open</a>.
-      </p>
-      <p>
-        See also <a href="#file-close">file-close</a>, <a href="#file-open">file-open</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="file-delete">
-      <h3>
-        <a>file-delete<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">file-delete <i>string</i></span>
-      </h4>
-      <p>
-        Deletes the file specified as <i>string</i>
-      </p>
-      <p>
-        <i>string</i> must be an existing file with writable permission by
-        the user. Also, the file cannot be open. Use the command <a href="#file-close">file-close</a> to close an opened file before
-        deletion.
-      </p>
-      <p>
-        Note that the string can either be a file name or an absolute file
-        path. If it is a file name, it looks in whatever the current
-        directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It is defaulted
-        to the model's directory.
-      </p>
-      </div>
-    <div class="dict_entry" id="file-exists">
-      <h3>
-        <a>file-exists?<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">file-exists? <i>string</i></span>
-      </h4>
-      <p>
-        Reports true if <i>string</i> is the name of an existing file on
-        the system. Otherwise it reports false.
-      </p>
-      <p>
-        Note that the string can either be a file name or an absolute file
-        path. If it is a file name, it looks in whatever the current
-        directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It defaults to
-        to the model's directory.
-      </p>
-      </div>
-    <div class="dict_entry" id="file-flush">
-      <h3>
-        <a>file-flush<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">file-flush</span>
-      </h4>
-      <p>
-        Forces file updates to be written to disk. When you use file-write
-        or other output commands, the values may not be immediately written
-        to disk. This improves the performance of the file output commands.
-        Closing a file ensures that all output is written to disk.
-      </p>
-      <p>
-        Sometimes you need to ensure that data is written to disk without
-        closing the file. For example, you could be using a file to
-        communicate with another program on your machine and want the other
-        program to be able to see the output immediately.
-      </p>
-      </div>
-    <div class="dict_entry" id="file-open">
-      <h3>
-        <a>file-open<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">file-open <i>string</i></span>
-      </h4>
-      <p>
-        This command will interpret <i>string</i> as a path name to a file
-        and open the file. You may then use the reporters <a href="#file-read">file-read</a>, <a href="#file-read-line">file-read-line</a>, and <a href="#file-read-characters">file-read-characters</a> to read in from
-        the file, or <a href="#file-write">file-write</a>, <a href="#file-print">file-print</a>, <a href="#file-type">file-type</a>,
-        or <a href="#file-show">file-show</a> to write out to the file.
-      </p>
-      <p>
-        Note that you can only open a file for reading or writing but not
-        both. The next file i/o primitive you use after this command
-        dictates which mode the file is opened in. To switch modes, you
-        need to close the file using <a href="#file-close">file-close</a>.
-      </p>
-      <p>
-        Also, the file must already exist if opening a file in reading
-        mode.
-      </p>
-      <p>
-        When opening a file in writing mode, all new data will be appended
-        to the end of the original file. If there is no original file, a
-        new blank file will be created in its place. (You must have write
-        permission in the file's directory.) (If you don't want to
-        append, but want to replace the file's existing contents, use
-        <a href="#file-delete">file-delete</a> to delete it first, perhaps
-        inside a <a href="#carefully">carefully</a> if you're not sure
-        whether it already exists.)
-      </p>
-      <p>
-        Note that the string can either be a file name or an absolute file
-        path. If it is a file name, it looks in whatever the current
-        directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It is defaulted
-        to the model's directory.
-      </p>
-      <pre>
-file-open &quot;my-file-in.txt&quot;
-print file-read-line
-=&gt; First line in file ;; File is in reading mode
-file-open &quot;C:\\NetLogo\\my-file-out.txt&quot;
-;; assuming Windows machine
-file-print &quot;Hello World&quot; ;; File is in writing mode
-</pre>
-      <p>
-        Opening a file does not close previously opened files. You can use
-        <code>file-open</code> to switch back and forth between multiple open
-        files.
-      </p>
-      <p>
-        See also <a href="#file-close">file-close</a> See also <a href="#file-close-all">file-close-all</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="file-print">
-      <h3>
-        <a>file-print<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">file-print <i>value</i></span>
-      </h4>
-      <p>
-        Prints <i>value</i> to an opened file, followed by a carriage
-        return.
-      </p>
-      <p>
-        This agent is <i>not</i> printed before the value, unlike <a href="#file-show">file-show</a>.
-      </p>
-      <p>
-        Note that this command is the file i/o equivalent of <a href="#print">print</a>, and <a href="#file-open">file-open</a> needs to
-        be called before this command can be used.
-      </p>
-      <p>
-      See also <a href="#file-show">file-show</a>, <a href="#file-type">file-type</a>,
-      <a href="#file-write">file-write</a>,
-      and <a href="programming.html#output">Output (programming guide)</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="file-read">
-      <h3>
-        <a>file-read<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">file-read</span>
-      </h4>
-      <p>
-        This reporter will read in the next constant from the opened file
-        and interpret it as if it had been typed in the Command Center. It
-        reports the resulting value. The result may be a number, list,
-        string, boolean, or the special value nobody.
-      </p>
-      <p>
-        Whitespace separates the constants. Each call to file-read will
-        skip past both leading and trailing whitespace.
-      </p>
-      <p>
-        Note that strings need to have quotes around them. Use the command
-        <a href="#file-write">file-write</a> to have quotes included.
-      </p>
-      <p>
-        Also note that the <a href="#file-open">file-open</a> command must
-        be called before this reporter can be used, and there must be data
-        remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
-        of the file.
-      </p>
-      <pre>
-file-open &quot;my-file.data&quot;
-print file-read + 5
-;; Next value is the number 1
-=&gt; 6
-print length file-read
-;; Next value is the list [1 2 3 4]
-=&gt; 4
-</pre>
-      <p>
-        See also <a href="#file-open">file-open</a> and <a href="#file-write">file-write</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="file-read-characters">
-      <h3>
-        <a>file-read-characters<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">file-read-characters <i>number</i></span>
-      </h4>
-      <p>
-        Reports the given <i>number</i> of characters from an opened file
-        as a string. If there are fewer than that many characters left, it
-        will report all of the remaining characters.
-      </p>
-      <p>
-        Note that it will return every character including newlines and
-        spaces.
-      </p>
-      <p>
-        Also note that the <a href="#file-open">file-open</a> command must
-        be called before this reporter can be used, and there must be data
-        remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
-        of the file.
-      </p>
-      <pre>
-file-open &quot;my-file.txt&quot;
-print file-read-characters 5
-;; Current line in file is &quot;Hello World&quot;
-=&gt; Hello
-</pre>
-      <p>
-        See also <a href="#file-open">file-open</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="file-read-line">
-      <h3>
-        <a>file-read-line<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">file-read-line</span>
-      </h4>
-      <p>
-        Reads the next line in the file and reports it as a string. It
-        determines the end of the file by a carriage return, an end of file
-        character or both in a row. It does not return the line terminator
-        characters.
-      </p>
-      <p>
-        Also note that the <a href="#file-open">file-open</a> command must
-        be called before this reporter can be used, and there must be data
-        remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
-        of the file.
-      </p>
-      <pre>
-file-open &quot;my-file.txt&quot;
-print file-read-line
-=&gt; Hello World
-</pre>
-      <p>
-        See also <a href="#file-open">file-open</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="file-show">
-      <h3>
-        <a>file-show<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">file-show <i>value</i></span>
-      </h4>
-      <p>
-        Prints <i>value</i> to an opened file, preceded by this agent
-        agent, and followed by a carriage return. (This agent is included
-        to help you keep track of what agents are producing which lines of
-        output.) Also, all strings have their quotes included similar to
-        <a href="#file-write">file-write</a>.
-      </p>
-      <p>
-        Note that this command is the file i/o equivalent of <a href="#show">show</a>, and <a href="#file-open">file-open</a> needs to
-        be called before this command can be used.
-      </p>
-      <p>
-        See also <a href="#file-print">file-print</a>, <a href="#file-type">file-type</a>,
-        <a href="#file-write">file-write</a>,
-        and <a href="programming.html#output">Output (programming guide)</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="file-type">
-      <h3>
-        <a>file-type<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">file-type <i>value</i></span>
-      </h4>
-      <p>
-        Prints <i>value</i> to an opened file, <i>not</i> followed by a
-        carriage return (unlike <a href="#file-print">file-print</a> and
-        <a href="#file-show">file-show</a>). The lack of a carriage return
-        allows you to print several values on the same line.
-      </p>
-      <p>
-        This agent is <i>not</i> printed before the value. unlike <a href="#file-show">file-show</a>.
-      </p>
-      <p>
-        Note that this command is the file i/o equivalent of <a href="#type">type</a>, and <a href="#file-open">file-open</a> needs to
-        be called before this command can be used.
-      </p>
-      <p>
-        See also <a href="#file-print">file-print</a>, <a href="#file-show">file-show</a>, <a href="#file-write">file-write</a>, and
-        <a href="programming.html#output">Output (programming guide)</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="file-write">
-      <h3>
-        <a>file-write<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">file-write <i>value</i></span>
-      </h4>
-      <p>
-        This command will output <i>value</i>, which can be a number,
-        string, list, boolean, or nobody to an opened file, <i>not</i>
-        followed by a carriage return (unlike <a href="#file-print">file-print</a> and <a href="#file-show">file-show</a>).
-      </p>
-      <p>
-        This agent is <i>not</i> printed before the value, unlike <a href="#file-show">file-show</a>. Its output also includes quotes around
-        strings and is prepended with a space. It will output the value in
-        such a manner that <a href="#file-read">file-read</a> will be able
-        to interpret it.
-      </p>
-      <p>
-        Note that this command is the file i/o equivalent of <a href="#write">write</a>, and <a href="#file-open">file-open</a> needs to
-        be called before this command can be used.
-      </p>
-      <pre>
-file-open &quot;locations.txt&quot;
-ask turtles
-  [ file-write xcor file-write ycor ]
-</pre>
-      <p>
-        See also <a href="#file-print">file-print</a>, <a href="#file-show">file-show</a>,
-        <a href="#file-type">file-type</a>,
-        and <a href="programming.html#output">Output (programming guide)</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="filter">
-      <h3>
-        <a>filter<span class="since">1.3</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">filter <i>reporter</i> <i>list</i></span>
-      </h4>
-      <p>
-        Reports a list containing only those items of <i>list</i> for which
-        the reporter reports true -- in other words, the items satisfying the
-        given condition. <i>reporter</i> may be an anonymous reporter or the
-        name of a reporter.
-      </p>
-      <pre>
-show filter is-number? [1 &quot;2&quot; 3]
-=&gt; [1 3]
-show filter [ i -&gt; i &lt; 3 ] [1 3 2]
-=&gt; [1 2]
-show filter [ s -&gt; first s != &quot;t&quot; ] [&quot;hi&quot; &quot;there&quot; &quot;everyone&quot;]
-=&gt; [&quot;hi&quot; &quot;everyone&quot;]
-</pre>
-      <p>
-        See also <a href="#map">map</a>, <a href="#reduce">reduce</a>,
-        <a href="#arrow">-> (anonymous procedure)</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="first">
-      <h3>
-        <a>first<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">first <i>list</i></span>
-        <span class="prim_example">first <i>string</i></span>
-      </h4>
-      <p>
-        On a list, reports the first (0th) item in the list.
-      </p>
-      <p>
-        On a string, reports a one-character string containing only the
-        first character of the original string.
-      </p>
-      </div>
-    <div class="dict_entry" id="floor">
-      <h3>
-        <a>floor<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">floor <i>number</i></span>
-      </h4>
-      <p>
-        Reports the largest integer less than or equal to <i>number</i>.
-      </p>
-      <pre>
-show floor 4.5
-=&gt; 4
-show floor -4.5
-=&gt; -5
-</pre>
-      <p>
-        See also <a href="#ceiling">ceiling</a>, <a href="#round">round</a>, <a href="#precision">precision</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="follow">
-      <h3>
-        <a>follow<span class="since">3.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">follow <i>turtle</i></span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Similar to ride, but, in the 3D view, the observer&apos;s vantage
-        point is behind and above <i>turtle</i>.
-      </p>
-      <p>
-        The observer may only watch or follow a single subject.
-        Calling <code>follow</code> will alter the highlight created by
-        prior calls to <code>watch</code> and <code>watch-me</code>, highlighting
-        the followed turtle instead.
-      </p>
-      <p>
-        See also <a href="#follow-me">follow-me</a>, <a href="#ride">ride</a>,
-        <a href="#reset-perspective">reset-perspective</a>, <a href="#watch">watch</a>, <a href="#subject">subject</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="follow-me">
-      <h3>
-        <a>follow-me<span class="since">3.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">follow-me</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Asks the observer to follow this turtle.
-      </p>
-      <p>
-        The observer may only watch or follow a single subject.
-        Calling <code>follow-me</code> will remove the highlight created by
-        prior calls to <code>watch</code> and <code>watch-me</code>, highlighting
-        this turtle instead.
-      </p>
-      <p>
-        See also <a href="#follow">follow</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="foreach">
-      <h3>
-        <a>foreach<span class="since">1.3</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">foreach <i>list</i> <i>command</i></span>
-        <span class="prim_example">(foreach <i>list1</i> ... <i>command</i>)</span>
-      </h4>
-      <p>
-        With a single list, runs the command for each item of <i>list</i>.
-        <i>command</i> may be the name of a command, or an anonymous command
-        created with <a href="#arrow">-&gt;</a>.
-      </p>
-      <pre>
-foreach [1.1 2.2 2.6] show
-=&gt; 1.1
-=&gt; 2.2
-=&gt; 2.6
-foreach [1.1 2.2 2.6] [ x -&gt; show (word x &quot; -&gt; &quot; round x) ]
-=&gt; 1.1 -&gt; 1
-=&gt; 2.2 -&gt; 2
-=&gt; 2.6 -&gt; 3
-</pre>
-      <p>
-        With multiple lists, runs <i>command</i> for each group of items
-        from each list.
-        So, they are run once for the first items, once for
-        the second items, and so on. All the lists must be the same length.
-      </p>
-      <p>
-        Some examples make this clearer:
-      </p>
-      <pre>
-(foreach [1 2 3] [2 4 6]
-   [ [a b] -&gt; show word &quot;the sum is: &quot; (a + b) ])
-=&gt; &quot;the sum is: 3&quot;
-=&gt; &quot;the sum is: 6&quot;
-=&gt; &quot;the sum is: 9&quot;
-(foreach list (turtle 1) (turtle 2) [3 4]
-  [ [the-turtle num-steps] -&gt; ask the-turtle [ fd num-steps ] ])
-;; turtle 1 moves forward 3 patches
-;; turtle 2 moves forward 4 patches
-</pre>
-      <p>
-        See also <a href="#map">map</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="forward">
-      <h3>
-        <a>forward<span class="since">1.0</span></a>
-        <a>fd<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">forward <i>number</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        The turtle moves forward by <i>number</i> steps, one step at a
-        time. (If <i>number</i> is negative, the turtle moves backward.)
-      </p>
-      <p>
-        <code>fd 10</code> is equivalent to <code>repeat 10 [ jump 1 ]</code>.
-        <code>fd 10.5</code> is equivalent to <code>repeat 10 [ jump 1 ] jump
-        0.5</code>.
-      </p>
-      <p>
-        If the turtle cannot move forward <i>number</i> steps because it is
-        not permitted by the current topology the turtle will complete as
-        many steps of 1 as it can, then stop.
-      </p>
-      <p>
-        See also <a href="#jump">jump</a>, <a href="#can-move">can-move?</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="fput">
-      <h3>
-        <a>fput<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">fput <i>item list</i></span>
-      </h4>
-      <p>
-        Adds <i>item</i> to the beginning of a list and reports the new
-        list.
-      </p>
-      <pre>
-;; suppose mylist is [5 7 10]
-set mylist fput 2 mylist
-;; mylist is now [2 5 7 10]
-</pre>
-    </div><!-- ======================================== -->
-  </div>
-    <h2 id="G">
-      <a>G</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="globals">
-      <h3>
-        <a>globals</a>
-      </h3>
-      <h4>
-        <span class="prim_example">globals [<i>var1</i> ...]</span>
-      </h4>
-      <p>
-        This keyword, like the breed, <i>&lt;breeds&gt;</i>-own,
-        patches-own, and turtles-own keywords, can only be used at the
-        beginning of a program, before any function definitions. It defines
-        new global variables. Global variables are &quot;global&quot;
-        because they are accessible by all agents and can be used anywhere
-        in a model.
-      </p>
-      <p>
-        Most often, globals is used to define variables or constants that
-        need to be used in many parts of the program.
-      </p>
-      </div><!-- ======================================== -->
-    </div>
-    <h2 id="H">
-      <a>H</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="hatch">
-      <h3>
-        <a>hatch<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hatch <i>number</i> [ <i>commands</i> ]</span>
-        <span class="prim_example">hatch-<i>&lt;breeds&gt;</i> <i>number</i> [ <i>commands</i> ]</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        This turtle creates <i>number</i> new turtles. Each new turtle
-        inherits of all its variables, including its location, from its
-        parent. (Exceptions: each new turtle will have a new <code>who</code>
-        number, and it may be of a different breed than its parent if the
-        <code>hatch-<i>&lt;breeds&gt;</i></code> form is used.)
-      </p>
-      <p>
-        The new turtles then run <i>commands</i>. You can use the commands
-        to give the new turtles different colors, headings, locations, or
-        whatever. (The new turtles are created all at once, then run one at
-        a time, in random order.)
-      </p>
-      <p>
-        If the hatch-<i>&lt;breeds&gt;</i> form is used, the new turtles
-        are created as members of the given breed. Otherwise, the new
-        turtles are the same breed as their parent.
-      </p>
-      <pre>
-hatch 1 [ lt 45 fd 1 ]
-;; this turtle creates one new turtle,
-;; and the child turns and moves away
-hatch-sheep 1 [ set color black ]
-;; this turtle creates a new turtle
-;; of the sheep breed
-</pre>
-      <p>
-        See also <a href="#create-turtles">create-turtles</a>, <a href="#sprout">sprout</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="heading">
-      <h3>
-        <a>heading</a>
-      </h3>
-      <h4>
-        <span class="prim_example">heading</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        This is a built-in turtle variable. It indicates the direction the
-        turtle is facing. This is a number greater than or equal to 0 and
-        less than 360. 0 is north, 90 is east, and so on. You can set this
-        variable to make a turtle turn.
-      </p>
-      <p>
-        See also <a href="#right">right</a>, <a href="#left">left</a>,
-        <a href="#dxy">dx</a>, <a href="#dxy">dy</a>.
-      </p>
-      <p>
-        Example:
-      </p>
-      <pre>
-set heading 45      ;; turtle is now facing northeast
-set heading heading + 10 ;; same effect as &quot;rt 10&quot;
-</pre>
-    </div>
-    <div class="dict_entry" id="hidden">
-      <h3>
-        <a>hidden?</a>
-      </h3>
-      <h4>
-        <span class="prim_example">hidden?</span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        This is a built-in turtle or link variable. It holds a boolean
-        (true or false) value indicating whether the turtle or link is
-        currently hidden (i.e., invisible). You can set this variable to
-        make a turtle or link disappear or reappear.
-      </p>
-      <p>
-        See also <a href="#hide-turtle">hide-turtle</a>, <a href="#show-turtle">show-turtle</a>, <a href="#hide-link">hide-link</a>,
-        <a href="#show-link">show-link</a>
-      </p>
-      <p>
-        Example:
-      </p>
-      <pre>
-set hidden? not hidden?
-;; if turtle was showing, it hides, and if it was hiding,
-;; it reappears
-</pre>
-    </div>
-    <div class="dict_entry" id="hide-link">
-      <h3>
-        <a>hide-link<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hide-link</span>
-        <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        The link makes itself invisible.
-      </p>
-      <p>
-        Note: This command is equivalent to setting the link variable
-        &quot;hidden?&quot; to true.
-      </p>
-      <p>
-        See also <a href="#show-turtle">show-link</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="hide-turtle">
-      <h3>
-        <a>hide-turtle<span class="since">1.0</span></a>
-        <a>ht<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hide-turtle</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        The turtle makes itself invisible.
-      </p>
-      <p>
-        Note: This command is equivalent to setting the turtle variable
-        &quot;hidden?&quot; to true.
-      </p>
-      <p>
-        See also <a href="#show-turtle">show-turtle</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="histogram">
-      <h3>
-        <a>histogram<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">histogram <i>list</i></span>
-      </h4>
-      <p>
-        Histograms the values in the given list
-      </p>
-      <p>
-        Draws a histogram showing the frequency distribution of the values
-        in the list. The heights of the bars in the histogram represent the
-        numbers of values in each subrange.
-      </p>
-      <p>
-        Before the histogram is drawn, first any previous points drawn by
-        the current plot pen are removed.
-      </p>
-      <p>
-        Any non-numeric values in the list are ignored.
-      </p>
-      <p>
-        The histogram is drawn on the current plot using the current plot
-        pen and pen color. Auto scaling does not affect a histogram's
-        horizontal range, so set-plot-x-range should be used to control the
-        range, and the pen interval can then be set (either directly with
-        set-plot-pen-interval, or indirectly via set-histogram-num-bars) to
-        control how many bars that range is split up into.
-      </p>
-      <p>
-        Be sure that if you want the histogram drawn with bars that the
-        current pen is in bar mode (mode 1).
-      </p>
-      <p>
-        For histogramming purposes the plot's X range is not considered
-        to include the maximum X value. Values equal to the maximum X will
-        fall outside of the histogram's range.
-      </p>
-      <pre>
-histogram [color] of turtles
-;; draws a histogram showing how many turtles there are
-;; of each color
-</pre>
-    </div>
-    <div class="dict_entry" id="home">
-      <h3>
-        <a>home<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">home</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        This turtle moves to the origin (0,0). Equivalent to <code>setxy 0
-        0</code>.
-      </p>
-      </div>
-    <div class="dict_entry" id="hsb">
-      <h3>
-        <a>hsb<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hsb <i>hue saturation brightness</i></span>
-      </h4>
-      <p>
-        Reports a RGB list when given three numbers describing an HSB
-        color. Hue, saturation, and brightness are integers in the range
-        0-360, 0-100, 0-100 respectively. The RGB list contains three
-        integers in the range of 0-255.
-      </p>
-      <p>
-        See also <a href="#rgb">rgb</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-broadcast">
-      <h3>
-        <a>hubnet-broadcast<span class="since">1.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-broadcast <i>tag-name value</i></span>
-      </h4>
-      <p>
-        This broadcasts <i>value</i> from NetLogo to the interface element
-        with the name <i>tag-name</i> on the clients.
-      </p>
-      <p>
-        See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-        for details and instructions.
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-broadcast-clear-output">
-      <h3>
-        <a>hubnet-broadcast-clear-output<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-broadcast-clear-output</span>
-      </h4>
-      <p>
-        This clears all messages printed to the text area on every client.
-      </p>
-      <p>
-        See also: <a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>, <a href="#hubnet-send-clear-output">hubnet-send-clear-output</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-broadcast-message">
-      <h3>
-        <a>hubnet-broadcast-message<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-broadcast-message <i>value</i></span>
-      </h4>
-      <p>
-        This prints the value in the text area on each client. This is the
-        same functionality as the &quot;Broadcast Message&quot; button in
-        the HubNet Control Center.
-      </p>
-      <p>
-        See also: <a href="#hubnet-send-message">hubnet-send-message</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-clear-override">
-      <h3>
-        <a>hubnet-clear-override<span class="since">4.1</span></a>
-        <a>hubnet-clear-overrides<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-clear-override <i>client</i> <i>agent-or-set</i> <i>variable-name</i></span>
-        <span class="prim_example">hubnet-clear-overrides <i>client</i></span>
-      </h4>
-      <p>
-        Remove overrides from the override list on <i>client</i>.
-        <code>hubnet-clear-override</code> removes only the override for the
-        specified variable for the specified agent or agentset.
-        <code>hubnet-clear-overrides</code> removes all overrides from the
-        specified client.
-      </p>
-      <p>
-        See also: <a href="#hubnet-send-override">hubnet-send-override</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-clients-list">
-      <h3>
-        <a>hubnet-clients-list<span class="since">5.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-clients-list</span>
-      </h4>
-      <p>
-        Reports a list containing the names of all the clients currently
-        connected to the HubNet server.
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-enter-message">
-      <h3>
-        <a>hubnet-enter-message?<span class="since">1.2.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-enter-message?</span>
-      </h4>
-      <p>
-        Reports true if a new client just entered the simulation. Reports
-        false otherwise. <a href="#hubnet-message-source">hubnet-message-source</a> will contain the
-        user name of the client that just logged on.
-      </p>
-      <p>
-        See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-        for details and instructions.
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-exit-message">
-      <h3>
-        <a>hubnet-exit-message?<span class="since">1.2.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-exit-message?</span>
-      </h4>
-      <p>
-        Reports true if a client just exited the simulation. Reports false
-        otherwise. <a href="#hubnet-message-source">hubnet-message-source</a> will contain the
-        user name of the client that just logged off.
-      </p>
-      <p>
-        See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-        for details and instructions.
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-fetch-message">
-      <h3>
-        <a>hubnet-fetch-message<span class="since">1.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-fetch-message</span>
-      </h4>
-      <p>
-        If there is any new data sent by the clients, this retrieves the
-        next piece of data, so that it can be accessed by <a href="#hubnet-message">hubnet-message</a>, <a href="#hubnet-message-source">hubnet-message-source</a>, and <a href="#hubnet-message-tag">hubnet-message-tag</a>. This will cause an
-        error if there is no new data from the clients.
-      </p>
-      <p>
-        See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-        for details.
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-kick-client">
-      <h3>
-        <a>hubnet-kick-client<span class="since">5.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-kick-client <i>client-name</i></span>
-      </h4>
-      <p>
-        Kicks the client with the given client-name. This is equivalent to
-        clicking the client name in the HubNet Control Center and pressing
-        the Kick button.
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-kick-all-clients">
-      <h3>
-        <a>hubnet-kick-all-clients<span class="since">5.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-kick-all-clients</span>
-      </h4>
-      <p>
-        Kicks out all currently connected HubNet clients. This is
-        equivalent to selecting all clients in the HubNet Control Center
-        and pressing the Kick button.
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-message">
-      <h3>
-        <a>hubnet-message<span class="since">1.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-message</span>
-      </h4>
-      <p>
-        Reports the message retrieved by <a href="#hubnet-fetch-message">hubnet-fetch-message</a>.
-      </p>
-      <p>
-        See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-        for details.
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-message-source">
-      <h3>
-        <a>hubnet-message-source<span class="since">1.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-message-source</span>
-      </h4>
-      <p>
-        Reports the name of the client that sent the message retrieved by
-        <a href="#hubnet-fetch-message">hubnet-fetch-message</a>.
-      </p>
-      <p>
-        See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-        for details.
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-message-tag">
-      <h3>
-        <a>hubnet-message-tag<span class="since">1.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-message-tag</span>
-      </h4>
-      <p>
-        Reports the tag that is associated with the data that was retrieved
-        by <a href="#hubnet-fetch-message">hubnet-fetch-message</a>. The
-        tag will be one of the Display Names of the interface elements in
-        the client interface.
-      </p>
-      <p>
-        See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-        for details.
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-message-waiting">
-      <h3>
-        <a>hubnet-message-waiting?<span class="since">1.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-message-waiting?</span>
-      </h4>
-      <p>
-        This looks for a new message sent by the clients. It reports true
-        if there is one, and false if there is not.
-      </p>
-      <p>
-        See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-        for details.
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-reset">
-      <h3>
-        <a>hubnet-reset<span class="since">1.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-reset</span>
-      </h4>
-      <p>
-        Starts up the HubNet system. HubNet must be started to use any of
-        the other hubnet primitives.
-      </p>
-      <p>
-        See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-        for details.
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-reset-perspective">
-      <h3>
-        <a>hubnet-reset-perspective<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-reset-perspective <i>tag-name</i></span>
-      </h4>
-      <p>
-        Clears watch or follow sent directly to the client. The view
-        perspective will revert to the server perspective.
-      </p>
-      <p>
-        See also: <a href="#hubnet-send-watch">hubnet-send-watch</a>
-        <a href="#hubnet-send-follow">hubnet-send-follow</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-send">
-      <h3>
-        <a>hubnet-send<span class="since">1.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-send <i>string tag-name value</i></span>
-      </h4>
-      <h4>
-        <span class="prim_example">hubnet-send <i>list-of-strings tag-name value</i></span>
-      </h4>
-      <p>
-        For a <i>string</i>, this sends <i>value</i> from NetLogo to the
-        tag <i>tag-name</i> on the client that has <i>string</i> for its
-        user name.
-      </p>
-      <p>
-        For a <i>list-of-strings</i>, this sends <i>value</i> from NetLogo
-        to the tag <i>tag-name</i> on all the clients that have a user name
-        that is in the <i>list-of-strings</i>.
-      </p>
-      <p>
-        Sending a message to a non-existent client, using
-        <code>hubnet-send</code>, generates a <code>hubnet-exit-message</code>.
-      </p>
-      <p>
-        See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-        for details.
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-send-clear-output">
-      <h3>
-        <a>hubnet-send-clear-output<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-send-clear-output <i>string</i></span>
-      </h4>
-      <h4>
-        <span class="prim_example">hubnet-send-clear-output <i>list-of-strings</i></span>
-      </h4>
-      <p>
-        This clears all messages printed to the text area on the given
-        client or clients (specified in the <i>string</i> or
-        <i>list-of-strings</i>.
-      </p>
-      <p>
-        See also: <a href="#hubnet-send-message">hubnet-send-message</a>,
-        <a href="#hubnet-broadcast-clear-output">hubnet-broadcast-clear-output</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-send-follow">
-      <h3>
-        <a>hubnet-send-follow<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-send-follow <i>client-name agent radius</i></span>
-      </h4>
-      <p>
-        Tells the client associated with <i>client-name</i> to follow
-        <i>agent</i> showing a <i>radius</i> sized Moore neighborhood
-        around the agent.
-      </p>
-      <p>
-        A client may only watch or follow a single subject.
-        Calling <code>hubnet-send-follow</code> will alter the highlight created by
-        prior calls to <code>hubnet-send-watch</code>, highlighting
-        the followed agent instead.
-      </p>
-      <p>
-        See also: <a href="#hubnet-send-watch">hubnet-send-watch</a>,
-        <a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-send-message">
-      <h3>
-        <a>hubnet-send-message<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-send-message <i>string</i> <i>value</i></span>
-      </h4>
-      <p>
-        This prints <code>value</code> in the text area on the client specified
-        by <code>string</code>.
-      </p>
-      <p>
-        See also: <a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-send-override">
-      <h3>
-        <a>hubnet-send-override<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-send-override <i>client-name agent-or-set variable-name</i></span>
-        <span class="prim_example">[ <i>reporter</i> ]</span>
-      </h4>
-      <p>
-        Evaluates <i>reporter</i> for the agent or agentset indicated then
-        sends the values to the client to &quot;override&quot; the value of
-        <i>variable-name</i> only on <i>client-name</i>. This is used to
-        change the appearance of agents in the client view, hence, only
-        built-in variables that affect the appearance of the agent may be
-        selected. For example, you can override the color variable of a
-        turtle:
-      </p>
-      <pre>
-ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
-</pre>
-      <p>
-        In this example assume that there is a turtles-own variable
-        client-name which is associated with a logged in client, and all
-        the turtles are blue. This code makes the turtle associated with
-        each client appear red in his or her own view but not on anyone
-        else's or on the server.
-      </p>
-      <p>
-        See also: <a href="#hubnet-clear-override">hubnet-clear-overrides</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="hubnet-send-watch">
-      <h3>
-        <a>hubnet-send-watch<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">hubnet-send-watch <i>client-name agent</i></span>
-      </h4>
-      <p>
-        Tells the client associated with <i>client-name</i> to watch
-        <i>agent</i>.
-      </p>
-      <p>
-        A client may only watch or follow a single subject.
-        Calling <code>hubnet-send-watch</code> will undo perspective changes caused
-        by prior calls to <code>hubnet-send-follow</code>.
-      </p>
-      <p>
-        See also: <a href="#hubnet-send-follow">hubnet-send-follow</a>,
-        <a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
-      </p>
-      </div>
-    </div> <!-- ======================================== -->
-    <h2 id="I">
-      <a>I</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="if">
-      <h3>
-        <a>if<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">if <i>condition</i> [ <i>commands</i> ]</span>
-      </h4>
-      <p>
-        Reporter must report a boolean (true or false) value.
-      </p>
-      <p>
-        If <i>condition</i> reports true, runs <i>commands</i>.
-      </p>
-      <p>
-        The reporter may report a different value for different agents, so
-        some agents may run <i>commands</i> and others don't.
-      </p>
-      <pre>
-if xcor &gt; 0[ set color blue ]
-;; turtles in the right half of the world
-;; turn blue
-</pre>
-      <p>
-        See also <a href="#ifelse">ifelse</a>, <a href="#ifelse-value">ifelse-value</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="ifelse">
-      <h3>
-        <a>ifelse<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">ifelse <i>reporter1</i> [ <i>commands1</i> ] [ <i>elsecommands</i> ]</span>
-        <span class="prim_example">(ifelse <i>reporter1</i> [ <i>commands1</i> ] <i>reporter2</i> [ <i>commands2</i> ] ... [ <i>elsecommands</i> ])</span>
-      </h4>
-      <p>
-        The <i>reporter</i>s must report boolean (true or false) values.
-      </p>
-      <p>
-        For the first <i>reporter</i> that reports true, runs the <i>commands</i> that follow.
-      </p>
-      <p>
-        If no <i>reporter</i> reports true, runs <i>elsecommands</i> or does nothing if
-        <i>elsecommands</i> is not given.  When using only one <i>reporter</i>
-        you do not need to surround the entire <i>ifelse</i> primitive and its blocks in parentheses.
-      </p>
-        <pre>
-  ask patches
-    [ ifelse pxcor &gt; 0
-        [ set pcolor blue ]
-        [ set pcolor red ] ]
-  ;; the left half of the world turns red and
-  ;; the right half turns blue
-  </pre>
-      <p>
-        The reporters may report a different value for different agents, so
-        some agents may run different command blocks.  When using more than one <i>reporter</i> you
-        must surround the whole <i>ifelse</i> primitive and its blocks in parentheses.
-      </p>
-      <pre>
-        ask patches [
-          let choice random 4
-          (ifelse
-            choice = 0 [
-              set pcolor red
-              set plabel "r"
-            ]
-            choice = 1 [
-              set pcolor blue
-              set plabel "b"
-            ]
-            choice = 2 [
-              set pcolor green
-              set plabel "g"
-            ]
-            ; elsecommands
-            [
-              set pcolor yellow
-              set plabel "y"
-          ])
-        ]
-      </pre>
-      <p>
-        See also <a href="#if">if</a>, <a href="#ifelse-value">ifelse-value</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="ifelse-value">
-      <h3>
-        <a>ifelse-value<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">ifelse-value <i>tfreporter1</i> [ <i>reporter1</i> ] [ <i>elsereporter</i> ]</span>
-        <span class="prim_example">(ifelse-value <i>tfreporter1</i> [ <i>reporter1</i> ] <i>tfreporter2</i> [ <i>reporter2</i> ] ... [ <i>elsereporter</i> ])</span>
-      </h4>
-      <p>
-        The <i>tfreporter</i>s must report boolean (true or false) values.
-      </p>
-      <p>
-        For the first <i>tfreporter</i> that reports true, runs the
-        <i>reporter</i> that follows and reports that result.  When using only one <i>tfreporter1</i>
-        you do not need to surround the entire <i>ifelse-value</i> primitive and its blocks in parentheses.
-      </p>
-      <p>
-        If all <i>tfreporter</i>s report false, the result is the value of
-        <i>elsereporter</i>.  You may leave out the <i>elsereporter</i>, but
-        if all <i>tfreporter</i>s report false then a runtime error will occur.
-      </p>
-      <p>
-        This can be used when a conditional is needed in the context of a
-        reporter, where commands (such as <a href="#ifelse">ifelse</a>) are
-        not allowed.
-      </p>
-      <pre>
-ask patches [
-  set pcolor ifelse-value (pxcor &gt; 0) [blue] [red]
-]
-;; the left half of the world turns red and
-;; the right half turns blue
-show n-values 10 [ifelse-value (? &lt; 5) [0] [1]]
-=&gt; [0 0 0 0 0 1 1 1 1 1]
-show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
-  [1 3 2 5 3 8 3 2 1]
-=&gt; 8
-</pre>
-      <p>
-        When using more than one <i>tfreporter</i> you
-        must surround the whole <i>ifelse-value</i> primitive and its blocks in parentheses.
-      </p>
-      <pre>
-        ask patches [
-          let choice random 4
-          set pcolor (ifelse-value
-            choice = 0 [ red ]
-            choice = 1 [ blue ]
-            choice = 2 [ green ]
-                       [ yellow ])
-        ]
-      </pre>
-      <p>
-        A runtime error can occur if there is no <i>elsereporter</i>.
-      </p>
-      <pre>
-        ask patches [
-          let x = 2
-          set pcolor (ifelse-value
-            x = 0 [ red ]
-            x = 1 [ blue ]
-            ; no final else reporter is given, and x is 2 so there will be a runtime error
-          )
-      </pre>
-      <p>
-        See also <a href="#if">if</a>, <a href="#ifelse">ifelse</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="import-drawing">
-      <h3>
-        <a>import-drawing<span class="since">3.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">import-drawing <i>filename</i></span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Reads an image file into the drawing, scaling it to the size of the
-        world, while retaining the original aspect ratio of the image. The
-        image is centered in the drawing. The old drawing is not cleared
-        first.
-      </p>
-      <p>
-        Agents cannot sense the drawing, so they cannot interact with or
-        process images imported by import-drawing. If you need agents to
-        sense an image, use <a href="#import-pcolors">import-pcolors</a> or
-        <a href="#import-pcolors-rgb">import-pcolors-rgb</a>.
-      </p>
-      <p>
-        The following image file formats are supported: BMP, JPG, GIF, and
-        PNG. If the image format supports transparency (alpha), that
-        information will be imported as well.
-      </p>
-      </div>
-    <div class="dict_entry" id="import-pcolors">
-      <h3>
-        <a>import-pcolors<span class="since">3.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">import-pcolors <i>filename</i></span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Reads an image file, scales it to the same dimensions as the patch
-        grid while maintaining the original aspect ratio of the image, and
-        transfers the resulting pixel colors to the patches. The image is
-        centered in the patch grid. The resulting patch colors may be
-        distorted, since the NetLogo color space does not include all
-        possible colors. (See the Color section of the Programming Guide.)
-        import-pcolors may be slow for some images, particularly when you
-        have many patches and a large image with many different colors.
-      </p>
-      <p>
-        Since import-pcolors sets the pcolor of patches, agents can sense
-        the image. This is useful if agents need to analyze, process, or
-        otherwise interact with the image. If you want to simply display a
-        static backdrop, without color distortion, see <a href="#import-drawing">import-drawing</a>.
-      </p>
-      <p>
-        The following image file formats are supported: BMP, JPG, GIF, and
-        PNG. If the image format supports transparency (alpha), then all
-        fully transparent pixels will be ignored. (Partially transparent
-        pixels will be treated as opaque.)
-      </p>
-      </div>
-    <div class="dict_entry" id="import-pcolors-rgb">
-      <h3>
-        <a>import-pcolors-rgb<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">import-pcolors-rgb <i>filename</i></span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Reads an image file, scales it to the same dimensions as the patch
-        grid while maintaining the original aspect ratio of the image, and
-        transfers the resulting pixel colors to the patches. The image is
-        centered in the patch grid. Unlike <a href="#import-pcolors">import-pcolors</a> the exact colors in the
-        original image are retained. The pcolor variable of all the patches
-        will be an RGB list rather than an (approximated) NetLogo color.
-      </p>
-      <p>
-        The following image file formats are supported: BMP, JPG, GIF, and
-        PNG. If the image format supports transparency (alpha), then all
-        fully transparent pixels will be ignored. (Partially transparent
-        pixels will be treated as opaque.)
-      </p>
-      </div>
-    <div class="dict_entry" id="import-world">
-      <h3>
-        <a>import-world<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">import-world <i>filename</i></span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Reads the values of all variables for a model, both built-in and
-        user-defined, including all observer, turtle, and patch variables,
-        from an external file named by the given string. The file should be
-        in the format used by the <a href="#export-cmds">export-world</a>
-        primitive.
-      </p>
-      <p>
-        Note that the functionality of this primitive is also directly
-        available from NetLogo's File menu.
-      </p>
-      <p>
-        When using import-world, to avoid errors, perform these steps in
-        the following order:
-      </p>
-      <ol>
-        <li>Open the model from which you created the export file.
-        <li>Press the Setup button, to get the model in a state from which
-        it can be run.
-        <li>Import the file.
-        <li>Re-open any files that the model had opened with the
-        <code>file-open</code> command.
-        <li>If you want, press Go button to continue running the model from
-        the point where it left off.
-        </ol>
-      <p>
-        If you wish to import a file from a location other than the
-        model's location, you may include the full path to the file you
-        wish to import. See <a href="#export-cmds">export-world</a> for an
-        example.
-      </p>
-      </div>
-    <div class="dict_entry" id="in-cone">
-      <h3>
-        <a>in-cone<span class="since">3.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example"><i>agentset</i> in-cone <i>distance</i> <i>angle</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        This reporter lets you give a turtle a &quot;cone of vision&quot;
-        in front of itself. The cone is defined by the two inputs, the
-        vision distance (radius) and the viewing angle. The viewing angle
-        may range from 0 to 360 and is centered around the turtle's
-        current heading. (If the angle is 360, then in-cone is equivalent
-        to in-radius.)
-      </p>
-      <p>
-        in-cone reports an agentset that includes only those agents from
-        the original agentset that fall in the cone. (This can include the
-        agent itself.)
-      </p>
-      <p>
-        The distance to a patch is measured from the center of the patch.
-      </p>
-      <pre>
-ask turtles
-  [ ask patches in-cone 3 60
-      [ set pcolor red ] ]
-;; each turtle makes a red &quot;splotch&quot; of patches in a 60 degree
-;; cone of radius 3 ahead of itself
-</pre>
-    </div>
-    <div class="dict_entry" id="in-link-neighbor">
-      <h3>
-        <a>in-&lt;breed&gt;-neighbor?</a>
-        <a>in-link-neighbor?<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">in-&lt;breed&gt;-neighbor? <i>agent</i></span>
-        <span class="prim_example">in-link-neighbor? <i>turtle</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Reports true if there is a directed link going from <i>turtle</i>
-        to the caller or an undirected link connecting <i>turtle</i> to the
-        caller. You can think of this as "is there a link I can use to get from
-        <i>turtle</i> to the caller?"
-      </p>
-      <pre>
-crt 2
-ask turtle 0 [
-  create-link-to turtle 1
-  show in-link-neighbor? turtle 1  ;; prints false
-  show out-link-neighbor? turtle 1 ;; prints true
-]
-ask turtle 1 [
-  show in-link-neighbor? turtle 0  ;; prints true
-  show out-link-neighbor? turtle 0 ;; prints false
-]
-</pre>
-    </div>
-    <div class="dict_entry" id="in-link-neighbors">
-      <h3>
-        <a>in-&lt;breed&gt;-neighbors</a>
-        <a>in-link-neighbors<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">in-&lt;breed&gt;-neighbors</span>
-        <span class="prim_example">in-link-neighbors</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Reports the agentset of all the turtles that have directed links coming
-        from them to the caller as well as all turtles that have an undirected
-        link connecting them with the caller. You can think of this as "all the
-        turtles that can get to the caller using a link."
-      </p>
-      <pre>
-crt 4
-ask turtle 0 [ create-links-to other turtles ]
-ask turtle 1 [ ask in-link-neighbors [ set color blue ] ] ;; turtle 0 turns blue
-</pre>
-    </div>
-    <div class="dict_entry" id="in-link-from">
-      <h3>
-        <a>in-&lt;breed&gt;-from</a>
-        <a>in-link-from<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">in-&lt;breed&gt;-from <i>turtle</i></span>
-        <span class="prim_example">in-link-from <i>turtle</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Reports a directed link from <i>turtle</i> to the caller or an
-        undirected link connecting the two. If no link exists then it
-        reports nobody. If more than one such link exists, reports a
-        random one. You can think of this as "give me a link that I can use
-        to travel from <i>turtle</i> to the caller."
-      </p>
-      <pre>
-crt 2
-ask turtle 0 [ create-link-to turtle 1 ]
-ask turtle 1 [ show in-link-from turtle 0 ] ;; shows link 0 1
-ask turtle 0 [ show in-link-from turtle 1 ] ;; shows nobody
-</pre>
-      <p>
-        See also: <a href="#out-link-to">out-link-to</a> <a href="#link-with">link-with</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="includes">
-      <h3>
-        <a>__includes<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">__includes [ <i>filename</i> ... ]</span>
-      </h4>
-      <p>
-        Causes external NetLogo source files (with the <code>.nls</code>
-        suffix) to be included in this model. Included files may contain
-        breed, variable, and procedure definitions. <code>__includes</code> can
-        only be used once per file.
-      </p>
-      <p>
-        The file names must be strings, for example:
-      </p>
-      <pre>
-__includes [ &quot;utils.nls&quot; ]
-      </pre>
-      <p>
-        Or, for multiple files:
-      </p>
-      <pre>
-__includes [ &quot;utils1.nls&quot; &quot;utils2.nls&quot; ]
-      </pre>
-    </div>
-    <div class="dict_entry" id="in-radius">
-      <h3>
-        <a>in-radius<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example"><i>agentset</i> in-radius <i>number</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        Reports an agentset that includes only those agents from the
-        original agentset whose distance from the caller is less than or
-        equal to <i>number</i>. (This can include the agent itself.)
-      </p>
-      <p>
-        The distance to or a from a patch is measured from the center of
-        the patch.
-      </p>
-      <pre>
-ask turtles
-  [ ask patches in-radius 3
-      [ set pcolor red ] ]
-;; each turtle makes a red &quot;splotch&quot; around itself
-</pre>
-    </div>
+					ask turtle 0 [ show one-of my-in-links ]
+					;; prints (street 0 1)
+					ask turtle 0 [ show one-of my-out-links ]
+					;; prints (highway 1 0)
+				</pre>
+				<p>
+					See also <a href="#breed">breed</a>, <a href="#undirected-link-breed">undirected-link-breed</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="display">
+				<h3>
+					<a>display<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">display</span>
+				</h4>
+				<p>
+					Causes the view to be updated immediately. (Exception: if the user
+					is using the speed slider to fast-forward the model, then the
+					update may be skipped.)
+				</p>
+				<p>
+					Also undoes the effect of the no-display command, so that if view
+					updates were suspended by that command, they will resume.
+				</p>
+				<pre>
+					no-display
+					ask turtles [ jump 10 set color blue set size 5 ]
+					display
+					;; turtles move, change color, and grow, with none of
+					;; their intermediate states visible to the user, only
+					;; their final state
+				</pre>
+				<p>
+					Even if no-display was not used, &quot;display&quot; can still be
+					useful, because ordinarily NetLogo is free to skip some view
+					updates, so that fewer total updates take place, so that models run
+					faster. This command lets you force a view update, so whatever
+					changes have taken place in the world are visible to the user.
+				</p>
+				<pre>
+					ask turtles [ set color red ]
+					display
+					ask turtles [ set color blue]
+					;; turtles turn red, then blue; use of &quot;display&quot; forces
+					;; red turtles to appear briefly
+				</pre>
+				<p>
+					Note that display and no-display operate independently of the
+					switch in the view control strip that freezes the view.
+				</p>
+				<p>
+					See also <a href="#no-display">no-display</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="distance">
+				<h3>
+					<a>distance<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">distance <i>agent</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					Reports the distance from this agent to the given turtle or patch.
+				</p>
+				<p>
+					The distance to or a from a patch is measured from the center of
+					the patch. Turtles and patches use the wrapped distance (around the
+					edges of the world) if wrapping is allowed by the topology and the
+					wrapped distance is shorter.
+				</p>
+				<pre>
+					ask turtles [ show max-one-of turtles [distance myself] ]
+					;; each turtle prints the turtle farthest from itself
+				</pre>
+			</div>
+			<div class="dict_entry" id="distancexy">
+				<h3>
+					<a>distancexy<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">distancexy <i>x</i> <i>y</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					Reports the distance from this agent to the point (<i>x</i>,
+					<i>y</i>).
+				</p>
+				<p>
+					The distance from a patch is measured from the center of the patch.
+					Turtles and patches use the wrapped distance (around the edges of
+					the world) if wrapping is allowed by the topology and the wrapped
+					distance is shorter.
+				</p>
+				<pre>
+					if (distancexy 0 0) &gt; 10
+					[ set color green ]
+					;; all turtles more than 10 units from
+					;; the center of the world turn green.
+				</pre>
+			</div>
+			<div class="dict_entry" id="downhill">
+				<h3>
+					<a>downhill<span class="since">1.0</span></a>
+					<a>downhill4<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">downhill <i>patch-variable</i></span>
+					<span class="prim_example">downhill4 <i>patch-variable</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Moves the turtle to the neighboring patch with the lowest value for
+					<i>patch-variable</i>. If no neighboring patch has a smaller value
+					than the current patch, the turtle stays put. If there are multiple
+					patches with the same lowest value, the turtle picks one randomly.
+					Non-numeric values are ignored.
+				</p>
+				<p>
+					downhill considers the eight neighboring patches; downhill4 only
+					considers the four neighbors.
+				</p>
+				<p>
+					Equivalent to the following code (assumes variable values are
+					numeric):
+				</p>
+				<pre>
+					move-to patch-here  ;; go to patch center
+					let p min-one-of neighbors [<i>patch-variable</i>]  ;; or neighbors4
+					if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
+					face p
+					move-to p
+					]
+				</pre>
+				<p>
+					Note that the turtle always ends up on a patch center and has a
+					heading that is a multiple of 45 (downhill) or 90 (downhill4).
+				</p>
+				<p>
+					See also <a href="#uphill">uphill</a>, <a href="#uphill">uphill4</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="dxy">
+				<h3>
+					<a>dx<span class="since">1.0</span></a>
+					<a>dy<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">dx</span>
+					<span class="prim_example">dy</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Reports the x-increment or y-increment (the amount by which the
+					turtle's xcor or ycor would change) if the turtle were to take
+					one step forward in its current heading.
+				</p>
+				<p>
+					Note: dx is simply the sine of the turtle's heading, and dy is
+					simply the cosine. (If this is the reverse of what you expected,
+					it's because in NetLogo a heading of 0 is north and 90 is east,
+					which is the reverse of how angles are usually defined in
+					geometry.)
+				</p>
+				<p>
+					Note: In earlier versions of NetLogo, these primitives were used in
+					many situations where the new <code>patch-ahead</code> primitive is now
+					more appropriate.
+				</p> <!-- ======================================== -->
+			</div>
+		</div>
+		<h2 id="E">
+			<a>E</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="empty">
+				<h3>
+					<a>empty?<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">empty? <i>list</i></span>
+					<span class="prim_example">empty? <i>string</i></span>
+				</h4>
+				<p>
+					Reports true if the given list or string is empty, false otherwise.
+				</p>
+				<p>
+					Note: the empty list is written <code>[]</code>. The empty string is
+					written <code>&quot;&quot;</code>.
+				</p>
+			</div>
+			<div class="dict_entry" id="end">
+				<h3>
+					<a>end</a>
+				</h3>
+				<h4>
+					<span class="prim_example">end</span>
+				</h4>
+				<p>
+					Used to conclude a procedure. See <a href="#to">to</a> and <a href="#to-report">to-report</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="end1">
+				<h3>
+					<a>end1<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">end1</span>
+					<img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					This is a built-in link variable. It indicates the first endpoint
+					(turtle) of a link. For directed links this will always be the
+					source for undirected links it will always be the turtle with the
+					lower who number. You cannot set end1.
+				</p>
+				<pre>
+					crt 2
+					ask turtle 0
+					[ create-link-to turtle 1 ]
+					ask links
+					[ show end1 ] ;; shows turtle 0
+				</pre>
+			</div>
+			<div class="dict_entry" id="end2">
+				<h3>
+					<a>end2<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">end2</span>
+					<img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					This is a built-in link variable. It indicates the second endpoint
+					(turtle) of a link. For directed links this will always be the
+					destination for undirected links it will always be the turtle with
+					the higher who number. You cannot set end2.
+				</p>
+				<pre>
+					crt 2
+					ask turtle 1
+					[ create-link-with turtle 0 ]
+					ask links
+					[ show end2 ] ;; shows turtle 1
+				</pre>
+			</div>
+			<div class="dict_entry" id="error">
+				<h3>
+					<a>error<span class="since">5.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">error <i>value</i></span>
+				</h4>
+				<p>
+					Causes a runtime error to occur.
+				</p>
+				<p>
+					The given value is converted to a string (if it isn't one
+					already) and used as the error message.
+				</p>
+				<p>
+					See also <a href="#error-message">error-message</a>, <a href="#carefully">carefully</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="error-message">
+				<h3>
+					<a>error-message<span class="since">2.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">error-message</span>
+				</h4>
+				<p>
+					Reports a string describing the error that was suppressed by
+					carefully.
+				</p>
+				<p>
+					This reporter can only be used in the second block of a carefully
+					command.
+				</p>
+				<p>
+					See also <a href="#error">error</a>, <a href="#carefully">carefully</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="every">
+				<h3>
+					<a>every<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">every <i>number</i> [ <i>commands</i> ]</span>
+				</h4>
+				<p>
+					Runs the given commands only if it's been more than
+					<i>number</i> seconds since the last time this agent ran them in
+					this context. Otherwise, the commands are skipped.
+				</p>
+				<p>
+					By itself, every doesn't make commands run over and over again.
+					You need to use every inside a loop, or inside a forever button, if
+					you want the commands run over and over again. every only limits
+					how often the commands run.
+				</p>
+				<p>
+					Above, &quot;in this context&quot; means during the same ask (or
+					button press or command typed in the Command Center). So it
+					doesn't make sense to write <code>ask turtles [ every 0.5 [ ... ]
+						]</code>, because when the ask finishes the turtles will all discard
+					their timers for the &quot;every&quot;. The correct usage is shown
+					below.
+				</p>
+				<pre>
+					every 0.5 [ ask turtles [ fd 1 ] ]
+					;; twice a second the turtles will move forward 1
+					every 2 [ set index index + 1 ]
+					;; every 2 seconds index is incremented
+				</pre>
+				<p>
+					See also <a href="#wait">wait</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="exp">
+				<h3>
+					<a>exp<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">exp <i>number</i></span>
+				</h4>
+				<p>
+					Reports the value of e raised to the <i>number</i> power.
+				</p>
+				<p>
+					Note: This is the same as e ^ <i>number</i>.
+				</p>
+			</div>
+			<div class="dict_entry" id="export-cmds">
+				<h3>
+					<a>export-view<span class="since">3.0</span></a>
+					<a>export-interface<span class="since">2.0</span></a>
+					<a>export-output<span class="since">1.0</span></a>
+					<a>export-plot<span class="since">1.0</span></a>
+					<a>export-all-plots<span class="since">1.2.1</span></a>
+					<a>export-world<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">export-view <i>filename</i></span>
+					<span class="prim_example">export-interface <i>filename</i></span>
+					<span class="prim_example">export-output <i>filename</i></span>
+					<span class="prim_example">export-plot <i>plotname</i> <i>filename</i></span>
+					<span class="prim_example">export-all-plots <i>filename</i></span>
+					<span class="prim_example">export-world <i>filename</i></span>
+				</h4>
+				<p>
+					export-view writes the current contents of the current view to an
+					external file given by the string <i>filename</i>. The file is
+					saved in PNG (Portable Network Graphics) format, so it is
+					recommended to supply a filename ending in &quot;.png&quot;.
+				</p>
+				<p>
+					export-interface is similar, but for the whole interface tab.
+				</p>
+				<p>
+					Note that export-view still works when running NetLogo in headless
+					mode, but export-interface doesn't.
+				</p>
+				<p>
+					export-output writes the contents of the model's output area to
+					an external file given by the string <i>filename</i>. (If the model
+					does not have a separate output area, the output portion of the
+					Command Center is used.)
+				</p>
+				<p>
+					export-plot writes the x and y values of all points plotted by all
+					the plot pens in the plot given by the string <i>plotname</i> to an
+					external file given by the string <i>filename</i>. If a pen is in
+					bar mode (mode 0) and the y value of the point plotted is greater
+					than 0, the upper-left corner point of the bar will be exported. If
+					the y value is less than 0, then the lower-left corner point of the
+					bar will be exported.
+				</p>
+				<p>
+					export-all-plots writes every plot in the current model to an
+					external file given by the string <i>filename</i>. Each plot is
+					identical in format to the output of export-plot.
+				</p>
+				<p>
+					export-world writes the values of all variables, both built-in and
+					user-defined, including all observer, turtle, and patch variables,
+					the drawing, the contents of the output area if one exists, the
+					contents of any plots and the state of the random number generator,
+					to an external file given by the string <i>filename</i>. (The
+					result file can be read back into NetLogo with the <a href="#import-world">import-world</a> primitive.) export-world does not
+					save the state of open files.
+				</p>
+				<p>
+					export-plot, export-all-plots and export-world save files in in
+					plain-text, &quot;comma-separated values&quot; (<code>.csv</code>)
+					format. CSV files can be read by most popular spreadsheet and
+					database programs as well as any text editor.
+				</p>
+				<p>
+					If you wish to export to a file in a location other than the
+					model's location, you should include the full path to the file
+					you wish to export. (Use the forward-slash &quot;/&quot; as the
+					folder separator.)
+				</p>
+				<p>
+					Note that the functionality of these primitives is also available
+					directly from NetLogo's File menu.
+				</p>
+				<pre>
+					export-world &quot;fire.csv&quot;
+					;; exports the state of the model to the file fire.csv
+					;; located in the NetLogo folder
+					export-plot &quot;Temperature&quot; &quot;c:/My Documents/plot.csv&quot;
+					;; exports the plot named
+					;; &quot;Temperature&quot; to the file plot.csv located in
+					;; the C:\My Documents folder
+					export-all-plots &quot;c:/My Documents/plots.csv&quot;
+					;; exports all plots to the file plots.csv
+					;; located in the C:\My Documents folder
+				</pre>
+				<p>
+					If the file already exists, it is overwritten. To avoid this you
+					may wish to use some method of generating fresh names. Examples:
+				</p>
+				<pre>
+					export-world user-new-file
+					export-world (word &quot;results &quot; date-and-time &quot;.csv&quot;) ;; Colon characters in the time cause errors on Windows
+					export-world (word &quot;results &quot; random-float 1.0 &quot;.csv&quot;)
+				</pre>
+			</div>
+			<div class="dict_entry" id="extensions">
+				<h3>
+					<a>extensions</a>
+				</h3>
+				<h4>
+					<span class="prim_example">extensions [<i>name</i> ...]</span>
+				</h4>
+				<p>
+					Allows the model to use primitives from the extensions with the
+					given names. See the <a href="extensions.html">Extensions guide</a>
+					for more information.
+				</p>
+			</div>
+			<div class="dict_entry" id="extract-hsb">
+				<h3>
+					<a>extract-hsb<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">extract-hsb <i>color</i></span>
+				</h4>
+				<p>
+					Reports a list of three values, the first (hue) in the range of
+					0 to 360, the second and third (brightness and saturation) in
+					the range of 0 to 100.
+				</p>
+				<p>
+					The given <i>color</i> can either be a NetLogo color in the
+					range 0 to 140, not including 140 itself, or an RGB list of
+					three values in the range 0 to 255 representing the levels
+					of red, green, and blue.
+				</p>
+				<pre>
+					show extract-hsb cyan
+					=&gt; [180 57.143 76.863]
+					show extract-hsb red
+					=&gt; [3.103 80.93 84.314]
+					show extract-hsb [255 0 0]
+					=&gt; [0 100 100]
+				</pre>
+				<p>
+					See also <a href="#approximate-hsb">approximate-hsb</a>, <a href="#approximate-rgb">approximate-rgb</a>, <a href="#extract-rgb">extract-rgb</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="extract-rgb">
+				<h3>
+					<a>extract-rgb<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">extract-rgb <i>color</i></span>
+				</h4>
+				<p>
+					Reports a list of three values in the range 0 to 255 representing
+					the levels of red, green, and blue, respectively, of the given
+					NetLogo <i>color</i> in the range 0 to 140, not including 140
+					itself.
+				</p>
+				<pre>
+					show extract-rgb red
+					=&gt; [215 50 41]
+					show extract-rgb cyan
+					=&gt; [84 196 196]
+				</pre>
+				<p>
+					See also <a href="#approximate-rgb">approximate-rgb</a>, <a href="#approximate-hsb">approximate-hsb</a>, <a href="#extract-hsb">extract-hsb</a>.
+				</p>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="F">
+			<a>F</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="face">
+				<h3>
+					<a>face<span class="since">3.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">face <i>agent</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Set the caller's heading towards <i>agent</i>.
+				</p>
+				<p>
+					If wrapping is allowed by the topology and the wrapped distance
+					(around the edges of the world) is shorter, face will use the
+					wrapped path.
+				</p>
+				<p>
+					If the caller and the agent are at the exact same position, the
+					caller's heading won't change.
+				</p>
+			</div>
+			<div class="dict_entry" id="facexy">
+				<h3>
+					<a>facexy<span class="since">3.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">facexy <i>x</i> <i>y</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Set the caller's heading towards the point (x,y).
+				</p>
+				<p>
+					If wrapping is allowed by the topology and the wrapped distance
+					(around the edges of the world) is shorter and wrapping is allowed,
+					facexy will use the wrapped path.
+				</p>
+				<p>
+					If the caller is on the point (x,y), the caller's heading
+					won't change.
+				</p>
+			</div>
+			<div class="dict_entry" id="file-at-end">
+				<h3>
+					<a>file-at-end?<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">file-at-end?</span>
+				</h4>
+				<p>
+					Reports true when there are no more characters left to read in from
+					the current file (that was opened previously with <a href="#file-open">file-open</a>). Otherwise, reports false.
+				</p>
+				<pre>
+					file-open &quot;my-file.txt&quot;
+					print file-at-end?
+					=&gt; false ;; Can still read in more characters
+					print file-read-line
+					=&gt; This is the last line in file
+					print file-at-end?
+					=&gt; true ;; We reached the end of the file
+				</pre>
+				<p>
+					See also <a href="#file-open">file-open</a>, <a href="#file-close-all">file-close-all</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="file-close">
+				<h3>
+					<a>file-close<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">file-close</span>
+				</h4>
+				<p>
+					Closes a file that has been opened previously with <a href="#file-open">file-open</a>.
+				</p>
+				<p>
+					Note that this and file-close-all are the only ways to restart to
+					the beginning of an opened file or to switch between file modes.
+				</p>
+				<p>
+					If no file is open, does nothing.
+				</p>
+				<p>
+					See also <a href="#file-close-all">file-close-all</a>, <a href="#file-open">file-open</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="file-close-all">
+				<h3>
+					<a>file-close-all<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">file-close-all</span>
+				</h4>
+				<p>
+					Closes all files (if any) that have been opened previously with
+					<a href="#file-open">file-open</a>.
+				</p>
+				<p>
+					See also <a href="#file-close">file-close</a>, <a href="#file-open">file-open</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="file-delete">
+				<h3>
+					<a>file-delete<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">file-delete <i>string</i></span>
+				</h4>
+				<p>
+					Deletes the file specified as <i>string</i>
+				</p>
+				<p>
+					<i>string</i> must be an existing file with writable permission by
+					the user. Also, the file cannot be open. Use the command <a href="#file-close">file-close</a> to close an opened file before
+					deletion.
+				</p>
+				<p>
+					Note that the string can either be a file name or an absolute file
+					path. If it is a file name, it looks in whatever the current
+					directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It is defaulted
+					to the model's directory.
+				</p>
+			</div>
+			<div class="dict_entry" id="file-exists">
+				<h3>
+					<a>file-exists?<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">file-exists? <i>string</i></span>
+				</h4>
+				<p>
+					Reports true if <i>string</i> is the name of an existing file on
+					the system. Otherwise it reports false.
+				</p>
+				<p>
+					Note that the string can either be a file name or an absolute file
+					path. If it is a file name, it looks in whatever the current
+					directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It defaults to
+					to the model's directory.
+				</p>
+			</div>
+			<div class="dict_entry" id="file-flush">
+				<h3>
+					<a>file-flush<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">file-flush</span>
+				</h4>
+				<p>
+					Forces file updates to be written to disk. When you use file-write
+					or other output commands, the values may not be immediately written
+					to disk. This improves the performance of the file output commands.
+					Closing a file ensures that all output is written to disk.
+				</p>
+				<p>
+					Sometimes you need to ensure that data is written to disk without
+					closing the file. For example, you could be using a file to
+					communicate with another program on your machine and want the other
+					program to be able to see the output immediately.
+				</p>
+			</div>
+			<div class="dict_entry" id="file-open">
+				<h3>
+					<a>file-open<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">file-open <i>string</i></span>
+				</h4>
+				<p>
+					This command will interpret <i>string</i> as a path name to a file
+					and open the file. You may then use the reporters <a href="#file-read">file-read</a>, <a href="#file-read-line">file-read-line</a>, and <a href="#file-read-characters">file-read-characters</a> to read in from
+					the file, or <a href="#file-write">file-write</a>, <a href="#file-print">file-print</a>, <a href="#file-type">file-type</a>,
+					or <a href="#file-show">file-show</a> to write out to the file.
+				</p>
+				<p>
+					Note that you can only open a file for reading or writing but not
+					both. The next file i/o primitive you use after this command
+					dictates which mode the file is opened in. To switch modes, you
+					need to close the file using <a href="#file-close">file-close</a>.
+				</p>
+				<p>
+					Also, the file must already exist if opening a file in reading
+					mode.
+				</p>
+				<p>
+					When opening a file in writing mode, all new data will be appended
+					to the end of the original file. If there is no original file, a
+					new blank file will be created in its place. (You must have write
+					permission in the file's directory.) (If you don't want to
+					append, but want to replace the file's existing contents, use
+					<a href="#file-delete">file-delete</a> to delete it first, perhaps
+					inside a <a href="#carefully">carefully</a> if you're not sure
+					whether it already exists.)
+				</p>
+				<p>
+					Note that the string can either be a file name or an absolute file
+					path. If it is a file name, it looks in whatever the current
+					directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It is defaulted
+					to the model's directory.
+				</p>
+				<pre>
+					file-open &quot;my-file-in.txt&quot;
+					print file-read-line
+					=&gt; First line in file ;; File is in reading mode
+					file-open &quot;C:\\NetLogo\\my-file-out.txt&quot;
+					;; assuming Windows machine
+					file-print &quot;Hello World&quot; ;; File is in writing mode
+				</pre>
+				<p>
+					Opening a file does not close previously opened files. You can use
+					<code>file-open</code> to switch back and forth between multiple open
+					files.
+				</p>
+				<p>
+					See also <a href="#file-close">file-close</a> See also <a href="#file-close-all">file-close-all</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="file-print">
+				<h3>
+					<a>file-print<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">file-print <i>value</i></span>
+				</h4>
+				<p>
+					Prints <i>value</i> to an opened file, followed by a carriage
+					return.
+				</p>
+				<p>
+					This agent is <i>not</i> printed before the value, unlike <a href="#file-show">file-show</a>.
+				</p>
+				<p>
+					Note that this command is the file i/o equivalent of <a href="#print">print</a>, and <a href="#file-open">file-open</a> needs to
+					be called before this command can be used.
+				</p>
+				<p>
+					See also <a href="#file-show">file-show</a>, <a href="#file-type">file-type</a>,
+					<a href="#file-write">file-write</a>,
+					and <a href="programming.html#output">Output (programming guide)</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="file-read">
+				<h3>
+					<a>file-read<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">file-read</span>
+				</h4>
+				<p>
+					This reporter will read in the next constant from the opened file
+					and interpret it as if it had been typed in the Command Center. It
+					reports the resulting value. The result may be a number, list,
+					string, boolean, or the special value nobody.
+				</p>
+				<p>
+					Whitespace separates the constants. Each call to file-read will
+					skip past both leading and trailing whitespace.
+				</p>
+				<p>
+					Note that strings need to have quotes around them. Use the command
+					<a href="#file-write">file-write</a> to have quotes included.
+				</p>
+				<p>
+					Also note that the <a href="#file-open">file-open</a> command must
+					be called before this reporter can be used, and there must be data
+					remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
+					of the file.
+				</p>
+				<pre>
+					file-open &quot;my-file.data&quot;
+					print file-read + 5
+					;; Next value is the number 1
+					=&gt; 6
+					print length file-read
+					;; Next value is the list [1 2 3 4]
+					=&gt; 4
+				</pre>
+				<p>
+					See also <a href="#file-open">file-open</a> and <a href="#file-write">file-write</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="file-read-characters">
+				<h3>
+					<a>file-read-characters<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">file-read-characters <i>number</i></span>
+				</h4>
+				<p>
+					Reports the given <i>number</i> of characters from an opened file
+					as a string. If there are fewer than that many characters left, it
+					will report all of the remaining characters.
+				</p>
+				<p>
+					Note that it will return every character including newlines and
+					spaces.
+				</p>
+				<p>
+					Also note that the <a href="#file-open">file-open</a> command must
+					be called before this reporter can be used, and there must be data
+					remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
+					of the file.
+				</p>
+				<pre>
+					file-open &quot;my-file.txt&quot;
+					print file-read-characters 5
+					;; Current line in file is &quot;Hello World&quot;
+					=&gt; Hello
+				</pre>
+				<p>
+					See also <a href="#file-open">file-open</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="file-read-line">
+				<h3>
+					<a>file-read-line<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">file-read-line</span>
+				</h4>
+				<p>
+					Reads the next line in the file and reports it as a string. It
+					determines the end of the file by a carriage return, an end of file
+					character or both in a row. It does not return the line terminator
+					characters.
+				</p>
+				<p>
+					Also note that the <a href="#file-open">file-open</a> command must
+					be called before this reporter can be used, and there must be data
+					remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
+					of the file.
+				</p>
+				<pre>
+					file-open &quot;my-file.txt&quot;
+					print file-read-line
+					=&gt; Hello World
+				</pre>
+				<p>
+					See also <a href="#file-open">file-open</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="file-show">
+				<h3>
+					<a>file-show<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">file-show <i>value</i></span>
+				</h4>
+				<p>
+					Prints <i>value</i> to an opened file, preceded by this agent
+					agent, and followed by a carriage return. (This agent is included
+					to help you keep track of what agents are producing which lines of
+					output.) Also, all strings have their quotes included similar to
+					<a href="#file-write">file-write</a>.
+				</p>
+				<p>
+					Note that this command is the file i/o equivalent of <a href="#show">show</a>, and <a href="#file-open">file-open</a> needs to
+					be called before this command can be used.
+				</p>
+				<p>
+					See also <a href="#file-print">file-print</a>, <a href="#file-type">file-type</a>,
+					<a href="#file-write">file-write</a>,
+					and <a href="programming.html#output">Output (programming guide)</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="file-type">
+				<h3>
+					<a>file-type<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">file-type <i>value</i></span>
+				</h4>
+				<p>
+					Prints <i>value</i> to an opened file, <i>not</i> followed by a
+					carriage return (unlike <a href="#file-print">file-print</a> and
+					<a href="#file-show">file-show</a>). The lack of a carriage return
+					allows you to print several values on the same line.
+				</p>
+				<p>
+					This agent is <i>not</i> printed before the value. unlike <a href="#file-show">file-show</a>.
+				</p>
+				<p>
+					Note that this command is the file i/o equivalent of <a href="#type">type</a>, and <a href="#file-open">file-open</a> needs to
+					be called before this command can be used.
+				</p>
+				<p>
+					See also <a href="#file-print">file-print</a>, <a href="#file-show">file-show</a>, <a href="#file-write">file-write</a>, and
+					<a href="programming.html#output">Output (programming guide)</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="file-write">
+				<h3>
+					<a>file-write<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">file-write <i>value</i></span>
+				</h4>
+				<p>
+					This command will output <i>value</i>, which can be a number,
+					string, list, boolean, or nobody to an opened file, <i>not</i>
+					followed by a carriage return (unlike <a href="#file-print">file-print</a> and <a href="#file-show">file-show</a>).
+				</p>
+				<p>
+					This agent is <i>not</i> printed before the value, unlike <a href="#file-show">file-show</a>. Its output also includes quotes around
+					strings and is prepended with a space. It will output the value in
+					such a manner that <a href="#file-read">file-read</a> will be able
+					to interpret it.
+				</p>
+				<p>
+					Note that this command is the file i/o equivalent of <a href="#write">write</a>, and <a href="#file-open">file-open</a> needs to
+					be called before this command can be used.
+				</p>
+				<pre>
+					file-open &quot;locations.txt&quot;
+					ask turtles
+					[ file-write xcor file-write ycor ]
+				</pre>
+				<p>
+					See also <a href="#file-print">file-print</a>, <a href="#file-show">file-show</a>,
+					<a href="#file-type">file-type</a>,
+					and <a href="programming.html#output">Output (programming guide)</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="filter">
+				<h3>
+					<a>filter<span class="since">1.3</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">filter <i>reporter</i> <i>list</i></span>
+				</h4>
+				<p>
+					Reports a list containing only those items of <i>list</i> for which
+					the reporter reports true -- in other words, the items satisfying the
+					given condition. <i>reporter</i> may be an anonymous reporter or the
+					name of a reporter.
+				</p>
+				<pre>
+					show filter is-number? [1 &quot;2&quot; 3]
+					=&gt; [1 3]
+					show filter [ i -&gt; i &lt; 3 ] [1 3 2]
+					=&gt; [1 2]
+					show filter [ s -&gt; first s != &quot;t&quot; ] [&quot;hi&quot; &quot;there&quot; &quot;everyone&quot;]
+					=&gt; [&quot;hi&quot; &quot;everyone&quot;]
+				</pre>
+				<p>
+					See also <a href="#map">map</a>, <a href="#reduce">reduce</a>,
+					<a href="#arrow">-> (anonymous procedure)</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="first">
+				<h3>
+					<a>first<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">first <i>list</i></span>
+					<span class="prim_example">first <i>string</i></span>
+				</h4>
+				<p>
+					On a list, reports the first (0th) item in the list.
+				</p>
+				<p>
+					On a string, reports a one-character string containing only the
+					first character of the original string.
+				</p>
+			</div>
+			<div class="dict_entry" id="floor">
+				<h3>
+					<a>floor<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">floor <i>number</i></span>
+				</h4>
+				<p>
+					Reports the largest integer less than or equal to <i>number</i>.
+				</p>
+				<pre>
+					show floor 4.5
+					=&gt; 4
+					show floor -4.5
+					=&gt; -5
+				</pre>
+				<p>
+					See also <a href="#ceiling">ceiling</a>, <a href="#round">round</a>, <a href="#precision">precision</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="follow">
+				<h3>
+					<a>follow<span class="since">3.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">follow <i>turtle</i></span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Similar to ride, but, in the 3D view, the observer&apos;s vantage
+					point is behind and above <i>turtle</i>.
+				</p>
+				<p>
+					The observer may only watch or follow a single subject.
+					Calling <code>follow</code> will alter the highlight created by
+					prior calls to <code>watch</code> and <code>watch-me</code>, highlighting
+					the followed turtle instead.
+				</p>
+				<p>
+					See also <a href="#follow-me">follow-me</a>, <a href="#ride">ride</a>,
+					<a href="#reset-perspective">reset-perspective</a>, <a href="#watch">watch</a>, <a href="#subject">subject</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="follow-me">
+				<h3>
+					<a>follow-me<span class="since">3.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">follow-me</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Asks the observer to follow this turtle.
+				</p>
+				<p>
+					The observer may only watch or follow a single subject.
+					Calling <code>follow-me</code> will remove the highlight created by
+					prior calls to <code>watch</code> and <code>watch-me</code>, highlighting
+					this turtle instead.
+				</p>
+				<p>
+					See also <a href="#follow">follow</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="foreach">
+				<h3>
+					<a>foreach<span class="since">1.3</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">foreach <i>list</i> <i>command</i></span>
+					<span class="prim_example">(foreach <i>list1</i> ... <i>command</i>)</span>
+				</h4>
+				<p>
+					With a single list, runs the command for each item of <i>list</i>.
+					<i>command</i> may be the name of a command, or an anonymous command
+					created with <a href="#arrow">-&gt;</a>.
+				</p>
+				<pre>
+					foreach [1.1 2.2 2.6] show
+					=&gt; 1.1
+					=&gt; 2.2
+					=&gt; 2.6
+					foreach [1.1 2.2 2.6] [ x -&gt; show (word x &quot; -&gt; &quot; round x) ]
+					=&gt; 1.1 -&gt; 1
+					=&gt; 2.2 -&gt; 2
+					=&gt; 2.6 -&gt; 3
+				</pre>
+				<p>
+					With multiple lists, runs <i>command</i> for each group of items
+					from each list.
+					So, they are run once for the first items, once for
+					the second items, and so on. All the lists must be the same length.
+				</p>
+				<p>
+					Some examples make this clearer:
+				</p>
+				<pre>
+					(foreach [1 2 3] [2 4 6]
+					[ [a b] -&gt; show word &quot;the sum is: &quot; (a + b) ])
+					=&gt; &quot;the sum is: 3&quot;
+					=&gt; &quot;the sum is: 6&quot;
+					=&gt; &quot;the sum is: 9&quot;
+					(foreach list (turtle 1) (turtle 2) [3 4]
+					[ [the-turtle num-steps] -&gt; ask the-turtle [ fd num-steps ] ])
+					;; turtle 1 moves forward 3 patches
+					;; turtle 2 moves forward 4 patches
+				</pre>
+				<p>
+					See also <a href="#map">map</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="forward">
+				<h3>
+					<a>forward<span class="since">1.0</span></a>
+					<a>fd<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">forward <i>number</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					The turtle moves forward by <i>number</i> steps, one step at a
+					time. (If <i>number</i> is negative, the turtle moves backward.)
+				</p>
+				<p>
+					<code>fd 10</code> is equivalent to <code>repeat 10 [ jump 1 ]</code>.
+					<code>fd 10.5</code> is equivalent to <code>repeat 10 [ jump 1 ] jump
+						0.5</code>.
+				</p>
+				<p>
+					If the turtle cannot move forward <i>number</i> steps because it is
+					not permitted by the current topology the turtle will complete as
+					many steps of 1 as it can, then stop.
+				</p>
+				<p>
+					See also <a href="#jump">jump</a>, <a href="#can-move">can-move?</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="fput">
+				<h3>
+					<a>fput<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">fput <i>item list</i></span>
+				</h4>
+				<p>
+					Adds <i>item</i> to the beginning of a list and reports the new
+					list.
+				</p>
+				<pre>
+					;; suppose mylist is [5 7 10]
+					set mylist fput 2 mylist
+					;; mylist is now [2 5 7 10]
+				</pre>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="G">
+			<a>G</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="globals">
+				<h3>
+					<a>globals</a>
+				</h3>
+				<h4>
+					<span class="prim_example">globals [<i>var1</i> ...]</span>
+				</h4>
+				<p>
+					This keyword, like the breed, <i>&lt;breeds&gt;</i>-own,
+					patches-own, and turtles-own keywords, can only be used at the
+					beginning of a program, before any function definitions. It defines
+					new global variables. Global variables are &quot;global&quot;
+					because they are accessible by all agents and can be used anywhere
+					in a model.
+				</p>
+				<p>
+					Most often, globals is used to define variables or constants that
+					need to be used in many parts of the program.
+				</p>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="H">
+			<a>H</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="hatch">
+				<h3>
+					<a>hatch<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hatch <i>number</i> [ <i>commands</i> ]</span>
+					<span class="prim_example">hatch-<i>&lt;breeds&gt;</i> <i>number</i> [ <i>commands</i> ]</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					This turtle creates <i>number</i> new turtles. Each new turtle
+					inherits of all its variables, including its location, from its
+					parent. (Exceptions: each new turtle will have a new <code>who</code>
+					number, and it may be of a different breed than its parent if the
+					<code>hatch-<i>&lt;breeds&gt;</i></code> form is used.)
+				</p>
+				<p>
+					The new turtles then run <i>commands</i>. You can use the commands
+					to give the new turtles different colors, headings, locations, or
+					whatever. (The new turtles are created all at once, then run one at
+					a time, in random order.)
+				</p>
+				<p>
+					If the hatch-<i>&lt;breeds&gt;</i> form is used, the new turtles
+					are created as members of the given breed. Otherwise, the new
+					turtles are the same breed as their parent.
+				</p>
+				<pre>
+					hatch 1 [ lt 45 fd 1 ]
+					;; this turtle creates one new turtle,
+					;; and the child turns and moves away
+					hatch-sheep 1 [ set color black ]
+					;; this turtle creates a new turtle
+					;; of the sheep breed
+				</pre>
+				<p>
+					See also <a href="#create-turtles">create-turtles</a>, <a href="#sprout">sprout</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="heading">
+				<h3>
+					<a>heading</a>
+				</h3>
+				<h4>
+					<span class="prim_example">heading</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					This is a built-in turtle variable. It indicates the direction the
+					turtle is facing. This is a number greater than or equal to 0 and
+					less than 360. 0 is north, 90 is east, and so on. You can set this
+					variable to make a turtle turn.
+				</p>
+				<p>
+					See also <a href="#right">right</a>, <a href="#left">left</a>,
+					<a href="#dxy">dx</a>, <a href="#dxy">dy</a>.
+				</p>
+				<p>
+					Example:
+				</p>
+				<pre>
+					set heading 45      ;; turtle is now facing northeast
+					set heading heading + 10 ;; same effect as &quot;rt 10&quot;
+				</pre>
+			</div>
+			<div class="dict_entry" id="hidden">
+				<h3>
+					<a>hidden?</a>
+				</h3>
+				<h4>
+					<span class="prim_example">hidden?</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					This is a built-in turtle or link variable. It holds a boolean
+					(true or false) value indicating whether the turtle or link is
+					currently hidden (i.e., invisible). You can set this variable to
+					make a turtle or link disappear or reappear.
+				</p>
+				<p>
+					See also <a href="#hide-turtle">hide-turtle</a>, <a href="#show-turtle">show-turtle</a>, <a href="#hide-link">hide-link</a>,
+					<a href="#show-link">show-link</a>
+				</p>
+				<p>
+					Example:
+				</p>
+				<pre>
+					set hidden? not hidden?
+					;; if turtle was showing, it hides, and if it was hiding,
+					;; it reappears
+				</pre>
+			</div>
+			<div class="dict_entry" id="hide-link">
+				<h3>
+					<a>hide-link<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hide-link</span>
+					<img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					The link makes itself invisible.
+				</p>
+				<p>
+					Note: This command is equivalent to setting the link variable
+					&quot;hidden?&quot; to true.
+				</p>
+				<p>
+					See also <a href="#show-turtle">show-link</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="hide-turtle">
+				<h3>
+					<a>hide-turtle<span class="since">1.0</span></a>
+					<a>ht<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hide-turtle</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					The turtle makes itself invisible.
+				</p>
+				<p>
+					Note: This command is equivalent to setting the turtle variable
+					&quot;hidden?&quot; to true.
+				</p>
+				<p>
+					See also <a href="#show-turtle">show-turtle</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="histogram">
+				<h3>
+					<a>histogram<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">histogram <i>list</i></span>
+				</h4>
+				<p>
+					Histograms the values in the given list
+				</p>
+				<p>
+					Draws a histogram showing the frequency distribution of the values
+					in the list. The heights of the bars in the histogram represent the
+					numbers of values in each subrange.
+				</p>
+				<p>
+					Before the histogram is drawn, first any previous points drawn by
+					the current plot pen are removed.
+				</p>
+				<p>
+					Any non-numeric values in the list are ignored.
+				</p>
+				<p>
+					The histogram is drawn on the current plot using the current plot
+					pen and pen color. Auto scaling does not affect a histogram's
+					horizontal range, so set-plot-x-range should be used to control the
+					range, and the pen interval can then be set (either directly with
+					set-plot-pen-interval, or indirectly via set-histogram-num-bars) to
+					control how many bars that range is split up into.
+				</p>
+				<p>
+					Be sure that if you want the histogram drawn with bars that the
+					current pen is in bar mode (mode 1).
+				</p>
+				<p>
+					For histogramming purposes the plot's X range is not considered
+					to include the maximum X value. Values equal to the maximum X will
+					fall outside of the histogram's range.
+				</p>
+				<pre>
+					histogram [color] of turtles
+					;; draws a histogram showing how many turtles there are
+					;; of each color
+				</pre>
+			</div>
+			<div class="dict_entry" id="home">
+				<h3>
+					<a>home<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">home</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					This turtle moves to the origin (0,0). Equivalent to <code>setxy 0
+						0</code>.
+				</p>
+			</div>
+			<div class="dict_entry" id="hsb">
+				<h3>
+					<a>hsb<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hsb <i>hue saturation brightness</i></span>
+				</h4>
+				<p>
+					Reports a RGB list when given three numbers describing an HSB
+					color. Hue, saturation, and brightness are integers in the range
+					0-360, 0-100, 0-100 respectively. The RGB list contains three
+					integers in the range of 0-255.
+				</p>
+				<p>
+					See also <a href="#rgb">rgb</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-broadcast">
+				<h3>
+					<a>hubnet-broadcast<span class="since">1.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-broadcast <i>tag-name value</i></span>
+				</h4>
+				<p>
+					This broadcasts <i>value</i> from NetLogo to the interface element
+					with the name <i>tag-name</i> on the clients.
+				</p>
+				<p>
+					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+					for details and instructions.
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-broadcast-clear-output">
+				<h3>
+					<a>hubnet-broadcast-clear-output<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-broadcast-clear-output</span>
+				</h4>
+				<p>
+					This clears all messages printed to the text area on every client.
+				</p>
+				<p>
+					See also: <a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>, <a href="#hubnet-send-clear-output">hubnet-send-clear-output</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-broadcast-message">
+				<h3>
+					<a>hubnet-broadcast-message<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-broadcast-message <i>value</i></span>
+				</h4>
+				<p>
+					This prints the value in the text area on each client. This is the
+					same functionality as the &quot;Broadcast Message&quot; button in
+					the HubNet Control Center.
+				</p>
+				<p>
+					See also: <a href="#hubnet-send-message">hubnet-send-message</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-clear-override">
+				<h3>
+					<a>hubnet-clear-override<span class="since">4.1</span></a>
+					<a>hubnet-clear-overrides<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-clear-override <i>client</i> <i>agent-or-set</i> <i>variable-name</i></span>
+					<span class="prim_example">hubnet-clear-overrides <i>client</i></span>
+				</h4>
+				<p>
+					Remove overrides from the override list on <i>client</i>.
+					<code>hubnet-clear-override</code> removes only the override for the
+					specified variable for the specified agent or agentset.
+					<code>hubnet-clear-overrides</code> removes all overrides from the
+					specified client.
+				</p>
+				<p>
+					See also: <a href="#hubnet-send-override">hubnet-send-override</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-clients-list">
+				<h3>
+					<a>hubnet-clients-list<span class="since">5.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-clients-list</span>
+				</h4>
+				<p>
+					Reports a list containing the names of all the clients currently
+					connected to the HubNet server.
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-enter-message">
+				<h3>
+					<a>hubnet-enter-message?<span class="since">1.2.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-enter-message?</span>
+				</h4>
+				<p>
+					Reports true if a new client just entered the simulation. Reports
+					false otherwise. <a href="#hubnet-message-source">hubnet-message-source</a> will contain the
+					user name of the client that just logged on.
+				</p>
+				<p>
+					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+					for details and instructions.
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-exit-message">
+				<h3>
+					<a>hubnet-exit-message?<span class="since">1.2.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-exit-message?</span>
+				</h4>
+				<p>
+					Reports true if a client just exited the simulation. Reports false
+					otherwise. <a href="#hubnet-message-source">hubnet-message-source</a> will contain the
+					user name of the client that just logged off.
+				</p>
+				<p>
+					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+					for details and instructions.
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-fetch-message">
+				<h3>
+					<a>hubnet-fetch-message<span class="since">1.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-fetch-message</span>
+				</h4>
+				<p>
+					If there is any new data sent by the clients, this retrieves the
+					next piece of data, so that it can be accessed by <a href="#hubnet-message">hubnet-message</a>, <a href="#hubnet-message-source">hubnet-message-source</a>, and <a href="#hubnet-message-tag">hubnet-message-tag</a>. This will cause an
+					error if there is no new data from the clients.
+				</p>
+				<p>
+					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+					for details.
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-kick-client">
+				<h3>
+					<a>hubnet-kick-client<span class="since">5.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-kick-client <i>client-name</i></span>
+				</h4>
+				<p>
+					Kicks the client with the given client-name. This is equivalent to
+					clicking the client name in the HubNet Control Center and pressing
+					the Kick button.
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-kick-all-clients">
+				<h3>
+					<a>hubnet-kick-all-clients<span class="since">5.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-kick-all-clients</span>
+				</h4>
+				<p>
+					Kicks out all currently connected HubNet clients. This is
+					equivalent to selecting all clients in the HubNet Control Center
+					and pressing the Kick button.
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-message">
+				<h3>
+					<a>hubnet-message<span class="since">1.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-message</span>
+				</h4>
+				<p>
+					Reports the message retrieved by <a href="#hubnet-fetch-message">hubnet-fetch-message</a>.
+				</p>
+				<p>
+					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+					for details.
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-message-source">
+				<h3>
+					<a>hubnet-message-source<span class="since">1.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-message-source</span>
+				</h4>
+				<p>
+					Reports the name of the client that sent the message retrieved by
+					<a href="#hubnet-fetch-message">hubnet-fetch-message</a>.
+				</p>
+				<p>
+					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+					for details.
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-message-tag">
+				<h3>
+					<a>hubnet-message-tag<span class="since">1.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-message-tag</span>
+				</h4>
+				<p>
+					Reports the tag that is associated with the data that was retrieved
+					by <a href="#hubnet-fetch-message">hubnet-fetch-message</a>. The
+					tag will be one of the Display Names of the interface elements in
+					the client interface.
+				</p>
+				<p>
+					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+					for details.
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-message-waiting">
+				<h3>
+					<a>hubnet-message-waiting?<span class="since">1.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-message-waiting?</span>
+				</h4>
+				<p>
+					This looks for a new message sent by the clients. It reports true
+					if there is one, and false if there is not.
+				</p>
+				<p>
+					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+					for details.
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-reset">
+				<h3>
+					<a>hubnet-reset<span class="since">1.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-reset</span>
+				</h4>
+				<p>
+					Starts up the HubNet system. HubNet must be started to use any of
+					the other hubnet primitives.
+				</p>
+				<p>
+					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+					for details.
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-reset-perspective">
+				<h3>
+					<a>hubnet-reset-perspective<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-reset-perspective <i>tag-name</i></span>
+				</h4>
+				<p>
+					Clears watch or follow sent directly to the client. The view
+					perspective will revert to the server perspective.
+				</p>
+				<p>
+					See also: <a href="#hubnet-send-watch">hubnet-send-watch</a>
+					<a href="#hubnet-send-follow">hubnet-send-follow</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-send">
+				<h3>
+					<a>hubnet-send<span class="since">1.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-send <i>string tag-name value</i></span>
+				</h4>
+				<h4>
+					<span class="prim_example">hubnet-send <i>list-of-strings tag-name value</i></span>
+				</h4>
+				<p>
+					For a <i>string</i>, this sends <i>value</i> from NetLogo to the
+					tag <i>tag-name</i> on the client that has <i>string</i> for its
+					user name.
+				</p>
+				<p>
+					For a <i>list-of-strings</i>, this sends <i>value</i> from NetLogo
+					to the tag <i>tag-name</i> on all the clients that have a user name
+					that is in the <i>list-of-strings</i>.
+				</p>
+				<p>
+					Sending a message to a non-existent client, using
+					<code>hubnet-send</code>, generates a <code>hubnet-exit-message</code>.
+				</p>
+				<p>
+					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+					for details.
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-send-clear-output">
+				<h3>
+					<a>hubnet-send-clear-output<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-send-clear-output <i>string</i></span>
+				</h4>
+				<h4>
+					<span class="prim_example">hubnet-send-clear-output <i>list-of-strings</i></span>
+				</h4>
+				<p>
+					This clears all messages printed to the text area on the given
+					client or clients (specified in the <i>string</i> or
+					<i>list-of-strings</i>.
+				</p>
+				<p>
+					See also: <a href="#hubnet-send-message">hubnet-send-message</a>,
+					<a href="#hubnet-broadcast-clear-output">hubnet-broadcast-clear-output</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-send-follow">
+				<h3>
+					<a>hubnet-send-follow<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-send-follow <i>client-name agent radius</i></span>
+				</h4>
+				<p>
+					Tells the client associated with <i>client-name</i> to follow
+					<i>agent</i> showing a <i>radius</i> sized Moore neighborhood
+					around the agent.
+				</p>
+				<p>
+					A client may only watch or follow a single subject.
+					Calling <code>hubnet-send-follow</code> will alter the highlight created by
+					prior calls to <code>hubnet-send-watch</code>, highlighting
+					the followed agent instead.
+				</p>
+				<p>
+					See also: <a href="#hubnet-send-watch">hubnet-send-watch</a>,
+					<a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-send-message">
+				<h3>
+					<a>hubnet-send-message<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-send-message <i>string</i> <i>value</i></span>
+				</h4>
+				<p>
+					This prints <code>value</code> in the text area on the client specified
+					by <code>string</code>.
+				</p>
+				<p>
+					See also: <a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-send-override">
+				<h3>
+					<a>hubnet-send-override<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-send-override <i>client-name agent-or-set variable-name</i></span>
+					<span class="prim_example">[ <i>reporter</i> ]</span>
+				</h4>
+				<p>
+					Evaluates <i>reporter</i> for the agent or agentset indicated then
+					sends the values to the client to &quot;override&quot; the value of
+					<i>variable-name</i> only on <i>client-name</i>. This is used to
+					change the appearance of agents in the client view, hence, only
+					built-in variables that affect the appearance of the agent may be
+					selected. For example, you can override the color variable of a
+					turtle:
+				</p>
+				<pre>
+					ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
+				</pre>
+				<p>
+					In this example assume that there is a turtles-own variable
+					client-name which is associated with a logged in client, and all
+					the turtles are blue. This code makes the turtle associated with
+					each client appear red in his or her own view but not on anyone
+					else's or on the server.
+				</p>
+				<p>
+					See also: <a href="#hubnet-clear-override">hubnet-clear-overrides</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="hubnet-send-watch">
+				<h3>
+					<a>hubnet-send-watch<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">hubnet-send-watch <i>client-name agent</i></span>
+				</h4>
+				<p>
+					Tells the client associated with <i>client-name</i> to watch
+					<i>agent</i>.
+				</p>
+				<p>
+					A client may only watch or follow a single subject.
+					Calling <code>hubnet-send-watch</code> will undo perspective changes caused
+					by prior calls to <code>hubnet-send-follow</code>.
+				</p>
+				<p>
+					See also: <a href="#hubnet-send-follow">hubnet-send-follow</a>,
+					<a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
+				</p>
+			</div>
+		</div> <!-- ======================================== -->
+		<h2 id="I">
+			<a>I</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="if">
+				<h3>
+					<a>if<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">if <i>condition</i> [ <i>commands</i> ]</span>
+				</h4>
+				<p>
+					Reporter must report a boolean (true or false) value.
+				</p>
+				<p>
+					If <i>condition</i> reports true, runs <i>commands</i>.
+				</p>
+				<p>
+					The reporter may report a different value for different agents, so
+					some agents may run <i>commands</i> and others don't.
+				</p>
+				<pre>
+					if xcor &gt; 0[ set color blue ]
+					;; turtles in the right half of the world
+					;; turn blue
+				</pre>
+				<p>
+					See also <a href="#ifelse">ifelse</a>, <a href="#ifelse-value">ifelse-value</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="ifelse">
+				<h3>
+					<a>ifelse<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">ifelse <i>reporter1</i> [ <i>commands1</i> ] [ <i>elsecommands</i> ]</span>
+					<span class="prim_example">(ifelse <i>reporter1</i> [ <i>commands1</i> ] <i>reporter2</i> [ <i>commands2</i> ] ... [ <i>elsecommands</i> ])</span>
+				</h4>
+				<p>
+					The <i>reporter</i>s must report boolean (true or false) values.
+				</p>
+				<p>
+					For the first <i>reporter</i> that reports true, runs the <i>commands</i> that follow.
+				</p>
+				<p>
+					If no <i>reporter</i> reports true, runs <i>elsecommands</i> or does nothing if
+					<i>elsecommands</i> is not given.  When using only one <i>reporter</i>
+					you do not need to surround the entire <i>ifelse</i> primitive and its blocks in parentheses.
+				</p>
+				<pre>
+					ask patches
+					[ ifelse pxcor &gt; 0
+					[ set pcolor blue ]
+					[ set pcolor red ] ]
+					;; the left half of the world turns red and
+					;; the right half turns blue
+				</pre>
+				<p>
+					The reporters may report a different value for different agents, so
+					some agents may run different command blocks.  When using more than one <i>reporter</i> you
+					must surround the whole <i>ifelse</i> primitive and its blocks in parentheses.
+				</p>
+				<pre>
+					ask patches [
+					let choice random 4
+					(ifelse
+					choice = 0 [
+					set pcolor red
+					set plabel "r"
+					]
+					choice = 1 [
+					set pcolor blue
+					set plabel "b"
+					]
+					choice = 2 [
+					set pcolor green
+					set plabel "g"
+					]
+					; elsecommands
+					[
+					set pcolor yellow
+					set plabel "y"
+					])
+					]
+				</pre>
+				<p>
+					See also <a href="#if">if</a>, <a href="#ifelse-value">ifelse-value</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="ifelse-value">
+				<h3>
+					<a>ifelse-value<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">ifelse-value <i>tfreporter1</i> [ <i>reporter1</i> ] [ <i>elsereporter</i> ]</span>
+					<span class="prim_example">(ifelse-value <i>tfreporter1</i> [ <i>reporter1</i> ] <i>tfreporter2</i> [ <i>reporter2</i> ] ... [ <i>elsereporter</i> ])</span>
+				</h4>
+				<p>
+					The <i>tfreporter</i>s must report boolean (true or false) values.
+				</p>
+				<p>
+					For the first <i>tfreporter</i> that reports true, runs the
+					<i>reporter</i> that follows and reports that result.  When using only one <i>tfreporter1</i>
+					you do not need to surround the entire <i>ifelse-value</i> primitive and its blocks in parentheses.
+				</p>
+				<p>
+					If all <i>tfreporter</i>s report false, the result is the value of
+					<i>elsereporter</i>.  You may leave out the <i>elsereporter</i>, but
+					if all <i>tfreporter</i>s report false then a runtime error will occur.
+				</p>
+				<p>
+					This can be used when a conditional is needed in the context of a
+					reporter, where commands (such as <a href="#ifelse">ifelse</a>) are
+					not allowed.
+				</p>
+				<pre>
+					ask patches [
+					set pcolor ifelse-value (pxcor &gt; 0) [blue] [red]
+					]
+					;; the left half of the world turns red and
+					;; the right half turns blue
+					show n-values 10 [ifelse-value (? &lt; 5) [0] [1]]
+					=&gt; [0 0 0 0 0 1 1 1 1 1]
+					show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
+					[1 3 2 5 3 8 3 2 1]
+					=&gt; 8
+				</pre>
+				<p>
+					When using more than one <i>tfreporter</i> you
+					must surround the whole <i>ifelse-value</i> primitive and its blocks in parentheses.
+				</p>
+				<pre>
+					ask patches [
+					let choice random 4
+					set pcolor (ifelse-value
+					choice = 0 [ red ]
+					choice = 1 [ blue ]
+					choice = 2 [ green ]
+					[ yellow ])
+					]
+				</pre>
+				<p>
+					A runtime error can occur if there is no <i>elsereporter</i>.
+				</p>
+				<pre>
+					ask patches [
+					let x = 2
+					set pcolor (ifelse-value
+					x = 0 [ red ]
+					x = 1 [ blue ]
+					; no final else reporter is given, and x is 2 so there will be a runtime error
+					)
+				</pre>
+				<p>
+					See also <a href="#if">if</a>, <a href="#ifelse">ifelse</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="import-drawing">
+				<h3>
+					<a>import-drawing<span class="since">3.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">import-drawing <i>filename</i></span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Reads an image file into the drawing, scaling it to the size of the
+					world, while retaining the original aspect ratio of the image. The
+					image is centered in the drawing. The old drawing is not cleared
+					first.
+				</p>
+				<p>
+					Agents cannot sense the drawing, so they cannot interact with or
+					process images imported by import-drawing. If you need agents to
+					sense an image, use <a href="#import-pcolors">import-pcolors</a> or
+					<a href="#import-pcolors-rgb">import-pcolors-rgb</a>.
+				</p>
+				<p>
+					The following image file formats are supported: BMP, JPG, GIF, and
+					PNG. If the image format supports transparency (alpha), that
+					information will be imported as well.
+				</p>
+			</div>
+			<div class="dict_entry" id="import-pcolors">
+				<h3>
+					<a>import-pcolors<span class="since">3.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">import-pcolors <i>filename</i></span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Reads an image file, scales it to the same dimensions as the patch
+					grid while maintaining the original aspect ratio of the image, and
+					transfers the resulting pixel colors to the patches. The image is
+					centered in the patch grid. The resulting patch colors may be
+					distorted, since the NetLogo color space does not include all
+					possible colors. (See the Color section of the Programming Guide.)
+					import-pcolors may be slow for some images, particularly when you
+					have many patches and a large image with many different colors.
+				</p>
+				<p>
+					Since import-pcolors sets the pcolor of patches, agents can sense
+					the image. This is useful if agents need to analyze, process, or
+					otherwise interact with the image. If you want to simply display a
+					static backdrop, without color distortion, see <a href="#import-drawing">import-drawing</a>.
+				</p>
+				<p>
+					The following image file formats are supported: BMP, JPG, GIF, and
+					PNG. If the image format supports transparency (alpha), then all
+					fully transparent pixels will be ignored. (Partially transparent
+					pixels will be treated as opaque.)
+				</p>
+			</div>
+			<div class="dict_entry" id="import-pcolors-rgb">
+				<h3>
+					<a>import-pcolors-rgb<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">import-pcolors-rgb <i>filename</i></span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Reads an image file, scales it to the same dimensions as the patch
+					grid while maintaining the original aspect ratio of the image, and
+					transfers the resulting pixel colors to the patches. The image is
+					centered in the patch grid. Unlike <a href="#import-pcolors">import-pcolors</a> the exact colors in the
+					original image are retained. The pcolor variable of all the patches
+					will be an RGB list rather than an (approximated) NetLogo color.
+				</p>
+				<p>
+					The following image file formats are supported: BMP, JPG, GIF, and
+					PNG. If the image format supports transparency (alpha), then all
+					fully transparent pixels will be ignored. (Partially transparent
+					pixels will be treated as opaque.)
+				</p>
+			</div>
+			<div class="dict_entry" id="import-world">
+				<h3>
+					<a>import-world<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">import-world <i>filename</i></span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Reads the values of all variables for a model, both built-in and
+					user-defined, including all observer, turtle, and patch variables,
+					from an external file named by the given string. The file should be
+					in the format used by the <a href="#export-cmds">export-world</a>
+					primitive.
+				</p>
+				<p>
+					Note that the functionality of this primitive is also directly
+					available from NetLogo's File menu.
+				</p>
+				<p>
+					When using import-world, to avoid errors, perform these steps in
+					the following order:
+				</p>
+				<ol>
+					<li>Open the model from which you created the export file.</li>
+					<li>Press the Setup button, to get the model in a state from which
+						it can be run.</li>
+					<li>Import the file.</li>
+					<li>Re-open any files that the model had opened with the
+						<code>file-open</code> command.</li>
+					<li>If you want, press Go button to continue running the model from
+						the point where it left off.</li>
+				</ol>
+				<p>
+					If you wish to import a file from a location other than the
+					model's location, you may include the full path to the file you
+					wish to import. See <a href="#export-cmds">export-world</a> for an
+					example.
+				</p>
+			</div>
+			<div class="dict_entry" id="in-cone">
+				<h3>
+					<a>in-cone<span class="since">3.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example"><i>agentset</i> in-cone <i>distance</i> <i>angle</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					This reporter lets you give a turtle a &quot;cone of vision&quot;
+					in front of itself. The cone is defined by the two inputs, the
+					vision distance (radius) and the viewing angle. The viewing angle
+					may range from 0 to 360 and is centered around the turtle's
+					current heading. (If the angle is 360, then in-cone is equivalent
+					to in-radius.)
+				</p>
+				<p>
+					in-cone reports an agentset that includes only those agents from
+					the original agentset that fall in the cone. (This can include the
+					agent itself.)
+				</p>
+				<p>
+					The distance to a patch is measured from the center of the patch.
+				</p>
+				<pre>
+					ask turtles
+					[ ask patches in-cone 3 60
+					[ set pcolor red ] ]
+					;; each turtle makes a red &quot;splotch&quot; of patches in a 60 degree
+					;; cone of radius 3 ahead of itself
+				</pre>
+			</div>
+			<div class="dict_entry" id="in-link-neighbor">
+				<h3>
+					<a>in-&lt;breed&gt;-neighbor?</a>
+					<a>in-link-neighbor?<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">in-&lt;breed&gt;-neighbor? <i>agent</i></span>
+					<span class="prim_example">in-link-neighbor? <i>turtle</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Reports true if there is a directed link going from <i>turtle</i>
+					to the caller or an undirected link connecting <i>turtle</i> to the
+					caller. You can think of this as "is there a link I can use to get from
+					<i>turtle</i> to the caller?"
+				</p>
+				<pre>
+					crt 2
+					ask turtle 0 [
+					create-link-to turtle 1
+					show in-link-neighbor? turtle 1  ;; prints false
+					show out-link-neighbor? turtle 1 ;; prints true
+					]
+					ask turtle 1 [
+					show in-link-neighbor? turtle 0  ;; prints true
+					show out-link-neighbor? turtle 0 ;; prints false
+					]
+				</pre>
+			</div>
+			<div class="dict_entry" id="in-link-neighbors">
+				<h3>
+					<a>in-&lt;breed&gt;-neighbors</a>
+					<a>in-link-neighbors<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">in-&lt;breed&gt;-neighbors</span>
+					<span class="prim_example">in-link-neighbors</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Reports the agentset of all the turtles that have directed links coming
+					from them to the caller as well as all turtles that have an undirected
+					link connecting them with the caller. You can think of this as "all the
+					turtles that can get to the caller using a link."
+				</p>
+				<pre>
+					crt 4
+					ask turtle 0 [ create-links-to other turtles ]
+					ask turtle 1 [ ask in-link-neighbors [ set color blue ] ] ;; turtle 0 turns blue
+				</pre>
+			</div>
+			<div class="dict_entry" id="in-link-from">
+				<h3>
+					<a>in-&lt;breed&gt;-from</a>
+					<a>in-link-from<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">in-&lt;breed&gt;-from <i>turtle</i></span>
+					<span class="prim_example">in-link-from <i>turtle</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Reports a directed link from <i>turtle</i> to the caller or an
+					undirected link connecting the two. If no link exists then it
+					reports nobody. If more than one such link exists, reports a
+					random one. You can think of this as "give me a link that I can use
+					to travel from <i>turtle</i> to the caller."
+				</p>
+				<pre>
+					crt 2
+					ask turtle 0 [ create-link-to turtle 1 ]
+					ask turtle 1 [ show in-link-from turtle 0 ] ;; shows link 0 1
+					ask turtle 0 [ show in-link-from turtle 1 ] ;; shows nobody
+				</pre>
+				<p>
+					See also: <a href="#out-link-to">out-link-to</a> <a href="#link-with">link-with</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="includes">
+				<h3>
+					<a>__includes<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">__includes [ <i>filename</i> ... ]</span>
+				</h4>
+				<p>
+					Causes external NetLogo source files (with the <code>.nls</code>
+					suffix) to be included in this model. Included files may contain
+					breed, variable, and procedure definitions. <code>__includes</code> can
+					only be used once per file.
+				</p>
+				<p>
+					The file names must be strings, for example:
+				</p>
+				<pre>
+					__includes [ &quot;utils.nls&quot; ]
+				</pre>
+				<p>
+					Or, for multiple files:
+				</p>
+				<pre>
+					__includes [ &quot;utils1.nls&quot; &quot;utils2.nls&quot; ]
+				</pre>
+			</div>
+			<div class="dict_entry" id="in-radius">
+				<h3>
+					<a>in-radius<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example"><i>agentset</i> in-radius <i>number</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					Reports an agentset that includes only those agents from the
+					original agentset whose distance from the caller is less than or
+					equal to <i>number</i>. (This can include the agent itself.)
+				</p>
+				<p>
+					The distance to or a from a patch is measured from the center of
+					the patch.
+				</p>
+				<pre>
+					ask turtles
+					[ ask patches in-radius 3
+					[ set pcolor red ] ]
+					;; each turtle makes a red &quot;splotch&quot; around itself
+				</pre>
+			</div>
 
-    <div class="dict_entry" id="insert-item">
-      <h3>
-        <a>insert-item<span class="since">6.0.2</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">insert-item <i>index list value</i></span>
-        <span class="prim_example">insert-item <i>index string1 string2</i></span>
-      </h4>
-      <p>
-        On a list, inserts an item in that list. <i>index</i> is the index
-        where the item will be inserted. The first item has an index of 0.
-        (The 6th item in a list would have an index of 5.)
-      </p>
-      <p>
-        Likewise for a string, but all characters in a multiple-character <i>string2</i>
-        are inserted at <i>index</i>.
-      </p>
-      <pre>
-show insert-item 2 [2 7 4 5] 15
-=&gt; [2 7 15 4 5]
-show insert-item 2 &quot;cat&quot; &quot;re&quot;
-=&gt; &quot;caret&quot;
-</pre>
-    </div>
+			<div class="dict_entry" id="insert-item">
+				<h3>
+					<a>insert-item<span class="since">6.0.2</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">insert-item <i>index list value</i></span>
+					<span class="prim_example">insert-item <i>index string1 string2</i></span>
+				</h4>
+				<p>
+					On a list, inserts an item in that list. <i>index</i> is the index
+					where the item will be inserted. The first item has an index of 0.
+					(The 6th item in a list would have an index of 5.)
+				</p>
+				<p>
+					Likewise for a string, but all characters in a multiple-character <i>string2</i>
+					are inserted at <i>index</i>.
+				</p>
+				<pre>
+					show insert-item 2 [2 7 4 5] 15
+					=&gt; [2 7 15 4 5]
+					show insert-item 2 &quot;cat&quot; &quot;re&quot;
+					=&gt; &quot;caret&quot;
+				</pre>
+			</div>
 
 
-    <div class="dict_entry" id="inspect">
-      <h3>
-        <a>inspect<span class="since">1.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">inspect <i>agent</i></span>
-      </h4>
-      <p>
-        Opens an agent monitor for the given agent (turtle or patch).
-      </p>
-      <pre>
-inspect patch 2 4
-;; an agent monitor opens for that patch
-inspect one-of sheep
-;; an agent monitor opens for a random turtle from
-;; the &quot;sheep&quot; breed
-</pre>
-      <p>
-        See <a href="#stop-inspecting">stop-inspecting</a> and <a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>
-      </p>
-    </div>
-    <div class="dict_entry" id="int">
-      <h3>
-        <a>int<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">int <i>number</i></span>
-      </h4>
-      <p>
-        Reports the integer part of number -- any fractional part is
-        discarded.
-      </p>
-      <pre>
-show int 4.7
-=&gt; 4
-show int -3.5
-=&gt; -3
-</pre>
-    </div>
-    <div class="dict_entry" id="is-of-type">
-      <h3>
-        <a>is-agent?<span class="since">1.2.1</span></a>
-        <a>is-agentset?<span class="since">1.2.1</span></a>
-        <a>is-anonymous-command?<span class="since">6.0</span></a>
-        <a>is-anonymous-reporter?<span class="since">6.0</span></a>
-        <a>is-boolean?<span class="since">1.2.1</span></a>
-        <a>is-directed-link?<span class="since">4.0</span></a>
-        <a>is-link?<span class="since">4.0</span></a>
-        <a>is-link-set?<span class="since">4.0</span></a>
-        <a>is-list?<span class="since">1.0</span></a>
-        <a>is-number?<span class="since">1.2.1</span></a>
-        <a>is-patch?<span class="since">1.2.1</span></a>
-        <a>is-patch-set?<span class="since">4.0</span></a>
-        <a>is-string?<span class="since">1.0</span></a>
-        <a>is-turtle?<span class="since">1.2.1</span></a>
-        <a>is-turtle-set?<span class="since">4.0</span></a>
-        <a>is-undirected-link?<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">is-agent? <i>value</i></span>
-        <span class="prim_example">is-agentset? <i>value</i></span>
-        <span class="prim_example">is-anonymous-command? <i>value</i></span>
-        <span class="prim_example">is-anonymous-reporter? <i>value</i></span>
-        <span class="prim_example">is-boolean? <i>value</i></span>
-        <span class="prim_example">is-<i>&lt;breed&gt;</i>? <i>value</i></span>
-        <span class="prim_example">is-<i>&lt;link-breed&gt;</i>? <i>value</i></span>
-        <span class="prim_example">is-directed-link? <i>value</i></span>
-        <span class="prim_example">is-link? <i>value</i></span>
-        <span class="prim_example">is-link-set? <i>value</i></span>
-        <span class="prim_example">is-list? <i>value</i></span>
-        <span class="prim_example">is-number? <i>value</i></span>
-        <span class="prim_example">is-patch? <i>value</i></span>
-        <span class="prim_example">is-patch-set? <i>value</i></span>
-        <span class="prim_example">is-string? <i>value</i></span>
-        <span class="prim_example">is-turtle? <i>value</i></span>
-        <span class="prim_example">is-turtle-set? <i>value</i></span>
-        <span class="prim_example">is-undirected-link? <i>value</i></span>
-      </h4>
-      <p>
-        Reports true if <i>value</i> is of the given type, false otherwise.
-      </p>
-      </div>
-    <div class="dict_entry" id="item">
-      <h3>
-        <a>item<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">item <i>index list</i></span>
-        <span class="prim_example">item <i>index string</i></span>
-      </h4>
-      <p>
-        On lists, reports the value of the item in the given list with the
-        given index.
-      </p>
-      <p>
-        On strings, reports the character in the given string at the given
-        index.
-      </p>
-      <p>
-        Note that the indices begin from 0, not 1. (The first item is item
-        0, the second item is item 1, and so on.)
-      </p>
-      <pre>
-;; suppose mylist is [2 4 6 8 10]
-show item 2 mylist
-=&gt; 6
-show item 3 &quot;my-shoe&quot;
-=&gt; &quot;s&quot;
-</pre>
-    </div><!-- ======================================== -->
-  </div>
-    <h2 id="J">
-      <a>J</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="jump">
-      <h3>
-        <a>jump<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">jump <i>number</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        The turtle moves forward by <i>number</i> units all at once (rather
-        than one step at a time as with the <code>forward</code> command).
-      </p>
-      <p>
-        If the turtle cannot jump <i>number</i> units because it is not
-        permitted by the current topology the turtle does not move at all.
-      </p>
-      <p>
-        See also <a href="#forward">forward</a>, <a href="#can-move">can-move?</a>.
-      </p>
-      </div><!-- ======================================== -->
-    </div>
-    <h2 id="L">
-      <a>L</a>
-    </h2><!-- ======================================== -->
-    <div class="dict_entry" id="label">
-      <h3>
-        <a>label</a>
-      </h3>
-      <h4>
-        <span class="prim_example">label</span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        This is a built-in turtle or link variable. It may hold a value of
-        any type. The turtle or link appears in the view with the given
-        value &quot;attached&quot; to it as text. You can set this variable
-        to add, change, or remove a turtle or link's label.
-      </p>
-      <p>
-        See also <a href="#label-color">label-color</a>, <a href="#plabel">plabel</a>, <a href="#plabel-color">plabel-color</a>.
-      </p>
-      <p>
-        Example:
-      </p>
-      <pre>
-ask turtles [ set label who ]
-;; all the turtles now are labeled with their
-;; who numbers
-ask turtles [ set label &quot;&quot; ]
-;; all turtles now are not labeled
-</pre>
-    </div>
-    <div class="dict_entry" id="label-color">
-      <h3>
-        <a>label-color</a>
-      </h3>
-      <h4>
-        <span class="prim_example">label-color</span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        This is a built-in turtle or link variable. It holds a number
-        greater than or equal to 0 and less than 140. This number
-        determines what color the turtle or link's label appears in (if
-        it has a label). You can set this variable to change the color of a
-        turtle or link's label.
-      </p>
-      <p>
-        See also <a href="#label">label</a>, <a href="#plabel">plabel</a>,
-        <a href="#plabel-color">plabel-color</a>.
-      </p>
-      <p>
-        Example:
-      </p>
-      <pre>
-ask turtles [ set label-color red ]
-;; all the turtles now have red labels
-</pre>
-    </div>
-    <div class="dict_entry" id="last">
-      <h3>
-        <a>last<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">last <i>list</i></span>
-        <span class="prim_example">last <i>string</i></span>
-      </h4>
-      <p>
-        On a list, reports the last item in the list.
-      </p>
-      <p>
-        On a string, reports a one-character string containing only the
-        last character of the original string.
-      </p>
-      </div>
-    <div class="dict_entry" id="layout-circle">
-      <h3>
-        <a>layout-circle<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">layout-circle <i>agentset</i> <i>radius</i></span>
-        <span class="prim_example">layout-circle <i>list-of-turtles</i> <i>radius</i></span>
-      </h4>
-      <p>
-        Arranges the given turtles in a circle centered on the patch at the
-        center of the world with the given radius. (If the world has an
-        even size the center of the circle is rounded down to the nearest
-        patch.) The turtles point outwards.
-      </p>
-      <p>
-        If the first input is an agentset, the turtles are arranged in
-        random order.
-      </p>
-      <p>
-        If the first input is a list, the turtles are arranged clockwise in
-        the given order, starting at the top of the circle. (Any
-        non-turtles in the list are ignored.)
-      </p>
-      <pre>
-;; in random order
-layout-circle turtles 10
-;; in order by who number
-layout-circle sort turtles 10
-;; in order by size
-layout-circle sort-by [ [a b] -&gt; [size] of a &lt; [size] of b ] turtles 10
-</pre>
-    </div>
-    <div class="dict_entry" id="layout-radial">
-      <h3>
-        <a>layout-radial<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">layout-radial <i>turtle-set</i> <i>link-set</i> <i>root-agent</i></span>
-      </h4>
-      <p>
-        Arranges the turtles in <i>turtle-set</i> connected by links in
-        <i>link-set</i>, in a radial tree layout, centered around the
-        <i>root-agent</i> which is moved to the center of the world view.
-      </p>
-      <p>
-        Only links in the <i>link-set</i> will be used to determine the
-        layout. If links connect turtles that are not in <i>turtle-set</i>
-        those turtles will remain stationary.
-      </p>
-      <p>
-        Even if the network does contain cycles, and is not a true tree
-        structure, this layout will still work, although the results will
-        not always be pretty.
-      </p>
-      <pre>
-to make-a-tree
-  set-default-shape turtles &quot;circle&quot;
-  crt 6
-  ask turtle 0 [
-    create-link-with turtle 1
-    create-link-with turtle 2
-    create-link-with turtle 3
-  ]
-  ask turtle 1 [
-    create-link-with turtle 4
-    create-link-with turtle 5
-  ]
-  ; do a radial tree layout, centered on turtle 0
-  layout-radial turtles links (turtle 0)
-end
-</pre>
-    </div>
-    <div class="dict_entry" id="layout-spring">
-      <h3>
-        <a>layout-spring<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">layout-spring <i>turtle-set</i> <i>link-set</i>
-          <i>spring-constant</i> <i>spring-length</i> <i>repulsion-constant</i></span>
-      </h4>
-      <p>
-        Arranges the turtles in <i>turtle-set</i>, as if the links in
-        <i>link-set</i> are springs and the turtles are repelling each
-        other. Turtles that are connected by links in <i>link-set</i> but
-        not included in <i>turtle-set</i> are treated as anchors and are
-        not moved.
-      </p>
-      <p>
-        <i>spring-constant</i> is a measure of the &quot;tautness&quot; of
-        the spring. It is the &quot;resistance&quot; to change in their
-        length. spring-constant is the force the spring would exert if
-        it's length were changed by 1 unit.
-      </p>
-      <p>
-        spring-length is the &quot;zero-force&quot; length or the natural
-        length of the springs. This is the length which all springs try to
-        achieve either by pushing out their nodes or pulling them in.
-      </p>
-      <p>
-        repulsion-constant is a measure of repulsion between the nodes. It
-        is the force that 2 nodes at a distance of 1 unit will exert on
-        each other.
-      </p>
-      <p>
-        The repulsion effect tries to get the nodes as far as possible from
-        each other, in order to avoid crowding and the spring effect tries
-        to keep them at &quot;about&quot; a certain distance from the nodes
-        they are connected to. The result is the laying out of the whole
-        network in a way which highlights relationships among the nodes and
-        at the same time is crowded less and is visually pleasing.
-      </p>
-      <p>
-        The layout algorithm is based on the Fruchterman-Reingold layout
-        algorithm. More information about this algorithm can be obtained
-        <a href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.13.8444" target="_blank">here</a>.
-      </p>
-      <pre>
-to make-a-triangle
-  set-default-shape turtles &quot;circle&quot;
-  crt 3
-  ask turtle 0
-  [
-    create-links-with other turtles
-  ]
-  ask turtle 1
-  [
-    create-link-with turtle 2
-  ]
-  repeat 30 [ layout-spring turtles links 0.2 5 1 ] ;; lays the nodes in a triangle
-end
-</pre>
-    </div>
-    <div class="dict_entry" id="layout-tutte">
-      <h3>
-        <a>layout-tutte<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">layout-tutte <i>turtle-set</i> <i>link-set</i> <i>radius</i></span>
-      </h4>
-      <p>
-        The turtles that are connected by links in <i>link-set</i> but not
-        included in <i>turtle-set</i> are placed in a circle layout with
-        the given <i>radius</i>. There should be at least 3 agents in this
-        agentset.
-      </p>
-      <p>
-        The turtles in <i>turtle-set</i> are then laid out in the following
-        manner: Each turtle is placed at centroid (or barycenter) of the
-        polygon formed by its linked neighbors. (The centroid is like a
-        2-dimensional average of the coordinates of the neighbors.)
-      </p>
-      <p>
-        (The purpose of the circle of &quot;anchor agents&quot; is to
-        prevent all the turtles from collapsing down to one point.)
-      </p>
-      <p>
-        After a few iterations of this, the layout will stabilize.
-      </p>
-      <p>
-        This layout is named after the mathematician William Thomas Tutte,
-        who proposed it as a method for graph layout.
-      </p>
-      <pre>
-to make-a-tree
-  set-default-shape turtles &quot;circle&quot;
-  crt 6
-  ask turtle 0 [
-    create-link-with turtle 1
-    create-link-with turtle 2
-    create-link-with turtle 3
-  ]
-  ask turtle 1 [
-    create-link-with turtle 4
-    create-link-with turtle 5
-  ]
-  ; place all the turtles with just one
-  ; neighbor on the perimeter of a circle
-  ; and then place the remaining turtles inside
-  ; this circle, spread between their neighbors.
-  repeat 10 [ layout-tutte (turtles with [link-neighbors = 1]) links 12 ]
-end
-</pre>
-    </div>
-    <div class="dict_entry" id="left">
-      <h3>
-        <a>left<span class="since">1.0</span></a>
-        <a>lt<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">left <i>number</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        The turtle turns left by <i>number</i> degrees. (If <i>number</i>
-        is negative, it turns right.)
-      </p>
-      </div>
-    <div class="dict_entry" id="length">
-      <h3>
-        <a>length<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">length <i>list</i></span>
-        <span class="prim_example">length <i>string</i></span>
-      </h4>
-      <p>
-        Reports the number of items in the given list, or the number of
-        characters in the given string.
-      </p>
-      </div>
-    <div class="dict_entry" id="let">
-      <h3>
-        <a>let<span class="since">2.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">let <i>variable</i> <i>value</i></span>
-      </h4>
-      <p>
-        Creates a new local variable and gives it the given value. A local
-        variable is one that exists only within the enclosing block of
-        commands.
-      </p>
-      <p>
-        If you want to change the value afterwards, use <a href="#set">set</a>.
-      </p>
-      <p>
-        Example:
-      </p>
-      <pre>
-let prey one-of sheep-here
-if prey != nobody
-  [ ask prey [ die ] ]
-</pre>
-    </div>
-    <div class="dict_entry" id="link">
-      <h3>
-        <a>link<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">link <i>end1</i> <i>end2</i></span>
-        <span class="prim_example">&lt;breed&gt; <i>end1</i> <i>end2</i></span>
-      </h4>
-      <p>
-        Given the who numbers of the endpoints, reports the link connecting
-        the turtles. If there is no such link reports <code>nobody</code>. To
-        refer to breeded links you must use the singular breed form with
-        the endpoints.
-      </p>
-      <pre>
-ask link 0 1 [ set color green ]
-;; unbreeded link connecting turtle 0 and turtle 1 will turn green
-ask directed-link 0 1 [ set color red ]
-;; directed link connecting turtle 0 and turtle 1 will turn red
-</pre>
-      <p>
-        See also <a href="#patch-at">patch-at</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="link-heading">
-      <h3>
-        <a>link-heading<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">link-heading</span>
-        <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        Reports the heading in degrees (at least 0, less than 360) from
-        <code>end1</code> to <code>end2</code> of the link. Throws a runtime error
-        if the endpoints are at the same location.
-      </p>
-      <pre>
-ask link 0 1 [ print link-heading ]
-;; prints [[towards other-end] of end1] of link 0 1
-</pre>
-      <p>
-        See also <a href="#link-length">link-length</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="link-length">
-      <h3>
-        <a>link-length<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">link-length</span>
-        <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        Reports the distance between the endpoints of the link.
-      </p>
-      <pre>
-ask link 0 1 [ print link-length ]
-;; prints [[distance other-end] of end1] of link 0 1
-</pre>
-      <p>
-        See also <a href="#link-heading">link-heading</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="link-set">
-      <h3>
-        <a>link-set<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">link-set <i>value</i></span>
-        <span class="prim_example">(link-set <i>value1</i> <i>value2</i> ...)</span>
-      </h4>
-      <p>
-        Reports an agentset containing all of the links anywhere in any of
-        the inputs. The inputs may be individual links, link agentsets,
-        nobody, or lists (or nested lists) containing any of the above.
-      </p>
-      <pre>
-link-set self
-link-set [my-links] of nodes with [color = red]
-</pre>
-      <p>
-        See also <a href="#turtle-set">turtle-set</a>, <a href="#patch-set">patch-set</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="link-shapes">
-      <h3>
-        <a>link-shapes<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">link-shapes</span>
-      </h4>
-      <p>
-        Reports a list of strings containing all of the link shapes in the
-        model.
-      </p>
-      <p>
-        New shapes can be created, or imported from other models, in the
-        <a href="shapes.html">Link Shapes Editor</a>.
-      </p>
-      <pre>
-show link-shapes
-=&gt; [&quot;default&quot;]
-</pre>
-    </div>
-    <div class="dict_entry" id="links">
-      <h3>
-        <a>links<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">links</span>
-      </h4>
-      <p>
-        Reports the agentset consisting of all links. This is a special agentset that can grow as links are added to the world, see <a href="programming.html#special-agentsets">the programming guide for more info</a>.
-      </p>
-      <pre>
-show count links
-;; prints the number of links
-</pre>
-    </div>
-    <div class="dict_entry" id="links-own">
-      <h3>
-        <a>links-own</a>
-      </h3>
-      <h4>
-        <span class="prim_example">links-own [<i>var1</i> ...]</span>
-        <span class="prim_example"><i>&lt;link-breeds&gt;</i>-own [<i>var1</i> ...]</span>
-      </h4>
-      <p>
-        The links-own keyword, like the globals, breed,
-        <i>&lt;breeds&gt;</i>-own, turtles-own, and patches-own keywords,
-        can only be used at the beginning of a program, before any function
-        definitions. It defines the variables belonging to each link.
-      </p>
-      <p>
-        If you specify a breed instead of &quot;links&quot;, only links of
-        that breed have the listed variables. (More than one link breed may
-        list the same variable.)
-      </p>
-      <pre>
-undirected-link-breed [sidewalks sidewalk]
-directed-link-breed [streets street]
-links-own [traffic]   ;; applies to all breeds
-sidewalks-own [pedestrians]
-streets-own [cars bikes]
-</pre>
-      <div class="dict_entry" id="list">
-        <h3>
-          <a>list<span class="since">1.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">list <i>value1</i> <i>value2</i></span>
-          <span class="prim_example">(list <i>value1</i> ...)</span>
-        </h4>
-        <p>
-          Reports a list containing the given items. The items can be of
-          any type, produced by any kind of reporter.
-        </p>
-        <pre>
-show list (random 10) (random 10)
-=&gt; [4 9]  ;; or similar list
-show (list 5)
-=&gt; [5]
-show (list (random 10) 1 2 3 (random 10))
-=&gt; [4 1 2 3 9]  ;; or similar list
-</pre>
-      </div>
-      <div class="dict_entry" id="ln">
-        <h3>
-          <a>ln<span class="since">1.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">ln <i>number</i></span>
-        </h4>
-        <p>
-          Reports the natural logarithm of <i>number</i>, that is, the
-          logarithm to the base e (2.71828...).
-        </p>
-        <p>
-          See also <a href="#num-e">e</a>, <a href="#log">log</a>.
-        </p>
-        </div>
-      <div class="dict_entry" id="log">
-        <h3>
-          <a>log<span class="since">1.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">log <i>number</i> <i>base</i></span>
-        </h4>
-        <p>
-          Reports the logarithm of <i>number</i> in base <i>base</i>.
-        </p>
-        <pre>
-show log 64 2
-=&gt; 6
-</pre>
-        <p>
-          See also <a href="#ln">ln</a>.
-        </p>
-        </div>
-      <div class="dict_entry" id="loop">
-        <h3>
-          <a>loop<span class="since">1.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">loop [ <i>commands</i> ]</span>
-        </h4>
-        <p>
-          Repeats the commands forever, or until the enclosing procedure
-          exits through use of the <a href="#stop">stop</a> or
-          <a href="#report">report</a> commands.
-        </p>
-          <pre>to move-to-world-edge  ;; turtle procedure
-  loop [
-    if not can-move? 1 [ stop ]
-    fd 1
-  ]
-end</pre>
-        <p>In this example, <code>stop</code> exits not just the loop,
-           but the entire procedure.
-        </p>
-        <p>
-          Note: in many circumstances, it is more appropriate to use
-          a forever button to repeat something indefinitely.  See
-          <a href="programming.html#buttons">Buttons</a> in the
-          Programming Guide.
-        </p>
-        </div>
-      <div class="dict_entry" id="lput">
-        <h3>
-          <a>lput<span class="since">1.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">lput <i>value list</i></span>
-        </h4>
-        <p>
-          Adds <i>value</i> to the end of a list and reports the new list.
-        </p>
-        <pre>
-;; suppose mylist is [2 7 10 &quot;Bob&quot;]
-set mylist lput 42 mylist
-;; mylist now is [2 7 10 &quot;Bob&quot; 42]
-</pre>
-      </div><!-- ======================================== -->
-    </div>
-      <h2 id="M">
-        <a>M</a>
-      </h2><!-- ======================================== -->
-      <div>
-      <div class="dict_entry" id="map">
-        <h3>
-          <a>map<span class="since">1.3</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">map <i>reporter</i> <i>list</i></span>
-          <span class="prim_example">(map <i>reporter</i> <i>list1</i> ...)</span>
-        </h4>
-        <p>
-          With a single <i>list</i>, the given reporter is run for each item in
-          the list, and a list of the results is collected and reported.
-          <i>reporter</i> may be an anonymous reporter or the name of a reporter.
-        </p>
-        <pre>
-show map round [1.1 2.2 2.7]
-=&gt; [1 2 3]
-show map [ i -&gt; i * i ] [1 2 3]
-=&gt; [1 4 9]
-</pre>
-        <p>
-          With multiple lists, the given reporter is run for each group of
-          items from each list. So, it is run once for the first items,
-          once for the second items, and so on. All the lists must be the
-          same length.
-        </p>
-        <p>
-          Some examples make this clearer:
-        </p>
-        <pre>
-show (map + [1 2 3] [2 4 6])
-=&gt; [3 6 9]
-show (map [ [a b c] -&gt; a + b = c ] [1 2 3] [2 4 6] [3 5 9])
-=&gt; [true false true]
-</pre>
-        <p>
-        See also <a href="#foreach">foreach</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>.
-        </p>
-        </div>
-      <div class="dict_entry" id="max">
-        <h3>
-          <a>max<span class="since">1.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">max <i>list</i></span>
-        </h4>
-        <p>
-          Reports the maximum number value in the list. It ignores other
-          types of items.
-        </p>
-        <pre>
-show max [xcor] of turtles
-;; prints the x coordinate of the turtle which is
-;; farthest right in the world
-show max list a b
-;; prints the larger of the two variables a and b
-show max (list a b c)
-;; prints the largest of the three variables a, b, and c
-</pre>
-      </div>
-      <div class="dict_entry" id="max-n-of">
-        <h3>
-          <a>max-n-of<span class="since">4.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">max-n-of <i>number</i> <i>agentset</i> [<i>reporter</i>]</span>
-        </h4>
-        <p>
-          Reports an agentset containing <i>number</i> agents from
-          <i>agentset</i> with the highest values of <i>reporter</i>. The
-          agentset is built by finding all the agents with the highest
-          value of <i>reporter</i>, if there are not <i>number</i> agents
-          with that value then agents with the second highest value are
-          found, and so on. At the end, if there is a tie that would make
-          the resulting agentset too large, the tie is broken randomly.
-        </p>
-        <pre>
-;; assume the world is 11 x 11
-show max-n-of 5 patches [pxcor]
-;; shows 5 patches with pxcor = max-pxcor
-show max-n-of 5 patches with [pycor = 0] [pxcor]
-;; shows an agentset containing:
-;; (patch 1 0) (patch 2 0) (patch 3 0) (patch 4 0) (patch 5 0)
-</pre>
-        <p>
-          See also <a href="#max-one-of">max-one-of</a>, <a href="#with-max">with-max</a>.
-        </p>
-        </div>
-      <div class="dict_entry" id="max-one-of">
-        <h3>
-          <a>max-one-of<span class="since">1.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">max-one-of <i>agentset</i> [<i>reporter</i>]</span>
-        </h4>
-        <p>
-          Reports the agent in the agentset that has the highest value for
-          the given reporter. If there is a tie this command reports one
-          random agent with the highest value. If you want all such agents,
-          use with-max instead.
-        </p>
-        <pre>
-show max-one-of patches [count turtles-here]
-<br>;; prints the first patch with the most turtles on it
-</pre>
-        <p>
-          See also <a href="#max-n-of">max-n-of</a>, <a href="#with-max">with-max</a>.
-        </p>
-        </div>
-      <div class="dict_entry" id="max-pcor">
-        <h3>
-          <a>max-pxcor<span class="since">3.1</span></a>
-          <a>max-pycor<span class="since">3.1</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">max-pxcor</span>
-          <span class="prim_example">max-pycor</span>
-        </h4>
-        <p>
-          These reporters give the maximum x-coordinate and maximum
-          y-coordinate, (respectively) for patches, which determines the
-          size of the world.
-        </p>
-        <p>
-          Unlike in older versions of NetLogo the origin does not have to
-          be at the center of the world. However, the maximum x- and y-
-          coordinates must be greater than or equal to zero.
-        </p>
-        <p>
-          Note: You can set the size of the world only by editing the view
-          -- these are reporters which cannot be set.
-        </p>
-        <pre>
-crt 100 [ setxy random-float max-pxcor
-                random-float max-pycor ]
-;; distributes 100 turtles randomly in the
-;; first quadrant
-</pre>
-        <p>
-          See also <a href="#min-pcor">min-pxcor</a>, <a href="#min-pcor">min-pycor</a>, <a href="#world-dim">world-width</a>, and <a href="#world-dim">world-height</a>
-        </p>
-        </div>
-      <div class="dict_entry" id="mean">
-        <h3>
-          <a>mean<span class="since">1.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">mean <i>list</i></span>
-        </h4>
-        <p>
-          Reports the statistical mean of the numeric items in the given
-          list. Errors on non-numeric items. The mean is the average, i.e.,
-          the sum of the items divided by the total number of items.
-        </p>
-        <pre>
-show mean [xcor] of turtles
-;; prints the average of all the turtles' x coordinates
-</pre>
-      </div>
-      <div class="dict_entry" id="median">
-        <h3>
-          <a>median<span class="since">1.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">median <i>list</i></span>
-        </h4>
-        <p>
-          Reports the statistical median of the numeric items of the given
-          list. Ignores non-numeric items. The median is the item that
-          would be in the middle if all the items were arranged in order.
-          (If two items would be in the middle, the median is the average
-          of the two.)
-        </p>
-        <pre>
-show median [xcor] of turtles
-;; prints the median of all the turtles' x coordinates
-</pre>
-      </div>
-      <div class="dict_entry" id="member">
-        <h3>
-          <a>member?<span class="since">1.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">member? <i>value list</i></span>
-          <span class="prim_example">member? <i>string1 string2</i></span>
-          <span class="prim_example">member? <i>agent agentset</i></span>
-        </h4>
-        <p>
-          For a list, reports true if the given value appears in the given
-          list, otherwise reports false.
-        </p>
-        <p>
-          For a string, reports true or false depending on whether
-          <i>string1</i> appears anywhere inside <i>string2</i> as a
-          substring.
-        </p>
-        <p>
-          For an agentset, reports true if the given agent is appears in
-          the given agentset, otherwise reports false.
-        </p>
-        <pre>
-show member? 2 [1 2 3]
-=&gt; true
-show member? 4 [1 2 3]
-=&gt; false
-show member? &quot;bat&quot; &quot;abate&quot;
-=&gt; true
-show member? turtle 0 turtles
-=&gt; true
-show member? turtle 0 patches
-=&gt; false
-</pre>
-        <p>
-          See also <a href="#position">position</a>.
-        </p>
-        </div>
-      <div class="dict_entry" id="min">
-        <h3>
-          <a>min<span class="since">1.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">min <i>list</i></span>
-        </h4>
-        <p>
-          Reports the minimum number value in the list. It ignores other
-          types of items.
-        </p>
-        <pre>
-show min [xcor] of turtles
-;; prints the lowest x-coordinate of all the turtles
-show min list a b
-;; prints the smaller of the two variables a and b
-show min (list a b c)
-;; prints the smallest of the three variables a, b, and c
-</pre>
-      </div>
-      <div class="dict_entry" id="min-n-of">
-        <h3>
-          <a>min-n-of<span class="since">4.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">min-n-of <i>number</i> <i>agentset</i> [<i>reporter</i>]</span>
-        </h4>
-        <p>
-          Reports an agentset containing <i>number</i> agents from
-          <i>agentset</i> with the lowest values of <i>reporter</i>. The
-          agentset is built by finding all the agents with the lowest value
-          of <i>reporter</i>, if there are not <i>number</i> agents with
-          that value then the agents with the second lowest value are
-          found, and so on. At the end, if there is a tie that would make
-          the resulting agentset too large, the tie is broken randomly.
-        </p>
-        <pre>
-;; assume the world is 11 x 11
-show min-n-of 5 patches [pxcor]
-;; shows 5 patches with pxcor = min-pxcor
-show min-n-of 5 patches with [pycor = 0] [pxcor]
-;; shows an agentset containing:
-;; (patch -5 0) (patch -4 0) (patch -3 0) (patch -2 0) (patch -1 0)
-</pre>
-        <p>
-          See also <a href="#min-one-of">min-one-of</a>, <a href="#with-min">with-min</a>.
-        </p>
-        </div>
-      <div class="dict_entry" id="min-one-of">
-        <h3>
-          <a>min-one-of<span class="since">1.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">min-one-of <i>agentset</i> [<i>reporter</i>]</span>
-        </h4>
-        <p>
-          Reports a random agent in the agentset that reports the lowest
-          value for the given reporter. If there is a tie, this command
-          reports one random agent that meets the condition. If you want
-          all such agents use with-min instead.
-        </p>
-        <pre>
-show min-one-of turtles [xcor + ycor]
-;; reports the first turtle with the smallest sum of
-;; coordinates
-</pre>
-        <p>
-          See also <a href="#with-min">with-min</a>, <a href="#min-n-of">min-n-of</a>.
-        </p>
-        </div>
-      <div class="dict_entry" id="min-pcor">
-        <h3>
-          <a>min-pxcor<span class="since">3.1</span></a>
-          <a>min-pycor<span class="since">3.1</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">min-pxcor</span>
-          <span class="prim_example">min-pycor</span>
-        </h4>
-        <p>
-          These reporters give the minimum x-coordinate and minimum
-          y-coordinate, (respectively) for patches, which determines the
-          size of the world.
-        </p>
-        <p>
-          Unlike in older versions of NetLogo the origin does not have to
-          be at the center of the world. However, the minimum x- and y-
-          coordinates must be less than or equal to zero.
-        </p>
-        <p>
-          Note: You can set the size of the world only by editing the view
-          -- these are reporters which cannot be set.
-        </p>
-        <pre>
-crt 100 [ setxy random-float min-pxcor
-                random-float min-pycor ]
-;; distributes 100 turtles randomly in the
-;; third quadrant
-</pre>
-        <p>
-          See also <a href="#max-pcor">max-pxcor</a>, <a href="#max-pcor">max-pycor</a>, <a href="#world-dim">world-width</a>, and <a href="#world-dim">world-height</a>
-        </p>
-        </div>
-      <div class="dict_entry" id="mod">
-        <h3>
-          <a>mod<span class="since">1.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example"><i>number1</i> mod <i>number2</i></span>
-        </h4>
-        <p>
-          Reports <i>number1</i> modulo <i>number2</i>: that is, the
-          residue of <i>number1</i> (mod <i>number2</i>). mod is is
-          equivalent to the following NetLogo code:
-        </p>
-        <pre>
-<i>number1</i> - (floor (<i>number1</i> / <i>number2</i>)) * <i>number2</i>
-</pre>
-        <p>
-          Note that mod is &quot;infix&quot;, that is, it comes between its
-          two inputs.
-        </p>
-        <pre>
-show 62 mod 5
-=&gt; 2
-show -8 mod 3
-=&gt; 1
-</pre>
-        <p>
-          See also <a href="#remainder">remainder</a>. mod and remainder
-          behave the same for positive numbers, but differently for
-          negative numbers.
-        </p>
-        </div>
-      <div class="dict_entry" id="modes">
-        <h3>
-          <a>modes<span class="since">2.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">modes <i>list</i></span>
-        </h4>
-        <p>
-          Reports a list of the most common item or items in <i>list</i>.
-        </p>
-        <p>
-          The input list may contain any NetLogo values.
-        </p>
-        <p>
-          If the input is an empty list, reports an empty list.
-        </p>
-        <pre>
-show modes [1 2 2 3 4]
-=&gt; [2]
-show modes [1 2 2 3 3 4]
-=&gt; [2 3]
-show modes [ [1 2 [3]] [1 2 [3]] [2 3 4] ]
-=&gt; [[1 2 [3]]]
-show modes [pxcor] of turtles
-;; shows which columns of patches have the most
-;; turtles on them
-</pre>
-      </div>
-      <div class="dict_entry" id="mouse-down">
-        <h3>
-          <a>mouse-down?<span class="since">1.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">mouse-down?</span>
-        </h4>
-        <p>
-          Reports true if the mouse button is down, false otherwise.
-        </p>
-        <p>
-          Note: If the mouse pointer is outside of the current view ,
-          mouse-down? will always report false.
-        </p>
-        </div>
-      <div class="dict_entry" id="mouse-inside">
-        <h3>
-          <a>mouse-inside?<span class="since">3.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">mouse-inside?</span>
-        </h4>
-        <p>
-          Reports true if the mouse pointer is inside the current view,
-          false otherwise.
-        </p>
-        </div>
-      <div class="dict_entry" id="mouse-cor">
-        <h3>
-          <a>mouse-xcor<span class="since">1.0</span></a>
-          <a>mouse-ycor<span class="since">1.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">mouse-xcor</span>
-          <span class="prim_example">mouse-ycor</span>
-        </h4>
-        <p>
-          Reports the x or y coordinate of the mouse in the 2D view. The
-          value is in terms of turtle coordinates, so it might not be an
-          integer. If you want patch coordinates, use <code>round
-          mouse-xcor</code> and <code>round mouse-ycor</code>.
-        </p>
-        <p>
-          Note: If the mouse is outside of the 2D view, reports the value
-          from the last time it was inside.
-        </p>
-        <pre>
-;; to make the mouse &quot;draw&quot; in red:
-if mouse-down?
-  [ ask patch mouse-xcor mouse-ycor [ set pcolor red ] ]
-</pre>
-      </div>
-      <div class="dict_entry" id="move-to">
-        <h3>
-          <a>move-to<span class="since">4.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">move-to <i>agent</i></span>
-          <img alt="Turtle Command" src="images/turtle.gif">
-        </h4>
-        <p>
-          The turtle sets its x and y coordinates to be the same as the
-          given agent's.
-        </p>
-        <p>
-          (If that agent is a patch, the effect is to move the turtle to
-          the center of that patch.)
-        </p>
-        <pre>
-move-to turtle 5
-;; turtle moves to same point as turtle 5
-move-to one-of patches
-;; turtle moves to the center of a random patch
-move-to max-one-of turtles [size]
-;; turtle moves to same point as biggest turtle
-</pre>
-        <p>
-          Note that the turtle's heading is unaltered. You may want to
-          use the <a href="#face">face</a> command first to orient the
-          turtle in the direction of motion.
-        </p>
-        <p>
-          See also <a href="#setxy">setxy</a>.
-        </p>
-        </div>
-      <div class="dict_entry" id="my-links">
-        <h3>
-          <a>my-&lt;breeds&gt;</a>
-          <a>my-links<span class="since">4.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">my-&lt;breeds&gt;</span>
-          <span class="prim_example">my-links</span>
-          <img alt="Turtle Command" src="images/turtle.gif">
-        </h4>
-        <p>
-          Reports an agentset of all links connected to the caller of
-          the corresponding breed, regardless of directedness.
-          Generally, you might consider using
-          <a href="#my-out-links"><code>my-out-links</code></a> instead
-          of this primitive, as it works well for either directed or
-          undirected networks (since it excludes directed, incoming
-          links).
-        </p>
-        <pre>
-crt 5
-ask turtle 0
-[
-  create-links-with other turtles
-  show my-links ;; prints the agentset containing all links
-                ;; (since all the links we created were with turtle 0 )
-]
-ask turtle 1
-[
-  show my-links ;; shows an agentset containing the link 0 1
-]
-end
-</pre>
-        If you only want the undirected links connected to a node, you
-        can do <code>my-links with [ not is-directed-link? self ]</code>.
-      </div>
-      <div class="dict_entry" id="my-in-links">
-        <h3>
-          <a>my-in-&lt;breeds&gt;</a>
-          <a>my-in-links<span class="since">4.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">my-in-&lt;breeds&gt;</span>
-          <span class="prim_example">my-in-links</span>
-          <img alt="Turtle Command" src="images/turtle.gif">
-        </h4>
-        <p>
-          Reports an agentset of all the directed links coming in from
-          other nodes to the caller as well as all undirected links
-          connected to the caller. You can think of this as "all links
-          that you can use to travel <i>to</i> this node".
-        </p>
-        <pre>
-crt 5
-ask turtle 0
-[
-  create-links-to other turtles
-  show my-in-links ;; shows an empty agentset
-]
-ask turtle 1
-[
-  show my-in-links ;; shows an agentset containing the link 0 1
-]
-</pre>
-      </div>
-      <div class="dict_entry" id="my-out-links">
-        <h3>
-          <a>my-out-&lt;breeds&gt;</a>
-          <a>my-out-links<span class="since">4.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">my-out-&lt;breeds&gt;</span>
-          <span class="prim_example">my-out-links</span>
-          <img alt="Turtle Command" src="images/turtle.gif">
-        </h4>
-        <p>
-          Reports an agentset of all the directed links going out from the
-          caller to other nodes as well as undirected links connected to the
-          caller. You can think of this as "all links you can use to travel
-          <i>from</i> this node".
-        </p>
-        <pre>
-crt 5
-ask turtle 0
-[
-  create-links-to other turtles
-  show my-out-links ;; shows agentset containing all the links
-]
-ask turtle 1
-[
-  show my-out-links ;; shows an empty agentset
-]
-</pre>
-      </div>
-      <div class="dict_entry" id="myself">
-        <h3>
-          <a>myself<span class="since">1.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">myself</span>
-          <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif"> <img alt="Link Command" src="images/link.gif">
-        </h4>
-        <p>
-          &quot;self&quot; and &quot;myself&quot; are very different.
-          &quot;self&quot; is simple; it means &quot;me&quot;.
-          &quot;myself&quot; means &quot;the turtle, patch or link who asked me
-          to do what I'm doing right now.&quot;
-        </p>
-        <p>
-          When an agent has been asked to run some code, using myself in
-          that code reports the agent (turtle, patch or link) that did the
-          asking.
-        </p>
-        <p>
-          myself is most often used in conjunction with <code>of</code> to read
-          or set variables in the asking agent.
-        </p>
-        <p>
-          myself can be used within blocks of code not just in the ask
-          command, but also hatch, sprout, of, with, all?, with-min,
-          with-max, min-one-of, max-one-of, min-n-of, max-n-of.
-        </p>
-        <pre>
-ask turtles
-  [ ask patches in-radius 3
-      [ set pcolor [color] of myself ] ]
-;; each turtle makes a colored &quot;splotch&quot; around itself
-</pre>
-        <p>
-          See the &quot;Myself Example&quot; code example for more
-          examples.
-        </p>
-        <p>
-          See also <a href="#self">self</a>.
-        </p>
-        </div><!-- ======================================== -->
-      </div>
-      <h2 id="N">
-        <a>N</a>
-      </h2><!-- ======================================== -->
-      <div>
-      <div class="dict_entry" id="n-of">
-        <h3>
-          <a>n-of<span class="since">3.1</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">n-of <i>size</i> <i>agentset</i></span>
-          <span class="prim_example">n-of <i>size</i> <i>list</i></span>
-        </h4>
-        <p>
-          From an agentset, reports an agentset of size <i>size</i>
-          randomly chosen from the input set, with no repeats.
-        </p>
-        <p>
-          From a list, reports a list of size <i>size</i> randomly chosen
-          from the input set, with no repeats. The items in the result
-          appear in the same order that they appeared in the input list.
-          (If you want them in random order, use shuffle on the result.)
-        </p>
-        <p>
-          It is an error for <i>size</i> to be greater than the size of the
-          input.
-        </p>
-        <pre>
-ask n-of 50 patches [ set pcolor green ]
-;; 50 randomly chosen patches turn green
-</pre>
-        <p>
-          See also <a href="#one-of">one-of</a> and <a href="#up-to-n-of">up-to-n-of</a>,
-          a version that does not error with a <i>size</i> greater than
-          the size of the input.
-        </p>
-        </div>
-      <div class="dict_entry" id="n-values">
-        <h3>
-          <a>n-values<span class="since">2.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">n-values <i>size</i> <i>reporter</i></span>
-        </h4>
-        <p>
-          Reports a list of length <i>size</i> containing values computed
-          by repeatedly running the reporter. <i>reporter</i> may be an anonymous
-          reporter or the name of a reporter.
-        </p>
-        <p>
-          If the reporter accepts inputs, the input will be the number of the
-          item currently being computed, starting from zero.
-        </p>
-        <pre>
-show n-values 5 [1]
-=&gt; [1 1 1 1 1]
-show n-values 5 [ i -&gt; i ]
-=&gt; [0 1 2 3 4]
-show n-values 3 turtle
-=&gt; [(turtle 0) (turtle 1) (turtle 2)]
-show n-values 5 [ x -&gt; x * x ]
-=&gt; [0 1 4 9 16]
-</pre>
-        <p>
-        See also <a href="#reduce">reduce</a>, <a href="#filter">filter</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>, <a href="#range">range</a>.
-        </p>
-        </div>
-      <div class="dict_entry" id="neighbors">
-        <h3>
-          <a>neighbors<span class="since">1.1</span></a>
-          <a>neighbors4<span class="since">1.1</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">neighbors</span>
-          <span class="prim_example">neighbors4</span>
-          <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-        </h4>
-        <p>
-          Reports an agentset containing the 8 surrounding patches
-          (neighbors) or 4 surrounding patches (neighbors4).
-        </p>
-        <pre>
-show sum [count turtles-here] of neighbors
-  ;; prints the total number of turtles on the eight
-  ;; patches around this turtle or patch
-show count turtles-on neighbors
-  ;; a shorter way to say the same thing
-ask neighbors4 [ set pcolor red ]
-  ;; turns the four neighboring patches red
-</pre>
-      </div>
-      <div class="dict_entry" id="link-neighbors">
-        <h3>
-          <a>&lt;breed&gt;-neighbors</a>
-          <a>link-neighbors<span class="since">4.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">&lt;breed&gt;-neighbors</span>
-          <span class="prim_example">link-neighbors</span>
-          <img alt="Turtle Command" src="images/turtle.gif">
-        </h4>
-        <p>
-          Reports the agentset of all turtles found at the other end of
-          any links (undirected or directed, incoming or outgoing)
-          connected to this turtle.
-        </p>
-        <pre>
-crt 3
-ask turtle 0
-[
-  create-links-with other turtles
-  ask link-neighbors [ set color red ] ;; turtles 1 and 2 turn red
-]
-ask turtle 1
-[
-  ask link-neighbors [ set color blue ] ;; turtle 0 turns blue
-]
-end
-</pre>
-      </div>
-      <div class="dict_entry" id="link-neighbor">
-        <h3>
-          <a>&lt;breed&gt;-neighbor?</a>
-          <a>link-neighbor?<span class="since">4.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">&lt;breed&gt;-neighbor? <i>turtle</i></span>
-          <span class="prim_example">link-neighbor? <i>turtle</i></span>
-          <img alt="Turtle Command" src="images/turtle.gif">
-        </h4>
-        <p>
-          Reports true if there is a link (either directed or undirected,
-          incoming or outgoing) between <i>turtle</i> and the caller.
-        </p>
-        <pre>
-crt 2
-ask turtle 0
-[
-  create-link-with turtle 1
-  show link-neighbor? turtle 1  ;; prints true
-]
-ask turtle 1
-[
-  show link-neighbor? turtle 0     ;; prints true
-]
-</pre>
-    </div>
-    <div class="dict_entry" id="netlogo-version">
-      <h3>
-        <a>netlogo-version<span class="since">3.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">netlogo-version</span>
-      </h4>
-      <p>
-        Reports a string containing the version number of the NetLogo you
-        are running.
-      </p>
-      <pre>
-show netlogo-version
-=&gt; &quot;{{version}}&quot;
-</pre>
-    </div>
-    <div class="dict_entry" id="netlogo-web">
-      <h3>
-        <a>netlogo-web?<span class="since">5.2</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">netlogo-web?</span>
-      </h4>
-      <p>
-        Reports true if the model is running in NetLogo Web.
-      </p>
-      </div>
-    <div class="dict_entry" id="new-seed">
-      <h3>
-        <a>new-seed<span class="since">3.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">new-seed</span>
-      </h4>
-      <p>
-        Reports a number suitable for seeding the random number generator.
-      </p>
-      <p>
-        The numbers reported by new-seed are based on the current date and
-        time in milliseconds and lie in the generator's usable range of
-        seeds, -2147483648 to 2147483647.
-      </p>
-      <p>
-        new-seed never reports the same number twice in succession, even
-        across parallel BehaviorSpace runs. (This
-        is accomplished by waiting a millisecond if the seed for the
-        current millisecond was already used.)
-      </p>
-      <p>
-        See also <a href="#random-seed">random-seed</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="no-display">
-      <h3>
-        <a>no-display<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">no-display</span>
-      </h4>
-      <p>
-        Turns off all updates to the current view until the display command
-        is issued. This has two major uses.
-      </p>
-      <p>
-        One, you can control when the user sees view updates. You might
-        want to change lots of things on the view behind the user's
-        back, so to speak, then make them visible to the user all at once.
-      </p>
-      <p>
-        Two, your model will run faster when view updating is off, so if
-        you're in a hurry, this command will let you get results
-        faster. (Note that normally you don't need to use no-display
-        for this, since you can also use the on/off switch in view control
-        strip to freeze the view.)
-      </p>
-      <p>
-        Note that display and no-display operate independently of the
-        switch in the view control strip that freezes the view.
-      </p>
-      <p>
-        See also <a href="#display">display</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="nobody">
-      <h3>
-        <a>nobody</a>
-      </h3>
-      <h4>
-        <span class="prim_example">nobody</span>
-      </h4>
-      <p>
-        This is a special value which some primitives such as turtle,
-        one-of, max-one-of, etc. report to indicate that no agent was
-        found. Also, when a turtle dies, it becomes equal to nobody.
-      </p>
-      <p>
-        Note: Empty agentsets are not equal to nobody. If you want to test
-        for an empty agentset, use <a href="#any">any?</a>. You only get
-        nobody back in situations where you were expecting a single agent,
-        not a whole agentset.
-      </p>
-      <pre>
-set target one-of other turtles-here
-if target != nobody
-  [ ask target [ set color red ] ]
-</pre>
-    </div>
-    <div class="dict_entry" id="no-links">
-      <h3>
-        <a>no-links<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">no-links</span>
-      </h4>
-      <p>
-        Reports an empty link agentset.
-      </p>
-    </div>
-    <div class="dict_entry" id="no-patches">
-      <h3>
-        <a>no-patches<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">no-patches</span>
-      </h4>
-      <p>
-        Reports an empty patch agentset.
-      </p>
-    </div>
-    <div class="dict_entry" id="not">
-      <h3>
-        <a>not<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">not <i>boolean</i></span>
-      </h4>
-      <p>
-        Reports true if <i>boolean</i> is false, otherwise reports false.
-      </p>
-      <pre>
-if not any? turtles [ crt 10 ]
-</pre>
-    </div>
-    <div class="dict_entry" id="no-turtles">
-      <h3>
-        <a>no-turtles<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">no-turtles</span>
-      </h4>
-      <p>
-        Reports an empty turtle agentset.
-      </p>
-      </div><!-- ======================================== -->
-    </div>
-    <h2 id="O">
-      <a>O</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="of">
-      <h3>
-        <a>of<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">[<i>reporter</i>] of <i>agent</i></span>
-        <span class="prim_example">[<i>reporter</i>] of <i>agentset</i></span>
-      </h4>
-      <p>
-        For an agent, reports the value of the reporter for that agent
-        (turtle or patch).
-      </p>
-      <pre>
-show [pxcor] of patch 3 5
-;; prints 3
-show [pxcor] of one-of patches
-;; prints the value of a random patch's pxcor variable
-show [who * who] of turtle 5
-=&gt; 25
-show [count turtles in-radius 3] of patch 0 0
-;; prints the number of turtles located within a
-;; three-patch radius of the origin
-</pre>
-      <p>
-        For an agentset, reports a list that contains the value of the
-        reporter for each agent in the agentset (in random order).
-      </p>
-      <pre>
-crt 4
-show sort [who] of turtles
-=&gt; [0 1 2 3]
-show sort [who * who] of turtles
-=&gt; [0 1 4 9]
-</pre>
-    </div>
-    <div class="dict_entry" id="one-of">
-      <h3>
-        <a>one-of<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">one-of <i>agentset</i></span>
-        <span class="prim_example">one-of <i>list</i></span>
-      </h4>
-      <p>
-        From an agentset, reports a random agent. If the agentset is empty,
-        reports <a href="#nobody">nobody</a>.
-      </p>
-      <p>
-        From a list, reports a random list item. It is an error for the
-        list to be empty.
-      </p>
-      <pre>
-ask one-of patches [ set pcolor green ]
-;; a random patch turns green
-ask patches with [any? turtles-here]
-  [ show one-of turtles-here ]
-;; for each patch containing turtles, prints one of
-;; those turtles
+			<div class="dict_entry" id="inspect">
+				<h3>
+					<a>inspect<span class="since">1.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">inspect <i>agent</i></span>
+				</h4>
+				<p>
+					Opens an agent monitor for the given agent (turtle or patch).
+				</p>
+				<pre>
+					inspect patch 2 4
+					;; an agent monitor opens for that patch
+					inspect one-of sheep
+					;; an agent monitor opens for a random turtle from
+					;; the &quot;sheep&quot; breed
+				</pre>
+				<p>
+					See <a href="#stop-inspecting">stop-inspecting</a> and <a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="int">
+				<h3>
+					<a>int<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">int <i>number</i></span>
+				</h4>
+				<p>
+					Reports the integer part of number -- any fractional part is
+					discarded.
+				</p>
+				<pre>
+					show int 4.7
+					=&gt; 4
+					show int -3.5
+					=&gt; -3
+				</pre>
+			</div>
+			<div class="dict_entry" id="is-of-type">
+				<h3>
+					<a>is-agent?<span class="since">1.2.1</span></a>
+					<a>is-agentset?<span class="since">1.2.1</span></a>
+					<a>is-anonymous-command?<span class="since">6.0</span></a>
+					<a>is-anonymous-reporter?<span class="since">6.0</span></a>
+					<a>is-boolean?<span class="since">1.2.1</span></a>
+					<a>is-directed-link?<span class="since">4.0</span></a>
+					<a>is-link?<span class="since">4.0</span></a>
+					<a>is-link-set?<span class="since">4.0</span></a>
+					<a>is-list?<span class="since">1.0</span></a>
+					<a>is-number?<span class="since">1.2.1</span></a>
+					<a>is-patch?<span class="since">1.2.1</span></a>
+					<a>is-patch-set?<span class="since">4.0</span></a>
+					<a>is-string?<span class="since">1.0</span></a>
+					<a>is-turtle?<span class="since">1.2.1</span></a>
+					<a>is-turtle-set?<span class="since">4.0</span></a>
+					<a>is-undirected-link?<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">is-agent? <i>value</i></span>
+					<span class="prim_example">is-agentset? <i>value</i></span>
+					<span class="prim_example">is-anonymous-command? <i>value</i></span>
+					<span class="prim_example">is-anonymous-reporter? <i>value</i></span>
+					<span class="prim_example">is-boolean? <i>value</i></span>
+					<span class="prim_example">is-<i>&lt;breed&gt;</i>? <i>value</i></span>
+					<span class="prim_example">is-<i>&lt;link-breed&gt;</i>? <i>value</i></span>
+					<span class="prim_example">is-directed-link? <i>value</i></span>
+					<span class="prim_example">is-link? <i>value</i></span>
+					<span class="prim_example">is-link-set? <i>value</i></span>
+					<span class="prim_example">is-list? <i>value</i></span>
+					<span class="prim_example">is-number? <i>value</i></span>
+					<span class="prim_example">is-patch? <i>value</i></span>
+					<span class="prim_example">is-patch-set? <i>value</i></span>
+					<span class="prim_example">is-string? <i>value</i></span>
+					<span class="prim_example">is-turtle? <i>value</i></span>
+					<span class="prim_example">is-turtle-set? <i>value</i></span>
+					<span class="prim_example">is-undirected-link? <i>value</i></span>
+				</h4>
+				<p>
+					Reports true if <i>value</i> is of the given type, false otherwise.
+				</p>
+			</div>
+			<div class="dict_entry" id="item">
+				<h3>
+					<a>item<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">item <i>index list</i></span>
+					<span class="prim_example">item <i>index string</i></span>
+				</h4>
+				<p>
+					On lists, reports the value of the item in the given list with the
+					given index.
+				</p>
+				<p>
+					On strings, reports the character in the given string at the given
+					index.
+				</p>
+				<p>
+					Note that the indices begin from 0, not 1. (The first item is item
+					0, the second item is item 1, and so on.)
+				</p>
+				<pre>
+					;; suppose mylist is [2 4 6 8 10]
+					show item 2 mylist
+					=&gt; 6
+					show item 3 &quot;my-shoe&quot;
+					=&gt; &quot;s&quot;
+				</pre>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="J">
+			<a>J</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="jump">
+				<h3>
+					<a>jump<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">jump <i>number</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					The turtle moves forward by <i>number</i> units all at once (rather
+					than one step at a time as with the <code>forward</code> command).
+				</p>
+				<p>
+					If the turtle cannot jump <i>number</i> units because it is not
+					permitted by the current topology the turtle does not move at all.
+				</p>
+				<p>
+					See also <a href="#forward">forward</a>, <a href="#can-move">can-move?</a>.
+				</p>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="L">
+			<a>L</a>
+		</h2><!-- ======================================== -->
+		<div class="dict_entry" id="label">
+			<h3>
+				<a>label</a>
+			</h3>
+			<h4>
+				<span class="prim_example">label</span>
+				<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+			</h4>
+			<p>
+				This is a built-in turtle or link variable. It may hold a value of
+				any type. The turtle or link appears in the view with the given
+				value &quot;attached&quot; to it as text. You can set this variable
+				to add, change, or remove a turtle or link's label.
+			</p>
+			<p>
+				See also <a href="#label-color">label-color</a>, <a href="#plabel">plabel</a>, <a href="#plabel-color">plabel-color</a>.
+			</p>
+			<p>
+				Example:
+			</p>
+			<pre>
+				ask turtles [ set label who ]
+				;; all the turtles now are labeled with their
+				;; who numbers
+				ask turtles [ set label &quot;&quot; ]
+				;; all turtles now are not labeled
+			</pre>
+		</div>
+		<div class="dict_entry" id="label-color">
+			<h3>
+				<a>label-color</a>
+			</h3>
+			<h4>
+				<span class="prim_example">label-color</span>
+				<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+			</h4>
+			<p>
+				This is a built-in turtle or link variable. It holds a number
+				greater than or equal to 0 and less than 140. This number
+				determines what color the turtle or link's label appears in (if
+				it has a label). You can set this variable to change the color of a
+				turtle or link's label.
+			</p>
+			<p>
+				See also <a href="#label">label</a>, <a href="#plabel">plabel</a>,
+				<a href="#plabel-color">plabel-color</a>.
+			</p>
+			<p>
+				Example:
+			</p>
+			<pre>
+				ask turtles [ set label-color red ]
+				;; all the turtles now have red labels
+			</pre>
+		</div>
+		<div class="dict_entry" id="last">
+			<h3>
+				<a>last<span class="since">1.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">last <i>list</i></span>
+				<span class="prim_example">last <i>string</i></span>
+			</h4>
+			<p>
+				On a list, reports the last item in the list.
+			</p>
+			<p>
+				On a string, reports a one-character string containing only the
+				last character of the original string.
+			</p>
+		</div>
+		<div class="dict_entry" id="layout-circle">
+			<h3>
+				<a>layout-circle<span class="since">4.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">layout-circle <i>agentset</i> <i>radius</i></span>
+				<span class="prim_example">layout-circle <i>list-of-turtles</i> <i>radius</i></span>
+			</h4>
+			<p>
+				Arranges the given turtles in a circle centered on the patch at the
+				center of the world with the given radius. (If the world has an
+				even size the center of the circle is rounded down to the nearest
+				patch.) The turtles point outwards.
+			</p>
+			<p>
+				If the first input is an agentset, the turtles are arranged in
+				random order.
+			</p>
+			<p>
+				If the first input is a list, the turtles are arranged clockwise in
+				the given order, starting at the top of the circle. (Any
+				non-turtles in the list are ignored.)
+			</p>
+			<pre>
+				;; in random order
+				layout-circle turtles 10
+				;; in order by who number
+				layout-circle sort turtles 10
+				;; in order by size
+				layout-circle sort-by [ [a b] -&gt; [size] of a &lt; [size] of b ] turtles 10
+			</pre>
+		</div>
+		<div class="dict_entry" id="layout-radial">
+			<h3>
+				<a>layout-radial<span class="since">4.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">layout-radial <i>turtle-set</i> <i>link-set</i> <i>root-agent</i></span>
+			</h4>
+			<p>
+				Arranges the turtles in <i>turtle-set</i> connected by links in
+				<i>link-set</i>, in a radial tree layout, centered around the
+				<i>root-agent</i> which is moved to the center of the world view.
+			</p>
+			<p>
+				Only links in the <i>link-set</i> will be used to determine the
+				layout. If links connect turtles that are not in <i>turtle-set</i>
+				those turtles will remain stationary.
+			</p>
+			<p>
+				Even if the network does contain cycles, and is not a true tree
+				structure, this layout will still work, although the results will
+				not always be pretty.
+			</p>
+			<pre>
+				to make-a-tree
+				set-default-shape turtles &quot;circle&quot;
+				crt 6
+				ask turtle 0 [
+				create-link-with turtle 1
+				create-link-with turtle 2
+				create-link-with turtle 3
+				]
+				ask turtle 1 [
+				create-link-with turtle 4
+				create-link-with turtle 5
+				]
+				; do a radial tree layout, centered on turtle 0
+				layout-radial turtles links (turtle 0)
+				end
+			</pre>
+		</div>
+		<div class="dict_entry" id="layout-spring">
+			<h3>
+				<a>layout-spring<span class="since">4.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">layout-spring <i>turtle-set</i> <i>link-set</i>
+					<i>spring-constant</i> <i>spring-length</i> <i>repulsion-constant</i></span>
+			</h4>
+			<p>
+				Arranges the turtles in <i>turtle-set</i>, as if the links in
+				<i>link-set</i> are springs and the turtles are repelling each
+				other. Turtles that are connected by links in <i>link-set</i> but
+				not included in <i>turtle-set</i> are treated as anchors and are
+				not moved.
+			</p>
+			<p>
+				<i>spring-constant</i> is a measure of the &quot;tautness&quot; of
+				the spring. It is the &quot;resistance&quot; to change in their
+				length. spring-constant is the force the spring would exert if
+				it's length were changed by 1 unit.
+			</p>
+			<p>
+				spring-length is the &quot;zero-force&quot; length or the natural
+				length of the springs. This is the length which all springs try to
+				achieve either by pushing out their nodes or pulling them in.
+			</p>
+			<p>
+				repulsion-constant is a measure of repulsion between the nodes. It
+				is the force that 2 nodes at a distance of 1 unit will exert on
+				each other.
+			</p>
+			<p>
+				The repulsion effect tries to get the nodes as far as possible from
+				each other, in order to avoid crowding and the spring effect tries
+				to keep them at &quot;about&quot; a certain distance from the nodes
+				they are connected to. The result is the laying out of the whole
+				network in a way which highlights relationships among the nodes and
+				at the same time is crowded less and is visually pleasing.
+			</p>
+			<p>
+				The layout algorithm is based on the Fruchterman-Reingold layout
+				algorithm. More information about this algorithm can be obtained
+				<a href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.13.8444" target="_blank">here</a>.
+			</p>
+			<pre>
+				to make-a-triangle
+				set-default-shape turtles &quot;circle&quot;
+				crt 3
+				ask turtle 0
+				[
+				create-links-with other turtles
+				]
+				ask turtle 1
+				[
+				create-link-with turtle 2
+				]
+				repeat 30 [ layout-spring turtles links 0.2 5 1 ] ;; lays the nodes in a triangle
+				end
+			</pre>
+		</div>
+		<div class="dict_entry" id="layout-tutte">
+			<h3>
+				<a>layout-tutte<span class="since">4.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">layout-tutte <i>turtle-set</i> <i>link-set</i> <i>radius</i></span>
+			</h4>
+			<p>
+				The turtles that are connected by links in <i>link-set</i> but not
+				included in <i>turtle-set</i> are placed in a circle layout with
+				the given <i>radius</i>. There should be at least 3 agents in this
+				agentset.
+			</p>
+			<p>
+				The turtles in <i>turtle-set</i> are then laid out in the following
+				manner: Each turtle is placed at centroid (or barycenter) of the
+				polygon formed by its linked neighbors. (The centroid is like a
+				2-dimensional average of the coordinates of the neighbors.)
+			</p>
+			<p>
+				(The purpose of the circle of &quot;anchor agents&quot; is to
+				prevent all the turtles from collapsing down to one point.)
+			</p>
+			<p>
+				After a few iterations of this, the layout will stabilize.
+			</p>
+			<p>
+				This layout is named after the mathematician William Thomas Tutte,
+				who proposed it as a method for graph layout.
+			</p>
+			<pre>
+				to make-a-tree
+				set-default-shape turtles &quot;circle&quot;
+				crt 6
+				ask turtle 0 [
+				create-link-with turtle 1
+				create-link-with turtle 2
+				create-link-with turtle 3
+				]
+				ask turtle 1 [
+				create-link-with turtle 4
+				create-link-with turtle 5
+				]
+				; place all the turtles with just one
+				; neighbor on the perimeter of a circle
+				; and then place the remaining turtles inside
+				; this circle, spread between their neighbors.
+				repeat 10 [ layout-tutte (turtles with [link-neighbors = 1]) links 12 ]
+				end
+			</pre>
+		</div>
+		<div class="dict_entry" id="left">
+			<h3>
+				<a>left<span class="since">1.0</span></a>
+				<a>lt<span class="since">1.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">left <i>number</i></span>
+				<img alt="Turtle Command" src="images/turtle.gif"/>
+			</h4>
+			<p>
+				The turtle turns left by <i>number</i> degrees. (If <i>number</i>
+				is negative, it turns right.)
+			</p>
+		</div>
+		<div class="dict_entry" id="length">
+			<h3>
+				<a>length<span class="since">1.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">length <i>list</i></span>
+				<span class="prim_example">length <i>string</i></span>
+			</h4>
+			<p>
+				Reports the number of items in the given list, or the number of
+				characters in the given string.
+			</p>
+		</div>
+		<div class="dict_entry" id="let">
+			<h3>
+				<a>let<span class="since">2.1</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">let <i>variable</i> <i>value</i></span>
+			</h4>
+			<p>
+				Creates a new local variable and gives it the given value. A local
+				variable is one that exists only within the enclosing block of
+				commands.
+			</p>
+			<p>
+				If you want to change the value afterwards, use <a href="#set">set</a>.
+			</p>
+			<p>
+				Example:
+			</p>
+			<pre>
+				let prey one-of sheep-here
+				if prey != nobody
+				[ ask prey [ die ] ]
+			</pre>
+		</div>
+		<div class="dict_entry" id="link">
+			<h3>
+				<a>link<span class="since">4.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">link <i>end1</i> <i>end2</i></span>
+				<span class="prim_example">&lt;breed&gt; <i>end1</i> <i>end2</i></span>
+			</h4>
+			<p>
+				Given the who numbers of the endpoints, reports the link connecting
+				the turtles. If there is no such link reports <code>nobody</code>. To
+				refer to breeded links you must use the singular breed form with
+				the endpoints.
+			</p>
+			<pre>
+				ask link 0 1 [ set color green ]
+				;; unbreeded link connecting turtle 0 and turtle 1 will turn green
+				ask directed-link 0 1 [ set color red ]
+				;; directed link connecting turtle 0 and turtle 1 will turn red
+			</pre>
+			<p>
+				See also <a href="#patch-at">patch-at</a>.
+			</p>
+		</div>
+		<div class="dict_entry" id="link-heading">
+			<h3>
+				<a>link-heading<span class="since">4.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">link-heading</span>
+				<img alt="Link Command" src="images/link.gif"/>
+			</h4>
+			<p>
+				Reports the heading in degrees (at least 0, less than 360) from
+				<code>end1</code> to <code>end2</code> of the link. Throws a runtime error
+				if the endpoints are at the same location.
+			</p>
+			<pre>
+				ask link 0 1 [ print link-heading ]
+				;; prints [[towards other-end] of end1] of link 0 1
+			</pre>
+			<p>
+				See also <a href="#link-length">link-length</a>
+			</p>
+		</div>
+		<div class="dict_entry" id="link-length">
+			<h3>
+				<a>link-length<span class="since">4.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">link-length</span>
+				<img alt="Link Command" src="images/link.gif"/>
+			</h4>
+			<p>
+				Reports the distance between the endpoints of the link.
+			</p>
+			<pre>
+				ask link 0 1 [ print link-length ]
+				;; prints [[distance other-end] of end1] of link 0 1
+			</pre>
+			<p>
+				See also <a href="#link-heading">link-heading</a>
+			</p>
+		</div>
+		<div class="dict_entry" id="link-set">
+			<h3>
+				<a>link-set<span class="since">4.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">link-set <i>value</i></span>
+				<span class="prim_example">(link-set <i>value1</i> <i>value2</i> ...)</span>
+			</h4>
+			<p>
+				Reports an agentset containing all of the links anywhere in any of
+				the inputs. The inputs may be individual links, link agentsets,
+				nobody, or lists (or nested lists) containing any of the above.
+			</p>
+			<pre>
+				link-set self
+				link-set [my-links] of nodes with [color = red]
+			</pre>
+			<p>
+				See also <a href="#turtle-set">turtle-set</a>, <a href="#patch-set">patch-set</a>.
+			</p>
+		</div>
+		<div class="dict_entry" id="link-shapes">
+			<h3>
+				<a>link-shapes<span class="since">4.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">link-shapes</span>
+			</h4>
+			<p>
+				Reports a list of strings containing all of the link shapes in the
+				model.
+			</p>
+			<p>
+				New shapes can be created, or imported from other models, in the
+				<a href="shapes.html">Link Shapes Editor</a>.
+			</p>
+			<pre>
+				show link-shapes
+				=&gt; [&quot;default&quot;]
+			</pre>
+		</div>
+		<div class="dict_entry" id="links">
+			<h3>
+				<a>links<span class="since">4.0</span></a>
+			</h3>
+			<h4>
+				<span class="prim_example">links</span>
+			</h4>
+			<p>
+				Reports the agentset consisting of all links. This is a special agentset that can grow as links are added to the world, see <a href="programming.html#special-agentsets">the programming guide for more info</a>.
+			</p>
+			<pre>
+				show count links
+				;; prints the number of links
+			</pre>
+		</div>
+		<div class="dict_entry" id="links-own">
+			<h3>
+				<a>links-own</a>
+			</h3>
+			<h4>
+				<span class="prim_example">links-own [<i>var1</i> ...]</span>
+				<span class="prim_example"><i>&lt;link-breeds&gt;</i>-own [<i>var1</i> ...]</span>
+			</h4>
+			<p>
+				The links-own keyword, like the globals, breed,
+				<i>&lt;breeds&gt;</i>-own, turtles-own, and patches-own keywords,
+				can only be used at the beginning of a program, before any function
+				definitions. It defines the variables belonging to each link.
+			</p>
+			<p>
+				If you specify a breed instead of &quot;links&quot;, only links of
+				that breed have the listed variables. (More than one link breed may
+				list the same variable.)
+			</p>
+			<pre>
+				undirected-link-breed [sidewalks sidewalk]
+				directed-link-breed [streets street]
+				links-own [traffic]   ;; applies to all breeds
+				sidewalks-own [pedestrians]
+				streets-own [cars bikes]
+			</pre>
+			<div class="dict_entry" id="list">
+				<h3>
+					<a>list<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">list <i>value1</i> <i>value2</i></span>
+					<span class="prim_example">(list <i>value1</i> ...)</span>
+				</h4>
+				<p>
+					Reports a list containing the given items. The items can be of
+					any type, produced by any kind of reporter.
+				</p>
+				<pre>
+					show list (random 10) (random 10)
+					=&gt; [4 9]  ;; or similar list
+					show (list 5)
+					=&gt; [5]
+					show (list (random 10) 1 2 3 (random 10))
+					=&gt; [4 1 2 3 9]  ;; or similar list
+				</pre>
+			</div>
+			<div class="dict_entry" id="ln">
+				<h3>
+					<a>ln<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">ln <i>number</i></span>
+				</h4>
+				<p>
+					Reports the natural logarithm of <i>number</i>, that is, the
+					logarithm to the base e (2.71828...).
+				</p>
+				<p>
+					See also <a href="#num-e">e</a>, <a href="#log">log</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="log">
+				<h3>
+					<a>log<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">log <i>number</i> <i>base</i></span>
+				</h4>
+				<p>
+					Reports the logarithm of <i>number</i> in base <i>base</i>.
+				</p>
+				<pre>
+					show log 64 2
+					=&gt; 6
+				</pre>
+				<p>
+					See also <a href="#ln">ln</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="loop">
+				<h3>
+					<a>loop<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">loop [ <i>commands</i> ]</span>
+				</h4>
+				<p>
+					Repeats the commands forever, or until the enclosing procedure
+					exits through use of the <a href="#stop">stop</a> or
+					<a href="#report">report</a> commands.
+				</p>
+				<pre>to move-to-world-edge  ;; turtle procedure
+					loop [
+					if not can-move? 1 [ stop ]
+					fd 1
+					]
+					end</pre>
+				<p>In this example, <code>stop</code> exits not just the loop,
+					but the entire procedure.
+				</p>
+				<p>
+					Note: in many circumstances, it is more appropriate to use
+					a forever button to repeat something indefinitely.  See
+					<a href="programming.html#buttons">Buttons</a> in the
+					Programming Guide.
+				</p>
+			</div>
+			<div class="dict_entry" id="lput">
+				<h3>
+					<a>lput<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">lput <i>value list</i></span>
+				</h4>
+				<p>
+					Adds <i>value</i> to the end of a list and reports the new list.
+				</p>
+				<pre>
+					;; suppose mylist is [2 7 10 &quot;Bob&quot;]
+					set mylist lput 42 mylist
+					;; mylist now is [2 7 10 &quot;Bob&quot; 42]
+				</pre>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="M">
+			<a>M</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="map">
+				<h3>
+					<a>map<span class="since">1.3</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">map <i>reporter</i> <i>list</i></span>
+					<span class="prim_example">(map <i>reporter</i> <i>list1</i> ...)</span>
+				</h4>
+				<p>
+					With a single <i>list</i>, the given reporter is run for each item in
+					the list, and a list of the results is collected and reported.
+					<i>reporter</i> may be an anonymous reporter or the name of a reporter.
+				</p>
+				<pre>
+					show map round [1.1 2.2 2.7]
+					=&gt; [1 2 3]
+					show map [ i -&gt; i * i ] [1 2 3]
+					=&gt; [1 4 9]
+				</pre>
+				<p>
+					With multiple lists, the given reporter is run for each group of
+					items from each list. So, it is run once for the first items,
+					once for the second items, and so on. All the lists must be the
+					same length.
+				</p>
+				<p>
+					Some examples make this clearer:
+				</p>
+				<pre>
+					show (map + [1 2 3] [2 4 6])
+					=&gt; [3 6 9]
+					show (map [ [a b c] -&gt; a + b = c ] [1 2 3] [2 4 6] [3 5 9])
+					=&gt; [true false true]
+				</pre>
+				<p>
+					See also <a href="#foreach">foreach</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="max">
+				<h3>
+					<a>max<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">max <i>list</i></span>
+				</h4>
+				<p>
+					Reports the maximum number value in the list. It ignores other
+					types of items.
+				</p>
+				<pre>
+					show max [xcor] of turtles
+					;; prints the x coordinate of the turtle which is
+					;; farthest right in the world
+					show max list a b
+					;; prints the larger of the two variables a and b
+					show max (list a b c)
+					;; prints the largest of the three variables a, b, and c
+				</pre>
+			</div>
+			<div class="dict_entry" id="max-n-of">
+				<h3>
+					<a>max-n-of<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">max-n-of <i>number</i> <i>agentset</i> [<i>reporter</i>]</span>
+				</h4>
+				<p>
+					Reports an agentset containing <i>number</i> agents from
+					<i>agentset</i> with the highest values of <i>reporter</i>. The
+					agentset is built by finding all the agents with the highest
+					value of <i>reporter</i>, if there are not <i>number</i> agents
+					with that value then agents with the second highest value are
+					found, and so on. At the end, if there is a tie that would make
+					the resulting agentset too large, the tie is broken randomly.
+				</p>
+				<pre>
+					;; assume the world is 11 x 11
+					show max-n-of 5 patches [pxcor]
+					;; shows 5 patches with pxcor = max-pxcor
+					show max-n-of 5 patches with [pycor = 0] [pxcor]
+					;; shows an agentset containing:
+					;; (patch 1 0) (patch 2 0) (patch 3 0) (patch 4 0) (patch 5 0)
+				</pre>
+				<p>
+					See also <a href="#max-one-of">max-one-of</a>, <a href="#with-max">with-max</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="max-one-of">
+				<h3>
+					<a>max-one-of<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">max-one-of <i>agentset</i> [<i>reporter</i>]</span>
+				</h4>
+				<p>
+					Reports the agent in the agentset that has the highest value for
+					the given reporter. If there is a tie this command reports one
+					random agent with the highest value. If you want all such agents,
+					use with-max instead.
+				</p>
+				<pre>
+					show max-one-of patches [count turtles-here]
+					<br/>;; prints the first patch with the most turtles on it
+				</pre>
+				<p>
+					See also <a href="#max-n-of">max-n-of</a>, <a href="#with-max">with-max</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="max-pcor">
+				<h3>
+					<a>max-pxcor<span class="since">3.1</span></a>
+					<a>max-pycor<span class="since">3.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">max-pxcor</span>
+					<span class="prim_example">max-pycor</span>
+				</h4>
+				<p>
+					These reporters give the maximum x-coordinate and maximum
+					y-coordinate, (respectively) for patches, which determines the
+					size of the world.
+				</p>
+				<p>
+					Unlike in older versions of NetLogo the origin does not have to
+					be at the center of the world. However, the maximum x- and y-
+					coordinates must be greater than or equal to zero.
+				</p>
+				<p>
+					Note: You can set the size of the world only by editing the view
+					-- these are reporters which cannot be set.
+				</p>
+				<pre>
+					crt 100 [ setxy random-float max-pxcor
+					random-float max-pycor ]
+					;; distributes 100 turtles randomly in the
+					;; first quadrant
+				</pre>
+				<p>
+					See also <a href="#min-pcor">min-pxcor</a>, <a href="#min-pcor">min-pycor</a>, <a href="#world-dim">world-width</a>, and <a href="#world-dim">world-height</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="mean">
+				<h3>
+					<a>mean<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">mean <i>list</i></span>
+				</h4>
+				<p>
+					Reports the statistical mean of the numeric items in the given
+					list. Errors on non-numeric items. The mean is the average, i.e.,
+					the sum of the items divided by the total number of items.
+				</p>
+				<pre>
+					show mean [xcor] of turtles
+					;; prints the average of all the turtles' x coordinates
+				</pre>
+			</div>
+			<div class="dict_entry" id="median">
+				<h3>
+					<a>median<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">median <i>list</i></span>
+				</h4>
+				<p>
+					Reports the statistical median of the numeric items of the given
+					list. Ignores non-numeric items. The median is the item that
+					would be in the middle if all the items were arranged in order.
+					(If two items would be in the middle, the median is the average
+					of the two.)
+				</p>
+				<pre>
+					show median [xcor] of turtles
+					;; prints the median of all the turtles' x coordinates
+				</pre>
+			</div>
+			<div class="dict_entry" id="member">
+				<h3>
+					<a>member?<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">member? <i>value list</i></span>
+					<span class="prim_example">member? <i>string1 string2</i></span>
+					<span class="prim_example">member? <i>agent agentset</i></span>
+				</h4>
+				<p>
+					For a list, reports true if the given value appears in the given
+					list, otherwise reports false.
+				</p>
+				<p>
+					For a string, reports true or false depending on whether
+					<i>string1</i> appears anywhere inside <i>string2</i> as a
+					substring.
+				</p>
+				<p>
+					For an agentset, reports true if the given agent is appears in
+					the given agentset, otherwise reports false.
+				</p>
+				<pre>
+					show member? 2 [1 2 3]
+					=&gt; true
+					show member? 4 [1 2 3]
+					=&gt; false
+					show member? &quot;bat&quot; &quot;abate&quot;
+					=&gt; true
+					show member? turtle 0 turtles
+					=&gt; true
+					show member? turtle 0 patches
+					=&gt; false
+				</pre>
+				<p>
+					See also <a href="#position">position</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="min">
+				<h3>
+					<a>min<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">min <i>list</i></span>
+				</h4>
+				<p>
+					Reports the minimum number value in the list. It ignores other
+					types of items.
+				</p>
+				<pre>
+					show min [xcor] of turtles
+					;; prints the lowest x-coordinate of all the turtles
+					show min list a b
+					;; prints the smaller of the two variables a and b
+					show min (list a b c)
+					;; prints the smallest of the three variables a, b, and c
+				</pre>
+			</div>
+			<div class="dict_entry" id="min-n-of">
+				<h3>
+					<a>min-n-of<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">min-n-of <i>number</i> <i>agentset</i> [<i>reporter</i>]</span>
+				</h4>
+				<p>
+					Reports an agentset containing <i>number</i> agents from
+					<i>agentset</i> with the lowest values of <i>reporter</i>. The
+					agentset is built by finding all the agents with the lowest value
+					of <i>reporter</i>, if there are not <i>number</i> agents with
+					that value then the agents with the second lowest value are
+					found, and so on. At the end, if there is a tie that would make
+					the resulting agentset too large, the tie is broken randomly.
+				</p>
+				<pre>
+					;; assume the world is 11 x 11
+					show min-n-of 5 patches [pxcor]
+					;; shows 5 patches with pxcor = min-pxcor
+					show min-n-of 5 patches with [pycor = 0] [pxcor]
+					;; shows an agentset containing:
+					;; (patch -5 0) (patch -4 0) (patch -3 0) (patch -2 0) (patch -1 0)
+				</pre>
+				<p>
+					See also <a href="#min-one-of">min-one-of</a>, <a href="#with-min">with-min</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="min-one-of">
+				<h3>
+					<a>min-one-of<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">min-one-of <i>agentset</i> [<i>reporter</i>]</span>
+				</h4>
+				<p>
+					Reports a random agent in the agentset that reports the lowest
+					value for the given reporter. If there is a tie, this command
+					reports one random agent that meets the condition. If you want
+					all such agents use with-min instead.
+				</p>
+				<pre>
+					show min-one-of turtles [xcor + ycor]
+					;; reports the first turtle with the smallest sum of
+					;; coordinates
+				</pre>
+				<p>
+					See also <a href="#with-min">with-min</a>, <a href="#min-n-of">min-n-of</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="min-pcor">
+				<h3>
+					<a>min-pxcor<span class="since">3.1</span></a>
+					<a>min-pycor<span class="since">3.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">min-pxcor</span>
+					<span class="prim_example">min-pycor</span>
+				</h4>
+				<p>
+					These reporters give the minimum x-coordinate and minimum
+					y-coordinate, (respectively) for patches, which determines the
+					size of the world.
+				</p>
+				<p>
+					Unlike in older versions of NetLogo the origin does not have to
+					be at the center of the world. However, the minimum x- and y-
+					coordinates must be less than or equal to zero.
+				</p>
+				<p>
+					Note: You can set the size of the world only by editing the view
+					-- these are reporters which cannot be set.
+				</p>
+				<pre>
+					crt 100 [ setxy random-float min-pxcor
+					random-float min-pycor ]
+					;; distributes 100 turtles randomly in the
+					;; third quadrant
+				</pre>
+				<p>
+					See also <a href="#max-pcor">max-pxcor</a>, <a href="#max-pcor">max-pycor</a>, <a href="#world-dim">world-width</a>, and <a href="#world-dim">world-height</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="mod">
+				<h3>
+					<a>mod<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example"><i>number1</i> mod <i>number2</i></span>
+				</h4>
+				<p>
+					Reports <i>number1</i> modulo <i>number2</i>: that is, the
+					residue of <i>number1</i> (mod <i>number2</i>). mod is is
+					equivalent to the following NetLogo code:
+				</p>
+				<pre>
+					<i>number1</i> - (floor (<i>number1</i> / <i>number2</i>)) * <i>number2</i>
+				</pre>
+				<p>
+					Note that mod is &quot;infix&quot;, that is, it comes between its
+					two inputs.
+				</p>
+				<pre>
+					show 62 mod 5
+					=&gt; 2
+					show -8 mod 3
+					=&gt; 1
+				</pre>
+				<p>
+					See also <a href="#remainder">remainder</a>. mod and remainder
+					behave the same for positive numbers, but differently for
+					negative numbers.
+				</p>
+			</div>
+			<div class="dict_entry" id="modes">
+				<h3>
+					<a>modes<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">modes <i>list</i></span>
+				</h4>
+				<p>
+					Reports a list of the most common item or items in <i>list</i>.
+				</p>
+				<p>
+					The input list may contain any NetLogo values.
+				</p>
+				<p>
+					If the input is an empty list, reports an empty list.
+				</p>
+				<pre>
+					show modes [1 2 2 3 4]
+					=&gt; [2]
+					show modes [1 2 2 3 3 4]
+					=&gt; [2 3]
+					show modes [ [1 2 [3]] [1 2 [3]] [2 3 4] ]
+					=&gt; [[1 2 [3]]]
+					show modes [pxcor] of turtles
+					;; shows which columns of patches have the most
+					;; turtles on them
+				</pre>
+			</div>
+			<div class="dict_entry" id="mouse-down">
+				<h3>
+					<a>mouse-down?<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">mouse-down?</span>
+				</h4>
+				<p>
+					Reports true if the mouse button is down, false otherwise.
+				</p>
+				<p>
+					Note: If the mouse pointer is outside of the current view ,
+					mouse-down? will always report false.
+				</p>
+			</div>
+			<div class="dict_entry" id="mouse-inside">
+				<h3>
+					<a>mouse-inside?<span class="since">3.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">mouse-inside?</span>
+				</h4>
+				<p>
+					Reports true if the mouse pointer is inside the current view,
+					false otherwise.
+				</p>
+			</div>
+			<div class="dict_entry" id="mouse-cor">
+				<h3>
+					<a>mouse-xcor<span class="since">1.0</span></a>
+					<a>mouse-ycor<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">mouse-xcor</span>
+					<span class="prim_example">mouse-ycor</span>
+				</h4>
+				<p>
+					Reports the x or y coordinate of the mouse in the 2D view. The
+					value is in terms of turtle coordinates, so it might not be an
+					integer. If you want patch coordinates, use <code>round
+						mouse-xcor</code> and <code>round mouse-ycor</code>.
+				</p>
+				<p>
+					Note: If the mouse is outside of the 2D view, reports the value
+					from the last time it was inside.
+				</p>
+				<pre>
+					;; to make the mouse &quot;draw&quot; in red:
+					if mouse-down?
+					[ ask patch mouse-xcor mouse-ycor [ set pcolor red ] ]
+				</pre>
+			</div>
+			<div class="dict_entry" id="move-to">
+				<h3>
+					<a>move-to<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">move-to <i>agent</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					The turtle sets its x and y coordinates to be the same as the
+					given agent's.
+				</p>
+				<p>
+					(If that agent is a patch, the effect is to move the turtle to
+					the center of that patch.)
+				</p>
+				<pre>
+					move-to turtle 5
+					;; turtle moves to same point as turtle 5
+					move-to one-of patches
+					;; turtle moves to the center of a random patch
+					move-to max-one-of turtles [size]
+					;; turtle moves to same point as biggest turtle
+				</pre>
+				<p>
+					Note that the turtle's heading is unaltered. You may want to
+					use the <a href="#face">face</a> command first to orient the
+					turtle in the direction of motion.
+				</p>
+				<p>
+					See also <a href="#setxy">setxy</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="my-links">
+				<h3>
+					<a>my-&lt;breeds&gt;</a>
+					<a>my-links<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">my-&lt;breeds&gt;</span>
+					<span class="prim_example">my-links</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Reports an agentset of all links connected to the caller of
+					the corresponding breed, regardless of directedness.
+					Generally, you might consider using
+					<a href="#my-out-links"><code>my-out-links</code></a> instead
+					of this primitive, as it works well for either directed or
+					undirected networks (since it excludes directed, incoming
+					links).
+				</p>
+				<pre>
+					crt 5
+					ask turtle 0
+					[
+					create-links-with other turtles
+					show my-links ;; prints the agentset containing all links
+					;; (since all the links we created were with turtle 0 )
+					]
+					ask turtle 1
+					[
+					show my-links ;; shows an agentset containing the link 0 1
+					]
+					end
+				</pre>
+				If you only want the undirected links connected to a node, you
+				can do <code>my-links with [ not is-directed-link? self ]</code>.
+			</div>
+			<div class="dict_entry" id="my-in-links">
+				<h3>
+					<a>my-in-&lt;breeds&gt;</a>
+					<a>my-in-links<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">my-in-&lt;breeds&gt;</span>
+					<span class="prim_example">my-in-links</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Reports an agentset of all the directed links coming in from
+					other nodes to the caller as well as all undirected links
+					connected to the caller. You can think of this as "all links
+					that you can use to travel <i>to</i> this node".
+				</p>
+				<pre>
+					crt 5
+					ask turtle 0
+					[
+					create-links-to other turtles
+					show my-in-links ;; shows an empty agentset
+					]
+					ask turtle 1
+					[
+					show my-in-links ;; shows an agentset containing the link 0 1
+					]
+				</pre>
+			</div>
+			<div class="dict_entry" id="my-out-links">
+				<h3>
+					<a>my-out-&lt;breeds&gt;</a>
+					<a>my-out-links<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">my-out-&lt;breeds&gt;</span>
+					<span class="prim_example">my-out-links</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Reports an agentset of all the directed links going out from the
+					caller to other nodes as well as undirected links connected to the
+					caller. You can think of this as "all links you can use to travel
+					<i>from</i> this node".
+				</p>
+				<pre>
+					crt 5
+					ask turtle 0
+					[
+					create-links-to other turtles
+					show my-out-links ;; shows agentset containing all the links
+					]
+					ask turtle 1
+					[
+					show my-out-links ;; shows an empty agentset
+					]
+				</pre>
+			</div>
+			<div class="dict_entry" id="myself">
+				<h3>
+					<a>myself<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">myself</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/> <img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					&quot;self&quot; and &quot;myself&quot; are very different.
+					&quot;self&quot; is simple; it means &quot;me&quot;.
+					&quot;myself&quot; means &quot;the turtle, patch or link who asked me
+					to do what I'm doing right now.&quot;
+				</p>
+				<p>
+					When an agent has been asked to run some code, using myself in
+					that code reports the agent (turtle, patch or link) that did the
+					asking.
+				</p>
+				<p>
+					myself is most often used in conjunction with <code>of</code> to read
+					or set variables in the asking agent.
+				</p>
+				<p>
+					myself can be used within blocks of code not just in the ask
+					command, but also hatch, sprout, of, with, all?, with-min,
+					with-max, min-one-of, max-one-of, min-n-of, max-n-of.
+				</p>
+				<pre>
+					ask turtles
+					[ ask patches in-radius 3
+					[ set pcolor [color] of myself ] ]
+					;; each turtle makes a colored &quot;splotch&quot; around itself
+				</pre>
+				<p>
+					See the &quot;Myself Example&quot; code example for more
+					examples.
+				</p>
+				<p>
+					See also <a href="#self">self</a>.
+				</p>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="N">
+			<a>N</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="n-of">
+				<h3>
+					<a>n-of<span class="since">3.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">n-of <i>size</i> <i>agentset</i></span>
+					<span class="prim_example">n-of <i>size</i> <i>list</i></span>
+				</h4>
+				<p>
+					From an agentset, reports an agentset of size <i>size</i>
+					randomly chosen from the input set, with no repeats.
+				</p>
+				<p>
+					From a list, reports a list of size <i>size</i> randomly chosen
+					from the input set, with no repeats. The items in the result
+					appear in the same order that they appeared in the input list.
+					(If you want them in random order, use shuffle on the result.)
+				</p>
+				<p>
+					It is an error for <i>size</i> to be greater than the size of the
+					input.
+				</p>
+				<pre>
+					ask n-of 50 patches [ set pcolor green ]
+					;; 50 randomly chosen patches turn green
+				</pre>
+				<p>
+					See also <a href="#one-of">one-of</a> and <a href="#up-to-n-of">up-to-n-of</a>,
+					a version that does not error with a <i>size</i> greater than
+					the size of the input.
+				</p>
+			</div>
+			<div class="dict_entry" id="n-values">
+				<h3>
+					<a>n-values<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">n-values <i>size</i> <i>reporter</i></span>
+				</h4>
+				<p>
+					Reports a list of length <i>size</i> containing values computed
+					by repeatedly running the reporter. <i>reporter</i> may be an anonymous
+					reporter or the name of a reporter.
+				</p>
+				<p>
+					If the reporter accepts inputs, the input will be the number of the
+					item currently being computed, starting from zero.
+				</p>
+				<pre>
+					show n-values 5 [1]
+					=&gt; [1 1 1 1 1]
+					show n-values 5 [ i -&gt; i ]
+					=&gt; [0 1 2 3 4]
+					show n-values 3 turtle
+					=&gt; [(turtle 0) (turtle 1) (turtle 2)]
+					show n-values 5 [ x -&gt; x * x ]
+					=&gt; [0 1 4 9 16]
+				</pre>
+				<p>
+					See also <a href="#reduce">reduce</a>, <a href="#filter">filter</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>, <a href="#range">range</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="neighbors">
+				<h3>
+					<a>neighbors<span class="since">1.1</span></a>
+					<a>neighbors4<span class="since">1.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">neighbors</span>
+					<span class="prim_example">neighbors4</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					Reports an agentset containing the 8 surrounding patches
+					(neighbors) or 4 surrounding patches (neighbors4).
+				</p>
+				<pre>
+					show sum [count turtles-here] of neighbors
+					;; prints the total number of turtles on the eight
+					;; patches around this turtle or patch
+					show count turtles-on neighbors
+					;; a shorter way to say the same thing
+					ask neighbors4 [ set pcolor red ]
+					;; turns the four neighboring patches red
+				</pre>
+			</div>
+			<div class="dict_entry" id="link-neighbors">
+				<h3>
+					<a>&lt;breed&gt;-neighbors</a>
+					<a>link-neighbors<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">&lt;breed&gt;-neighbors</span>
+					<span class="prim_example">link-neighbors</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Reports the agentset of all turtles found at the other end of
+					any links (undirected or directed, incoming or outgoing)
+					connected to this turtle.
+				</p>
+				<pre>
+					crt 3
+					ask turtle 0
+					[
+					create-links-with other turtles
+					ask link-neighbors [ set color red ] ;; turtles 1 and 2 turn red
+					]
+					ask turtle 1
+					[
+					ask link-neighbors [ set color blue ] ;; turtle 0 turns blue
+					]
+					end
+				</pre>
+			</div>
+			<div class="dict_entry" id="link-neighbor">
+				<h3>
+					<a>&lt;breed&gt;-neighbor?</a>
+					<a>link-neighbor?<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">&lt;breed&gt;-neighbor? <i>turtle</i></span>
+					<span class="prim_example">link-neighbor? <i>turtle</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Reports true if there is a link (either directed or undirected,
+					incoming or outgoing) between <i>turtle</i> and the caller.
+				</p>
+				<pre>
+					crt 2
+					ask turtle 0
+					[
+					create-link-with turtle 1
+					show link-neighbor? turtle 1  ;; prints true
+					]
+					ask turtle 1
+					[
+					show link-neighbor? turtle 0     ;; prints true
+					]
+				</pre>
+			</div>
+			<div class="dict_entry" id="netlogo-version">
+				<h3>
+					<a>netlogo-version<span class="since">3.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">netlogo-version</span>
+				</h4>
+				<p>
+					Reports a string containing the version number of the NetLogo you
+					are running.
+				</p>
+				<pre>
+					show netlogo-version
+					=&gt; &quot;{{version}}&quot;
+				</pre>
+			</div>
+			<div class="dict_entry" id="netlogo-web">
+				<h3>
+					<a>netlogo-web?<span class="since">5.2</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">netlogo-web?</span>
+				</h4>
+				<p>
+					Reports true if the model is running in NetLogo Web.
+				</p>
+			</div>
+			<div class="dict_entry" id="new-seed">
+				<h3>
+					<a>new-seed<span class="since">3.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">new-seed</span>
+				</h4>
+				<p>
+					Reports a number suitable for seeding the random number generator.
+				</p>
+				<p>
+					The numbers reported by new-seed are based on the current date and
+					time in milliseconds and lie in the generator's usable range of
+					seeds, -2147483648 to 2147483647.
+				</p>
+				<p>
+					new-seed never reports the same number twice in succession, even
+					across parallel BehaviorSpace runs. (This
+					is accomplished by waiting a millisecond if the seed for the
+					current millisecond was already used.)
+				</p>
+				<p>
+					See also <a href="#random-seed">random-seed</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="no-display">
+				<h3>
+					<a>no-display<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">no-display</span>
+				</h4>
+				<p>
+					Turns off all updates to the current view until the display command
+					is issued. This has two major uses.
+				</p>
+				<p>
+					One, you can control when the user sees view updates. You might
+					want to change lots of things on the view behind the user's
+					back, so to speak, then make them visible to the user all at once.
+				</p>
+				<p>
+					Two, your model will run faster when view updating is off, so if
+					you're in a hurry, this command will let you get results
+					faster. (Note that normally you don't need to use no-display
+					for this, since you can also use the on/off switch in view control
+					strip to freeze the view.)
+				</p>
+				<p>
+					Note that display and no-display operate independently of the
+					switch in the view control strip that freezes the view.
+				</p>
+				<p>
+					See also <a href="#display">display</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="nobody">
+				<h3>
+					<a>nobody</a>
+				</h3>
+				<h4>
+					<span class="prim_example">nobody</span>
+				</h4>
+				<p>
+					This is a special value which some primitives such as turtle,
+					one-of, max-one-of, etc. report to indicate that no agent was
+					found. Also, when a turtle dies, it becomes equal to nobody.
+				</p>
+				<p>
+					Note: Empty agentsets are not equal to nobody. If you want to test
+					for an empty agentset, use <a href="#any">any?</a>. You only get
+					nobody back in situations where you were expecting a single agent,
+					not a whole agentset.
+				</p>
+				<pre>
+					set target one-of other turtles-here
+					if target != nobody
+					[ ask target [ set color red ] ]
+				</pre>
+			</div>
+			<div class="dict_entry" id="no-links">
+				<h3>
+					<a>no-links<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">no-links</span>
+				</h4>
+				<p>
+					Reports an empty link agentset.
+				</p>
+			</div>
+			<div class="dict_entry" id="no-patches">
+				<h3>
+					<a>no-patches<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">no-patches</span>
+				</h4>
+				<p>
+					Reports an empty patch agentset.
+				</p>
+			</div>
+			<div class="dict_entry" id="not">
+				<h3>
+					<a>not<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">not <i>boolean</i></span>
+				</h4>
+				<p>
+					Reports true if <i>boolean</i> is false, otherwise reports false.
+				</p>
+				<pre>
+					if not any? turtles [ crt 10 ]
+				</pre>
+			</div>
+			<div class="dict_entry" id="no-turtles">
+				<h3>
+					<a>no-turtles<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">no-turtles</span>
+				</h4>
+				<p>
+					Reports an empty turtle agentset.
+				</p>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="O">
+			<a>O</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="of">
+				<h3>
+					<a>of<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">[<i>reporter</i>] of <i>agent</i></span>
+					<span class="prim_example">[<i>reporter</i>] of <i>agentset</i></span>
+				</h4>
+				<p>
+					For an agent, reports the value of the reporter for that agent
+					(turtle or patch).
+				</p>
+				<pre>
+					show [pxcor] of patch 3 5
+					;; prints 3
+					show [pxcor] of one-of patches
+					;; prints the value of a random patch's pxcor variable
+					show [who * who] of turtle 5
+					=&gt; 25
+					show [count turtles in-radius 3] of patch 0 0
+					;; prints the number of turtles located within a
+					;; three-patch radius of the origin
+				</pre>
+				<p>
+					For an agentset, reports a list that contains the value of the
+					reporter for each agent in the agentset (in random order).
+				</p>
+				<pre>
+					crt 4
+					show sort [who] of turtles
+					=&gt; [0 1 2 3]
+					show sort [who * who] of turtles
+					=&gt; [0 1 4 9]
+				</pre>
+			</div>
+			<div class="dict_entry" id="one-of">
+				<h3>
+					<a>one-of<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">one-of <i>agentset</i></span>
+					<span class="prim_example">one-of <i>list</i></span>
+				</h4>
+				<p>
+					From an agentset, reports a random agent. If the agentset is empty,
+					reports <a href="#nobody">nobody</a>.
+				</p>
+				<p>
+					From a list, reports a random list item. It is an error for the
+					list to be empty.
+				</p>
+				<pre>
+					ask one-of patches [ set pcolor green ]
+					;; a random patch turns green
+					ask patches with [any? turtles-here]
+					[ show one-of turtles-here ]
+					;; for each patch containing turtles, prints one of
+					;; those turtles
 
-;; suppose mylist is [1 2 3 4 5 6]
-show one-of mylist
-;; prints a value randomly chosen from the list
-</pre>
-      <p>
-        See also <a href="#n-of">n-of</a>, <a href="#up-to-n-of">up-to-n-of</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="or">
-      <h3>
-        <a>or<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example"><i>boolean1</i> or <i>boolean2</i></span>
-      </h4>
-      <p>
-        Reports true if either <i>boolean1</i> or <i>boolean2</i>, or both,
-        is true.
-      </p>
-      <p>
-        Note that if <i>condition1</i> is true, then <i>condition2</i> will
-        not be run (since it can't affect the result).
-      </p>
-      <pre>
-if (pxcor &gt; 0) or (pycor &gt; 0) [ set pcolor red ]
-;; patches turn red except in lower-left quadrant
-</pre>
-    </div>
-    <div class="dict_entry" id="other">
-      <h3>
-        <a>other<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">other <i>agentset</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        Reports an agentset which is the same as the input agentset but
-        omits this agent.
-      </p>
-      <pre>
-show count turtles-here
-=&gt; 10
-show count other turtles-here
-=&gt; 9
-</pre>
-    </div>
-    <div class="dict_entry" id="other-end">
-      <h3>
-        <a>other-end<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">other-end</span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        If run by a turtle, reports the turtle at the other end of the
-        asking link.
-      </p>
-      <p>
-        If run by a link, reports the turtle at the end of the link that
-        isn't the asking turtle.
-      </p>
-      <p>
-        These definitions are difficult to understand in the abstract, but
-        the following examples should help:
-      </p>
-      <pre>
-ask turtle 0 [ create-link-with turtle 1 ]
-ask turtle 0 [ ask link 0 1 [ show other-end ] ] ;; prints turtle 1
-ask turtle 1 [ ask link 0 1 [ show other-end ] ] ;; prints turtle 0
-ask link 0 1 [ ask turtle 0 [ show other-end ] ] ;; prints turtle 1
-</pre>
-      <p>
-        As these examples hopefully make plain, the &quot;other&quot; end
-        is the end that is neither asking nor being asked.
-      </p>
-      </div>
-    <div class="dict_entry" id="out-link-neighbor">
-      <h3>
-        <a>out-&lt;breed&gt;-neighbor?</a>
-        <a>out-link-neighbor?<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">out-&lt;breed&gt;-neighbor? <i>turtle</i></span>
-        <span class="prim_example">out-link-neighbor? <i>turtle</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Reports true if there is a directed link going from the caller to
-        <i>turtle</i> or if there is an undirected link connecting the caller
-        with <i>turtle</i>. You can think of this as "can I get from the caller
-        to <i>turtle</i> using a link?"
-      </p>
-      <pre>
-crt 2
-ask turtle 0 [
-  create-link-to turtle 1
-  show in-link-neighbor? turtle 1  ;; prints false
-  show out-link-neighbor? turtle 1 ;; prints true
-]
-ask turtle 1 [
-  show in-link-neighbor? turtle 0  ;; prints true
-  show out-link-neighbor? turtle 0 ;; prints false
-]
-</pre>
-    </div>
-    <div class="dict_entry" id="out-link-neighbors">
-      <h3>
-        <a>out-&lt;breed&gt;-neighbors</a>
-        <a>out-link-neighbors<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">out-&lt;breed&gt;-neighbors</span>
-        <span class="prim_example">out-link-neighbors</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Reports the agentset of all the turtles that have directed links
-        from the caller, or undirected links with the caller. You can think
-        of this as "who can I get to from the caller using a link?"
-      </p>
-      <pre>
-crt 4
-ask turtle 0
-[
-  create-links-to other turtles
-  ask out-link-neighbors [ set color pink ] ;; turtles 1-3 turn pink
-]
-ask turtle 1
-[
-  ask out-link-neighbors [ set color orange ]  ;; no turtles change colors
-                                               ;; since turtle 1 only has in-links
-]
-end
-</pre>
-    </div>
-    <div class="dict_entry" id="out-link-to">
-      <h3>
-        <a>out-&lt;breed&gt;-to</a>
-        <a>out-link-to<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">out-&lt;breed&gt;-to <i>turtle</i></span>
-        <span class="prim_example">out-link-to <i>turtle</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Reports a directed link from the caller to <i>turtle</i> or an
-        undirected link connecting the two. If no link exists then it
-        reports nobody. If more than one such link exists, reports a
-        random one. You can think of this as "give me a link that I can use
-        to travel from the caller to <i>turtle</i>."
-      </p>
-      <pre>
-crt 2
-ask turtle 0 [
-  create-link-to turtle 1
-  show out-link-to turtle 1 ;; shows link 0 1
-]
-ask turtle 1
-[
-  show out-link-to turtle 0 ;; shows nobody
-]
-</pre>
-      <p>
-        See also: <a href="#in-link-from">in-link-from</a> <a href="#link-with">link-with</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="output-cmds">
-      <h3>
-        <a>output-print<span class="since">2.1</span></a>
-        <a>output-show<span class="since">2.1</span></a>
-        <a>output-type<span class="since">2.1</span></a>
-        <a>output-write<span class="since">2.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">output-print <i>value</i></span>
-        <span class="prim_example">output-show <i>value</i></span>
-        <span class="prim_example">output-type <i>value</i></span>
-        <span class="prim_example">output-write <i>value</i></span>
-      </h4>
-      <p>
-        These commands are the same as the <a href="#print">print</a>,
-        <a href="#show">show</a>, <a href="#type">type</a>, and <a href="#write">write</a> commands except that <i>value</i> is printed in
-        the model's output area, instead of in the Command Center. (If
-        the model does not have a separate output area, then the Command
-        Center is used.) See also <a href="programming.html#output">Output (programming guide)</a>.
-      </p>
-      </div><!-- ======================================== -->
-    </div>
-    <h2 id="P">
-      <a>P</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="patch">
-      <h3>
-        <a>patch<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">patch <i>xcor</i> <i>ycor</i></span>
-      </h4>
-      <p>
-        Given the x and y coordinates of a point, reports the patch
-        containing that point. (The coordinates are absolute coordinates;
-        they are not computed relative to this agent, as with patch-at.)
-      </p>
-      <p>
-        If x and y are integers, the point is the center of a patch. If x
-        or y is not an integer, rounding to the nearest integer is used to
-        determine which patch contains the point.
-      </p>
-      <p>
-        If wrapping is allowed by the topology, the given coordinates will
-        be wrapped to be within the world. If wrapping is not allowed and
-        the given coordinates are outside the world, reports nobody.
-      </p>
-      <pre>
-ask patch 3 -4 [ set pcolor green ]
-;; patch with pxcor of 3 and pycor of -4 turns green
-show patch 1.2 3.7
-;; prints (patch 1 4); note rounding
-show patch 18 19
-;; supposing min-pxcor and min-pycor are -17
-;; and max-pxcor and max-pycor are 17,
-;; in a wrapping topology, prints (patch -17 -16);
-;; in a non-wrapping topology, prints nobody
-</pre>
-      <p>
-        See also <a href="#patch-at">patch-at</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="patch-ahead">
-      <h3>
-        <a>patch-ahead<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">patch-ahead <i>distance</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Reports the single patch that is the given distance
-        &quot;ahead&quot; of this turtle, that is, along the turtle's
-        current heading. Reports nobody if the patch does not exist because
-        it is outside the world.
-      </p>
-      <pre>
-ask patch-ahead 1 [ set pcolor green ]
-;; turns the patch 1 in front of this turtle
-;;   green; note that this might be the same patch
-;;   the turtle is standing on
-</pre>
-      <p>
-        See also <a href="#patch-at">patch-at</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="patch-at">
-      <h3>
-        <a>patch-at<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">patch-at <i>dx</i> <i>dy</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        Reports the patch at (dx, dy) from the caller, that is, the patch
-        containing the point dx east and dy patches north of this agent.
-      </p>
-      <p>
-        Reports nobody if there is no such patch because that point is
-        beyond a non-wrapping world boundary.
-      </p>
-      <pre>
-ask patch-at 1 -1 [ set pcolor green ]
-;; if caller is a turtle or patch, turns the
-;;   patch just southeast of the caller green
-</pre>
-      <p>
-        See also <a href="#patch">patch</a>, <a href="#patch-ahead">patch-ahead</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="patch-at-heading-and-distance">
-      <h3>
-        <a>patch-at-heading-and-distance<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">patch-at-heading-and-distance <i>heading</i> <i>distance</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        patch-at-heading-and-distance reports the single patch that is the
-        given distance from this turtle or patch, along the given absolute
-        heading. (In contrast to patch-left-and-ahead and
-        patch-right-and-ahead, this turtle's current heading is not
-        taken into account.) Reports nobody if the patch does not exist
-        because it is outside the world.
-      </p>
-      <pre>
-ask patch-at-heading-and-distance -90 1 [ set pcolor green ]
-;; turns the patch 1 to the west of this patch green
-</pre>
-      <p>
-        See also <a href="#patch">patch</a>, <a href="#patch-at">patch-at</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="patch-here">
-      <h3>
-        <a>patch-here<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">patch-here</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        patch-here reports the patch under the turtle.
-      </p>
-      <p>
-        Note that this reporter isn't available to a patch because a
-        patch can just say &quot;self&quot;.
-      </p>
-      </div>
-    <div class="dict_entry" id="patch-lr-and-ahead">
-      <h3>
-        <a>patch-left-and-ahead<span class="since">2.0</span></a>
-        <a>patch-right-and-ahead<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">patch-left-and-ahead <i>angle</i> <i>distance</i></span>
-        <span class="prim_example">patch-right-and-ahead <i>angle</i> <i>distance</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Reports the single patch that is the given distance from this
-        turtle, in the direction turned left or right the given angle (in
-        degrees) from the turtle's current heading. Reports nobody if
-        the patch does not exist because it is outside the world.
-      </p>
-      <p>
-        (If you want to find a patch in a given absolute heading, rather
-        than one relative to the current turtle's heading, use
-        patch-at-heading-and-distance instead.)
-      </p>
-      <pre>
-ask patch-right-and-ahead 30 1 [ set pcolor green ]
-;; this turtle &quot;looks&quot; 30 degrees right of its
-;;   current heading at the patch 1 unit away, and turns
-;;   that patch green; note that this might be the same
-;;   patch the turtle is standing on
-</pre>
-      <p>
-        See also <a href="#patch">patch</a>, <a href="#patch-at">patch-at</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="patch-set">
-      <h3>
-        <a>patch-set<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">patch-set <i>value1</i></span>
-        <span class="prim_example">(patch-set <i>value1</i> <i>value2</i> ...)</span>
-      </h4>
-      <p>
-        Reports an agentset containing all of the patches anywhere in any
-        of the inputs. The inputs may be individual patches, patch
-        agentsets, nobody, or lists (or nested lists) containing any of the
-        above.
-      </p>
-      <pre>
-patch-set self
-patch-set patch-here
-(patch-set self neighbors)
-(patch-set patch-here neighbors)
-(patch-set patch 0 0 patch 1 3 patch 4 -2)
-(patch-set patch-at -1 1 patch-at 0 1 patch-at 1 1)
-patch-set [patch-here] of turtles
-patch-set [neighbors] of turtles
-</pre>
-      <p>
-        See also <a href="#turtle-set">turtle-set</a>, <a href="#link-set">link-set</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="patch-size">
-      <h3>
-        <a>patch-size<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">patch-size</span>
-      </h4>
-      <p>
-        Reports the size of the patches in the view in pixels. The size is
-        typically an integer, but may also be a floating point number.
-      </p>
-      <p>
-        See also <a href="#set-patch-size">set-patch-size</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="patches">
-      <h3>
-        <a>patches<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">patches</span>
-      </h4>
-      <p>
-        Reports the agentset consisting of all patches.
-      </p>
-      </div>
-    <div class="dict_entry" id="patches-own">
-      <h3>
-        <a>patches-own</a>
-      </h3>
-      <h4>
-        <span class="prim_example">patches-own [<i>var1</i> ...]</span>
-      </h4>
-      <p>
-        This keyword, like the globals, breed, <i>&lt;breed&gt;</i>-own,
-        and turtles-own keywords, can only be used at the beginning of a
-        program, before any function definitions. It defines the variables
-        that all patches can use.
-      </p>
-      <p>
-        All patches will then have the given variables and be able to use
-        them.
-      </p>
-      <p>
-        All patch variables can also be directly accessed by any turtle
-        standing on the patch.
-      </p>
-      <p>
-        See also <a href="#globals">globals</a>, <a href="#turtles-own">turtles-own</a>, <a href="#breed">breed</a>,
-        <a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="pcolor">
-      <h3>
-        <a>pcolor</a>
-      </h3>
-      <h4>
-        <span class="prim_example">pcolor</span>
-        <img alt="Patch Command" src="images/patch.gif"> <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        This is a built-in patch variable. It holds the color of the patch.
-        You can set this variable to make the patch change color.
-      </p>
-      <p>
-        All patch variables can be directly accessed by any turtle standing
-        on the patch. Color can be represented either as a NetLogo color (a
-        single number) or an RGB color (a list of 3 numbers). See details
-        in the <a href="programming.html#colors">Colors section</a> of the
-        Programming Guide.
-      </p>
-      <p>
-        See also <a href="#color">color</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="pen-switch-status">
-      <h3>
-        <a>pen-down<span class="since">1.0</span></a>
-        <a>pd<span class="since">1.0</span></a>
-        <a>pen-erase<span class="since">3.0</span></a>
-        <a>pe<span class="since">3.0</span></a>
-        <a>pen-up<span class="since">1.0</span></a>
-        <a>pu<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">pen-down</span>
-        <span class="prim_example">pen-erase</span>
-        <span class="prim_example">pen-up</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        The turtle changes modes between drawing lines, removing lines or
-        neither. The lines will always be displayed on top of the patches
-        and below the turtles. To change the color of the pen set the color
-        of the turtle using <code>set color</code>.
-      </p>
-      <p>
-        Note: When a turtle's pen is down, all movement commands cause
-        lines to be drawn, including jump, setxy, and move-to.
-      </p>
-      <p>
-        Note: These commands are equivalent to setting the turtle variable
-        &quot;pen-mode&quot; to &quot;down&quot; , &quot;up&quot;, and
-        &quot;erase&quot;.
-      </p>
-      <p>
-        Note: On Windows drawing and erasing a line might not erase every
-        pixel.
-      </p>
-      </div>
-    <div class="dict_entry" id="pen-mode">
-      <h3>
-        <a>pen-mode</a>
-      </h3>
-      <h4>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        This is a built-in turtle variable. It holds the state of the
-        turtle's pen. You set the variable to draw lines, erase lines
-        or stop either of these actions. Possible values are
-        &quot;up&quot;, &quot;down&quot;, and &quot;erase&quot;.
-      </p>
-      </div>
-    <div class="dict_entry" id="pen-size">
-      <h3>
-        <a>pen-size</a>
-      </h3>
-      <h4>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        This is a built-in turtle variable. It holds the width of the line,
-        in pixels, that the turtle will draw (or erase) when the pen is
-        down (or erasing).
-      </p>
-      </div>
-    <div class="dict_entry" id="plabel">
-      <h3>
-        <a>plabel</a>
-      </h3>
-      <h4>
-        <span class="prim_example">plabel</span>
-        <img alt="Patch Command" src="images/patch.gif"> <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        This is a built-in patch variable. It may hold a value of any type.
-        The patch appears in the view with the given value
-        &quot;attached&quot; to it as text. You can set this variable to
-        add, change, or remove a patch's label.
-      </p>
-      <p>
-        All patch variables can be directly accessed by any turtle standing
-        on the patch.
-      </p>
-      <p>
-        See also <a href="#plabel-color">plabel-color</a>, <a href="#label">label</a>, <a href="#label-color">label-color</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="plabel-color">
-      <h3>
-        <a>plabel-color</a>
-      </h3>
-      <h4>
-        <span class="prim_example">plabel-color</span>
-        <img alt="Patch Command" src="images/patch.gif"> <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        This is a built-in patch variable. It holds a number greater than
-        or equal to 0 and less than 140. This number determines what color
-        the patch's label appears in (if it has a label). You can set
-        this variable to change the color of a patch's label.
-      </p>
-      <p>
-        All patch variables can be directly accessed by any turtle standing
-        on the patch.
-      </p>
-      <p>
-        See also <a href="#plabel">plabel</a>, <a href="#label">label</a>,
-        <a href="#label-color">label-color</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="plot">
-      <h3>
-        <a>plot<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">plot <i>number</i></span>
-      </h4>
-      <p>
-        Increments the x-value of the plot pen by plot-pen-interval, then
-        plots a point at the updated x-value and a y-value of
-        <i>number</i>. (The first time the command is used on a plot, the
-        point plotted has an x-value of 0.)
-      </p>
-      </div>
-    <div class="dict_entry" id="plot-name">
-      <h3>
-        <a>plot-name<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">plot-name</span>
-      </h4>
-      <p>
-        Reports the name of the current plot (a string)
-      </p>
-      </div>
-    <div class="dict_entry" id="plot-pen-exists">
-      <h3>
-        <a>plot-pen-exists?<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">plot-pen-exists? <i>string</i></span>
-      </h4>
-      <p>
-        Reports true if a plot pen with the given name is defined in the
-        current plot. Otherwise reports false.
-      </p>
-      </div>
-    <div class="dict_entry" id="plot-pen-switch-status">
-      <h3>
-        <a>plot-pen-down<span class="since">1.0</span></a>
-        <a>plot-pen-up<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">plot-pen-down</span>
-        <span class="prim_example">plot-pen-up</span>
-      </h4>
-      <p>
-        Puts down (or up) the current plot-pen, so that it draws (or
-        doesn't). (By default, all pens are down initially.)
-      </p>
-      </div>
-    <div class="dict_entry" id="plot-pen-reset">
-      <h3>
-        <a>plot-pen-reset<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">plot-pen-reset</span>
-      </h4>
-      <p>
-        Clears everything the current plot pen has drawn, moves it to
-        (0,0), and puts it down. If the pen is a permanent pen, the color,
-        mode, and interval are reset to the default values from the plot
-        Edit dialog.
-      </p>
-      </div>
-    <div class="dict_entry" id="plotxy">
-      <h3>
-        <a>plotxy<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">plotxy <i>number1 number2</i></span>
-      </h4>
-      <p>
-        Moves the current plot pen to the point with coordinates
-        (<i>number1</i>, <i>number2</i>). If the pen is down, a line, bar,
-        or point will be drawn (depending on the pen's mode).
-      </p>
-      </div>
-    <div class="dict_entry" id="plot-cor-max-or-min">
-      <h3>
-        <a>plot-x-min<span class="since">1.0</span></a>
-        <a>plot-x-max<span class="since">1.0</span></a>
-        <a>plot-y-min<span class="since">1.0</span></a>
-        <a>plot-y-max<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">plot-x-min</span>
-        <span class="prim_example">plot-x-max</span>
-        <span class="prim_example">plot-y-min</span>
-        <span class="prim_example">plot-y-max</span>
-      </h4>
-      <p>
-        Reports the minimum or maximum value on the x or y axis of the
-        current plot.
-      </p>
-      <p>
-        These values can be set with the commands set-plot-x-range and
-        set-plot-y-range. (Their default values are set from the plot Edit
-        dialog.)
-      </p>
-      </div>
-    <div class="dict_entry" id="position">
-      <h3>
-        <a>position<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">position <i>item</i> <i>list</i></span>
-        <span class="prim_example">position <i>string1</i> <i>string2</i></span>
-      </h4>
-      <p>
-        On a list, reports the first position of <i>item</i> in
-        <i>list</i>, or false if it does not appear.
-      </p>
-      <p>
-        On strings, reports the position of the first appearance
-        <i>string1</i> as a substring of <i>string2</i>, or false if it
-        does not appear.
-      </p>
-      <p>
-        Note: The positions are numbered beginning with 0, not with 1.
-      </p>
-      <pre>
-;; suppose mylist is [2 7 4 7 &quot;Bob&quot;]
-show position 7 mylist
-=&gt; 1
-show position 10 mylist
-=&gt; false
-show position &quot;in&quot; &quot;string&quot;
-=&gt; 3
-</pre>
-      <p>
-        See also <a href="#member">member?</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="precision">
-      <h3>
-        <a>precision<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">precision <i>number places</i></span>
-      </h4>
-      <p>
-        Reports <i>number</i> rounded to <i>places</i> decimal places.
-      </p>
-      <p>
-        If <i>places</i> is negative, the rounding takes place to the left
-        of the decimal point.
-      </p>
-      <pre>
-show precision 1.23456789 3
-=&gt; 1.235
-show precision 3834 -3
-=&gt; 4000
-</pre>
-      <p>
-        See also <a href="#round">round</a>, <a href="#ceiling">ceiling</a>, <a href="#floor">floor</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="print">
-      <h3>
-        <a>print<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">print <i>value</i></span>
-      </h4>
-      <p>
-        Prints <i>value</i> in the Command Center, followed by a carriage
-        return.
-      </p>
-      <p>
-        This agent is <i>not</i> printed before the value, unlike <a href="#show">show</a>.
-      </p>
-      <p>
-        See also <a href="#show">show</a>, <a href="#type">type</a>,
-        <a href="#write">write</a>, <a href="#output-cmds">output-print</a>, and
-        <a href="programming.html#output">Output (programming guide)</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="pcor">
-      <h3>
-        <a>pxcor</a>
-        <a>pycor</a>
-      </h3>
-      <h4>
-        <span class="prim_example">pxcor</span>
-        <span class="prim_example">pycor</span>
-        <img alt="Patch Command" src="images/patch.gif"> <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        These are built-in patch variables. They hold the x and y
-        coordinate of the patch. They are always integers. You cannot set
-        these variables, because patches don't move.
-      </p>
-      <p>
-        pxcor is greater than or equal to min-pxcor and less than or equal
-        to max-pxcor; similarly for pycor and min-pycor and max-pycor.
-      </p>
-      <p>
-        All patch variables can be directly accessed by any turtle standing
-        on the patch.
-      </p>
-      <p>
-        See also <a href="#xcor">xcor</a>, <a href="#ycor">ycor</a>.
-      </p>
-      </div><!-- ======================================== -->
-    </div>
-    <h2 id="R">
-      <a>R</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="random">
-      <h3>
-        <a>random<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">random <i>number</i></span>
-      </h4>
-      <p>
-        If <i>number</i> is positive, reports a random integer greater than
-        or equal to 0, but strictly less than <i>number</i>.
-      </p>
-      <p>
-        If <i>number</i> is negative, reports a random integer less than or
-        equal to 0, but strictly greater than <i>number</i>.
-      </p>
-      <p>
-        If <i>number</i> is zero, the result is always 0 as well.
-      </p>
-      <p>
-        Note: In versions of NetLogo prior to version 2.0, this primitive
-        reported a floating point number if given a non-integer input. This
-        is no longer the case. If you want a floating point answer, you
-        must now use <a href="#random-float">random-float</a> instead.
-      </p>
-      <pre>
-show random 3
-;; prints 0, 1,  or 2
-show random -3
-;; prints 0, -1, or -2
-show random 3.5
-;; prints 0, 1, 2, or 3
-</pre>
-      <p>
-        See also <a href="#random-float">random-float</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="random-float">
-      <h3>
-        <a>random-float<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">random-float <i>number</i></span>
-      </h4>
-      <p>
-        If <i>number</i> is positive, reports a random floating point
-        number greater than or equal to 0 but strictly less than
-        <i>number</i>.
-      </p>
-      <p>
-        If <i>number</i> is negative, reports a random floating point
-        number less than or equal to 0, but strictly greater than
-        <i>number</i>.
-      </p>
-      <p>
-        If <i>number</i> is zero, the result is always 0.
-      </p>
-      <pre>
-show random-float 3
-;; prints a number at least 0 but less than 3,
-;; for example 2.589444906014774
-show random-float 2.5
-;; prints a number at least 0 but less than 2.5,
-;; for example 1.0897423196760796
-</pre>
-    </div>
-    <div class="dict_entry" id="random-reporters">
-      <h3>
-        <a>random-exponential<span class="since">1.2.1</span></a>
-        <a>random-gamma<span class="since">2.0</span></a>
-        <a>random-normal<span class="since">1.2.1</span></a>
-        <a>random-poisson<span class="since">1.2.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">random-exponential <i>mean</i></span>
-        <span class="prim_example">random-gamma <i>alpha lambda</i></span>
-        <span class="prim_example">random-normal <i>mean standard-deviation</i></span>
-        <span class="prim_example">random-poisson <i>mean</i></span>
-      </h4>
-      <p>
-        Reports an accordingly distributed random number with the
-        <i>mean</i> and, in the case of the normal distribution, the
-        <i>standard-deviation</i>. (The standard deviation may not be
-        negative.)
-      </p>
-      <p>
-        random-exponential reports an exponentially distributed random
-        floating point number. It is equivalent to <code>(- <i>mean</i>) * ln
-        random-float 1.0</code>.
-      </p>
-      <p>
-        random-gamma reports a gamma-distributed random floating point
-        number as controlled by the floating point alpha and lambda
-        parameters. Both inputs must be greater than zero. (Note: for
-        results with a given mean and variance, use inputs as follows:
-        alpha = mean * mean / variance; lambda = 1 / (variance / mean).)
-      </p>
-      <p>
-        random-normal reports a normally distributed random floating point
-        number.
-      </p>
-      <p>
-        random-poisson reports a Poisson-distributed random integer.
-      </p>
-      <pre>
-show random-exponential 2
-;; prints an exponentially distributed random floating
-;; point number with a mean of 2
-show random-normal 10.1 5.2
-;; prints a normally distributed random floating point
-;; number with a mean of 10.1 and a standard deviation
-;; of 5.2
-show random-poisson 3.4
-;; prints a Poisson-distributed random integer with a
-;; mean of 3.4
-</pre>
-    </div>
-    <div class="dict_entry" id="random-pcor">
-      <h3>
-        <a>random-pxcor<span class="since">3.1</span></a>
-        <a>random-pycor<span class="since">3.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">random-pxcor</span>
-        <span class="prim_example">random-pycor</span>
-      </h4>
-      <p>
-        Reports a random integer ranging from min-pxcor (or -y) to
-        max-pxcor (or -y) inclusive.
-      </p>
-      <pre>
-ask turtles [
-  ;; move each turtle to the center of a random patch
-  setxy random-pxcor random-pycor
-]
-</pre>
-      <p>
-        See also <a href="#random-cor">random-xcor</a>, <a href="#random-cor">random-ycor</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="random-seed">
-      <h3>
-        <a>random-seed<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">random-seed <i>number</i></span>
-      </h4>
-      <p>
-        Sets the seed of the pseudo-random number generator to the integer
-        part of <i>number</i>. The seed must be in the range -2147483648 to
-        2147483647; note that this is smaller than the full range of
-        integers supported by NetLogo (-9007199254740992 to
-        9007199254740992).
-      </p>
-      <p>
-        See the <a href="programming.html#random-numbers">Random Numbers</a>
-        section of the Programming Guide for more details.
-      </p>
-      <pre>
-random-seed 47822
-show random 100
-=&gt; 50
-show random 100
-=&gt; 35
-random-seed 47822
-show random 100
-=&gt; 50
-show random 100
-=&gt; 35
-</pre>
-    </div>
-    <div class="dict_entry" id="random-cor">
-      <h3>
-        <a>random-xcor<span class="since">3.1</span></a>
-        <a>random-ycor<span class="since">3.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">random-xcor</span>
-        <span class="prim_example">random-ycor</span>
-      </h4>
-      <p>
-        Reports a random floating point number from the allowable range of
-        turtle coordinates along the given axis, x or y.
-      </p>
-      <p>
-        Turtle coordinates range from min-pxcor - 0.5 (inclusive) to
-        max-pxcor + 0.5 (exclusive) horizontally; vertically, substitute -y
-        for -x.
-      </p>
-      <pre>
-ask turtles [
-  ;; move each turtle to a random point
-  setxy random-xcor random-ycor
-]
-</pre>
-      <p>
-        See also <a href="#random-pcor">random-pxcor</a>, <a href="#random-pcor">random-pycor</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="range">
-      <h3>
-        <a>range<span class="since">6.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">range <i>stop</i></span>
-        <span class="prim_example">(range <i>start</i> <i>stop</i>)</span>
-        <span class="prim_example">(range <i>start</i> <i>stop</i> <i>step</i>)</span>
-      </h4>
-      <p>
-        Generates a list of numbers, starting at <i>start</i>, ending before
-        <i>stop</i>, counting by <i>step</i>. <i>start</i> defaults to 0 and
-        <i>step</i> defaults to 1.
-      </p>
-        <pre>
-show range 5
-=&gt; [0 1 2 3 4]
-show (range 2 5)
-=&gt; [2 3 4]
-show (range 2 5 0.5)
-=&gt; [2 2.5 3 3.5 4 4.5]
-show (range 10 0 -1)
-=&gt; [10 9 8 7 6 5 4 3 2 1]
-</pre>
-      <p>
-      See also <a href="#n-values">n-values</a>
-      </p>
-    </div>
-    <div class="dict_entry" id="read-from-string">
-      <h3>
-        <a>read-from-string<span class="since">1.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">read-from-string <i>string</i></span>
-      </h4>
-      <p>
-        Interprets the given string as if it had been typed in the Command
-        Center, and reports the resulting value. The result may be a
-        number, list, string, or boolean value, or the special value
-        &quot;nobody&quot;.
-      </p>
-      <p>
-        Useful in conjunction with the <a href="#user-input">user-input</a>
-        primitive for converting the user's input into usable form.
-      </p>
-      <pre>
-show read-from-string &quot;3&quot; + read-from-string &quot;5&quot;
-=&gt; 8
-show length read-from-string &quot;[1 2 3]&quot;
-=&gt; 3
-crt read-from-string user-input &quot;Make how many turtles?&quot;
-;; the number of turtles input by the user
-;; are created
-</pre>
-    </div>
-    <div class="dict_entry" id="reduce">
-      <h3>
-        <a>reduce<span class="since">1.3</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">reduce <i>reporter</i> <i>list</i></span>
-      </h4>
-      <p>
-        Reduces a list from left to right using the given reporter, resulting
-        in a single value. This means, for example, that <code>reduce
-          [ [a b] -&gt; a + b] [1 2 3 4]</code>
-        is equivalent to <i>(((1 + 2) + 3) + 4)</i>. If
-        <i>list</i> has a single item, that item is reported. It is an
-        error to reduce an empty list. <i>reporter</i> may be an anonymous
-        reporter or the name of a reporter.
-      </p>
-      <p>
-        The first input passed to the reporter is the result so far, and the
-        second input is the next item in the list.
-      </p>
-      <p>
-        Since it can be difficult to develop an intuition about what
-        <code>reduce</code> does, here are some simple examples which, while
-        not useful in themselves, may give you a better understanding of
-        this primitive:
-      </p>
-      <pre>
-show reduce + [1 2 3]
-=&gt; 6
-show reduce - [1 2 3]
-=&gt; -4
-show reduce [ [result-so-far next-item] -&gt; next-item - result-so-far ] [1 2 3]
-=&gt; 2
-show reduce [ [result-so-far ignored-item] -&gt; result-so-far ] [1 2 3]
-=&gt; 1
-show reduce [ [ignored next-item] -&gt; next-item ] [1 2 3]
-=&gt; 3
-show reduce sentence [[1 2] [3 [4]] 5]
-=&gt; [1 2 3 [4] 5]
-show reduce [ [result-so-far next-item] -&gt; fput next-item result-so-far ] (fput [] [1 2 3 4 5])
-=&gt; [5 4 3 2 1]
-</pre>
-      <p>
-        Here are some more useful examples:
-      </p>
-      <pre>
-;; find the longest string in a list
-to-report longest-string [strings]
-  report reduce
-    [ [longest-so-far next-string] -&gt; ifelse-value (length longest-so-far &gt;= length next-string) [longest-so-far] [next-string] ]
-    strings
-end
+					;; suppose mylist is [1 2 3 4 5 6]
+					show one-of mylist
+					;; prints a value randomly chosen from the list
+				</pre>
+				<p>
+					See also <a href="#n-of">n-of</a>, <a href="#up-to-n-of">up-to-n-of</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="or">
+				<h3>
+					<a>or<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example"><i>boolean1</i> or <i>boolean2</i></span>
+				</h4>
+				<p>
+					Reports true if either <i>boolean1</i> or <i>boolean2</i>, or both,
+					is true.
+				</p>
+				<p>
+					Note that if <i>condition1</i> is true, then <i>condition2</i> will
+					not be run (since it can't affect the result).
+				</p>
+				<pre>
+					if (pxcor &gt; 0) or (pycor &gt; 0) [ set pcolor red ]
+					;; patches turn red except in lower-left quadrant
+				</pre>
+			</div>
+			<div class="dict_entry" id="other">
+				<h3>
+					<a>other<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">other <i>agentset</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					Reports an agentset which is the same as the input agentset but
+					omits this agent.
+				</p>
+				<pre>
+					show count turtles-here
+					=&gt; 10
+					show count other turtles-here
+					=&gt; 9
+				</pre>
+			</div>
+			<div class="dict_entry" id="other-end">
+				<h3>
+					<a>other-end<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">other-end</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					If run by a turtle, reports the turtle at the other end of the
+					asking link.
+				</p>
+				<p>
+					If run by a link, reports the turtle at the end of the link that
+					isn't the asking turtle.
+				</p>
+				<p>
+					These definitions are difficult to understand in the abstract, but
+					the following examples should help:
+				</p>
+				<pre>
+					ask turtle 0 [ create-link-with turtle 1 ]
+					ask turtle 0 [ ask link 0 1 [ show other-end ] ] ;; prints turtle 1
+					ask turtle 1 [ ask link 0 1 [ show other-end ] ] ;; prints turtle 0
+					ask link 0 1 [ ask turtle 0 [ show other-end ] ] ;; prints turtle 1
+				</pre>
+				<p>
+					As these examples hopefully make plain, the &quot;other&quot; end
+					is the end that is neither asking nor being asked.
+				</p>
+			</div>
+			<div class="dict_entry" id="out-link-neighbor">
+				<h3>
+					<a>out-&lt;breed&gt;-neighbor?</a>
+					<a>out-link-neighbor?<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">out-&lt;breed&gt;-neighbor? <i>turtle</i></span>
+					<span class="prim_example">out-link-neighbor? <i>turtle</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Reports true if there is a directed link going from the caller to
+					<i>turtle</i> or if there is an undirected link connecting the caller
+					with <i>turtle</i>. You can think of this as "can I get from the caller
+					to <i>turtle</i> using a link?"
+				</p>
+				<pre>
+					crt 2
+					ask turtle 0 [
+					create-link-to turtle 1
+					show in-link-neighbor? turtle 1  ;; prints false
+					show out-link-neighbor? turtle 1 ;; prints true
+					]
+					ask turtle 1 [
+					show in-link-neighbor? turtle 0  ;; prints true
+					show out-link-neighbor? turtle 0 ;; prints false
+					]
+				</pre>
+			</div>
+			<div class="dict_entry" id="out-link-neighbors">
+				<h3>
+					<a>out-&lt;breed&gt;-neighbors</a>
+					<a>out-link-neighbors<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">out-&lt;breed&gt;-neighbors</span>
+					<span class="prim_example">out-link-neighbors</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Reports the agentset of all the turtles that have directed links
+					from the caller, or undirected links with the caller. You can think
+					of this as "who can I get to from the caller using a link?"
+				</p>
+				<pre>
+					crt 4
+					ask turtle 0
+					[
+					create-links-to other turtles
+					ask out-link-neighbors [ set color pink ] ;; turtles 1-3 turn pink
+					]
+					ask turtle 1
+					[
+					ask out-link-neighbors [ set color orange ]  ;; no turtles change colors
+					;; since turtle 1 only has in-links
+					]
+					end
+				</pre>
+			</div>
+			<div class="dict_entry" id="out-link-to">
+				<h3>
+					<a>out-&lt;breed&gt;-to</a>
+					<a>out-link-to<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">out-&lt;breed&gt;-to <i>turtle</i></span>
+					<span class="prim_example">out-link-to <i>turtle</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Reports a directed link from the caller to <i>turtle</i> or an
+					undirected link connecting the two. If no link exists then it
+					reports nobody. If more than one such link exists, reports a
+					random one. You can think of this as "give me a link that I can use
+					to travel from the caller to <i>turtle</i>."
+				</p>
+				<pre>
+					crt 2
+					ask turtle 0 [
+					create-link-to turtle 1
+					show out-link-to turtle 1 ;; shows link 0 1
+					]
+					ask turtle 1
+					[
+					show out-link-to turtle 0 ;; shows nobody
+					]
+				</pre>
+				<p>
+					See also: <a href="#in-link-from">in-link-from</a> <a href="#link-with">link-with</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="output-cmds">
+				<h3>
+					<a>output-print<span class="since">2.1</span></a>
+					<a>output-show<span class="since">2.1</span></a>
+					<a>output-type<span class="since">2.1</span></a>
+					<a>output-write<span class="since">2.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">output-print <i>value</i></span>
+					<span class="prim_example">output-show <i>value</i></span>
+					<span class="prim_example">output-type <i>value</i></span>
+					<span class="prim_example">output-write <i>value</i></span>
+				</h4>
+				<p>
+					These commands are the same as the <a href="#print">print</a>,
+					<a href="#show">show</a>, <a href="#type">type</a>, and <a href="#write">write</a> commands except that <i>value</i> is printed in
+					the model's output area, instead of in the Command Center. (If
+					the model does not have a separate output area, then the Command
+					Center is used.) See also <a href="programming.html#output">Output (programming guide)</a>.
+				</p>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="P">
+			<a>P</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="patch">
+				<h3>
+					<a>patch<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">patch <i>xcor</i> <i>ycor</i></span>
+				</h4>
+				<p>
+					Given the x and y coordinates of a point, reports the patch
+					containing that point. (The coordinates are absolute coordinates;
+					they are not computed relative to this agent, as with patch-at.)
+				</p>
+				<p>
+					If x and y are integers, the point is the center of a patch. If x
+					or y is not an integer, rounding to the nearest integer is used to
+					determine which patch contains the point.
+				</p>
+				<p>
+					If wrapping is allowed by the topology, the given coordinates will
+					be wrapped to be within the world. If wrapping is not allowed and
+					the given coordinates are outside the world, reports nobody.
+				</p>
+				<pre>
+					ask patch 3 -4 [ set pcolor green ]
+					;; patch with pxcor of 3 and pycor of -4 turns green
+					show patch 1.2 3.7
+					;; prints (patch 1 4); note rounding
+					show patch 18 19
+					;; supposing min-pxcor and min-pycor are -17
+					;; and max-pxcor and max-pycor are 17,
+					;; in a wrapping topology, prints (patch -17 -16);
+					;; in a non-wrapping topology, prints nobody
+				</pre>
+				<p>
+					See also <a href="#patch-at">patch-at</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="patch-ahead">
+				<h3>
+					<a>patch-ahead<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">patch-ahead <i>distance</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Reports the single patch that is the given distance
+					&quot;ahead&quot; of this turtle, that is, along the turtle's
+					current heading. Reports nobody if the patch does not exist because
+					it is outside the world.
+				</p>
+				<pre>
+					ask patch-ahead 1 [ set pcolor green ]
+					;; turns the patch 1 in front of this turtle
+					;;   green; note that this might be the same patch
+					;;   the turtle is standing on
+				</pre>
+				<p>
+					See also <a href="#patch-at">patch-at</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="patch-at">
+				<h3>
+					<a>patch-at<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">patch-at <i>dx</i> <i>dy</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					Reports the patch at (dx, dy) from the caller, that is, the patch
+					containing the point dx east and dy patches north of this agent.
+				</p>
+				<p>
+					Reports nobody if there is no such patch because that point is
+					beyond a non-wrapping world boundary.
+				</p>
+				<pre>
+					ask patch-at 1 -1 [ set pcolor green ]
+					;; if caller is a turtle or patch, turns the
+					;;   patch just southeast of the caller green
+				</pre>
+				<p>
+					See also <a href="#patch">patch</a>, <a href="#patch-ahead">patch-ahead</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="patch-at-heading-and-distance">
+				<h3>
+					<a>patch-at-heading-and-distance<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">patch-at-heading-and-distance <i>heading</i> <i>distance</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					patch-at-heading-and-distance reports the single patch that is the
+					given distance from this turtle or patch, along the given absolute
+					heading. (In contrast to patch-left-and-ahead and
+					patch-right-and-ahead, this turtle's current heading is not
+					taken into account.) Reports nobody if the patch does not exist
+					because it is outside the world.
+				</p>
+				<pre>
+					ask patch-at-heading-and-distance -90 1 [ set pcolor green ]
+					;; turns the patch 1 to the west of this patch green
+				</pre>
+				<p>
+					See also <a href="#patch">patch</a>, <a href="#patch-at">patch-at</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="patch-here">
+				<h3>
+					<a>patch-here<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">patch-here</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					patch-here reports the patch under the turtle.
+				</p>
+				<p>
+					Note that this reporter isn't available to a patch because a
+					patch can just say &quot;self&quot;.
+				</p>
+			</div>
+			<div class="dict_entry" id="patch-lr-and-ahead">
+				<h3>
+					<a>patch-left-and-ahead<span class="since">2.0</span></a>
+					<a>patch-right-and-ahead<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">patch-left-and-ahead <i>angle</i> <i>distance</i></span>
+					<span class="prim_example">patch-right-and-ahead <i>angle</i> <i>distance</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Reports the single patch that is the given distance from this
+					turtle, in the direction turned left or right the given angle (in
+					degrees) from the turtle's current heading. Reports nobody if
+					the patch does not exist because it is outside the world.
+				</p>
+				<p>
+					(If you want to find a patch in a given absolute heading, rather
+					than one relative to the current turtle's heading, use
+					patch-at-heading-and-distance instead.)
+				</p>
+				<pre>
+					ask patch-right-and-ahead 30 1 [ set pcolor green ]
+					;; this turtle &quot;looks&quot; 30 degrees right of its
+					;;   current heading at the patch 1 unit away, and turns
+					;;   that patch green; note that this might be the same
+					;;   patch the turtle is standing on
+				</pre>
+				<p>
+					See also <a href="#patch">patch</a>, <a href="#patch-at">patch-at</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="patch-set">
+				<h3>
+					<a>patch-set<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">patch-set <i>value1</i></span>
+					<span class="prim_example">(patch-set <i>value1</i> <i>value2</i> ...)</span>
+				</h4>
+				<p>
+					Reports an agentset containing all of the patches anywhere in any
+					of the inputs. The inputs may be individual patches, patch
+					agentsets, nobody, or lists (or nested lists) containing any of the
+					above.
+				</p>
+				<pre>
+					patch-set self
+					patch-set patch-here
+					(patch-set self neighbors)
+					(patch-set patch-here neighbors)
+					(patch-set patch 0 0 patch 1 3 patch 4 -2)
+					(patch-set patch-at -1 1 patch-at 0 1 patch-at 1 1)
+					patch-set [patch-here] of turtles
+					patch-set [neighbors] of turtles
+				</pre>
+				<p>
+					See also <a href="#turtle-set">turtle-set</a>, <a href="#link-set">link-set</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="patch-size">
+				<h3>
+					<a>patch-size<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">patch-size</span>
+				</h4>
+				<p>
+					Reports the size of the patches in the view in pixels. The size is
+					typically an integer, but may also be a floating point number.
+				</p>
+				<p>
+					See also <a href="#set-patch-size">set-patch-size</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="patches">
+				<h3>
+					<a>patches<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">patches</span>
+				</h4>
+				<p>
+					Reports the agentset consisting of all patches.
+				</p>
+			</div>
+			<div class="dict_entry" id="patches-own">
+				<h3>
+					<a>patches-own</a>
+				</h3>
+				<h4>
+					<span class="prim_example">patches-own [<i>var1</i> ...]</span>
+				</h4>
+				<p>
+					This keyword, like the globals, breed, <i>&lt;breed&gt;</i>-own,
+					and turtles-own keywords, can only be used at the beginning of a
+					program, before any function definitions. It defines the variables
+					that all patches can use.
+				</p>
+				<p>
+					All patches will then have the given variables and be able to use
+					them.
+				</p>
+				<p>
+					All patch variables can also be directly accessed by any turtle
+					standing on the patch.
+				</p>
+				<p>
+					See also <a href="#globals">globals</a>, <a href="#turtles-own">turtles-own</a>, <a href="#breed">breed</a>,
+					<a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="pcolor">
+				<h3>
+					<a>pcolor</a>
+				</h3>
+				<h4>
+					<span class="prim_example">pcolor</span>
+					<img alt="Patch Command" src="images/patch.gif"/> <img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					This is a built-in patch variable. It holds the color of the patch.
+					You can set this variable to make the patch change color.
+				</p>
+				<p>
+					All patch variables can be directly accessed by any turtle standing
+					on the patch. Color can be represented either as a NetLogo color (a
+					single number) or an RGB color (a list of 3 numbers). See details
+					in the <a href="programming.html#colors">Colors section</a> of the
+					Programming Guide.
+				</p>
+				<p>
+					See also <a href="#color">color</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="pen-switch-status">
+				<h3>
+					<a>pen-down<span class="since">1.0</span></a>
+					<a>pd<span class="since">1.0</span></a>
+					<a>pen-erase<span class="since">3.0</span></a>
+					<a>pe<span class="since">3.0</span></a>
+					<a>pen-up<span class="since">1.0</span></a>
+					<a>pu<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">pen-down</span>
+					<span class="prim_example">pen-erase</span>
+					<span class="prim_example">pen-up</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					The turtle changes modes between drawing lines, removing lines or
+					neither. The lines will always be displayed on top of the patches
+					and below the turtles. To change the color of the pen set the color
+					of the turtle using <code>set color</code>.
+				</p>
+				<p>
+					Note: When a turtle's pen is down, all movement commands cause
+					lines to be drawn, including jump, setxy, and move-to.
+				</p>
+				<p>
+					Note: These commands are equivalent to setting the turtle variable
+					&quot;pen-mode&quot; to &quot;down&quot; , &quot;up&quot;, and
+					&quot;erase&quot;.
+				</p>
+				<p>
+					Note: On Windows drawing and erasing a line might not erase every
+					pixel.
+				</p>
+			</div>
+			<div class="dict_entry" id="pen-mode">
+				<h3>
+					<a>pen-mode</a>
+				</h3>
+				<h4>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					This is a built-in turtle variable. It holds the state of the
+					turtle's pen. You set the variable to draw lines, erase lines
+					or stop either of these actions. Possible values are
+					&quot;up&quot;, &quot;down&quot;, and &quot;erase&quot;.
+				</p>
+			</div>
+			<div class="dict_entry" id="pen-size">
+				<h3>
+					<a>pen-size</a>
+				</h3>
+				<h4>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					This is a built-in turtle variable. It holds the width of the line,
+					in pixels, that the turtle will draw (or erase) when the pen is
+					down (or erasing).
+				</p>
+			</div>
+			<div class="dict_entry" id="plabel">
+				<h3>
+					<a>plabel</a>
+				</h3>
+				<h4>
+					<span class="prim_example">plabel</span>
+					<img alt="Patch Command" src="images/patch.gif"/> <img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					This is a built-in patch variable. It may hold a value of any type.
+					The patch appears in the view with the given value
+					&quot;attached&quot; to it as text. You can set this variable to
+					add, change, or remove a patch's label.
+				</p>
+				<p>
+					All patch variables can be directly accessed by any turtle standing
+					on the patch.
+				</p>
+				<p>
+					See also <a href="#plabel-color">plabel-color</a>, <a href="#label">label</a>, <a href="#label-color">label-color</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="plabel-color">
+				<h3>
+					<a>plabel-color</a>
+				</h3>
+				<h4>
+					<span class="prim_example">plabel-color</span>
+					<img alt="Patch Command" src="images/patch.gif"/> <img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					This is a built-in patch variable. It holds a number greater than
+					or equal to 0 and less than 140. This number determines what color
+					the patch's label appears in (if it has a label). You can set
+					this variable to change the color of a patch's label.
+				</p>
+				<p>
+					All patch variables can be directly accessed by any turtle standing
+					on the patch.
+				</p>
+				<p>
+					See also <a href="#plabel">plabel</a>, <a href="#label">label</a>,
+					<a href="#label-color">label-color</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="plot">
+				<h3>
+					<a>plot<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">plot <i>number</i></span>
+				</h4>
+				<p>
+					Increments the x-value of the plot pen by plot-pen-interval, then
+					plots a point at the updated x-value and a y-value of
+					<i>number</i>. (The first time the command is used on a plot, the
+					point plotted has an x-value of 0.)
+				</p>
+			</div>
+			<div class="dict_entry" id="plot-name">
+				<h3>
+					<a>plot-name<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">plot-name</span>
+				</h4>
+				<p>
+					Reports the name of the current plot (a string)
+				</p>
+			</div>
+			<div class="dict_entry" id="plot-pen-exists">
+				<h3>
+					<a>plot-pen-exists?<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">plot-pen-exists? <i>string</i></span>
+				</h4>
+				<p>
+					Reports true if a plot pen with the given name is defined in the
+					current plot. Otherwise reports false.
+				</p>
+			</div>
+			<div class="dict_entry" id="plot-pen-switch-status">
+				<h3>
+					<a>plot-pen-down<span class="since">1.0</span></a>
+					<a>plot-pen-up<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">plot-pen-down</span>
+					<span class="prim_example">plot-pen-up</span>
+				</h4>
+				<p>
+					Puts down (or up) the current plot-pen, so that it draws (or
+					doesn't). (By default, all pens are down initially.)
+				</p>
+			</div>
+			<div class="dict_entry" id="plot-pen-reset">
+				<h3>
+					<a>plot-pen-reset<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">plot-pen-reset</span>
+				</h4>
+				<p>
+					Clears everything the current plot pen has drawn, moves it to
+					(0,0), and puts it down. If the pen is a permanent pen, the color,
+					mode, and interval are reset to the default values from the plot
+					Edit dialog.
+				</p>
+			</div>
+			<div class="dict_entry" id="plotxy">
+				<h3>
+					<a>plotxy<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">plotxy <i>number1 number2</i></span>
+				</h4>
+				<p>
+					Moves the current plot pen to the point with coordinates
+					(<i>number1</i>, <i>number2</i>). If the pen is down, a line, bar,
+					or point will be drawn (depending on the pen's mode).
+				</p>
+			</div>
+			<div class="dict_entry" id="plot-cor-max-or-min">
+				<h3>
+					<a>plot-x-min<span class="since">1.0</span></a>
+					<a>plot-x-max<span class="since">1.0</span></a>
+					<a>plot-y-min<span class="since">1.0</span></a>
+					<a>plot-y-max<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">plot-x-min</span>
+					<span class="prim_example">plot-x-max</span>
+					<span class="prim_example">plot-y-min</span>
+					<span class="prim_example">plot-y-max</span>
+				</h4>
+				<p>
+					Reports the minimum or maximum value on the x or y axis of the
+					current plot.
+				</p>
+				<p>
+					These values can be set with the commands set-plot-x-range and
+					set-plot-y-range. (Their default values are set from the plot Edit
+					dialog.)
+				</p>
+			</div>
+			<div class="dict_entry" id="position">
+				<h3>
+					<a>position<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">position <i>item</i> <i>list</i></span>
+					<span class="prim_example">position <i>string1</i> <i>string2</i></span>
+				</h4>
+				<p>
+					On a list, reports the first position of <i>item</i> in
+					<i>list</i>, or false if it does not appear.
+				</p>
+				<p>
+					On strings, reports the position of the first appearance
+					<i>string1</i> as a substring of <i>string2</i>, or false if it
+					does not appear.
+				</p>
+				<p>
+					Note: The positions are numbered beginning with 0, not with 1.
+				</p>
+				<pre>
+					;; suppose mylist is [2 7 4 7 &quot;Bob&quot;]
+					show position 7 mylist
+					=&gt; 1
+					show position 10 mylist
+					=&gt; false
+					show position &quot;in&quot; &quot;string&quot;
+					=&gt; 3
+				</pre>
+				<p>
+					See also <a href="#member">member?</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="precision">
+				<h3>
+					<a>precision<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">precision <i>number places</i></span>
+				</h4>
+				<p>
+					Reports <i>number</i> rounded to <i>places</i> decimal places.
+				</p>
+				<p>
+					If <i>places</i> is negative, the rounding takes place to the left
+					of the decimal point.
+				</p>
+				<pre>
+					show precision 1.23456789 3
+					=&gt; 1.235
+					show precision 3834 -3
+					=&gt; 4000
+				</pre>
+				<p>
+					See also <a href="#round">round</a>, <a href="#ceiling">ceiling</a>, <a href="#floor">floor</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="print">
+				<h3>
+					<a>print<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">print <i>value</i></span>
+				</h4>
+				<p>
+					Prints <i>value</i> in the Command Center, followed by a carriage
+					return.
+				</p>
+				<p>
+					This agent is <i>not</i> printed before the value, unlike <a href="#show">show</a>.
+				</p>
+				<p>
+					See also <a href="#show">show</a>, <a href="#type">type</a>,
+					<a href="#write">write</a>, <a href="#output-cmds">output-print</a>, and
+					<a href="programming.html#output">Output (programming guide)</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="pcor">
+				<h3>
+					<a>pxcor</a>
+					<a>pycor</a>
+				</h3>
+				<h4>
+					<span class="prim_example">pxcor</span>
+					<span class="prim_example">pycor</span>
+					<img alt="Patch Command" src="images/patch.gif"/> <img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					These are built-in patch variables. They hold the x and y
+					coordinate of the patch. They are always integers. You cannot set
+					these variables, because patches don't move.
+				</p>
+				<p>
+					pxcor is greater than or equal to min-pxcor and less than or equal
+					to max-pxcor; similarly for pycor and min-pycor and max-pycor.
+				</p>
+				<p>
+					All patch variables can be directly accessed by any turtle standing
+					on the patch.
+				</p>
+				<p>
+					See also <a href="#xcor">xcor</a>, <a href="#ycor">ycor</a>.
+				</p>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="R">
+			<a>R</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="random">
+				<h3>
+					<a>random<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">random <i>number</i></span>
+				</h4>
+				<p>
+					If <i>number</i> is positive, reports a random integer greater than
+					or equal to 0, but strictly less than <i>number</i>.
+				</p>
+				<p>
+					If <i>number</i> is negative, reports a random integer less than or
+					equal to 0, but strictly greater than <i>number</i>.
+				</p>
+				<p>
+					If <i>number</i> is zero, the result is always 0 as well.
+				</p>
+				<p>
+					Note: In versions of NetLogo prior to version 2.0, this primitive
+					reported a floating point number if given a non-integer input. This
+					is no longer the case. If you want a floating point answer, you
+					must now use <a href="#random-float">random-float</a> instead.
+				</p>
+				<pre>
+					show random 3
+					;; prints 0, 1,  or 2
+					show random -3
+					;; prints 0, -1, or -2
+					show random 3.5
+					;; prints 0, 1, 2, or 3
+				</pre>
+				<p>
+					See also <a href="#random-float">random-float</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="random-float">
+				<h3>
+					<a>random-float<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">random-float <i>number</i></span>
+				</h4>
+				<p>
+					If <i>number</i> is positive, reports a random floating point
+					number greater than or equal to 0 but strictly less than
+					<i>number</i>.
+				</p>
+				<p>
+					If <i>number</i> is negative, reports a random floating point
+					number less than or equal to 0, but strictly greater than
+					<i>number</i>.
+				</p>
+				<p>
+					If <i>number</i> is zero, the result is always 0.
+				</p>
+				<pre>
+					show random-float 3
+					;; prints a number at least 0 but less than 3,
+					;; for example 2.589444906014774
+					show random-float 2.5
+					;; prints a number at least 0 but less than 2.5,
+					;; for example 1.0897423196760796
+				</pre>
+			</div>
+			<div class="dict_entry" id="random-reporters">
+				<h3>
+					<a>random-exponential<span class="since">1.2.1</span></a>
+					<a>random-gamma<span class="since">2.0</span></a>
+					<a>random-normal<span class="since">1.2.1</span></a>
+					<a>random-poisson<span class="since">1.2.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">random-exponential <i>mean</i></span>
+					<span class="prim_example">random-gamma <i>alpha lambda</i></span>
+					<span class="prim_example">random-normal <i>mean standard-deviation</i></span>
+					<span class="prim_example">random-poisson <i>mean</i></span>
+				</h4>
+				<p>
+					Reports an accordingly distributed random number with the
+					<i>mean</i> and, in the case of the normal distribution, the
+					<i>standard-deviation</i>. (The standard deviation may not be
+					negative.)
+				</p>
+				<p>
+					random-exponential reports an exponentially distributed random
+					floating point number. It is equivalent to <code>(- <i>mean</i>) * ln
+						random-float 1.0</code>.
+				</p>
+				<p>
+					random-gamma reports a gamma-distributed random floating point
+					number as controlled by the floating point alpha and lambda
+					parameters. Both inputs must be greater than zero. (Note: for
+					results with a given mean and variance, use inputs as follows:
+					alpha = mean * mean / variance; lambda = 1 / (variance / mean).)
+				</p>
+				<p>
+					random-normal reports a normally distributed random floating point
+					number.
+				</p>
+				<p>
+					random-poisson reports a Poisson-distributed random integer.
+				</p>
+				<pre>
+					show random-exponential 2
+					;; prints an exponentially distributed random floating
+					;; point number with a mean of 2
+					show random-normal 10.1 5.2
+					;; prints a normally distributed random floating point
+					;; number with a mean of 10.1 and a standard deviation
+					;; of 5.2
+					show random-poisson 3.4
+					;; prints a Poisson-distributed random integer with a
+					;; mean of 3.4
+				</pre>
+			</div>
+			<div class="dict_entry" id="random-pcor">
+				<h3>
+					<a>random-pxcor<span class="since">3.1</span></a>
+					<a>random-pycor<span class="since">3.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">random-pxcor</span>
+					<span class="prim_example">random-pycor</span>
+				</h4>
+				<p>
+					Reports a random integer ranging from min-pxcor (or -y) to
+					max-pxcor (or -y) inclusive.
+				</p>
+				<pre>
+					ask turtles [
+					;; move each turtle to the center of a random patch
+					setxy random-pxcor random-pycor
+					]
+				</pre>
+				<p>
+					See also <a href="#random-cor">random-xcor</a>, <a href="#random-cor">random-ycor</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="random-seed">
+				<h3>
+					<a>random-seed<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">random-seed <i>number</i></span>
+				</h4>
+				<p>
+					Sets the seed of the pseudo-random number generator to the integer
+					part of <i>number</i>. The seed must be in the range -2147483648 to
+					2147483647; note that this is smaller than the full range of
+					integers supported by NetLogo (-9007199254740992 to
+					9007199254740992).
+				</p>
+				<p>
+					See the <a href="programming.html#random-numbers">Random Numbers</a>
+					section of the Programming Guide for more details.
+				</p>
+				<pre>
+					random-seed 47822
+					show random 100
+					=&gt; 50
+					show random 100
+					=&gt; 35
+					random-seed 47822
+					show random 100
+					=&gt; 50
+					show random 100
+					=&gt; 35
+				</pre>
+			</div>
+			<div class="dict_entry" id="random-cor">
+				<h3>
+					<a>random-xcor<span class="since">3.1</span></a>
+					<a>random-ycor<span class="since">3.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">random-xcor</span>
+					<span class="prim_example">random-ycor</span>
+				</h4>
+				<p>
+					Reports a random floating point number from the allowable range of
+					turtle coordinates along the given axis, x or y.
+				</p>
+				<p>
+					Turtle coordinates range from min-pxcor - 0.5 (inclusive) to
+					max-pxcor + 0.5 (exclusive) horizontally; vertically, substitute -y
+					for -x.
+				</p>
+				<pre>
+					ask turtles [
+					;; move each turtle to a random point
+					setxy random-xcor random-ycor
+					]
+				</pre>
+				<p>
+					See also <a href="#random-pcor">random-pxcor</a>, <a href="#random-pcor">random-pycor</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="range">
+				<h3>
+					<a>range<span class="since">6.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">range <i>stop</i></span>
+					<span class="prim_example">(range <i>start</i> <i>stop</i>)</span>
+					<span class="prim_example">(range <i>start</i> <i>stop</i> <i>step</i>)</span>
+				</h4>
+				<p>
+					Generates a list of numbers, starting at <i>start</i>, ending before
+					<i>stop</i>, counting by <i>step</i>. <i>start</i> defaults to 0 and
+					<i>step</i> defaults to 1.
+				</p>
+				<pre>
+					show range 5
+					=&gt; [0 1 2 3 4]
+					show (range 2 5)
+					=&gt; [2 3 4]
+					show (range 2 5 0.5)
+					=&gt; [2 2.5 3 3.5 4 4.5]
+					show (range 10 0 -1)
+					=&gt; [10 9 8 7 6 5 4 3 2 1]
+				</pre>
+				<p>
+					See also <a href="#n-values">n-values</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="read-from-string">
+				<h3>
+					<a>read-from-string<span class="since">1.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">read-from-string <i>string</i></span>
+				</h4>
+				<p>
+					Interprets the given string as if it had been typed in the Command
+					Center, and reports the resulting value. The result may be a
+					number, list, string, or boolean value, or the special value
+					&quot;nobody&quot;.
+				</p>
+				<p>
+					Useful in conjunction with the <a href="#user-input">user-input</a>
+					primitive for converting the user's input into usable form.
+				</p>
+				<pre>
+					show read-from-string &quot;3&quot; + read-from-string &quot;5&quot;
+					=&gt; 8
+					show length read-from-string &quot;[1 2 3]&quot;
+					=&gt; 3
+					crt read-from-string user-input &quot;Make how many turtles?&quot;
+					;; the number of turtles input by the user
+					;; are created
+				</pre>
+			</div>
+			<div class="dict_entry" id="reduce">
+				<h3>
+					<a>reduce<span class="since">1.3</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">reduce <i>reporter</i> <i>list</i></span>
+				</h4>
+				<p>
+					Reduces a list from left to right using the given reporter, resulting
+					in a single value. This means, for example, that <code>reduce
+						[ [a b] -&gt; a + b] [1 2 3 4]</code>
+					is equivalent to <i>(((1 + 2) + 3) + 4)</i>. If
+					<i>list</i> has a single item, that item is reported. It is an
+					error to reduce an empty list. <i>reporter</i> may be an anonymous
+					reporter or the name of a reporter.
+				</p>
+				<p>
+					The first input passed to the reporter is the result so far, and the
+					second input is the next item in the list.
+				</p>
+				<p>
+					Since it can be difficult to develop an intuition about what
+					<code>reduce</code> does, here are some simple examples which, while
+					not useful in themselves, may give you a better understanding of
+					this primitive:
+				</p>
+				<pre>
+					show reduce + [1 2 3]
+					=&gt; 6
+					show reduce - [1 2 3]
+					=&gt; -4
+					show reduce [ [result-so-far next-item] -&gt; next-item - result-so-far ] [1 2 3]
+					=&gt; 2
+					show reduce [ [result-so-far ignored-item] -&gt; result-so-far ] [1 2 3]
+					=&gt; 1
+					show reduce [ [ignored next-item] -&gt; next-item ] [1 2 3]
+					=&gt; 3
+					show reduce sentence [[1 2] [3 [4]] 5]
+					=&gt; [1 2 3 [4] 5]
+					show reduce [ [result-so-far next-item] -&gt; fput next-item result-so-far ] (fput [] [1 2 3 4 5])
+					=&gt; [5 4 3 2 1]
+				</pre>
+				<p>
+					Here are some more useful examples:
+				</p>
+				<pre>
+					;; find the longest string in a list
+					to-report longest-string [strings]
+					report reduce
+					[ [longest-so-far next-string] -&gt; ifelse-value (length longest-so-far &gt;= length next-string) [longest-so-far] [next-string] ]
+					strings
+					end
 
-show longest-string [&quot;hi&quot; &quot;there&quot; &quot;!&quot;]
-=&gt; &quot;there&quot;
+					show longest-string [&quot;hi&quot; &quot;there&quot; &quot;!&quot;]
+					=&gt; &quot;there&quot;
 
-;; count the number of occurrences of an item in a list
-to-report occurrences [x the-list]
-  report reduce
-    [ [occurrence-count next-item] -&gt; ifelse-value (next-item = x) [occurrence-count + 1] [occurrence-count] ] (fput 0 the-list)
-end
+					;; count the number of occurrences of an item in a list
+					to-report occurrences [x the-list]
+					report reduce
+					[ [occurrence-count next-item] -&gt; ifelse-value (next-item = x) [occurrence-count + 1] [occurrence-count] ] (fput 0 the-list)
+					end
 
-show occurrences 1 [1 2 1 3 1 2 3 1 1 4 5 1]
-=&gt; 6
+					show occurrences 1 [1 2 1 3 1 2 3 1 1 4 5 1]
+					=&gt; 6
 
-;; evaluate the polynomial, with given coefficients, at x
-to-report evaluate-polynomial [coefficients x]
-  report reduce [ [value coefficient] -&gt; (x * value) + coefficient ] coefficients
-end
+					;; evaluate the polynomial, with given coefficients, at x
+					to-report evaluate-polynomial [coefficients x]
+					report reduce [ [value coefficient] -&gt; (x * value) + coefficient ] coefficients
+					end
 
-;; evaluate 3x^2 + 2x + 1 at x = 4
-show evaluate-polynomial [3 2 1] 4
-=&gt; 57
-</pre>
-      <p>
-      See also <a href="#filter">filter</a>, <a href="#arrow">-&gt; (anonymous procedure</a>.
-      </p>
-    </div>
-    <div class="dict_entry" id="remainder">
-      <h3>
-        <a>remainder<span class="since">1.2.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">remainder <i>number1</i> <i>number2</i></span>
-      </h4>
-      <p>
-        Reports the remainder when <i>number1</i> is divided by
-        <i>number2</i>. This is equivalent to the following NetLogo code:
-      </p>
-      <pre>
-<i>number1</i> - (int (<i>number1</i> / <i>number2</i>)) * <i>number2</i>
-</pre>
-      <pre>
-show remainder 62 5
-=&gt; 2
-show remainder -8 3
-=&gt; -2
-</pre>
-      <p>
-        See also <a href="#mod">mod</a>. mod and remainder behave the same
-        for positive numbers, but differently for negative numbers.
-      </p>
-      </div>
-    <div class="dict_entry" id="remove">
-      <h3>
-        <a>remove<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">remove <i>item</i> <i>list</i></span>
-        <span class="prim_example">remove <i>string1</i> <i>string2</i></span>
-      </h4>
-      <p>
-        For a list, reports a copy of <i>list</i> with all instances of
-        <i>item</i> removed.
-      </p>
-      <p>
-        For strings, reports a copy of <i>string2</i> with all the
-        appearances of <i>string1</i> as a substring removed.
-      </p>
-      <pre>
-set mylist [2 7 4 7 &quot;Bob&quot;]
-set mylist remove 7 mylist
-;; mylist is now [2 4 &quot;Bob&quot;]
-show remove &quot;to&quot; &quot;phototonic&quot;
-=&gt; &quot;phonic&quot;
-</pre>
-    </div>
-    <div class="dict_entry" id="remove-duplicates">
-      <h3>
-        <a>remove-duplicates<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">remove-duplicates <i>list</i></span>
-      </h4>
-      <p>
-        Reports a copy of <i>list</i> with all duplicate items removed. The
-        first of each item remains in place.
-      </p>
-      <pre>
-set mylist [2 7 4 7 &quot;Bob&quot; 7]
-set mylist remove-duplicates mylist
-;; mylist is now [2 7 4 &quot;Bob&quot;]
-</pre>
-    </div>
-    <div class="dict_entry" id="remove-item">
-      <h3>
-        <a>remove-item<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">remove-item <i>index</i> <i>list</i></span>
-        <span class="prim_example">remove-item <i>index</i> <i>string</i></span>
-      </h4>
-      <p>
-        For a list, reports a copy of <i>list</i> with the item at the
-        given index removed.
-      </p>
-      <p>
-        For strings, reports a copy of <i>string</i> with the character at
-        the given index removed.
-      </p>
-      <p>
-        Note that the indices begin from 0, not 1. (The first item is item
-        0, the second item is item 1, and so on.)
-      </p>
-      <pre>
-set mylist [2 7 4 7 &quot;Bob&quot;]
-set mylist remove-item 2 mylist
-;; mylist is now [2 7 7 &quot;Bob&quot;]
-show remove-item 2 &quot;string&quot;
-=&gt; &quot;sting&quot;
-</pre>
-    </div>
-    <div class="dict_entry" id="repeat">
-      <h3>
-        <a>repeat<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">repeat <i>number</i> [ <i>commands</i> ]</span>
-      </h4>
-      <p>
-        Runs <i>commands</i> <i>number</i> times.
-      </p>
-      <pre>
+					;; evaluate 3x^2 + 2x + 1 at x = 4
+					show evaluate-polynomial [3 2 1] 4
+					=&gt; 57
+				</pre>
+				<p>
+					See also <a href="#filter">filter</a>, <a href="#arrow">-&gt; (anonymous procedure</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="remainder">
+				<h3>
+					<a>remainder<span class="since">1.2.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">remainder <i>number1</i> <i>number2</i></span>
+				</h4>
+				<p>
+					Reports the remainder when <i>number1</i> is divided by
+					<i>number2</i>. This is equivalent to the following NetLogo code:
+				</p>
+				<pre>
+					<i>number1</i> - (int (<i>number1</i> / <i>number2</i>)) * <i>number2</i>
+				</pre>
+				<pre>
+					show remainder 62 5
+					=&gt; 2
+					show remainder -8 3
+					=&gt; -2
+				</pre>
+				<p>
+					See also <a href="#mod">mod</a>. mod and remainder behave the same
+					for positive numbers, but differently for negative numbers.
+				</p>
+			</div>
+			<div class="dict_entry" id="remove">
+				<h3>
+					<a>remove<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">remove <i>item</i> <i>list</i></span>
+					<span class="prim_example">remove <i>string1</i> <i>string2</i></span>
+				</h4>
+				<p>
+					For a list, reports a copy of <i>list</i> with all instances of
+					<i>item</i> removed.
+				</p>
+				<p>
+					For strings, reports a copy of <i>string2</i> with all the
+					appearances of <i>string1</i> as a substring removed.
+				</p>
+				<pre>
+					set mylist [2 7 4 7 &quot;Bob&quot;]
+					set mylist remove 7 mylist
+					;; mylist is now [2 4 &quot;Bob&quot;]
+					show remove &quot;to&quot; &quot;phototonic&quot;
+					=&gt; &quot;phonic&quot;
+				</pre>
+			</div>
+			<div class="dict_entry" id="remove-duplicates">
+				<h3>
+					<a>remove-duplicates<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">remove-duplicates <i>list</i></span>
+				</h4>
+				<p>
+					Reports a copy of <i>list</i> with all duplicate items removed. The
+					first of each item remains in place.
+				</p>
+				<pre>
+					set mylist [2 7 4 7 &quot;Bob&quot; 7]
+					set mylist remove-duplicates mylist
+					;; mylist is now [2 7 4 &quot;Bob&quot;]
+				</pre>
+			</div>
+			<div class="dict_entry" id="remove-item">
+				<h3>
+					<a>remove-item<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">remove-item <i>index</i> <i>list</i></span>
+					<span class="prim_example">remove-item <i>index</i> <i>string</i></span>
+				</h4>
+				<p>
+					For a list, reports a copy of <i>list</i> with the item at the
+					given index removed.
+				</p>
+				<p>
+					For strings, reports a copy of <i>string</i> with the character at
+					the given index removed.
+				</p>
+				<p>
+					Note that the indices begin from 0, not 1. (The first item is item
+					0, the second item is item 1, and so on.)
+				</p>
+				<pre>
+					set mylist [2 7 4 7 &quot;Bob&quot;]
+					set mylist remove-item 2 mylist
+					;; mylist is now [2 7 7 &quot;Bob&quot;]
+					show remove-item 2 &quot;string&quot;
+					=&gt; &quot;sting&quot;
+				</pre>
+			</div>
+			<div class="dict_entry" id="repeat">
+				<h3>
+					<a>repeat<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">repeat <i>number</i> [ <i>commands</i> ]</span>
+				</h4>
+				<p>
+					Runs <i>commands</i> <i>number</i> times.
+				</p>
+				<pre>
 
- pd repeat 36 [ fd 1 rt 10 ]
- ;; the turtle draws a circle
+					pd repeat 36 [ fd 1 rt 10 ]
+					;; the turtle draws a circle
 
-</pre>
-    </div>
-    <div class="dict_entry" id="replace-item">
-      <h3>
-        <a>replace-item<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">replace-item <i>index list value</i></span>
-        <span class="prim_example">replace-item <i>index string1 string2</i></span>
-      </h4>
-      <p>
-        On a list, replaces an item in that list. <i>index</i> is the index
-        of the item to be replaced, starting with 0. (The 6th item in a
-        list would have an index of 5.) Note that &quot;replace-item&quot;
-        is used in conjunction with &quot;set&quot; to change a list.
-      </p>
-      <p>
-        Likewise for a string, but the given character of <i>string1</i>
-        removed and the contents of <i>string2</i> spliced in instead.
-      </p>
-      <pre>
-show replace-item 2 [2 7 4 5] 15
-=&gt; [2 7 15 5]
-show replace-item 1 &quot;cat&quot; &quot;are&quot;
-=&gt; &quot;caret&quot;
-</pre>
-    </div>
-    <div class="dict_entry" id="report">
-      <h3>
-        <a>report<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">report <i>value</i></span>
-      </h4>
-      <p>
-        Immediately exits from the current to-report procedure and reports
-        <i>value</i> as the result of that procedure. report and to-report
-        are always used in conjunction with each other. See <a href="#to-report">to-report</a> for a discussion of how to use them.
-      </p>
-      </div>
-    <div class="dict_entry" id="reset-perspective">
-      <h3>
-        <a>reset-perspective<span class="since">3.0</span></a>
-        <a>rp<span class="since">3.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">reset-perspective</span>
-      </h4>
-      <p>
-        The observer stops watching, following, or riding any turtles (or
-        patches). (If it wasn't watching, following, or riding anybody,
-        nothing happens.) In the 3D view, the observer also returns to its
-        default position (above the origin, looking straight down).
-      </p>
-      <p>
-        See also <a href="#follow">follow</a>, <a href="#ride">ride</a>,
-        <a href="#watch">watch</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="reset-ticks">
-      <h3>
-        <a>reset-ticks<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">reset-ticks</span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Resets the tick counter to zero, sets up all plots, then updates
-        all plots (so that the initial state of the world is plotted).
-      </p>
-      <p>
-        Normally <code>reset-ticks</code> goes at the end of a setup procedure.
-      </p>
-      <p>
-        See also <a href="#clear-ticks">clear-ticks</a>, <a href="#tick">tick</a>, <a href="#ticks">ticks</a>, <a href="#tick-advance">tick-advance</a>, <a href="#setup-plots">setup-plots</a>, <a href="#update-plots">update-plots</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="reset-timer">
-      <h3>
-        <a>reset-timer<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">reset-timer</span>
-      </h4>
-      <p>
-        Resets the timer to zero seconds. See also <a href="#timer">timer</a>.
-      </p>
-      <p>
-        Note that the timer is different from the tick counter. The timer
-        measures elapsed real time in seconds; the tick counter measures
-        elapsed model time in ticks.
-      </p>
-      </div>
-    <div class="dict_entry" id="resize-world">
-      <h3>
-        <a>resize-world<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">resize-world <i>min-pxcor</i> <i>max-pxcor</i> <i>min-pycor</i> <i>max-pycor</i></span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Changes the size of the patch grid.
-      </p>
-      <p>
-        If the given patch grid coordinates are different than the ones
-        in use, all turtles and links die, and the existing patch grid is
-        discarded and new patches created. Otherwise, existing turtles
-        and links will live if the grid coordinates are unchanged.
-      </p>
-      <p>
-        Retaining references to old patches or patch sets is inadvisable
-        and may subsequently cause runtime errors or other unexpected
-        behavior.
-      </p>
-      <p>
-        See also <a href="#set-patch-size">set-patch-size</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="reverse">
-      <h3>
-        <a>reverse<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">reverse <i>list</i></span>
-        <span class="prim_example">reverse <i>string</i></span>
-      </h4>
-      <p>
-        Reports a reversed copy of the given list or string.
-      </p>
-      <pre>
-show mylist
-;; mylist is [2 7 4 &quot;Bob&quot;]
-set mylist reverse mylist
-;; mylist now is [&quot;Bob&quot; 4 7 2]
-show reverse &quot;live&quot;
-=&gt; &quot;evil&quot;
-</pre>
-    </div>
-    <div class="dict_entry" id="rgb">
-      <h3>
-        <a>rgb<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">rgb <i>red green blue</i></span>
-      </h4>
-      <p>
-        Reports a RGB list when given three numbers describing an RGB
-        color. The numbers are range checked to be between 0 and 255.
-      </p>
-      <p>
-        See also <a href="#hsb">hsb</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="ride">
-      <h3>
-        <a>ride<span class="since">3.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">ride <i>turtle</i></span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Set the perspective to <i>turtle</i>.
-      </p>
-      <p>
-        Every time <i>turtle</i> moves the observer also moves. Thus, in
-        the 2D View the turtle will stay at the center of the view. In the
-        3D view it is as if looking through the eyes of the turtle. If the
-        turtle dies, the perspective resets to the default.
-      </p>
-      <p>
-        The observer may only watch or follow a single subject.
-        Calling <code>ride</code> will remove the highlight created by
-        prior calls to <code>watch</code> and <code>watch-me</code>,
-        highlighting the ridden turtle instead.
-      </p>
-      <p>
-        See also <a href="#reset-perspective">reset-perspective</a>,
-        <a href="#watch">watch</a>, <a href="#follow">follow</a>, <a href="#subject">subject</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="ride-me">
-      <h3>
-        <a>ride-me<span class="since">3.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">ride-me</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Asks the observer to ride this turtle.
-      </p>
-      <p>
-        The observer may only watch or follow a single subject.
-        Calling <code>ride-me</code> will remove the highlight created by
-        prior calls to <code>watch</code> and <code>watch-me</code>,
-        highlighting this turtle instead.
-      </p>
-      <p>
-        See also <a href="#ride">ride</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="right">
-      <h3>
-        <a>right<span class="since">1.0</span></a>
-        <a>rt<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">right <i>number</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        The turtle turns right by <i>number</i> degrees. (If <i>number</i>
-        is negative, it turns left.)
-      </p>
-      </div>
-    <div class="dict_entry" id="round">
-      <h3>
-        <a>round<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">round <i>number</i></span>
-      </h4>
-      <p>
-        Reports the integer nearest to <i>number</i>.
-      </p>
-      <p>
-        If the decimal portion of <i>number</i> is exactly .5, the number
-        is rounded in the <b>positive</b> direction.
-      </p>
-      <p>
-        Note that rounding in the positive direction is not always how
-        rounding is done in other software programs. (In particular, it
-        does not match the behavior of StarLogoT, which always rounded
-        numbers ending in 0.5 to the nearest even integer.) The rationale
-        for this behavior is that it matches how turtle coordinates relate
-        to patch coordinates in NetLogo. For example, if a turtle's
-        xcor is -4.5, then it is on the boundary between a patch whose
-        pxcor is -4 and a patch whose pxcor is -5, but the turtle must be
-        considered to be in one patch or the other, so the turtle is
-        considered to be in the patch whose pxcor is -4, because we round
-        towards the positive numbers.
-      </p>
-      <pre>
-show round 4.2
-=&gt; 4
-show round 4.5
-=&gt; 5
-show round -4.5
-=&gt; -4
-</pre>
-      <p>
-        See also <a href="#precision">precision</a>, <a href="#ceiling">ceiling</a>, <a href="#floor">floor</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="run">
-      <h3>
-        <a>run<span class="since">1.3</span></a>
-        <a>runresult<span class="since">1.3</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">run <i>command</i></span>
-        <span class="prim_example">(run <i>command</i> <i>input1</i> ...)</span>
-        <span class="prim_example">run <i>string</i></span>
-        <span class="prim_example">runresult <i>reporter</i></span>
-        <span class="prim_example">(runresult <i>reporter</i> <i>input1</i> ...)</span>
-        <span class="prim_example">runresult <i>string</i></span>
-      </h4>
-      <p>
-        The <code>run</code> form expects the name of a command, an anonymous command,
-        or a string containing commands. This agent then runs them.
-      </p>
-      <p>
-        The <code>runresult</code> form expects the name of a reporter, an anonymous reporter,
-        or a string containing a reporter. This agent runs it and reports the result.
-      </p>
-      <p>
-        Note that you can't use <code>run</code> to define or redefine
-        procedures. If you care about performance, note that the code must
-        be compiled first which takes time. However, compiled bits of code
-        are cached by NetLogo and thus using <code>run</code> on the same
-        string over and over is much faster than running different strings.
-        The first run, though, will be many times slower than
-        running the same code directly, or in an anonymous command.
-      </p>
-      <p>
-        Anonymous procedures are recommended over strings whenever possible.
-        (An example of when you must use strings is if you accept pieces
-        of code from the user of your model.)
-      </p>
-      <p>
-        Anonymous procedures may freely read and/or set local variables
-        and procedure inputs. Trying to do the same with strings may
-        or may not work and should not be relied on.
-      </p>
-      <p>
-        When using anonymous procedures, you can provide them with inputs,
-        if you surround the entire call with parentheses. For example:
-      </p>
-      <pre>
-(run [ [turtle-count step-count] -&gt; crt turtle-count [ fd step-count ] ] 10 5)
-;; creates 10 turtles and move them forward 5 steps
-show (runresult [ [a b] -&gt; a + b ] 10 5)
-=&gt; 15
-;; adds 10 and 5
-</pre>
-        <p>
-        See also <a href="#foreach">foreach</a>, <a href="#arrow">-> (anonymous procedure)</a>.
-        </p>
-      </div><!-- ======================================== -->
-    </div>
-    <h2 id="S">
-      <a>S</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="scale-color">
-      <h3>
-        <a>scale-color<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">scale-color <i>color number range1 range2</i></span>
-      </h4>
-      <p>
-        Reports a shade of <i>color</i> proportional to the value of
-        <i>number</i>.
-      </p>
-      <p>
-        If <i>range1</i> is less than <i>range2</i>, then the larger the
-        number, the lighter the shade of <i>color</i>. But if <i>range2</i>
-        is less than <i>range1</i>, the color scaling is inverted.
-      </p>
-      <p>
-        If <i>number</i> is less than <i>range1</i>, then the darkest shade
-        of <i>color</i> is chosen.
-      </p>
-      <p>
-        If <i>number</i> is greater than <i>range2</i>, then the lightest
-        shade of <i>color</i> is chosen.
-      </p>
-      <p>
-        Note: for <i>color</i> shade is irrelevant, e.g. green and green +
-        2 are equivalent, and the same spectrum of colors will be used.
-      </p>
-      <pre>
-ask turtles [ set color scale-color red age 0 50 ]
-;; colors each turtle a shade of red proportional
-;; to its value for the age variable
-</pre>
-    </div>
-    <div class="dict_entry" id="self">
-      <h3>
-        <a>self<span class="since">1.3</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">self</span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif"> <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        Reports this turtle, patch, or link.
-      </p>
-      <p>
-        &quot;self&quot; and &quot;myself&quot; are very different.
-        &quot;self&quot; is simple; it means &quot;me&quot;.
-        &quot;myself&quot; means &quot;the agent who asked me to do what
-        I'm doing right now.&quot;
-      </p>
-      <p>
-        Note that it is always redundant to write <code>[foo] of self</code>.
-        This is always equivalent to simply writing <code>foo</code>.
-      </p>
-      <p>
-        See also <a href="#myself">myself</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="semicolon">
-      <h3>
-        <a>; (semicolon)</a>
-      </h3>
-      <h4>
-        <span class="prim_example">; <i>comments</i></span>
-      </h4>
-      <p>
-        After a semicolon, the rest of the line is ignored. This is useful
-        for adding &quot;comments&quot; to your code -- text that explains
-        the code to human readers. Extra semicolons can be added for visual
-        effect.
-      </p>
-      <p>
-        NetLogo's Edit menu has items that let you comment or uncomment
-        whole sections of code.
-      </p>
-      </div>
-    <div class="dict_entry" id="sentence">
-      <h3>
-        <a>sentence<span class="since">1.0</span></a>
-        <a>se<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">sentence <i>value1</i> <i>value2</i></span>
-        <span class="prim_example">(sentence <i>value1</i> ...)</span>
-      </h4>
-      <p>
-        Makes a list out of the values. If any value is a list, its items
-        are included in the result directly, rather than being included as
-        a sublist. Examples make this clearer:
-      </p>
-      <pre>
-show sentence 1 2
-=&gt; [1 2]
-show sentence [1 2] 3
-=&gt; [1 2 3]
-show sentence 1 [2 3]
-=&gt; [1 2 3]
-show sentence [1 2] [3 4]
-=&gt; [1 2 3 4]
-show sentence [[1 2]] [[3 4]]
-=&gt; [[1 2] [3 4]]
-show (sentence [1 2] 3 [4 5] (3 + 3) 7)
-=&gt; [1 2 3 4 5 6 7]
-</pre>
-    </div>
-    <div class="dict_entry" id="set">
-      <h3>
-        <a>set<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">set <i>variable</i> <i>value</i></span>
-      </h4>
-      <p>
-        Sets <i>variable</i> to the given value.
-      </p>
-      <p>
-        Variable can be any of the following:
-      </p>
-      <ul>
-        <li>A global variable declared using &quot;globals&quot;
-        <li>The global variable associated with a slider, switch, chooser,
-        or input box.
-        <li>A variable belonging to this agent
-        <li>If this agent is a turtle, a variable belonging to the patch
-        under the turtle.
-        <li>A local variable created by the <a href="#let">let</a> command.
-        <li>An input to the current procedure.
-        </ul>
-    </div>
-    <div class="dict_entry" id="set-current-directory">
-      <h3>
-        <a>set-current-directory<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">set-current-directory <i>string</i></span>
-      </h4>
-      <p>
-        Sets the current directory that is used by the primitives <a href="#file-delete">file-delete</a>, <a href="#file-exists">file-exists?</a>, and <a href="#file-open">file-open</a>.
-      </p>
-      <p>
-        The current directory is not used if the above commands are given
-        an absolute file path. This is defaulted to the user's home
-        directory for new models, and is changed to the model's
-        directory when a model is opened.
-      </p>
-      <p>
-        Note that in Windows file paths the backslash needs to be escaped
-        within a string by using another backslash &quot;C:\\&quot;
-      </p>
-      <p>
-        The change is temporary and is not saved with the model.
-      </p>
-      <pre>
-set-current-directory &quot;C:\\NetLogo&quot;
-;; Assume it is a Windows Machine
-file-open &quot;my-file.txt&quot;
-;; Opens file &quot;C:\\NetLogo\\my-file.txt&quot;
-</pre>
-    </div>
-    <div class="dict_entry" id="set-current-plot">
-      <h3>
-        <a>set-current-plot<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">set-current-plot <i>plotname</i></span>
-      </h4>
-      <p>
-        Sets the current plot to the plot with the given name (a string).
-        Subsequent plotting commands will affect the current plot.
-      </p>
-      </div>
-    <div class="dict_entry" id="set-current-plot-pen">
-      <h3>
-        <a>set-current-plot-pen<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">set-current-plot-pen <i>penname</i></span>
-      </h4>
-      <p>
-        The current plot's current pen is set to the pen named
-        <i>penname</i> (a string). If no such pen exists in the current
-        plot, a runtime error occurs.
-      </p>
-      </div>
-    <div class="dict_entry" id="set-default-shape">
-      <h3>
-        <a>set-default-shape<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">set-default-shape turtles <i>string</i></span>
-        <span class="prim_example">set-default-shape links <i>string</i></span>
-        <span class="prim_example">set-default-shape <i>breed</i> <i>string</i></span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Specifies a default initial shape for all turtles or links, or for
-        a particular breed of turtles or links. When a turtle or link is
-        created, or it changes breeds, it shape is set to the given shape.
-      </p>
-      <p>
-        This command doesn't affect existing agents, only agents you
-        create afterwards.
-      </p>
-      <p>
-        The given breed must be either turtles, links, or the name of a
-        breed. The given string must be the name of a currently defined
-        shape.
-      </p>
-      <p>
-        In new models, the default shape for all turtles is
-        &quot;default&quot;.
-      </p>
-      <p>
-        Note that specifying a default shape does not prevent you from
-        changing an agent's shape later. Agents don't have to be
-        stuck with their breed's default shape.
-      </p>
-      <pre>
-create-turtles 1 ;; new turtle's shape is &quot;default&quot;
-create-cats 1    ;; new turtle's shape is &quot;default&quot;
+				</pre>
+			</div>
+			<div class="dict_entry" id="replace-item">
+				<h3>
+					<a>replace-item<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">replace-item <i>index list value</i></span>
+					<span class="prim_example">replace-item <i>index string1 string2</i></span>
+				</h4>
+				<p>
+					On a list, replaces an item in that list. <i>index</i> is the index
+					of the item to be replaced, starting with 0. (The 6th item in a
+					list would have an index of 5.) Note that &quot;replace-item&quot;
+					is used in conjunction with &quot;set&quot; to change a list.
+				</p>
+				<p>
+					Likewise for a string, but the given character of <i>string1</i>
+					removed and the contents of <i>string2</i> spliced in instead.
+				</p>
+				<pre>
+					show replace-item 2 [2 7 4 5] 15
+					=&gt; [2 7 15 5]
+					show replace-item 1 &quot;cat&quot; &quot;are&quot;
+					=&gt; &quot;caret&quot;
+				</pre>
+			</div>
+			<div class="dict_entry" id="report">
+				<h3>
+					<a>report<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">report <i>value</i></span>
+				</h4>
+				<p>
+					Immediately exits from the current to-report procedure and reports
+					<i>value</i> as the result of that procedure. report and to-report
+					are always used in conjunction with each other. See <a href="#to-report">to-report</a> for a discussion of how to use them.
+				</p>
+			</div>
+			<div class="dict_entry" id="reset-perspective">
+				<h3>
+					<a>reset-perspective<span class="since">3.0</span></a>
+					<a>rp<span class="since">3.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">reset-perspective</span>
+				</h4>
+				<p>
+					The observer stops watching, following, or riding any turtles (or
+					patches). (If it wasn't watching, following, or riding anybody,
+					nothing happens.) In the 3D view, the observer also returns to its
+					default position (above the origin, looking straight down).
+				</p>
+				<p>
+					See also <a href="#follow">follow</a>, <a href="#ride">ride</a>,
+					<a href="#watch">watch</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="reset-ticks">
+				<h3>
+					<a>reset-ticks<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">reset-ticks</span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Resets the tick counter to zero, sets up all plots, then updates
+					all plots (so that the initial state of the world is plotted).
+				</p>
+				<p>
+					Normally <code>reset-ticks</code> goes at the end of a setup procedure.
+				</p>
+				<p>
+					See also <a href="#clear-ticks">clear-ticks</a>, <a href="#tick">tick</a>, <a href="#ticks">ticks</a>, <a href="#tick-advance">tick-advance</a>, <a href="#setup-plots">setup-plots</a>, <a href="#update-plots">update-plots</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="reset-timer">
+				<h3>
+					<a>reset-timer<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">reset-timer</span>
+				</h4>
+				<p>
+					Resets the timer to zero seconds. See also <a href="#timer">timer</a>.
+				</p>
+				<p>
+					Note that the timer is different from the tick counter. The timer
+					measures elapsed real time in seconds; the tick counter measures
+					elapsed model time in ticks.
+				</p>
+			</div>
+			<div class="dict_entry" id="resize-world">
+				<h3>
+					<a>resize-world<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">resize-world <i>min-pxcor</i> <i>max-pxcor</i> <i>min-pycor</i> <i>max-pycor</i></span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Changes the size of the patch grid.
+				</p>
+				<p>
+					If the given patch grid coordinates are different than the ones
+					in use, all turtles and links die, and the existing patch grid is
+					discarded and new patches created. Otherwise, existing turtles
+					and links will live if the grid coordinates are unchanged.
+				</p>
+				<p>
+					Retaining references to old patches or patch sets is inadvisable
+					and may subsequently cause runtime errors or other unexpected
+					behavior.
+				</p>
+				<p>
+					See also <a href="#set-patch-size">set-patch-size</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="reverse">
+				<h3>
+					<a>reverse<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">reverse <i>list</i></span>
+					<span class="prim_example">reverse <i>string</i></span>
+				</h4>
+				<p>
+					Reports a reversed copy of the given list or string.
+				</p>
+				<pre>
+					show mylist
+					;; mylist is [2 7 4 &quot;Bob&quot;]
+					set mylist reverse mylist
+					;; mylist now is [&quot;Bob&quot; 4 7 2]
+					show reverse &quot;live&quot;
+					=&gt; &quot;evil&quot;
+				</pre>
+			</div>
+			<div class="dict_entry" id="rgb">
+				<h3>
+					<a>rgb<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">rgb <i>red green blue</i></span>
+				</h4>
+				<p>
+					Reports a RGB list when given three numbers describing an RGB
+					color. The numbers are range checked to be between 0 and 255.
+				</p>
+				<p>
+					See also <a href="#hsb">hsb</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="ride">
+				<h3>
+					<a>ride<span class="since">3.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">ride <i>turtle</i></span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Set the perspective to <i>turtle</i>.
+				</p>
+				<p>
+					Every time <i>turtle</i> moves the observer also moves. Thus, in
+					the 2D View the turtle will stay at the center of the view. In the
+					3D view it is as if looking through the eyes of the turtle. If the
+					turtle dies, the perspective resets to the default.
+				</p>
+				<p>
+					The observer may only watch or follow a single subject.
+					Calling <code>ride</code> will remove the highlight created by
+					prior calls to <code>watch</code> and <code>watch-me</code>,
+					highlighting the ridden turtle instead.
+				</p>
+				<p>
+					See also <a href="#reset-perspective">reset-perspective</a>,
+					<a href="#watch">watch</a>, <a href="#follow">follow</a>, <a href="#subject">subject</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="ride-me">
+				<h3>
+					<a>ride-me<span class="since">3.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">ride-me</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Asks the observer to ride this turtle.
+				</p>
+				<p>
+					The observer may only watch or follow a single subject.
+					Calling <code>ride-me</code> will remove the highlight created by
+					prior calls to <code>watch</code> and <code>watch-me</code>,
+					highlighting this turtle instead.
+				</p>
+				<p>
+					See also <a href="#ride">ride</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="right">
+				<h3>
+					<a>right<span class="since">1.0</span></a>
+					<a>rt<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">right <i>number</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					The turtle turns right by <i>number</i> degrees. (If <i>number</i>
+					is negative, it turns left.)
+				</p>
+			</div>
+			<div class="dict_entry" id="round">
+				<h3>
+					<a>round<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">round <i>number</i></span>
+				</h4>
+				<p>
+					Reports the integer nearest to <i>number</i>.
+				</p>
+				<p>
+					If the decimal portion of <i>number</i> is exactly .5, the number
+					is rounded in the <b>positive</b> direction.
+				</p>
+				<p>
+					Note that rounding in the positive direction is not always how
+					rounding is done in other software programs. (In particular, it
+					does not match the behavior of StarLogoT, which always rounded
+					numbers ending in 0.5 to the nearest even integer.) The rationale
+					for this behavior is that it matches how turtle coordinates relate
+					to patch coordinates in NetLogo. For example, if a turtle's
+					xcor is -4.5, then it is on the boundary between a patch whose
+					pxcor is -4 and a patch whose pxcor is -5, but the turtle must be
+					considered to be in one patch or the other, so the turtle is
+					considered to be in the patch whose pxcor is -4, because we round
+					towards the positive numbers.
+				</p>
+				<pre>
+					show round 4.2
+					=&gt; 4
+					show round 4.5
+					=&gt; 5
+					show round -4.5
+					=&gt; -4
+				</pre>
+				<p>
+					See also <a href="#precision">precision</a>, <a href="#ceiling">ceiling</a>, <a href="#floor">floor</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="run">
+				<h3>
+					<a>run<span class="since">1.3</span></a>
+					<a>runresult<span class="since">1.3</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">run <i>command</i></span>
+					<span class="prim_example">(run <i>command</i> <i>input1</i> ...)</span>
+					<span class="prim_example">run <i>string</i></span>
+					<span class="prim_example">runresult <i>reporter</i></span>
+					<span class="prim_example">(runresult <i>reporter</i> <i>input1</i> ...)</span>
+					<span class="prim_example">runresult <i>string</i></span>
+				</h4>
+				<p>
+					The <code>run</code> form expects the name of a command, an anonymous command,
+					or a string containing commands. This agent then runs them.
+				</p>
+				<p>
+					The <code>runresult</code> form expects the name of a reporter, an anonymous reporter,
+					or a string containing a reporter. This agent runs it and reports the result.
+				</p>
+				<p>
+					Note that you can't use <code>run</code> to define or redefine
+					procedures. If you care about performance, note that the code must
+					be compiled first which takes time. However, compiled bits of code
+					are cached by NetLogo and thus using <code>run</code> on the same
+					string over and over is much faster than running different strings.
+					The first run, though, will be many times slower than
+					running the same code directly, or in an anonymous command.
+				</p>
+				<p>
+					Anonymous procedures are recommended over strings whenever possible.
+					(An example of when you must use strings is if you accept pieces
+					of code from the user of your model.)
+				</p>
+				<p>
+					Anonymous procedures may freely read and/or set local variables
+					and procedure inputs. Trying to do the same with strings may
+					or may not work and should not be relied on.
+				</p>
+				<p>
+					When using anonymous procedures, you can provide them with inputs,
+					if you surround the entire call with parentheses. For example:
+				</p>
+				<pre>
+					(run [ [turtle-count step-count] -&gt; crt turtle-count [ fd step-count ] ] 10 5)
+					;; creates 10 turtles and move them forward 5 steps
+					show (runresult [ [a b] -&gt; a + b ] 10 5)
+					=&gt; 15
+					;; adds 10 and 5
+				</pre>
+				<p>
+					See also <a href="#foreach">foreach</a>, <a href="#arrow">-> (anonymous procedure)</a>.
+				</p>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="S">
+			<a>S</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="scale-color">
+				<h3>
+					<a>scale-color<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">scale-color <i>color number range1 range2</i></span>
+				</h4>
+				<p>
+					Reports a shade of <i>color</i> proportional to the value of
+					<i>number</i>.
+				</p>
+				<p>
+					If <i>range1</i> is less than <i>range2</i>, then the larger the
+					number, the lighter the shade of <i>color</i>. But if <i>range2</i>
+					is less than <i>range1</i>, the color scaling is inverted.
+				</p>
+				<p>
+					If <i>number</i> is less than <i>range1</i>, then the darkest shade
+					of <i>color</i> is chosen.
+				</p>
+				<p>
+					If <i>number</i> is greater than <i>range2</i>, then the lightest
+					shade of <i>color</i> is chosen.
+				</p>
+				<p>
+					Note: for <i>color</i> shade is irrelevant, e.g. green and green +
+					2 are equivalent, and the same spectrum of colors will be used.
+				</p>
+				<pre>
+					ask turtles [ set color scale-color red age 0 50 ]
+					;; colors each turtle a shade of red proportional
+					;; to its value for the age variable
+				</pre>
+			</div>
+			<div class="dict_entry" id="self">
+				<h3>
+					<a>self<span class="since">1.3</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">self</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/> <img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					Reports this turtle, patch, or link.
+				</p>
+				<p>
+					&quot;self&quot; and &quot;myself&quot; are very different.
+					&quot;self&quot; is simple; it means &quot;me&quot;.
+					&quot;myself&quot; means &quot;the agent who asked me to do what
+					I'm doing right now.&quot;
+				</p>
+				<p>
+					Note that it is always redundant to write <code>[foo] of self</code>.
+					This is always equivalent to simply writing <code>foo</code>.
+				</p>
+				<p>
+					See also <a href="#myself">myself</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="semicolon">
+				<h3>
+					<a>; (semicolon)</a>
+				</h3>
+				<h4>
+					<span class="prim_example">; <i>comments</i></span>
+				</h4>
+				<p>
+					After a semicolon, the rest of the line is ignored. This is useful
+					for adding &quot;comments&quot; to your code -- text that explains
+					the code to human readers. Extra semicolons can be added for visual
+					effect.
+				</p>
+				<p>
+					NetLogo's Edit menu has items that let you comment or uncomment
+					whole sections of code.
+				</p>
+			</div>
+			<div class="dict_entry" id="sentence">
+				<h3>
+					<a>sentence<span class="since">1.0</span></a>
+					<a>se<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">sentence <i>value1</i> <i>value2</i></span>
+					<span class="prim_example">(sentence <i>value1</i> ...)</span>
+				</h4>
+				<p>
+					Makes a list out of the values. If any value is a list, its items
+					are included in the result directly, rather than being included as
+					a sublist. Examples make this clearer:
+				</p>
+				<pre>
+					show sentence 1 2
+					=&gt; [1 2]
+					show sentence [1 2] 3
+					=&gt; [1 2 3]
+					show sentence 1 [2 3]
+					=&gt; [1 2 3]
+					show sentence [1 2] [3 4]
+					=&gt; [1 2 3 4]
+					show sentence [[1 2]] [[3 4]]
+					=&gt; [[1 2] [3 4]]
+					show (sentence [1 2] 3 [4 5] (3 + 3) 7)
+					=&gt; [1 2 3 4 5 6 7]
+				</pre>
+			</div>
+			<div class="dict_entry" id="set">
+				<h3>
+					<a>set<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">set <i>variable</i> <i>value</i></span>
+				</h4>
+				<p>
+					Sets <i>variable</i> to the given value.
+				</p>
+				<p>
+					Variable can be any of the following:
+				</p>
+				<ul>
+					<li>A global variable declared using &quot;globals&quot;</li>
+					<li>The global variable associated with a slider, switch, chooser,
+						or input box.</li>
+					<li>A variable belonging to this agent</li>
+					<li>If this agent is a turtle, a variable belonging to the patch
+						under the turtle.</li>
+					<li>A local variable created by the <a href="#let">let</a> command.</li>
+					<li>An input to the current procedure.</li>
+				</ul>
+			</div>
+			<div class="dict_entry" id="set-current-directory">
+				<h3>
+					<a>set-current-directory<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">set-current-directory <i>string</i></span>
+				</h4>
+				<p>
+					Sets the current directory that is used by the primitives <a href="#file-delete">file-delete</a>, <a href="#file-exists">file-exists?</a>, and <a href="#file-open">file-open</a>.
+				</p>
+				<p>
+					The current directory is not used if the above commands are given
+					an absolute file path. This is defaulted to the user's home
+					directory for new models, and is changed to the model's
+					directory when a model is opened.
+				</p>
+				<p>
+					Note that in Windows file paths the backslash needs to be escaped
+					within a string by using another backslash &quot;C:\\&quot;
+				</p>
+				<p>
+					The change is temporary and is not saved with the model.
+				</p>
+				<pre>
+					set-current-directory &quot;C:\\NetLogo&quot;
+					;; Assume it is a Windows Machine
+					file-open &quot;my-file.txt&quot;
+					;; Opens file &quot;C:\\NetLogo\\my-file.txt&quot;
+				</pre>
+			</div>
+			<div class="dict_entry" id="set-current-plot">
+				<h3>
+					<a>set-current-plot<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">set-current-plot <i>plotname</i></span>
+				</h4>
+				<p>
+					Sets the current plot to the plot with the given name (a string).
+					Subsequent plotting commands will affect the current plot.
+				</p>
+			</div>
+			<div class="dict_entry" id="set-current-plot-pen">
+				<h3>
+					<a>set-current-plot-pen<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">set-current-plot-pen <i>penname</i></span>
+				</h4>
+				<p>
+					The current plot's current pen is set to the pen named
+					<i>penname</i> (a string). If no such pen exists in the current
+					plot, a runtime error occurs.
+				</p>
+			</div>
+			<div class="dict_entry" id="set-default-shape">
+				<h3>
+					<a>set-default-shape<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">set-default-shape turtles <i>string</i></span>
+					<span class="prim_example">set-default-shape links <i>string</i></span>
+					<span class="prim_example">set-default-shape <i>breed</i> <i>string</i></span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Specifies a default initial shape for all turtles or links, or for
+					a particular breed of turtles or links. When a turtle or link is
+					created, or it changes breeds, it shape is set to the given shape.
+				</p>
+				<p>
+					This command doesn't affect existing agents, only agents you
+					create afterwards.
+				</p>
+				<p>
+					The given breed must be either turtles, links, or the name of a
+					breed. The given string must be the name of a currently defined
+					shape.
+				</p>
+				<p>
+					In new models, the default shape for all turtles is
+					&quot;default&quot;.
+				</p>
+				<p>
+					Note that specifying a default shape does not prevent you from
+					changing an agent's shape later. Agents don't have to be
+					stuck with their breed's default shape.
+				</p>
+				<pre>
+					create-turtles 1 ;; new turtle's shape is &quot;default&quot;
+					create-cats 1    ;; new turtle's shape is &quot;default&quot;
 
-set-default-shape turtles &quot;circle&quot;
-create-turtles 1 ;; new turtle's shape is &quot;circle&quot;
-create-cats 1    ;; new turtle's shape is &quot;circle&quot;
+					set-default-shape turtles &quot;circle&quot;
+					create-turtles 1 ;; new turtle's shape is &quot;circle&quot;
+					create-cats 1    ;; new turtle's shape is &quot;circle&quot;
 
-set-default-shape cats &quot;cat&quot;
-set-default-shape dogs &quot;dog&quot;
-create-cats 1   ;; new turtle's shape is &quot;cat&quot;
-ask cats [ set breed dogs ]
-  ;; all cats become dogs, and automatically
-  ;; change their shape to &quot;dog&quot;
-</pre>
-      <p>
-        See also <a href="#shape">shape</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="set-histogram-num-bars">
-      <h3>
-        <a>set-histogram-num-bars<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">set-histogram-num-bars <i>number</i></span>
-      </h4>
-      <p>
-        Set the current plot pen's plot interval so that, given the
-        current x range for the plot, there would be <i>number</i> number
-        of bars drawn if the histogram command is called.
-      </p>
-      <p>
-        See also <a href="#histogram">histogram</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="set-line-thickness">
-      <h3>
-        <a>__set-line-thickness</a>
-      </h3>
-      <h4>
-        <span class="prim_example">__set-line-thickness <i>number</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Specifies the thickness of lines and outlined elements in the
-        turtle's shape.
-      </p>
-      <p>
-        The default value is 0. This always produces lines one pixel thick.
-      </p>
-      <p>
-        Non-zero values are interpreted as thickness in patches. A
-        thickness of 1, for example, produces lines which appear one patch
-        thick. (It's common to use a smaller value such as 0.5 or 0.2.)
-      </p>
-      <p>
-        Lines are always at least one pixel thick.
-      </p>
-      <p>
-        This command is experimental and may change in later releases.
-      </p>
-      </div>
-    <div class="dict_entry" id="set-patch-size">
-      <h3>
-        <a>set-patch-size<span class="since">4.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">set-patch-size <i>size</i></span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Sets the size of the patches of the view in pixels. The size is
-        typically an integer, but may also be a floating point number.
-      </p>
-      <p>
-        See also <a href="#patch-size">patch-size</a>, <a href="#resize-world">resize-world</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="set-plot-background-color">
-      <h3>
-        <a>set-plot-background-color<span class="since">6.0.2</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">set-plot-background-color <i>color</i></span>
-      </h4>
-      <p>
-        Sets the background color of the current plot.
-        The color may be specified as a number or a list.
-        See the <a href="programming.html#colors">Colors</a> section of the programming guide for more details.
-        This change is temporary and is not saved with the model. When the
-        plot is cleared, the background color will revert to white.
-      </p>
-      <p>
-        <b>Note:</b> Plot backgrounds do not support transparency.
-        If a list is used to set the color, the alpha component will be ignored.
-      </div>
-    <div class="dict_entry" id="set-plot-pen-color">
-      <h3>
-        <a>set-plot-pen-color<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">set-plot-pen-color <i>color</i></span>
-      </h4>
-      <p>
-        Sets the color of the current plot pen to <i>color</i>.
-      </p>
-      </div>
-    <div class="dict_entry" id="set-plot-pen-interval">
-      <h3>
-        <a>set-plot-pen-interval<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">set-plot-pen-interval <i>number</i></span>
-      </h4>
-      <p>
-        Tells the current plot pen to move a distance of <i>number</i> in
-        the x direction during each use of the plot command. (The plot pen
-        interval also affects the behavior of the histogram command.)
-      </p>
-      </div>
-    <div class="dict_entry" id="set-plot-pen-mode">
-      <h3>
-        <a>set-plot-pen-mode<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">set-plot-pen-mode <i>number</i></span>
-      </h4>
-      <p>
-        Sets the mode the current plot pen draws in to <i>number</i>. The
-        allowed plot pen modes are:
-      </p>
-      <ul>
-        <li>0 (line mode) the plot pen draws a line connecting two points
-        together.
-        <li>1 (bar mode): the plot pen draws a bar of width
-        plot-pen-interval with the point plotted as the upper (or lower, if
-        you are plotting a negative number) left corner of the bar.
-        <li>2 (point mode): the plot pen draws a point at the point
-        plotted. Points are not connected.
-        </ul>
-      <p>
-        The default mode for new pens is 0 (line mode).
-      </p>
-      </div>
-    <div class="dict_entry" id="setup-plots">
-      <h3>
-        <a>setup-plots<span class="since">5.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">setup-plots</span>
-      </h4>
-      <p>
-        For each plot, runs that plot's setup commands, including the
-        setup code for any pens in the plot.
-      </p>
-      <p>
-        <a href="#reset-ticks">reset-ticks</a> has the same effect, so in
-        models that use the tick counter, this primitive is not normally
-        used.
-      </p>
-      <p>
-        See the <a href="programming.html#plotting">Plotting section</a> of
-        the Programming Guide for more details.
-      </p>
-      <p>
-        See also <a href="#update-plots">update-plots</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="set-plot--range">
-      <h3>
-        <a>set-plot-x-range<span class="since">1.0</span></a>
-        <a>set-plot-y-range<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">set-plot-x-range <i>min max</i></span>
-        <span class="prim_example">set-plot-y-range <i>min max</i></span>
-      </h4>
-      <p>
-        Sets the minimum and maximum values of the x or y axis of the
-        current plot.
-      </p>
-      <p>
-        The change is temporary and is not saved with the model. When the
-        plot is cleared, the ranges will revert to their default values as
-        set in the plot's Edit dialog.
-      </p>
-      </div>
-    <div class="dict_entry" id="setxy">
-      <h3>
-        <a>setxy<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">setxy <i>x y</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        The turtle sets its x-coordinate to <i>x</i> and its y-coordinate
-        to <i>y</i>.
-      </p>
-      <p>
-        Equivalent to <code>set xcor x set ycor y</code>, except it happens in
-        one time step instead of two.
-      </p>
-      <p>
-        If <i>x</i> or <i>y</i> is outside the world, NetLogo will throw a
-        runtime error, unless wrapping is turned on in the relevant
-        dimensions. For example, with wrapping turned on in both dimensions
-        and the default world size where <code>min-pxcor = -16</code>,
-        <code>max-pxcor = 16</code>, <code>min-pycor = -16</code> and <code>max-pycor
-        = 16</code>, asking a turtle to <code>setxy 17 17</code> will move it to
-        the center of patch (-16, -16).
-      </p>
-      <pre>
-setxy 0 0
-;; turtle moves to the middle of the center patch
-setxy random-xcor random-ycor
-;; turtle moves to a random point
-setxy random-pxcor random-pycor
-;; turtle moves to the center of a random patch
-</pre>
-      <p>
-        See also <a href="#move-to">move-to</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="shade-of">
-      <h3>
-        <a>shade-of?<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">shade-of? <i>color1</i> <i>color2</i></span>
-      </h4>
-      <p>
-        Reports true if both colors are shades of one another, false
-        otherwise.
-      </p>
-      <pre>
-show shade-of? blue red
-=&gt; false
-show shade-of? blue (blue + 1)
-=&gt; true
-show shade-of? gray white
-=&gt; true
-</pre>
-    </div>
-    <div class="dict_entry" id="shape">
-      <h3>
-        <a>shape</a>
-      </h3>
-      <h4>
-        <span class="prim_example">shape</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-        <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        This is a built-in turtle and link variable. It holds a string that
-        is the name of the turtle or link's current shape. You can set
-        this variable to change the shape. New turtles and links have the
-        shape &quot;default&quot; unless the a different shape has been
-        specified using <a href="#set-default-shape">set-default-shape</a>.
-      </p>
-      <p>
-        Example:
-      </p>
-      <pre>
-ask turtles [ set shape &quot;wolf&quot; ]
-;; assumes you have made a &quot;wolf&quot;
-;; shape in NetLogo's <a href="shapes.html">Turtle Shapes Editor</a>
-ask links [ set shape &quot;link 1&quot; ]
-;; assumes you have made a &quot;link 1&quot; shape in
-;; the Link Shapes Editor
-</pre>
-      <p>
-        See also <a href="#set-default-shape">set-default-shape</a>,
-        <a href="#shapes">shapes</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="shapes">
-      <h3>
-        <a>shapes<span class="since">2.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">shapes</span>
-      </h4>
-      <p>
-        Reports a list of strings containing all of the turtle shapes in
-        the model.
-      </p>
-      <p>
-        New shapes can be created, or imported from the shapes library or
-        from other models, in the <a href="shapes.html">Shapes Editor</a>.
-      </p>
-      <pre>
-show shapes
-=&gt; [&quot;default&quot; &quot;airplane&quot; &quot;arrow&quot; &quot;box&quot; &quot;bug&quot; ...
-ask turtles [ set shape one-of shapes ]
-</pre>
-    </div>
-    <div class="dict_entry" id="show">
-      <h3>
-        <a>show<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">show <i>value</i></span>
-      </h4>
-      <p>
-        Prints <i>value</i> in the Command Center, preceded by this agent,
-        and followed by a carriage return. (This agent is included to help
-        you keep track of what agents are producing which lines of output.)
-        Also, all strings have their quotes included similar to <a href="#write">write</a>.
-      </p>
-      <p>
-        See also <a href="#print">print</a>, <a href="#type">type</a>,
-        <a href="#write">write</a>, <a href="#output-cmds">output-show</a>,
-        and <a href="programming.html#output">Output (programming guide)</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="show-turtle">
-      <h3>
-        <a>show-turtle<span class="since">1.0</span></a>
-        <a>st<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">show-turtle</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        The turtle becomes visible again.
-      </p>
-      <p>
-        Note: This command is equivalent to setting the turtle variable
-        &quot;hidden?&quot; to false.
-      </p>
-      <p>
-        See also <a href="#hide-turtle">hide-turtle</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="show-link">
-      <h3>
-        <a>show-link<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">show-link</span>
-        <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        The link becomes visible again.
-      </p>
-      <p>
-        Note: This command is equivalent to setting the link variable
-        &quot;hidden?&quot; to false.
-      </p>
-      <p>
-        See also <a href="#hide-link">hide-link</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="shuffle">
-      <h3>
-        <a>shuffle<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">shuffle <i>list</i></span>
-      </h4>
-      <p>
-        Reports a new list containing the same items as the input list, but
-        in randomized order.
-      </p>
-      <pre>
-show shuffle [1 2 3 4 5]
-=&gt; [5 2 4 1 3]
-show shuffle [1 2 3 4 5]
-=&gt; [1 3 5 2 4]
-</pre>
-    </div>
-    <div class="dict_entry" id="sin">
-      <h3>
-        <a>sin<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">sin <i>number</i></span>
-      </h4>
-      <p>
-        Reports the sine of the given angle. Assumes angle is given in
-        degrees.
-      </p>
-      <pre>
-show sin 270
-=&gt; -1
-</pre>
-    </div>
-    <div class="dict_entry" id="size">
-      <h3>
-        <a>size</a>
-      </h3>
-      <h4>
-        <span class="prim_example">size</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        This is a built-in turtle variable. It holds a number that is the
-        turtle's apparent size. The default size is 1, which means that
-        the turtle is the same size as a patch. You can set this variable
-        to change a turtle's size.
-      </p>
-      </div>
-    <div class="dict_entry" id="sort">
-      <h3>
-        <a>sort<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">sort <i>list</i></span>
-        <span class="prim_example">sort <i>agentset</i></span>
-      </h4>
-      <p>
-        Reports a sorted list of numbers, strings, or agents.
-      </p>
-      <p>
-        If the input contains no numbers, strings, or agents, the result is
-        the empty list.
-      </p>
-      <p>
-        If the input contains at least one number, the numbers in the list
-        are sorted in ascending order and a new list reported; non-numbers
-        are ignored.
-      </p>
-      <p>
-        Or, if the input contains at least one string, the strings in the
-        list are sorted in ascending order and a new list reported;
-        non-strings are ignored.
-      </p>
-      <p>
-        Or, if the input is an agentset or a list containing at least one
-        agent, a sorted list of agents (never an agentset) is reported;
-        non-agents are ignored. Agents are sorted in the same order the
-        &lt; operator uses. (Patches are sorted with the top left-most patch first
-        and the bottom right-most patch last, turtles are sorted by <code>who</code>
-        number).
-      </p>
-      <pre>
-show sort [3 1 4 2]
-=&gt; [1 2 3 4]
-show sort [2 1 "a"]
-=&gt; [1 2]
-show sort (list "a" "c" "b" (patch 0 0))
-=&gt; ["a" "b" "c"]
-show sort (list (patch 0 0) (patch 0 1) (patch 1 0))
-=&gt; [(patch 0 1) (patch 0 0) (patch 1 0)]
+					set-default-shape cats &quot;cat&quot;
+					set-default-shape dogs &quot;dog&quot;
+					create-cats 1   ;; new turtle's shape is &quot;cat&quot;
+					ask cats [ set breed dogs ]
+					;; all cats become dogs, and automatically
+					;; change their shape to &quot;dog&quot;
+				</pre>
+				<p>
+					See also <a href="#shape">shape</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="set-histogram-num-bars">
+				<h3>
+					<a>set-histogram-num-bars<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">set-histogram-num-bars <i>number</i></span>
+				</h4>
+				<p>
+					Set the current plot pen's plot interval so that, given the
+					current x range for the plot, there would be <i>number</i> number
+					of bars drawn if the histogram command is called.
+				</p>
+				<p>
+					See also <a href="#histogram">histogram</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="set-line-thickness">
+				<h3>
+					<a>__set-line-thickness</a>
+				</h3>
+				<h4>
+					<span class="prim_example">__set-line-thickness <i>number</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Specifies the thickness of lines and outlined elements in the
+					turtle's shape.
+				</p>
+				<p>
+					The default value is 0. This always produces lines one pixel thick.
+				</p>
+				<p>
+					Non-zero values are interpreted as thickness in patches. A
+					thickness of 1, for example, produces lines which appear one patch
+					thick. (It's common to use a smaller value such as 0.5 or 0.2.)
+				</p>
+				<p>
+					Lines are always at least one pixel thick.
+				</p>
+				<p>
+					This command is experimental and may change in later releases.
+				</p>
+			</div>
+			<div class="dict_entry" id="set-patch-size">
+				<h3>
+					<a>set-patch-size<span class="since">4.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">set-patch-size <i>size</i></span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Sets the size of the patches of the view in pixels. The size is
+					typically an integer, but may also be a floating point number.
+				</p>
+				<p>
+					See also <a href="#patch-size">patch-size</a>, <a href="#resize-world">resize-world</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="set-plot-background-color">
+				<h3>
+					<a>set-plot-background-color<span class="since">6.0.2</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">set-plot-background-color <i>color</i></span>
+				</h4>
+				<p>
+					Sets the background color of the current plot.
+					The color may be specified as a number or a list.
+					See the <a href="programming.html#colors">Colors</a> section of the programming guide for more details.
+					This change is temporary and is not saved with the model. When the
+					plot is cleared, the background color will revert to white.
+				</p>
+				<p>
+					<b>Note:</b> Plot backgrounds do not support transparency.
+					If a list is used to set the color, the alpha component will be ignored.
+				</p>
+			</div>
+			<div class="dict_entry" id="set-plot-pen-color">
+				<h3>
+					<a>set-plot-pen-color<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">set-plot-pen-color <i>color</i></span>
+				</h4>
+				<p>
+					Sets the color of the current plot pen to <i>color</i>.
+				</p>
+			</div>
+			<div class="dict_entry" id="set-plot-pen-interval">
+				<h3>
+					<a>set-plot-pen-interval<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">set-plot-pen-interval <i>number</i></span>
+				</h4>
+				<p>
+					Tells the current plot pen to move a distance of <i>number</i> in
+					the x direction during each use of the plot command. (The plot pen
+					interval also affects the behavior of the histogram command.)
+				</p>
+			</div>
+			<div class="dict_entry" id="set-plot-pen-mode">
+				<h3>
+					<a>set-plot-pen-mode<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">set-plot-pen-mode <i>number</i></span>
+				</h4>
+				<p>
+					Sets the mode the current plot pen draws in to <i>number</i>. The
+					allowed plot pen modes are:
+				</p>
+				<ul>
+					<li>0 (line mode) the plot pen draws a line connecting two points
+						together.
+					</li>
+					<li>1 (bar mode): the plot pen draws a bar of width
+						plot-pen-interval with the point plotted as the upper (or lower, if
+						you are plotting a negative number) left corner of the bar.
+					</li>
+					<li>2 (point mode): the plot pen draws a point at the point
+						plotted. Points are not connected.
+					</li>
+				</ul>
+				<p>
+					The default mode for new pens is 0 (line mode).
+				</p>
+			</div>
+			<div class="dict_entry" id="setup-plots">
+				<h3>
+					<a>setup-plots<span class="since">5.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">setup-plots</span>
+				</h4>
+				<p>
+					For each plot, runs that plot's setup commands, including the
+					setup code for any pens in the plot.
+				</p>
+				<p>
+					<a href="#reset-ticks">reset-ticks</a> has the same effect, so in
+					models that use the tick counter, this primitive is not normally
+					used.
+				</p>
+				<p>
+					See the <a href="programming.html#plotting">Plotting section</a> of
+					the Programming Guide for more details.
+				</p>
+				<p>
+					See also <a href="#update-plots">update-plots</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="set-plot--range">
+				<h3>
+					<a>set-plot-x-range<span class="since">1.0</span></a>
+					<a>set-plot-y-range<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">set-plot-x-range <i>min max</i></span>
+					<span class="prim_example">set-plot-y-range <i>min max</i></span>
+				</h4>
+				<p>
+					Sets the minimum and maximum values of the x or y axis of the
+					current plot.
+				</p>
+				<p>
+					The change is temporary and is not saved with the model. When the
+					plot is cleared, the ranges will revert to their default values as
+					set in the plot's Edit dialog.
+				</p>
+			</div>
+			<div class="dict_entry" id="setxy">
+				<h3>
+					<a>setxy<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">setxy <i>x y</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					The turtle sets its x-coordinate to <i>x</i> and its y-coordinate
+					to <i>y</i>.
+				</p>
+				<p>
+					Equivalent to <code>set xcor x set ycor y</code>, except it happens in
+					one time step instead of two.
+				</p>
+				<p>
+					If <i>x</i> or <i>y</i> is outside the world, NetLogo will throw a
+					runtime error, unless wrapping is turned on in the relevant
+					dimensions. For example, with wrapping turned on in both dimensions
+					and the default world size where <code>min-pxcor = -16</code>,
+					<code>max-pxcor = 16</code>, <code>min-pycor = -16</code> and <code>max-pycor
+						= 16</code>, asking a turtle to <code>setxy 17 17</code> will move it to
+					the center of patch (-16, -16).
+				</p>
+				<pre>
+					setxy 0 0
+					;; turtle moves to the middle of the center patch
+					setxy random-xcor random-ycor
+					;; turtle moves to a random point
+					setxy random-pxcor random-pycor
+					;; turtle moves to the center of a random patch
+				</pre>
+				<p>
+					See also <a href="#move-to">move-to</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="shade-of">
+				<h3>
+					<a>shade-of?<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">shade-of? <i>color1</i> <i>color2</i></span>
+				</h4>
+				<p>
+					Reports true if both colors are shades of one another, false
+					otherwise.
+				</p>
+				<pre>
+					show shade-of? blue red
+					=&gt; false
+					show shade-of? blue (blue + 1)
+					=&gt; true
+					show shade-of? gray white
+					=&gt; true
+				</pre>
+			</div>
+			<div class="dict_entry" id="shape">
+				<h3>
+					<a>shape</a>
+				</h3>
+				<h4>
+					<span class="prim_example">shape</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+					<img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					This is a built-in turtle and link variable. It holds a string that
+					is the name of the turtle or link's current shape. You can set
+					this variable to change the shape. New turtles and links have the
+					shape &quot;default&quot; unless the a different shape has been
+					specified using <a href="#set-default-shape">set-default-shape</a>.
+				</p>
+				<p>
+					Example:
+				</p>
+				<pre>
+					ask turtles [ set shape &quot;wolf&quot; ]
+					;; assumes you have made a &quot;wolf&quot;
+					;; shape in NetLogo's <a href="shapes.html">Turtle Shapes Editor</a>
+					ask links [ set shape &quot;link 1&quot; ]
+					;; assumes you have made a &quot;link 1&quot; shape in
+					;; the Link Shapes Editor
+				</pre>
+				<p>
+					See also <a href="#set-default-shape">set-default-shape</a>,
+					<a href="#shapes">shapes</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="shapes">
+				<h3>
+					<a>shapes<span class="since">2.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">shapes</span>
+				</h4>
+				<p>
+					Reports a list of strings containing all of the turtle shapes in
+					the model.
+				</p>
+				<p>
+					New shapes can be created, or imported from the shapes library or
+					from other models, in the <a href="shapes.html">Shapes Editor</a>.
+				</p>
+				<pre>
+					show shapes
+					=&gt; [&quot;default&quot; &quot;airplane&quot; &quot;arrow&quot; &quot;box&quot; &quot;bug&quot; ...
+					ask turtles [ set shape one-of shapes ]
+				</pre>
+			</div>
+			<div class="dict_entry" id="show">
+				<h3>
+					<a>show<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">show <i>value</i></span>
+				</h4>
+				<p>
+					Prints <i>value</i> in the Command Center, preceded by this agent,
+					and followed by a carriage return. (This agent is included to help
+					you keep track of what agents are producing which lines of output.)
+					Also, all strings have their quotes included similar to <a href="#write">write</a>.
+				</p>
+				<p>
+					See also <a href="#print">print</a>, <a href="#type">type</a>,
+					<a href="#write">write</a>, <a href="#output-cmds">output-show</a>,
+					and <a href="programming.html#output">Output (programming guide)</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="show-turtle">
+				<h3>
+					<a>show-turtle<span class="since">1.0</span></a>
+					<a>st<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">show-turtle</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					The turtle becomes visible again.
+				</p>
+				<p>
+					Note: This command is equivalent to setting the turtle variable
+					&quot;hidden?&quot; to false.
+				</p>
+				<p>
+					See also <a href="#hide-turtle">hide-turtle</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="show-link">
+				<h3>
+					<a>show-link<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">show-link</span>
+					<img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					The link becomes visible again.
+				</p>
+				<p>
+					Note: This command is equivalent to setting the link variable
+					&quot;hidden?&quot; to false.
+				</p>
+				<p>
+					See also <a href="#hide-link">hide-link</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="shuffle">
+				<h3>
+					<a>shuffle<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">shuffle <i>list</i></span>
+				</h4>
+				<p>
+					Reports a new list containing the same items as the input list, but
+					in randomized order.
+				</p>
+				<pre>
+					show shuffle [1 2 3 4 5]
+					=&gt; [5 2 4 1 3]
+					show shuffle [1 2 3 4 5]
+					=&gt; [1 3 5 2 4]
+				</pre>
+			</div>
+			<div class="dict_entry" id="sin">
+				<h3>
+					<a>sin<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">sin <i>number</i></span>
+				</h4>
+				<p>
+					Reports the sine of the given angle. Assumes angle is given in
+					degrees.
+				</p>
+				<pre>
+					show sin 270
+					=&gt; -1
+				</pre>
+			</div>
+			<div class="dict_entry" id="size">
+				<h3>
+					<a>size</a>
+				</h3>
+				<h4>
+					<span class="prim_example">size</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					This is a built-in turtle variable. It holds a number that is the
+					turtle's apparent size. The default size is 1, which means that
+					the turtle is the same size as a patch. You can set this variable
+					to change a turtle's size.
+				</p>
+			</div>
+			<div class="dict_entry" id="sort">
+				<h3>
+					<a>sort<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">sort <i>list</i></span>
+					<span class="prim_example">sort <i>agentset</i></span>
+				</h4>
+				<p>
+					Reports a sorted list of numbers, strings, or agents.
+				</p>
+				<p>
+					If the input contains no numbers, strings, or agents, the result is
+					the empty list.
+				</p>
+				<p>
+					If the input contains at least one number, the numbers in the list
+					are sorted in ascending order and a new list reported; non-numbers
+					are ignored.
+				</p>
+				<p>
+					Or, if the input contains at least one string, the strings in the
+					list are sorted in ascending order and a new list reported;
+					non-strings are ignored.
+				</p>
+				<p>
+					Or, if the input is an agentset or a list containing at least one
+					agent, a sorted list of agents (never an agentset) is reported;
+					non-agents are ignored. Agents are sorted in the same order the
+					&lt; operator uses. (Patches are sorted with the top left-most patch first
+					and the bottom right-most patch last, turtles are sorted by <code>who</code>
+					number).
+				</p>
+				<pre>
+					show sort [3 1 4 2]
+					=&gt; [1 2 3 4]
+					show sort [2 1 "a"]
+					=&gt; [1 2]
+					show sort (list "a" "c" "b" (patch 0 0))
+					=&gt; ["a" "b" "c"]
+					show sort (list (patch 0 0) (patch 0 1) (patch 1 0))
+					=&gt; [(patch 0 1) (patch 0 0) (patch 1 0)]
 
-;; label patches with numbers in left-to-right, top-to-bottom order
-let n 0
-foreach sort patches [ the-patch -&gt;
-  ask the-patch [
-    set plabel n
-    set n n + 1
-  ]
-]
+					;; label patches with numbers in left-to-right, top-to-bottom order
+					let n 0
+					foreach sort patches [ the-patch -&gt;
+					ask the-patch [
+					set plabel n
+					set n n + 1
+					]
+					]
 
-;; some additional examples to clarify behavior in strange cases
-show sort (list patch 0 0 patch 0 1 patch 1 0 turtle 0 turtle 1) ; turtles are always sorted lower than patches
-=&gt; [(turtle 0) (turtle 1) (patch 0 1) (patch 0 0) (patch 1 0)]
-show sort (list nobody false true) ; booleans and nobody cannot be sorted
-=&gt; []
-show sort (list [1 2 3] turtles) ; lists and agentsets are not included if they are inside a list passed to sort
-=&gt; []
-</pre>
-      <p>
-        See also <a href="#sort-by">sort-by</a>, <a href="#sort-on">sort-on</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="sort-by">
-      <h3>
-        <a>sort-by<span class="since">1.3</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">sort-by <i>reporter</i> <i>list</i></span>
-        <span class="prim_example">sort-by <i>reporter</i> <i>agentset</i></span>
-      </h4>
-      <p>
-        If the input is a list, reports a new list containing the same
-        items as the input list, in a sorted order defined by the boolean
-        reporter. <i>reporter</i> may be an anonymous reporter or
-        the name of a reporter.
-      </p>
-      <p>
-      The two inputs to <i>reporter</i> are the values being compared.
-        The reporter should report true if the first argument comes strictly before
-        the second in the desired sort order, and false otherwise.
-      </p>
-      <p>
-        If the input is an agentset or a list of agents, reports a list
-        (never an agentset) of agents.
-      </p>
-      <p>
-        If the input is a list, the sort is stable, that is, the order of
-        items considered equal by the reporter is not disturbed. If the
-        input is an agentset, ties are broken randomly.
-      </p>
-      <pre>
-show sort-by &lt; [3 1 4 2]
-=&gt; [1 2 3 4]
-show sort-by &gt; [3 1 4 2]
-=&gt; [4 3 2 1]
-show sort-by [ [string1 string2] -&gt; length string1 &lt; length string2 ] [&quot;Grumpy&quot; &quot;Doc&quot; &quot;Happy&quot;]
-=&gt; [&quot;Doc&quot; &quot;Happy&quot; &quot;Grumpy&quot;]
-</pre>
-      <p>
-      See also <a href="#sort">sort</a>, <a href="#sort-on">sort-on</a>, <a href="#arrow">-> (anonymous procedure)</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="sort-on">
-      <h3>
-        <a>sort-on<span class="since">5.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">sort-on [<i>reporter</i>] <i>agentset</i></span>
-      </h4>
-      <p>
-        Reports a list of agents, sorted according to each agent's
-        value for <i>reporter</i>. Ties are broken randomly.
-      </p>
-      <p>
-        The values must be all numbers, all strings, or all agents of the
-        same type.
-      </p>
-      <pre>
-crt 3
-show sort-on [who] turtles
-=&gt; [(turtle 0) (turtle 1) (turtle 2)]
-show sort-on [(- who)] turtles
-=&gt; [(turtle 2) (turtle 1) (turtle 0)]
-foreach sort-on [size] turtles
-  [ the-turtle -&gt; ask the-turtle [ do-something ] ]
-;; turtles run &quot;do-something&quot; one at a time, in
-;; ascending order by size
-</pre>
-      <p>
-        See also <a href="#sort">sort</a>, <a href="#sort-by">sort-by</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="sprout">
-      <h3>
-        <a>sprout<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">sprout <i>number</i> [ <i>commands</i> ]</span>
-        <span class="prim_example">sprout-<i>&lt;breeds&gt;</i> <i>number</i> [ <i>commands</i> ]</span>
-        <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        Creates <i>number</i> new turtles on the current patch. The new
-        turtles have random integer headings and the color is randomly
-        selected from the 14 primary colors. The turtles immediately run
-        <i>commands</i>. This is useful for giving the new turtles
-        different colors, headings, or whatever. (The new turtles are
-        created all at once then run one at a time, in random order.)
-      </p>
-      <p>
-        If the sprout-<i>&lt;breeds&gt;</i> form is used, the new turtles
-        are created as members of the given breed.
-      </p>
-      <pre>
-sprout 5
-sprout-wolves 10
-sprout 1 [ set color red ]
-sprout-sheep 1 [ set color black ]
-</pre>
-      <p>
-        See also <a href="#create-turtles">create-turtles</a>, <a href="#hatch">hatch</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="sqrt">
-      <h3>
-        <a>sqrt<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">sqrt <i>number</i></span>
-      </h4>
-      <p>
-        Reports the square root of <i>number</i>.
-      </p>
-      </div>
-    <div class="dict_entry" id="stamp">
-      <h3>
-        <a>stamp<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">stamp</span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        This turtle or link leaves an image of its shape in the drawing at
-        its current location.
-      </p>
-      <p>
-        Note: The shapes made by stamp may not be pixel-for-pixel identical
-        from computer to computer.
-      </p>
-      </div>
-    <div class="dict_entry" id="stamp-erase">
-      <h3>
-        <a>stamp-erase<span class="since">3.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">stamp-erase</span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        This turtle or link removes any pixels below it in the drawing
-        inside the bounds of its shape.
-      </p>
-      <p>
-        Note: The shapes made by stamp-erase may not be pixel-for-pixel
-        identical from computer to computer.
-      </p>
-      </div>
-    <div class="dict_entry" id="standard-deviation">
-      <h3>
-        <a>standard-deviation<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">standard-deviation <i>list</i></span>
-      </h4>
-      <p>
-        Reports the sample standard deviation of a <i>list</i> of numbers.
-        Ignores other types of items.
-      </p>
-      <p>
-        (Note that this estimates the standard deviation for a
-        <i>sample</i>, rather than for a whole <i>population</i>, using
-        Bessel's correction.)
-      </p>
-      <pre>
-show standard-deviation [1 2 3 4 5 6]
-=&gt; 1.8708286933869707
-show standard-deviation [energy] of turtles
-;; prints the standard deviation of the variable &quot;energy&quot;
-;; from all the turtles
-</pre>
-    </div>
-    <div class="dict_entry" id="startup">
-      <h3>
-        <a>startup</a>
-      </h3>
-      <h4>
-        <span class="prim_example">startup</span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        User-defined procedure which, if it exists, will be called when a
-        model is first loaded in the NetLogo application.
-      </p>
-      <pre>
-to startup
-  setup
-end
-</pre>
-      <p>
-        <code>startup</code> does not run when a model is run headless from the
-        command line, or by parallel BehaviorSpace.
-      </p>
-      </div>
-    <div class="dict_entry" id="stop">
-      <h3>
-        <a>stop<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">stop</span>
-      </h4>
-      <p>
-        This agent exits immediately from the enclosing procedure, ask, or
-        ask-like construct (e.g. crt, hatch, sprout). Only the enclosing
-        procedure or construct stops, not all execution for the agent.
-      </p>
-      <pre>
-if not any? turtles [ stop ]
-;; exits if there are no more turtles
-</pre>
-      <p>
-        Note: <code>stop</code> can also be used to stop a forever button. See
-        <a href="programming.html#buttons">Buttons</a> in the
-        Programming Guide for details.
-      </p>
-      <p>
-        <code>stop</code> can also be used to stop a BehaviorSpace model run. If the go
-        commands directly call a procedure, then when that procedure calls <i>stop</i>,
-        the run ends.
-      </p>
-      </div>
-    <div class="dict_entry" id="stop-inspecting">
-      <h3>
-        <a>stop-inspecting<span class="since">5.2</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">stop-inspecting <i>agent</i></span>
-      </h4>
-      <p>
-        Closes the agent monitor for the given agent (turtle or patch).
-        In the case that no agent monitor is open, <code>stop-inspecting</code> does
-        nothing.
-      </p>
-      <pre>
-stop-inspecting patch 2 4
-;; the agent monitor for that patch closes
-ask sheep [ stop-inspecting self ]
-;; close all agent monitors for sheep
-</pre>
-      <p>
-        See <a href="#inspect">inspect</a> and <a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>.
-      </p>
-    </div>
-    <div class="dict_entry" id="stop-inspecting-dead-agents">
-      <h3>
-        <a>stop-inspecting-dead-agents<span class="since">5.2</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">stop-inspecting-dead-agents</span>
-      </h4>
-      <p>
-        Closes all agent monitors for dead agents.
-        See <a href="#inspect">inspect</a> and <a href="#stop-inspecting">stop-inspecting</a>.
-      </p>
-    </div>
-    <div class="dict_entry" id="subject">
-      <h3>
-        <a>subject<span class="since">3.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">subject</span>
-      </h4>
-      <p>
-        Reports the turtle (or patch) that the observer is currently
-        watching, following, or riding. Reports <a href="#nobody">nobody</a> if there is no such turtle (or patch).
-      </p>
-      <p>
-        See also <a href="#watch">watch</a>, <a href="#follow">follow</a>,
-        <a href="#ride">ride</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="subliststring">
-      <h3>
-        <a>sublist<span class="since">2.1</span></a>
-        <a>substring<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">sublist <i>list position1 position2</i></span>
-        <span class="prim_example">substring <i>string position1 position2</i></span>
-      </h4>
-      <p>
-        Reports just a section of the given list or string, ranging between
-        the first position (inclusive) and the second position (exclusive).
-      </p>
-      <p>
-        Note: The positions are numbered beginning with 0, not with 1.
-      </p>
-      <pre>
-show sublist [99 88 77 66] 1 3
-=&gt; [88 77]
-show substring &quot;apartment&quot; 1 5
-=&gt; &quot;part&quot;
-</pre>
-    </div>
-    <div class="dict_entry" id="subtract-headings">
-      <h3>
-        <a>subtract-headings<span class="since">2.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">subtract-headings <i>heading1 heading2</i></span>
-      </h4>
-      <p>
-        Computes the difference between the given headings, that is, the
-        number of degrees in the smallest angle by which heading2 could be
-        rotated to produce heading1. A positive answer means a clockwise
-        rotation, a negative answer counterclockwise. The result is always
-        in the range -180 to 180, but is never exactly -180.
-      </p>
-      <p>
-        Note that simply subtracting the two headings using the - (minus)
-        operator wouldn't work. Just subtracting corresponds to always
-        rotating clockwise from heading2 to heading1; but sometimes the
-        counterclockwise rotation is shorter. For example, the difference
-        between 5 degrees and 355 degrees is 10 degrees, not -350 degrees.
-      </p>
-      <pre>
-show subtract-headings 80 60
-=&gt; 20
-show subtract-headings 60 80
-=&gt; -20
-show subtract-headings 5 355
-=&gt; 10
-show subtract-headings 355 5
-=&gt; -10
-show subtract-headings 180 0
-=&gt; 180
-show subtract-headings 0 180
-=&gt; 180
-</pre>
-    </div>
-    <div class="dict_entry" id="sum">
-      <h3>
-        <a>sum<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">sum <i>list</i></span>
-      </h4>
-      <p>
-        Reports the sum of the items in the list.
-      </p>
-      <pre>
-show sum [energy] of turtles
-;; prints the total of the variable &quot;energy&quot;
-;; from all the turtles
-</pre>
-    </div><!-- ======================================== -->
-  </div>
-    <h2 id="T">
-      <a>T</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="tan">
-      <h3>
-        <a>tan<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">tan <i>number</i></span>
-      </h4>
-      <p>
-        Reports the tangent of the given angle. Assumes the angle is given
-        in degrees.
-      </p>
-      </div>
-    <div class="dict_entry" id="thickness">
-      <h3>
-        <a>thickness</a>
-      </h3>
-      <h4>
-        <span class="prim_example">thickness</span>
-        <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        This is a built-in link variable. It holds a number that is the
-        link's apparent size as a fraction of the patch size. The
-        default thickness is 0, which means that regardless of patch-size
-        the links will always appear 1 pixel wide. You can set this
-        variable to change a link's thickness.
-      </p>
-      </div>
-    <div class="dict_entry" id="tick">
-      <h3>
-        <a>tick<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">tick</span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Advances the tick counter by one and updates all plots.
-      </p>
-      <p>
-        If the tick counter has not been started yet with
-        <code>reset-ticks</code>, an error results.
-      </p>
-      <p>
-        Normally <code>tick</code> goes at the end of a go procedure.
-      </p>
-      <p>
-        See also <a href="#ticks">ticks</a>, <a href="#tick-advance">tick-advance</a>, <a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>, <a href="#update-plots">update-plots</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="tick-advance">
-      <h3>
-        <a>tick-advance<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">tick-advance <i>number</i></span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Advances the tick counter by <i>number</i>. The input may be an
-        integer or a floating point number. (Some models divide ticks more
-        finely than by ones.) The input may not be negative.
-      </p>
-      <p>
-        When using <a href="programming.html#view-updates">tick-based view
-        updates</a>, the view is normally updated every 1.0 ticks, so using
-        <code>tick-advance</code> with a number less then 1.0 may not always
-        trigger an update. If you want to make sure that the view is
-        updated, you can use the <code>display</code> command.
-      </p>
-      <p>
-        If the tick counter has not been started yet with
-        <code>reset-ticks</code>, an error results.
-      </p>
-      <p>
-        Does not update plots.
-      </p>
-      <p>
-        See also <a href="#tick">tick</a>, <a href="#ticks">ticks</a>,
-        <a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="ticks">
-      <h3>
-        <a>ticks<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">ticks</span>
-      </h4>
-      <p>
-        Reports the current value of the tick counter. The result is always
-        a number and never negative.
-      </p>
-      <p>
-        If the tick counter has not been started yet with
-        <code>reset-ticks</code>, an error results.
-      </p>
-      <p>
-        Most models use the <code>tick</code> command to advance the tick
-        counter, in which case <code>ticks</code> will always report an
-        integer. If the <code>tick-advance</code> command is used, then
-        <code>ticks</code> may report a floating point number.
-      </p>
-      <p>
-        See also <a href="#tick">tick</a>, <a href="#tick-advance">tick-advance</a>, <a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="tie">
-      <h3>
-        <a>tie<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">tie</span>
-        <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        Ties <i>end1</i> and <i>end2</i> of the link together. If the link
-        is a directed link <i>end1</i> is the <i>root turtle</i> and
-        <i>end2</i> is the <i>leaf turtle</i>. The movement of the <i>root
-        turtle</i> affects the location and heading of the <i>leaf
-        turtle</i>. If the link is undirected the tie is reciprocal so both
-        turtles can be considered <i>root turtles</i> and <i>leaf
-        turtles</i>. Movement or change in heading of either turtle affects
-        the location and heading of the other turtle.
-      </p>
-      <p>
-        When the root turtle moves, the leaf turtles moves the same
-        distance, in the same direction. The heading of the leaf turtle is
-        not affected. This works with forward, jump, and setting the xcor
-        or ycor of the root turtle.
-      </p>
-      <p>
-        When the root turtle turns right or left, the leaf turtle is
-        rotated around the root turtle the same amount. The heading of the
-        leaf turtle is also changed by the same amount.
-      </p>
-      <p>
-        If the link dies, the tie relation is removed.
-      </p>
-      <pre>
-      crt 2 [ fd 3 ]
-      ;; creates a link and ties turtle 1 to turtle 0
-      ask turtle 0 [ create-link-to turtle 1 [ tie ] ]
-</pre>
-      <p>
-        See also <a href="#untie">untie</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="tie-mode">
-      <h3>
-        <a>tie-mode</a>
-      </h3>
-      <h4>
-        <span class="prim_example">tie-mode</span>
-        <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        This is a built-in link variable. It holds a string that is the
-        name of the tie mode the link is currently in. Using the <a href="#tie">tie</a> and <a href="#untie">untie</a> commands changes the
-        mode of the link. You can also set tie-mode to &quot;free&quot; to
-        create a non-rigid joint between two turtles (see the <a href="programming.html#tie">Tie section</a> of the Programming Guide for
-        details). By default links are not tied.
-      </p>
-      <p>
-        See also: <a href="#tie">tie</a>, <a href="#untie">untie</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="timer">
-      <h3>
-        <a>timer<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">timer</span>
-      </h4>
-      <p>
-        Reports how many seconds have passed since the command <a href="#reset-timer">reset-timer</a> was last run (or since NetLogo
-        started). The potential resolution of the clock is milliseconds.
-        (Whether you get resolution that high in practice may vary from
-        system to system, depending on the capabilities of the underlying
-        Java Virtual Machine.)
-      </p>
-      <p>
-        See also <a href="#reset-timer">reset-timer</a>.
-      </p>
-      <p>
-        Note that the timer is different from the tick counter. The timer
-        measures elapsed real time in seconds; the tick counter measures
-        elapsed model time in ticks.
-      </p>
-      </div>
-    <div class="dict_entry" id="to">
-      <h3>
-        <a>to</a>
-      </h3>
-      <h4>
-        <span class="prim_example">to <i>procedure-name</i></span>
-        <span class="prim_example">to <i>procedure-name</i> [<i>input1</i> ...]</span>
-      </h4>
-      <p>
-        Used to begin a command procedure.
-      </p>
-      <pre>
-to setup
-  clear-all
-  crt 500
-end
+					;; some additional examples to clarify behavior in strange cases
+					show sort (list patch 0 0 patch 0 1 patch 1 0 turtle 0 turtle 1) ; turtles are always sorted lower than patches
+					=&gt; [(turtle 0) (turtle 1) (patch 0 1) (patch 0 0) (patch 1 0)]
+					show sort (list nobody false true) ; booleans and nobody cannot be sorted
+					=&gt; []
+					show sort (list [1 2 3] turtles) ; lists and agentsets are not included if they are inside a list passed to sort
+					=&gt; []
+				</pre>
+				<p>
+					See also <a href="#sort-by">sort-by</a>, <a href="#sort-on">sort-on</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="sort-by">
+				<h3>
+					<a>sort-by<span class="since">1.3</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">sort-by <i>reporter</i> <i>list</i></span>
+					<span class="prim_example">sort-by <i>reporter</i> <i>agentset</i></span>
+				</h4>
+				<p>
+					If the input is a list, reports a new list containing the same
+					items as the input list, in a sorted order defined by the boolean
+					reporter. <i>reporter</i> may be an anonymous reporter or
+					the name of a reporter.
+				</p>
+				<p>
+					The two inputs to <i>reporter</i> are the values being compared.
+					The reporter should report true if the first argument comes strictly before
+					the second in the desired sort order, and false otherwise.
+				</p>
+				<p>
+					If the input is an agentset or a list of agents, reports a list
+					(never an agentset) of agents.
+				</p>
+				<p>
+					If the input is a list, the sort is stable, that is, the order of
+					items considered equal by the reporter is not disturbed. If the
+					input is an agentset, ties are broken randomly.
+				</p>
+				<pre>
+					show sort-by &lt; [3 1 4 2]
+					=&gt; [1 2 3 4]
+					show sort-by &gt; [3 1 4 2]
+					=&gt; [4 3 2 1]
+					show sort-by [ [string1 string2] -&gt; length string1 &lt; length string2 ] [&quot;Grumpy&quot; &quot;Doc&quot; &quot;Happy&quot;]
+					=&gt; [&quot;Doc&quot; &quot;Happy&quot; &quot;Grumpy&quot;]
+				</pre>
+				<p>
+					See also <a href="#sort">sort</a>, <a href="#sort-on">sort-on</a>, <a href="#arrow">-> (anonymous procedure)</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="sort-on">
+				<h3>
+					<a>sort-on<span class="since">5.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">sort-on [<i>reporter</i>] <i>agentset</i></span>
+				</h4>
+				<p>
+					Reports a list of agents, sorted according to each agent's
+					value for <i>reporter</i>. Ties are broken randomly.
+				</p>
+				<p>
+					The values must be all numbers, all strings, or all agents of the
+					same type.
+				</p>
+				<pre>
+					crt 3
+					show sort-on [who] turtles
+					=&gt; [(turtle 0) (turtle 1) (turtle 2)]
+					show sort-on [(- who)] turtles
+					=&gt; [(turtle 2) (turtle 1) (turtle 0)]
+					foreach sort-on [size] turtles
+					[ the-turtle -&gt; ask the-turtle [ do-something ] ]
+					;; turtles run &quot;do-something&quot; one at a time, in
+					;; ascending order by size
+				</pre>
+				<p>
+					See also <a href="#sort">sort</a>, <a href="#sort-by">sort-by</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="sprout">
+				<h3>
+					<a>sprout<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">sprout <i>number</i> [ <i>commands</i> ]</span>
+					<span class="prim_example">sprout-<i>&lt;breeds&gt;</i> <i>number</i> [ <i>commands</i> ]</span>
+					<img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					Creates <i>number</i> new turtles on the current patch. The new
+					turtles have random integer headings and the color is randomly
+					selected from the 14 primary colors. The turtles immediately run
+					<i>commands</i>. This is useful for giving the new turtles
+					different colors, headings, or whatever. (The new turtles are
+					created all at once then run one at a time, in random order.)
+				</p>
+				<p>
+					If the sprout-<i>&lt;breeds&gt;</i> form is used, the new turtles
+					are created as members of the given breed.
+				</p>
+				<pre>
+					sprout 5
+					sprout-wolves 10
+					sprout 1 [ set color red ]
+					sprout-sheep 1 [ set color black ]
+				</pre>
+				<p>
+					See also <a href="#create-turtles">create-turtles</a>, <a href="#hatch">hatch</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="sqrt">
+				<h3>
+					<a>sqrt<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">sqrt <i>number</i></span>
+				</h4>
+				<p>
+					Reports the square root of <i>number</i>.
+				</p>
+			</div>
+			<div class="dict_entry" id="stamp">
+				<h3>
+					<a>stamp<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">stamp</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					This turtle or link leaves an image of its shape in the drawing at
+					its current location.
+				</p>
+				<p>
+					Note: The shapes made by stamp may not be pixel-for-pixel identical
+					from computer to computer.
+				</p>
+			</div>
+			<div class="dict_entry" id="stamp-erase">
+				<h3>
+					<a>stamp-erase<span class="since">3.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">stamp-erase</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					This turtle or link removes any pixels below it in the drawing
+					inside the bounds of its shape.
+				</p>
+				<p>
+					Note: The shapes made by stamp-erase may not be pixel-for-pixel
+					identical from computer to computer.
+				</p>
+			</div>
+			<div class="dict_entry" id="standard-deviation">
+				<h3>
+					<a>standard-deviation<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">standard-deviation <i>list</i></span>
+				</h4>
+				<p>
+					Reports the sample standard deviation of a <i>list</i> of numbers.
+					Ignores other types of items.
+				</p>
+				<p>
+					(Note that this estimates the standard deviation for a
+					<i>sample</i>, rather than for a whole <i>population</i>, using
+					Bessel's correction.)
+				</p>
+				<pre>
+					show standard-deviation [1 2 3 4 5 6]
+					=&gt; 1.8708286933869707
+					show standard-deviation [energy] of turtles
+					;; prints the standard deviation of the variable &quot;energy&quot;
+					;; from all the turtles
+				</pre>
+			</div>
+			<div class="dict_entry" id="startup">
+				<h3>
+					<a>startup</a>
+				</h3>
+				<h4>
+					<span class="prim_example">startup</span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					User-defined procedure which, if it exists, will be called when a
+					model is first loaded in the NetLogo application.
+				</p>
+				<pre>
+					to startup
+					setup
+					end
+				</pre>
+				<p>
+					<code>startup</code> does not run when a model is run headless from the
+					command line, or by parallel BehaviorSpace.
+				</p>
+			</div>
+			<div class="dict_entry" id="stop">
+				<h3>
+					<a>stop<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">stop</span>
+				</h4>
+				<p>
+					This agent exits immediately from the enclosing procedure, ask, or
+					ask-like construct (e.g. crt, hatch, sprout). Only the enclosing
+					procedure or construct stops, not all execution for the agent.
+				</p>
+				<pre>
+					if not any? turtles [ stop ]
+					;; exits if there are no more turtles
+				</pre>
+				<p>
+					Note: <code>stop</code> can also be used to stop a forever button. See
+					<a href="programming.html#buttons">Buttons</a> in the
+					Programming Guide for details.
+				</p>
+				<p>
+					<code>stop</code> can also be used to stop a BehaviorSpace model run. If the go
+					commands directly call a procedure, then when that procedure calls <i>stop</i>,
+					the run ends.
+				</p>
+			</div>
+			<div class="dict_entry" id="stop-inspecting">
+				<h3>
+					<a>stop-inspecting<span class="since">5.2</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">stop-inspecting <i>agent</i></span>
+				</h4>
+				<p>
+					Closes the agent monitor for the given agent (turtle or patch).
+					In the case that no agent monitor is open, <code>stop-inspecting</code> does
+					nothing.
+				</p>
+				<pre>
+					stop-inspecting patch 2 4
+					;; the agent monitor for that patch closes
+					ask sheep [ stop-inspecting self ]
+					;; close all agent monitors for sheep
+				</pre>
+				<p>
+					See <a href="#inspect">inspect</a> and <a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="stop-inspecting-dead-agents">
+				<h3>
+					<a>stop-inspecting-dead-agents<span class="since">5.2</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">stop-inspecting-dead-agents</span>
+				</h4>
+				<p>
+					Closes all agent monitors for dead agents.
+					See <a href="#inspect">inspect</a> and <a href="#stop-inspecting">stop-inspecting</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="subject">
+				<h3>
+					<a>subject<span class="since">3.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">subject</span>
+				</h4>
+				<p>
+					Reports the turtle (or patch) that the observer is currently
+					watching, following, or riding. Reports <a href="#nobody">nobody</a> if there is no such turtle (or patch).
+				</p>
+				<p>
+					See also <a href="#watch">watch</a>, <a href="#follow">follow</a>,
+					<a href="#ride">ride</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="subliststring">
+				<h3>
+					<a>sublist<span class="since">2.1</span></a>
+					<a>substring<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">sublist <i>list position1 position2</i></span>
+					<span class="prim_example">substring <i>string position1 position2</i></span>
+				</h4>
+				<p>
+					Reports just a section of the given list or string, ranging between
+					the first position (inclusive) and the second position (exclusive).
+				</p>
+				<p>
+					Note: The positions are numbered beginning with 0, not with 1.
+				</p>
+				<pre>
+					show sublist [99 88 77 66] 1 3
+					=&gt; [88 77]
+					show substring &quot;apartment&quot; 1 5
+					=&gt; &quot;part&quot;
+				</pre>
+			</div>
+			<div class="dict_entry" id="subtract-headings">
+				<h3>
+					<a>subtract-headings<span class="since">2.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">subtract-headings <i>heading1 heading2</i></span>
+				</h4>
+				<p>
+					Computes the difference between the given headings, that is, the
+					number of degrees in the smallest angle by which heading2 could be
+					rotated to produce heading1. A positive answer means a clockwise
+					rotation, a negative answer counterclockwise. The result is always
+					in the range -180 to 180, but is never exactly -180.
+				</p>
+				<p>
+					Note that simply subtracting the two headings using the - (minus)
+					operator wouldn't work. Just subtracting corresponds to always
+					rotating clockwise from heading2 to heading1; but sometimes the
+					counterclockwise rotation is shorter. For example, the difference
+					between 5 degrees and 355 degrees is 10 degrees, not -350 degrees.
+				</p>
+				<pre>
+					show subtract-headings 80 60
+					=&gt; 20
+					show subtract-headings 60 80
+					=&gt; -20
+					show subtract-headings 5 355
+					=&gt; 10
+					show subtract-headings 355 5
+					=&gt; -10
+					show subtract-headings 180 0
+					=&gt; 180
+					show subtract-headings 0 180
+					=&gt; 180
+				</pre>
+			</div>
+			<div class="dict_entry" id="sum">
+				<h3>
+					<a>sum<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">sum <i>list</i></span>
+				</h4>
+				<p>
+					Reports the sum of the items in the list.
+				</p>
+				<pre>
+					show sum [energy] of turtles
+					;; prints the total of the variable &quot;energy&quot;
+					;; from all the turtles
+				</pre>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="T">
+			<a>T</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="tan">
+				<h3>
+					<a>tan<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">tan <i>number</i></span>
+				</h4>
+				<p>
+					Reports the tangent of the given angle. Assumes the angle is given
+					in degrees.
+				</p>
+			</div>
+			<div class="dict_entry" id="thickness">
+				<h3>
+					<a>thickness</a>
+				</h3>
+				<h4>
+					<span class="prim_example">thickness</span>
+					<img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					This is a built-in link variable. It holds a number that is the
+					link's apparent size as a fraction of the patch size. The
+					default thickness is 0, which means that regardless of patch-size
+					the links will always appear 1 pixel wide. You can set this
+					variable to change a link's thickness.
+				</p>
+			</div>
+			<div class="dict_entry" id="tick">
+				<h3>
+					<a>tick<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">tick</span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Advances the tick counter by one and updates all plots.
+				</p>
+				<p>
+					If the tick counter has not been started yet with
+					<code>reset-ticks</code>, an error results.
+				</p>
+				<p>
+					Normally <code>tick</code> goes at the end of a go procedure.
+				</p>
+				<p>
+					See also <a href="#ticks">ticks</a>, <a href="#tick-advance">tick-advance</a>, <a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>, <a href="#update-plots">update-plots</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="tick-advance">
+				<h3>
+					<a>tick-advance<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">tick-advance <i>number</i></span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Advances the tick counter by <i>number</i>. The input may be an
+					integer or a floating point number. (Some models divide ticks more
+					finely than by ones.) The input may not be negative.
+				</p>
+				<p>
+					When using <a href="programming.html#view-updates">tick-based view
+						updates</a>, the view is normally updated every 1.0 ticks, so using
+					<code>tick-advance</code> with a number less then 1.0 may not always
+					trigger an update. If you want to make sure that the view is
+					updated, you can use the <code>display</code> command.
+				</p>
+				<p>
+					If the tick counter has not been started yet with
+					<code>reset-ticks</code>, an error results.
+				</p>
+				<p>
+					Does not update plots.
+				</p>
+				<p>
+					See also <a href="#tick">tick</a>, <a href="#ticks">ticks</a>,
+					<a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="ticks">
+				<h3>
+					<a>ticks<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">ticks</span>
+				</h4>
+				<p>
+					Reports the current value of the tick counter. The result is always
+					a number and never negative.
+				</p>
+				<p>
+					If the tick counter has not been started yet with
+					<code>reset-ticks</code>, an error results.
+				</p>
+				<p>
+					Most models use the <code>tick</code> command to advance the tick
+					counter, in which case <code>ticks</code> will always report an
+					integer. If the <code>tick-advance</code> command is used, then
+					<code>ticks</code> may report a floating point number.
+				</p>
+				<p>
+					See also <a href="#tick">tick</a>, <a href="#tick-advance">tick-advance</a>, <a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="tie">
+				<h3>
+					<a>tie<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">tie</span>
+					<img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					Ties <i>end1</i> and <i>end2</i> of the link together. If the link
+					is a directed link <i>end1</i> is the <i>root turtle</i> and
+					<i>end2</i> is the <i>leaf turtle</i>. The movement of the <i>root
+						turtle</i> affects the location and heading of the <i>leaf
+						turtle</i>. If the link is undirected the tie is reciprocal so both
+					turtles can be considered <i>root turtles</i> and <i>leaf
+						turtles</i>. Movement or change in heading of either turtle affects
+					the location and heading of the other turtle.
+				</p>
+				<p>
+					When the root turtle moves, the leaf turtles moves the same
+					distance, in the same direction. The heading of the leaf turtle is
+					not affected. This works with forward, jump, and setting the xcor
+					or ycor of the root turtle.
+				</p>
+				<p>
+					When the root turtle turns right or left, the leaf turtle is
+					rotated around the root turtle the same amount. The heading of the
+					leaf turtle is also changed by the same amount.
+				</p>
+				<p>
+					If the link dies, the tie relation is removed.
+				</p>
+				<pre>
+					crt 2 [ fd 3 ]
+					;; creates a link and ties turtle 1 to turtle 0
+					ask turtle 0 [ create-link-to turtle 1 [ tie ] ]
+				</pre>
+				<p>
+					See also <a href="#untie">untie</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="tie-mode">
+				<h3>
+					<a>tie-mode</a>
+				</h3>
+				<h4>
+					<span class="prim_example">tie-mode</span>
+					<img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					This is a built-in link variable. It holds a string that is the
+					name of the tie mode the link is currently in. Using the <a href="#tie">tie</a> and <a href="#untie">untie</a> commands changes the
+					mode of the link. You can also set tie-mode to &quot;free&quot; to
+					create a non-rigid joint between two turtles (see the <a href="programming.html#tie">Tie section</a> of the Programming Guide for
+					details). By default links are not tied.
+				</p>
+				<p>
+					See also: <a href="#tie">tie</a>, <a href="#untie">untie</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="timer">
+				<h3>
+					<a>timer<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">timer</span>
+				</h4>
+				<p>
+					Reports how many seconds have passed since the command <a href="#reset-timer">reset-timer</a> was last run (or since NetLogo
+					started). The potential resolution of the clock is milliseconds.
+					(Whether you get resolution that high in practice may vary from
+					system to system, depending on the capabilities of the underlying
+					Java Virtual Machine.)
+				</p>
+				<p>
+					See also <a href="#reset-timer">reset-timer</a>.
+				</p>
+				<p>
+					Note that the timer is different from the tick counter. The timer
+					measures elapsed real time in seconds; the tick counter measures
+					elapsed model time in ticks.
+				</p>
+			</div>
+			<div class="dict_entry" id="to">
+				<h3>
+					<a>to</a>
+				</h3>
+				<h4>
+					<span class="prim_example">to <i>procedure-name</i></span>
+					<span class="prim_example">to <i>procedure-name</i> [<i>input1</i> ...]</span>
+				</h4>
+				<p>
+					Used to begin a command procedure.
+				</p>
+				<pre>
+					to setup
+					clear-all
+					crt 500
+					end
 
-to circle [radius]
-  crt 100 [ fd radius ]
-end
-</pre>
-    </div>
-    <div class="dict_entry" id="to-report">
-      <h3>
-        <a>to-report</a>
-      </h3>
-      <h4>
-        <span class="prim_example">to-report <i>procedure-name</i></span>
-        <span class="prim_example">to-report <i>procedure-name</i> [<i>input1</i> ...]</span>
-      </h4>
-      <p>
-        Used to begin a reporter procedure.
-      </p>
-      <p>
-        The body of the procedure should use <code>report</code> to report a
-        value for the procedure. See <a href="#report">report</a>.
-      </p>
-      <pre>
-to-report average [a b]
-  report (a + b) / 2
-end
+					to circle [radius]
+					crt 100 [ fd radius ]
+					end
+				</pre>
+			</div>
+			<div class="dict_entry" id="to-report">
+				<h3>
+					<a>to-report</a>
+				</h3>
+				<h4>
+					<span class="prim_example">to-report <i>procedure-name</i></span>
+					<span class="prim_example">to-report <i>procedure-name</i> [<i>input1</i> ...]</span>
+				</h4>
+				<p>
+					Used to begin a reporter procedure.
+				</p>
+				<p>
+					The body of the procedure should use <code>report</code> to report a
+					value for the procedure. See <a href="#report">report</a>.
+				</p>
+				<pre>
+					to-report average [a b]
+					report (a + b) / 2
+					end
 
-to-report absolute-value [number]
-  ifelse number &gt;= 0
-    [ report number ]
-    [ report (- number) ]
-end
+					to-report absolute-value [number]
+					ifelse number &gt;= 0
+					[ report number ]
+					[ report (- number) ]
+					end
 
-to-report first-turtle?
-  report who = 0  ;; reports true or false
-end
-</pre>
-    </div>
-    <div class="dict_entry" id="towards">
-      <h3>
-        <a>towards<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">towards <i>agent</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        Reports the heading from this agent to the given agent.
-      </p>
-      <p>
-        If wrapping is allowed by the topology and the wrapped distance
-        (around the edges of the world) is shorter, towards will use the
-        wrapped path.
-      </p>
-      <p>
-        Note: asking for the heading from an agent to itself, or an agent
-        on the same location, will cause a runtime error.
-      </p>
-      <pre>
-set heading towards turtle 1
-;; same as &quot;face turtle 1&quot;
-</pre>
-      <p>
-        See also <a href="#face">face</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="towardsxy">
-      <h3>
-        <a>towardsxy<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">towardsxy <i>x</i> <i>y</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        Reports the heading from the turtle or patch towards the point
-        (<i>x</i>,<i>y</i>).
-      </p>
-      <p>
-        If wrapping is allowed by the topology and the wrapped distance
-        (around the edges of the world) is shorter, towardsxy will use the
-        wrapped path.
-      </p>
-      <p>
-        Note: asking for the heading to the point the agent is already
-        standing on will cause a runtime error.
-      </p>
-      <p>
-        See also <a href="#facexy">facexy</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="turtle">
-      <h3>
-        <a>turtle<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">turtle <i>number</i></span>
-        <span class="prim_example">&lt;breed&gt; <i>number</i></span>
-      </h4>
-      <p>
-        Reports the turtle with the given who number, or <a href="#nobody">nobody</a> if there is no such turtle. For breeded
-        turtles you may also use the single breed form to refer to them.
-      </p>
-      <pre>
-ask turtle 5 [ set color red ]
-;; turtle with who number 5 turns red
-</pre>
-    </div>
-    <div class="dict_entry" id="turtle-set">
-      <h3>
-        <a>turtle-set<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">turtle-set <i>value1</i></span>
-        <span class="prim_example">(turtle-set <i>value1</i> <i>value2</i> ...)</span>
-      </h4>
-      <p>
-        Reports an agentset containing all of the turtles anywhere in any
-        of the inputs. The inputs may be individual turtles, turtle
-        agentsets, nobody, or lists (or nested lists) containing any of the
-        above.
-      </p>
-      <pre>
-turtle-set self
-(turtle-set self turtles-on neighbors)
-(turtle-set turtle 0 turtle 2 turtle 9)
-(turtle-set frogs mice)
-</pre>
-      <p>
-        See also <a href="#patch-set">patch-set</a>, <a href="#link-set">link-set</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="turtles">
-      <h3>
-        <a>turtles<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">turtles</span>
-      </h4>
-      <p>
-        Reports the agentset consisting of all turtles. This is a special agentset that can grow as turtles are added to the world, see <a href="programming.html#special-agentsets">the programming guide for more info</a>.
-      </p>
-      <pre>
-show count turtles
-;; prints the number of turtles
-</pre>
-    </div>
-    <div class="dict_entry" id="turtles-at">
-      <h3>
-        <a>turtles-at<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">turtles-at <i>dx</i> <i>dy</i></span>
-        <span class="prim_example"><i>&lt;breeds&gt;</i>-at <i>dx</i> <i>dy</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        Reports an agentset containing the turtles on the patch (dx, dy)
-        from the caller. (The result may include the caller itself if the
-        caller is a turtle.)
-      </p>
-      <pre>
-create-turtles 5 [ setxy 2 3 ]
-show count [turtles-at 1 1] of patch 1 2
-=&gt; 5
-</pre>
-      <p>
-        If the name of a breed is substituted for &quot;turtles&quot;, then
-        only turtles of that breed are included.
-      </p>
-      </div>
-    <div class="dict_entry" id="turtles-here">
-      <h3>
-        <a>turtles-here<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">turtles-here</span>
-        <span class="prim_example"><i>&lt;breeds&gt;</i>-here</span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        Reports an agentset containing all the turtles on the caller's
-        patch (including the caller itself if it's a turtle).
-      </p>
-      <pre>
-crt 10
-ask turtle 0 [ show count turtles-here ]
-=&gt; 10
-</pre>
-      <p>
-        If the name of a breed is substituted for &quot;turtles&quot;, then
-        only turtles of that breed are included.
-      </p>
-      <pre>
-breed [cats cat]
-breed [dogs dog]
-create-cats 5
-create-dogs 1
-ask dogs [ show count cats-here ]
-=&gt; 5
-</pre>
-    </div>
-    <div class="dict_entry" id="turtles-on">
-      <h3>
-        <a>turtles-on<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">turtles-on <i>agent</i></span>
-        <span class="prim_example">turtles-on <i>agentset</i></span>
-        <span class="prim_example"><i>&lt;breeds&gt;</i>-on <i>agent</i></span>
-        <span class="prim_example"><i>&lt;breeds&gt;</i>-on <i>agentset</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        Reports an agentset containing all the turtles that are on the
-        given patch or patches, or standing on the same patch as the given
-        turtle or turtles.
-      </p>
-      <pre>
-ask turtles [
-  if not any? turtles-on patch-ahead 1
-    [ fd 1 ]
-]
-ask turtles [
-  if not any? turtles-on neighbors [
-    die-of-loneliness
-  ]
-]
-</pre>
-      <p>
-        If the name of a breed is substituted for &quot;turtles&quot;, then
-        only turtles of that breed are included.
-      </p>
-      </div>
-    <div class="dict_entry" id="turtles-own">
-      <h3>
-        <a>turtles-own</a>
-      </h3>
-      <h4>
-        <span class="prim_example">turtles-own [<i>var1</i> ...]</span>
-        <span class="prim_example"><i>&lt;breeds&gt;</i>-own [<i>var1</i> ...]</span>
-      </h4>
-      <p>
-        The turtles-own keyword, like the globals, breed,
-        <i>&lt;breeds&gt;</i>-own, and patches-own keywords, can only be
-        used at the beginning of a program, before any function
-        definitions. It defines the variables belonging to each turtle.
-      </p>
-      <p>
-        If you specify a breed instead of &quot;turtles&quot;, only turtles
-        of that breed have the listed variables. (More than one turtle
-        breed may list the same variable.)
-      </p>
-      <pre>
-breed [cats cat ]
-breed [dogs dog]
-breed [hamsters hamster]
-turtles-own [eyes legs]   ;; applies to all breeds
-cats-own [fur kittens]
-hamsters-own [fur cage]
-dogs-own [hair puppies]
-</pre>
-      <p>
-        See also <a href="#globals">globals</a>, <a href="#patches-own">patches-own</a>, <a href="#breed">breed</a>,
-        <a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="type">
-      <h3>
-        <a>type<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">type <i>value</i></span>
-      </h4>
-      <p>
-        Prints <i>value</i> in the Command Center, <i>not</i> followed by a
-        carriage return (unlike <a href="#print">print</a> and <a href="#show">show</a>). The lack of a carriage return allows you to
-        print several values on the same line.
-      </p>
-      <p>
-        This agent is <i>not</i> printed before the value. unlike <a href="#show">show</a>.
-      </p>
-      <pre>
-type 3 type &quot; &quot; print 4
-=&gt; 3 4
-</pre>
-      <p>
-        See also <a href="#print">print</a>, <a href="#show">show</a>,
-        <a href="#write">write</a>, <a href="#output-cmds">output-type</a>, and
-        <a href="programming.html#output">Output (programming guide)</a>.
-      </p>
-      </div><!-- ======================================== -->
-    </div>
-    <h2 id="U">
-      <a>U</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="undirected-link-breed">
-      <h3>
-        <a>undirected-link-breed</a>
-      </h3>
-      <h4>
-        <span class="prim_example">undirected-link-breed [<i>&lt;link-breeds&gt;</i> <i>&lt;link-breed&gt;</i>]</span>
-      </h4>
-      <p>
-        This keyword, like the globals and breeds keywords, can only be
-        used at the beginning of the Code tab, before any procedure
-        definitions. It defines an undirected link breed. Links of a
-        particular breed are always either all directed or all undirected.
-        The first input defines the name of the agentset associated with
-        the link breed. The second input defines the name of a single
-        member of the breed.
-      </p>
-      <p>
-        Any link of the given link breed:
-      </p>
-      <ul>
-        <li>is part of the agentset named by the link breed name
-        <li>has its built-in variable <code>breed</code> set to that agentset
-        <li>is directed or undirected as declared by the keyword
-        </ul>
-      <p>
-        Most often, the agentset is used in conjunction with ask to give
-        commands to only the links of a particular breed.
-      </p>
-      <pre>
-undirected-link-breed [streets street]
-undirected-link-breed [highways highway]
-to setup
-  clear-all
-  crt 2
-  ask turtle 0 [ create-street-with turtle 1 ]
-  ask turtle 0 [ create-highway-with turtle 1 ]
-end
+					to-report first-turtle?
+					report who = 0  ;; reports true or false
+					end
+				</pre>
+			</div>
+			<div class="dict_entry" id="towards">
+				<h3>
+					<a>towards<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">towards <i>agent</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					Reports the heading from this agent to the given agent.
+				</p>
+				<p>
+					If wrapping is allowed by the topology and the wrapped distance
+					(around the edges of the world) is shorter, towards will use the
+					wrapped path.
+				</p>
+				<p>
+					Note: asking for the heading from an agent to itself, or an agent
+					on the same location, will cause a runtime error.
+				</p>
+				<pre>
+					set heading towards turtle 1
+					;; same as &quot;face turtle 1&quot;
+				</pre>
+				<p>
+					See also <a href="#face">face</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="towardsxy">
+				<h3>
+					<a>towardsxy<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">towardsxy <i>x</i> <i>y</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					Reports the heading from the turtle or patch towards the point
+					(<i>x</i>,<i>y</i>).
+				</p>
+				<p>
+					If wrapping is allowed by the topology and the wrapped distance
+					(around the edges of the world) is shorter, towardsxy will use the
+					wrapped path.
+				</p>
+				<p>
+					Note: asking for the heading to the point the agent is already
+					standing on will cause a runtime error.
+				</p>
+				<p>
+					See also <a href="#facexy">facexy</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="turtle">
+				<h3>
+					<a>turtle<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">turtle <i>number</i></span>
+					<span class="prim_example">&lt;breed&gt; <i>number</i></span>
+				</h4>
+				<p>
+					Reports the turtle with the given who number, or <a href="#nobody">nobody</a> if there is no such turtle. For breeded
+					turtles you may also use the single breed form to refer to them.
+				</p>
+				<pre>
+					ask turtle 5 [ set color red ]
+					;; turtle with who number 5 turns red
+				</pre>
+			</div>
+			<div class="dict_entry" id="turtle-set">
+				<h3>
+					<a>turtle-set<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">turtle-set <i>value1</i></span>
+					<span class="prim_example">(turtle-set <i>value1</i> <i>value2</i> ...)</span>
+				</h4>
+				<p>
+					Reports an agentset containing all of the turtles anywhere in any
+					of the inputs. The inputs may be individual turtles, turtle
+					agentsets, nobody, or lists (or nested lists) containing any of the
+					above.
+				</p>
+				<pre>
+					turtle-set self
+					(turtle-set self turtles-on neighbors)
+					(turtle-set turtle 0 turtle 2 turtle 9)
+					(turtle-set frogs mice)
+				</pre>
+				<p>
+					See also <a href="#patch-set">patch-set</a>, <a href="#link-set">link-set</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="turtles">
+				<h3>
+					<a>turtles<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">turtles</span>
+				</h4>
+				<p>
+					Reports the agentset consisting of all turtles. This is a special agentset that can grow as turtles are added to the world, see <a href="programming.html#special-agentsets">the programming guide for more info</a>.
+				</p>
+				<pre>
+					show count turtles
+					;; prints the number of turtles
+				</pre>
+			</div>
+			<div class="dict_entry" id="turtles-at">
+				<h3>
+					<a>turtles-at<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">turtles-at <i>dx</i> <i>dy</i></span>
+					<span class="prim_example"><i>&lt;breeds&gt;</i>-at <i>dx</i> <i>dy</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					Reports an agentset containing the turtles on the patch (dx, dy)
+					from the caller. (The result may include the caller itself if the
+					caller is a turtle.)
+				</p>
+				<pre>
+					create-turtles 5 [ setxy 2 3 ]
+					show count [turtles-at 1 1] of patch 1 2
+					=&gt; 5
+				</pre>
+				<p>
+					If the name of a breed is substituted for &quot;turtles&quot;, then
+					only turtles of that breed are included.
+				</p>
+			</div>
+			<div class="dict_entry" id="turtles-here">
+				<h3>
+					<a>turtles-here<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">turtles-here</span>
+					<span class="prim_example"><i>&lt;breeds&gt;</i>-here</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					Reports an agentset containing all the turtles on the caller's
+					patch (including the caller itself if it's a turtle).
+				</p>
+				<pre>
+					crt 10
+					ask turtle 0 [ show count turtles-here ]
+					=&gt; 10
+				</pre>
+				<p>
+					If the name of a breed is substituted for &quot;turtles&quot;, then
+					only turtles of that breed are included.
+				</p>
+				<pre>
+					breed [cats cat]
+					breed [dogs dog]
+					create-cats 5
+					create-dogs 1
+					ask dogs [ show count cats-here ]
+					=&gt; 5
+				</pre>
+			</div>
+			<div class="dict_entry" id="turtles-on">
+				<h3>
+					<a>turtles-on<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">turtles-on <i>agent</i></span>
+					<span class="prim_example">turtles-on <i>agentset</i></span>
+					<span class="prim_example"><i>&lt;breeds&gt;</i>-on <i>agent</i></span>
+					<span class="prim_example"><i>&lt;breeds&gt;</i>-on <i>agentset</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					Reports an agentset containing all the turtles that are on the
+					given patch or patches, or standing on the same patch as the given
+					turtle or turtles.
+				</p>
+				<pre>
+					ask turtles [
+					if not any? turtles-on patch-ahead 1
+					[ fd 1 ]
+					]
+					ask turtles [
+					if not any? turtles-on neighbors [
+					die-of-loneliness
+					]
+					]
+				</pre>
+				<p>
+					If the name of a breed is substituted for &quot;turtles&quot;, then
+					only turtles of that breed are included.
+				</p>
+			</div>
+			<div class="dict_entry" id="turtles-own">
+				<h3>
+					<a>turtles-own</a>
+				</h3>
+				<h4>
+					<span class="prim_example">turtles-own [<i>var1</i> ...]</span>
+					<span class="prim_example"><i>&lt;breeds&gt;</i>-own [<i>var1</i> ...]</span>
+				</h4>
+				<p>
+					The turtles-own keyword, like the globals, breed,
+					<i>&lt;breeds&gt;</i>-own, and patches-own keywords, can only be
+					used at the beginning of a program, before any function
+					definitions. It defines the variables belonging to each turtle.
+				</p>
+				<p>
+					If you specify a breed instead of &quot;turtles&quot;, only turtles
+					of that breed have the listed variables. (More than one turtle
+					breed may list the same variable.)
+				</p>
+				<pre>
+					breed [cats cat ]
+					breed [dogs dog]
+					breed [hamsters hamster]
+					turtles-own [eyes legs]   ;; applies to all breeds
+					cats-own [fur kittens]
+					hamsters-own [fur cage]
+					dogs-own [hair puppies]
+				</pre>
+				<p>
+					See also <a href="#globals">globals</a>, <a href="#patches-own">patches-own</a>, <a href="#breed">breed</a>,
+					<a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="type">
+				<h3>
+					<a>type<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">type <i>value</i></span>
+				</h4>
+				<p>
+					Prints <i>value</i> in the Command Center, <i>not</i> followed by a
+					carriage return (unlike <a href="#print">print</a> and <a href="#show">show</a>). The lack of a carriage return allows you to
+					print several values on the same line.
+				</p>
+				<p>
+					This agent is <i>not</i> printed before the value. unlike <a href="#show">show</a>.
+				</p>
+				<pre>
+					type 3 type &quot; &quot; print 4
+					=&gt; 3 4
+				</pre>
+				<p>
+					See also <a href="#print">print</a>, <a href="#show">show</a>,
+					<a href="#write">write</a>, <a href="#output-cmds">output-type</a>, and
+					<a href="programming.html#output">Output (programming guide)</a>.
+				</p>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="U">
+			<a>U</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="undirected-link-breed">
+				<h3>
+					<a>undirected-link-breed</a>
+				</h3>
+				<h4>
+					<span class="prim_example">undirected-link-breed [<i>&lt;link-breeds&gt;</i> <i>&lt;link-breed&gt;</i>]</span>
+				</h4>
+				<p>
+					This keyword, like the globals and breeds keywords, can only be
+					used at the beginning of the Code tab, before any procedure
+					definitions. It defines an undirected link breed. Links of a
+					particular breed are always either all directed or all undirected.
+					The first input defines the name of the agentset associated with
+					the link breed. The second input defines the name of a single
+					member of the breed.
+				</p>
+				<p>
+					Any link of the given link breed:
+				</p>
+				<ul>
+					<li>is part of the agentset named by the link breed name</li>
+					<li>has its built-in variable <code>breed</code> set to that agentset</li>
+					<li>is directed or undirected as declared by the keyword</li>
+				</ul>
+				<p>
+					Most often, the agentset is used in conjunction with ask to give
+					commands to only the links of a particular breed.
+				</p>
+				<pre>
+					undirected-link-breed [streets street]
+					undirected-link-breed [highways highway]
+					to setup
+					clear-all
+					crt 2
+					ask turtle 0 [ create-street-with turtle 1 ]
+					ask turtle 0 [ create-highway-with turtle 1 ]
+					end
 
-ask turtle 0 [ show sort my-links ]
-;; prints [(street 0 1) (highway 0 1)]
-</pre>
-      <p>
-        See also <a href="#breed">breed</a>, <a href="#directed-link-breed">directed-link-breed</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="untie">
-      <h3>
-        <a>untie<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">untie</span>
-        <img alt="Link Command" src="images/link.gif">
-      </h4>
-      <p>
-        Unties <i>end2</i> from <i>end1</i> (sets <a href="#tie-mode">tie-mode</a> to &quot;none&quot;) if they were
-        previously tied together. If the link is an undirected link, then
-        it will untie <i>end1</i> from <i>end2</i> as well. It does
-        <b>not</b> remove the link between the two turtles.
-      </p>
-      <p>
-        See also <a href="#tie">tie</a>
-      </p>
-      <p>
-        See the <a href="programming.html#tie">Tie</a> section of the
-        Programming Guide for more details.
-      </p>
-      </div>
-      <div class="dict_entry" id="up-to-n-of">
-        <h3>
-          <a>up-to-n-of<span class="since">6.1</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">up-to-n-of <i>size</i> <i>agentset</i></span>
-          <span class="prim_example">up-to-n-of <i>size</i> <i>list</i></span>
-        </h4>
-        <p>
-          From an agentset, reports an agentset of size <i>size</i>
-          randomly chosen from the input set, with no repeats.  If the
-          input does not have enough agents to satisfy the <i>size</i>,
-          reports the entire agentset.
-        </p>
-        <p>
-          From a list, reports a list of size <i>size</i> randomly chosen
-          from the input set, with no repeats. The items in the result
-          appear in the same order that they appeared in the input list.
-          (If you want them in random order, use shuffle on the result.)
-          If the input does not have enough items to satisfy the
-          <i>size</i>, reports the entire list.
-        </p>
-        <pre>
-          ask up-to-n-of 50 patches [ set pcolor green ]
-          ;; 50 randomly chosen patches turn green
-          ;; if less than 50 patches exist, they all turn green
-        </pre>
-        <p>
-          See also <a href="#n-of">n-of</a>, <a href="#one-of">one-of</a>.
-        </p>
-        </div>
-    <div class="dict_entry" id="update-plots">
-      <h3>
-        <a>update-plots<span class="since">5.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">update-plots</span>
-      </h4>
-      <p>
-        For each plot, runs that plot's update commands, including the
-        update code for any pens in the plot.
-      </p>
-      <p>
-        <a href="#tick">tick</a> has the same effect, so in models that use
-        the tick counter, this primitive is not normally used. Models that
-        use fractional ticks may need <code>update-plots</code>, since <a href="#tick-advance">tick-advance</a> does not update the plots.
-      </p>
-      <p>
-        See the <a href="programming.html#plotting">Plotting section</a> of
-        the Programming Guide for more details.
-      </p>
-      <p>
-        See also <a href="#setup-plots">setup-plots</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="uphill">
-      <h3>
-        <a>uphill<span class="since">1.0</span></a>
-        <a>uphill4<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">uphill <i>patch-variable</i></span>
-        <span class="prim_example">uphill4 <i>patch-variable</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Moves the turtle to the neighboring patch with the highest value
-        for <i>patch-variable</i>. If no neighboring patch has a higher
-        value than the current patch, the turtle stays put. If there are
-        multiple patches with the same highest value, the turtle picks one
-        randomly. Non-numeric values are ignored.
-      </p>
-      <p>
-        uphill considers the eight neighboring patches; uphill4 only
-        considers the four neighbors.
-      </p>
-      <p>
-        Equivalent to the following code (assumes variable values are
-        numeric):
-      </p>
-      <pre>
-move-to patch-here  ;; go to patch center
-let p max-one-of neighbors [<i>patch-variable</i>]  ;; or neighbors4
-if [<i>patch-variable</i>] of p &gt; <i>patch-variable</i> [
-  face p
-  move-to p
-]
-</pre>
-      <p>
-        Note that the turtle always ends up on a patch center and has a
-        heading that is a multiple of 45 (uphill) or 90 (uphill4).
-      </p>
-      <p>
-        See also <a href="#downhill">downhill</a>, <a href="#downhill">downhill4</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="user-directory">
-      <h3>
-        <a>user-directory<span class="since">3.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">user-directory</span>
-      </h4>
-      <p>
-        Opens a dialog that allows the user to choose an existing directory
-        on the system.
-      </p>
-      <p>
-        It reports a string with the absolute path or false if the user
-        cancels.
-      </p>
-      <pre>
-set-current-directory user-directory
-;; Assumes the user will choose a directory
-</pre>
-    </div>
-    <div class="dict_entry" id="user-file">
-      <h3>
-        <a>user-file<span class="since">3.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">user-file</span>
-      </h4>
-      <p>
-        Opens a dialog that allows the user to choose an existing file on
-        the system.
-      </p>
-      <p>
-        It reports a string with the absolute file path or false if the
-        user cancels.
-      </p>
-      <pre>
-file-open user-file
-;; Assumes the user will choose a file
-</pre>
-    </div>
-    <div class="dict_entry" id="user-new-file">
-      <h3>
-        <a>user-new-file<span class="since">3.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">user-new-file</span>
-      </h4>
-      <p>
-        Opens a dialog that allows the user to choose a location and name
-        of a new file to be created. It reports a string with the absolute
-        file path or false if the user cancels.
-      </p>
-      <pre>
-file-open user-new-file
-;; Assumes the user will choose a file
-</pre>
-      <p>
-        Note that this reporter doesn't actually create the file;
-        normally you would create the file using <code>file-open</code>, as in
-        the example.
-      </p>
-      <p>
-        If the user chooses an existing file, they will be asked if they
-        wish to replace it or not, but the reporter itself doesn't
-        cause the file to be replaced. To do that you would use
-        <code>file-delete</code>.
-      </p>
-      </div>
-    <div class="dict_entry" id="user-input">
-      <h3>
-        <a>user-input<span class="since">1.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">user-input <i>value</i></span>
-      </h4>
-      <p>
-        Reports the string that a user types into an entry field in a
-        dialog with title <i>value</i>.
-      </p>
-      <p>
-        <i>value</i> may be of any type, but is typically a string.
-      </p>
-      <pre>
-show user-input &quot;What is your name?&quot;
-</pre>
-      <p>
-        See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
-        Programming Guide for additional details.
-      </p>
-    </div>
-    <div class="dict_entry" id="user-message">
-      <h3>
-        <a>user-message<span class="since">1.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">user-message <i>value</i></span>
-      </h4>
-      <p>
-        Opens a dialog with <i>value</i> displayed as the message to the user.
-      </p>
-      <p>
-        <i>value</i> may be of any type, but is typically a string.
-      </p>
-        <pre>
-user-message (word &quot;There are &quot; count turtles &quot; turtles.&quot;)
-</pre>
-        <p>
-        Note that if a user closes the <code>user-message</code> dialog
-        with the &quot;X&quot; in the corner, the behavior will be the same as if they had clicked &quot;OK&quot;.
-        </p>
-        <p>
-        See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
-        Programming Guide for additional details.
-        </p>
-    </div>
-    <div class="dict_entry" id="user-one-of">
-      <h3>
-        <a>user-one-of<span class="since">3.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">user-one-of <i>value</i> <i>list-of-choices</i></span>
-      </h4>
-      <p>
-        Opens a dialog with <i>value</i> displayed as the message and
-        <i>list-of-choices</i> displayed as a popup menu for the user to
-        select from.
-      </p>
-      <p>
-        Reports the item in <i>list-of-choices</i> selected by the user.
-      </p>
-      <p>
-        <i>value</i> may be of any type, but is typically a string.
-      </p>
-      <pre>
-if &quot;yes&quot; = user-one-of &quot;Set up the model?&quot; [&quot;yes&quot; &quot;no&quot;]
-  [ setup ]
-</pre>
-        <p>
-        See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
-        Programming Guide for additional details.
-        </p>
-    </div>
-    <div class="dict_entry" id="user-yes-or-no">
-      <h3>
-        <a>user-yes-or-no?<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">user-yes-or-no? <i>value</i></span>
-      </h4>
-      <p>
-        Reports true or false based on the user's response to
-        <i>value</i>.
-      </p>
-      <p>
-        <i>value</i> may be of any type, but is typically a string.
-      </p>
-      <pre>
-if user-yes-or-no? &quot;Set up the model?&quot;
-  [ setup ]
-</pre>
-        <p>
-        See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
-        Programming Guide for additional details.
-        </p>
-    </div><!-- ======================================== -->
-  </div>
-    <h2 id="V">
-      <a>V</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="variance">
-      <h3>
-        <a>variance<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">variance <i>list</i></span>
-      </h4>
-      <p>
-        Reports the sample variance of a <i>list</i> of numbers. Ignores
-        other types of items.
-      </p>
-      <p>
-        (Note that this computes an unbiased estimate of the variance for a
-        <i>sample</i>, rather than for a whole <i>population</i>, using
-        Bessel's correction.)
-      </p>
-      <p>
-        The sample variance is the sum of the squares of the deviations of
-        the numbers from their mean, divided by one less than the number of
-        numbers in the list.
-      </p>
-      <pre>
-show variance [2 7 4 3 5]
-=&gt; 3.7
-</pre>
-    </div><!-- ======================================== -->
-  </div>
-    <h2 id="W">
-      <a>W</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="wait">
-      <h3>
-        <a>wait<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">wait <i>number</i></span>
-      </h4>
-      <p>
-        Wait the given number of seconds. (This needn't be an integer;
-        you can specify fractions of seconds.) Note that you can't
-        expect complete precision; the agent will never wait less than the
-        given amount, but might wait slightly more.
-      </p>
-      <pre>
-repeat 10 [ fd 1 wait 0.5 ]
-</pre>
-      <p>
-        While the agent is waiting, no other agents can do anything.
-        Everything stops until the agent is done.
-      </p>
-      <p>
-        See also <a href="#every">every</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="watch">
-      <h3>
-        <a>watch<span class="since">3.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">watch <i>agent</i></span>
-        <img alt="Observer Command" src="images/observer.gif">
-      </h4>
-      <p>
-        Puts a spotlight on <i>agent</i>. In the 3D view the observer will
-        also turn to face the subject.
-      </p>
-      <p>
-        The observer may only watch or follow a single subject.
-        Calling <code>watch</code> will undo perspective changes caused
-        by prior calls to <code>follow</code>, <code>follow-me</code>,
-        <code>ride</code>, and <code>ride-me</code>.
-      </p>
-      <p>
-        See also <a href="#follow">follow</a>, <a href="#subject">subject</a>, <a href="#reset-perspective">reset-perspective</a>,
-        <a href="#ride">ride</a>, <a href="#ride-me">ride-me</a>, <a href="#watch-me">watch-me</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="watch-me">
-      <h3>
-        <a>watch-me<span class="since">3.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">watch-me</span>
-        <img alt="Turtle Command" src="images/turtle.gif"> <img alt="Patch Command" src="images/patch.gif">
-      </h4>
-      <p>
-        Asks the observer to watch this agent.
-      </p>
-      <p>
-        The observer may only watch or follow a single subject.
-        Calling <code>watch</code> will undo perspective changes caused
-        by prior calls to <code>follow</code>, <code>follow-me</code>,
-        <code>ride</code>, and <code>ride-me</code>.
-      </p>
-      <p>
-        See also <a href="#follow">follow</a>, <a href="#subject">subject</a>, <a href="#reset-perspective">reset-perspective</a>,
-        <a href="#ride">ride</a>, <a href="#ride-me">ride-me</a>, <a href="#watch">watch</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="while">
-      <h3>
-        <a>while<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">while [<i>reporter</i>] [ <i>commands</i> ]</span>
-      </h4>
-      <p>
-        If <i>reporter</i> reports false, exit the loop. Otherwise run
-        <i>commands</i> and repeat.
-      </p>
-      <p>
-        The reporter may have different values for different agents, so
-        some agents may run <i>commands</i> a different number of times
-        than other agents.
-      </p>
-      <pre>
-while [any? other turtles-here]
-  [ fd 1 ]
-;; turtle moves until it finds a patch that has
-;; no other turtles on it
-</pre>
-    </div>
-    <div class="dict_entry" id="who">
-      <h3>
-        <a>who</a>
-      </h3>
-      <h4>
-        <span class="prim_example">who</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        This is a built-in turtle variable. It holds the turtle's
-        &quot;who number&quot; or ID number, an integer greater than or
-        equal to zero. You cannot set this variable; a turtle's who
-        number never changes.
-      </p>
-      <p>
-        Who numbers start at 0. A dead turtle's number will not be
-        reassigned to a new turtle until you use the <a href="#clear-turtles">clear-turtles</a> or <a href="#clear-all">clear-all</a> commands, at which time who numbering
-        starts over again at 0.
-      </p>
-      <p>
-        Example:
-      </p>
-      <pre>
-show [who] of turtles with [color = red]
-;; prints a list of the who numbers of all red turtles
-;; in the Command Center, in random order
-crt 100
-  [ ifelse who &lt; 50
-      [ set color red ]
-      [ set color blue ] ]
-;; turtles 0 through 49 are red, turtles 50
-;; through 99 are blue
-</pre>
-      <p>
-        You can use the turtle reporter to retrieve a turtle with a given
-        who number. See also <a href="#turtle">turtle</a>.
-      </p>
-      <p>
-        Note that who numbers aren't breed-specific. No two turtles can
-        have the same who number, even if they are different breeds:
-      </p>
-      <pre>
-clear-turtles
-create-frogs 1
-create-mice 1
-ask turtles [ print who ]
-;; prints (in some random order):
-;; (frog 0): 0
-;; (mouse 1): 1
-</pre>
-      <p>
-        Even though we only have one mouse, it is <code>mouse 1</code> not
-        <code>mouse 0</code>, because the who number 0 was already taken by the
-        frog.
-      </p>
-      </div>
-    <div class="dict_entry" id="with">
-      <h3>
-        <a>with<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example"><i>agentset</i> with [<i>reporter</i>]</span>
-      </h4>
-      <p>
-        Takes two inputs: on the left, an agentset (usually
-        &quot;turtles&quot; or &quot;patches&quot;). On the right, a
-        boolean reporter. Reports a new agentset containing only those
-        agents that reported true -- in other words, the agents satisfying
-        the given condition.
-      </p>
-      <pre>
-show count patches with [pcolor = red]
-;; prints the number of red patches
-</pre>
-    </div>
-    <div class="dict_entry" id="link-with">
-      <h3>
-        <a>&lt;breed&gt;-with</a>
-        <a>link-with<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">&lt;breed&gt;-with <i>turtle</i></span>
-        <span class="prim_example">link-with <i>turtle</i></span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        Reports a link between <i>turtle</i> and the caller (directed or
-        undirected, incoming or outgoing). If no link exists then it reports
-        nobody. If more than one such link exists, reports a random one.
-      </p>
-      <pre>
-crt 2
-ask turtle 0 [
-  create-link-with turtle 1
-  show link-with turtle 1 ;; prints link 0 1
-]
-</pre>
-      <p>
-        See also: <a href="#in-link-from">in-link-from</a>, <a href="#out-link-to">out-link-to</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="with-max">
-      <h3>
-        <a>with-max<span class="since">2.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example"><i>agentset</i> with-max [<i>reporter</i>]</span>
-      </h4>
-      <p>
-        Takes two inputs: on the left, an agentset (usually
-        &quot;turtles&quot; or &quot;patches&quot;). On the right, a
-        reporter. Reports a new agentset containing all agents reporting
-        the maximum value of the given reporter.
-      </p>
-      <pre>
-show count patches with-max [pxcor]
-;; prints the number of patches on the right edge
-</pre>
-      <p>
-        See also <a href="#max-one-of">max-one-of</a>, <a href="#max-n-of">max-n-of</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="with-min">
-      <h3>
-        <a>with-min<span class="since">2.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example"><i>agentset</i> with-min [<i>reporter</i>]</span>
-      </h4>
-      <p>
-        Takes two inputs: on the left, an agentset (usually
-        &quot;turtles&quot; or &quot;patches&quot;). On the right, a
-        reporter. Reports a new agentset containing only those agents that
-        have the minimum value of the given reporter.
-      </p>
-      <pre>
-show count patches with-min [pycor]
-;; prints the number of patches on the bottom edge
-</pre>
-      <p>
-        See also <a href="#min-one-of">min-one-of</a>, <a href="#min-n-of">min-n-of</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="with-local-randomness">
-      <h3>
-        <a>with-local-randomness<span class="since">4.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">with-local-randomness [ <i>commands</i> ]</span>
-      </h4>
-      <p>
-        The commands are run without affecting subsequent random events.
-        This is useful for performing extra operations (such as output)
-        without changing the outcome of a model.
-      </p>
-      <p>
-        Example:
-      </p>
-      <pre>
-;; Run #1:
-random-seed 50 setup repeat 10 [ go ]
-;; Run #2:
-random-seed 50 setup
-with-local-randomness [ watch one-of turtles ]
-repeat 10 [ go ]
-</pre>
-      <p>
-        Since <code>one-of</code> is used inside
-        <code>with-local-randomness</code>, both runs will be identical.
-      </p>
-      <p>
-        Specifically how it works is, the state of the random number
-        generator is remembered before the commands run, then restored
-        afterwards. (If you want to run the commands with a fresh random
-        state instead of the same random state that will be restored later,
-        you can begin the commands with <code>random-seed new-seed</code>.)
-      </p>
-      <p>
-        The following example demonstrates that the random number generator
-        state is the same both before the commands run and afterwards.
-      </p>
-      <pre>
-random-seed 10
-with-local-randomness [ print n-values 10 [random 10] ]
-;; prints [8 9 8 4 2 4 5 4 7 9]
-print n-values 10 [random 10]
-;; prints [8 9 8 4 2 4 5 4 7 9]
-</pre>
-    </div>
-    <div class="dict_entry" id="without-interruption">
-      <h3>
-        <a>without-interruption<span class="since">1.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">without-interruption [ <i>commands</i> ]</span>
-      </h4>
-      <p>
-        This primitive exists only for backwards compatibility. We
-        don't recommend using it in new models.
-      </p>
-      <p>
-        The agent runs all the commands in the block without allowing other
-        agents using <code>ask-concurrent</code> to &quot;interrupt&quot;. That
-        is, other agents are put &quot;on hold&quot; and do not run any
-        commands until the commands in the block are finished.
-      </p>
-      <p>
-        Note: This command is only useful in conjunction with
-        <code>ask-concurrent</code>.
-      </p>
-      <p>
-        See also <a href="#ask-concurrent">ask-concurrent</a>.
-      </p>
-      </div>
-    <div class="dict_entry" id="word">
-      <h3>
-        <a>word<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">word <i>value1</i> <i>value2</i></span>
-        <span class="prim_example">(word <i>value1</i> ...)</span>
-      </h4>
-      <p>
-        Concatenates the inputs together and reports the result as a
-        string.
-      </p>
-      <pre>
-show word &quot;tur&quot; &quot;tle&quot;
-=&gt; &quot;turtle&quot;
-word &quot;a&quot; 6
-=&gt; &quot;a6&quot;
-set directory &quot;c:\\foo\\fish\\&quot;
-show word directory &quot;bar.txt&quot;
-=&gt; &quot;c:\foo\fish\bar.txt&quot;
-show word [1 54 8] &quot;fishy&quot;
-=&gt; &quot;[1 54 8]fishy&quot;
-show (word 3)
-=&gt; &quot;3&quot;
-show (word &quot;a&quot; &quot;b&quot; &quot;c&quot; 1 23)
-=&gt; &quot;abc123&quot;
-</pre>
-    </div>
-    <div class="dict_entry" id="world-dim">
-      <h3>
-        <a>world-width<span class="since">3.1</span></a>
-        <a>world-height<span class="since">3.1</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">world-width</span>
-        <span class="prim_example">world-height</span>
-      </h4>
-      <p>
-        These reporters give the total width and height of the NetLogo
-        world.
-      </p>
-      <p>
-        The width equals max-pxcor - min-pxcor + 1 and the height equals
-        max-pycor - min-pycor + 1.
-      </p>
-      <p>
-        See also <a href="#max-pcor">max-pxcor</a>, <a href="#max-pcor">max-pycor</a>, <a href="#min-pcor">min-pxcor</a>, and
-        <a href="#min-pcor">min-pycor</a>
-      </p>
-      </div>
-    <div class="dict_entry" id="wrap-color">
-      <h3>
-        <a>wrap-color<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">wrap-color <i>number</i></span>
-      </h4>
-      <p>
-        wrap-color checks whether <i>number</i> is in the NetLogo color
-        range of 0 to 140 (not including 140 itself). If it is not,
-        wrap-color &quot;wraps&quot; the numeric input to the 0 to 140
-        range.
-      </p>
-      <p>
-        The wrapping is done by repeatedly adding or subtracting 140 from
-        the given number until it is in the 0 to 140 range. (This is the
-        same wrapping that is done automatically if you assign an
-        out-of-range number to the color turtle variable or pcolor patch
-        variable.)
-      </p>
-      <pre>
-show wrap-color 150
-=&gt; 10
-show wrap-color -10
-=&gt; 130
-</pre>
-    </div>
-    <div class="dict_entry" id="write">
-      <h3>
-        <a>write<span class="since">2.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example">write <i>value</i></span>
-      </h4>
-      <p>
-        This command will output <i>value</i>, which can be a number,
-        string, list, boolean, or nobody to the Command Center, <i>not</i>
-        followed by a carriage return (unlike <a href="#print">print</a>
-        and <a href="#show">show</a>).
-      </p>
-      <p>
-        This agent is <i>not</i> printed before the value, unlike <a href="#show">show</a>. Its output also includes quotes around strings
-        and is prepended with a space.
-      </p>
-      <pre>
-write &quot;hello world&quot;
-=&gt;  &quot;hello world&quot;
-</pre>
-      <p>
-        See also <a href="#print">print</a>, <a href="#show">show</a>,
-        <a href="#type">type</a>, <a href="#output-cmds">output-write</a>,
-        and <a href="programming.html#output">Output (programming guide)</a>.
-      </p>
-      </div><!-- ======================================== -->
-    </div>
-    <h2 id="X">
-      <a>X</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="xcor">
-      <h3>
-        <a>xcor</a>
-      </h3>
-      <h4>
-        <span class="prim_example">xcor</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        This is a built-in turtle variable. It holds the current x
-        coordinate of the turtle. You can set this variable to change the
-        turtle's location.
-      </p>
-      <p>
-        This variable is always greater than or equal to (min-pxcor - 0.5)
-        and strictly less than (max-pxcor + 0.5).
-      </p>
-      <p>
-        See also <a href="#setxy">setxy</a>, <a href="#ycor">ycor</a>,
-        <a href="#pcor">pxcor</a>, <a href="#pcor">pycor</a>,
-      </p>
-      </div>
-    <div class="dict_entry" id="xor">
-      <h3>
-        <a>xor<span class="since">1.0</span></a>
-      </h3>
-      <h4>
-        <span class="prim_example"><i>boolean1</i> xor <i>boolean2</i></span>
-      </h4>
-      <p>
-        Reports true if either <i>boolean1</i> or <i>boolean2</i> is true,
-        but not when both are true.
-      </p>
-      <pre>
-if (pxcor &gt; 0) xor (pycor &gt; 0)
-  [ set pcolor blue ]
-;; upper-left and lower-right quadrants turn blue
-</pre>
-    </div><!-- ======================================== -->
-  </div>
-    <h2 id="Y">
-      <a>Y</a>
-    </h2><!-- ======================================== -->
-    <div>
-    <div class="dict_entry" id="ycor">
-      <h3>
-        <a>ycor</a>
-      </h3>
-      <h4>
-        <span class="prim_example">ycor</span>
-        <img alt="Turtle Command" src="images/turtle.gif">
-      </h4>
-      <p>
-        This is a built-in turtle variable. It holds the current y
-        coordinate of the turtle. You can set this variable to change the
-        turtle's location.
-      </p>
-      <p>
-        This variable is always greater than or equal to (min-pycor - 0.5)
-        and strictly less than (max-pycor + 0.5).
-      </p>
-      <p>
-        See also <a href="#setxy">setxy</a>, <a href="#xcor">xcor</a>,
-        <a href="#pcor">pxcor</a>, <a href="#pcor">pycor</a>,
-      </p>
-      </div><!-- ======================================== -->
-    </div>
-    <h2>
-      <a>-&gt;</a>
-    </h2><!-- ======================================== -->
-    <div id="ops">
-      <div class="dict_entry" id="arrow">
-        <h3>
-          <a>-><span class="since">6.0</span></a>
-        </h3>
-        <h4>
-          <span class="prim_example">[ [<i>args</i>] -> <i>commands</i> ]</span>
-          <span class="prim_example">[ [<i>args</i>] -> <i>reporter</i> ]</span>
-        </h4>
-        <p>
-        Creates and reports an anonymous procedure - a command or reporter
-        - depending on the input. Within <i>commands</i> or <i>reporter</i> the listed
-        <i>args</i> may be used just as you would use <code>let</code> or procedure variables.
-        The variable names in <i>args</i> have the same restrictions
-        as variable names of commands and reporters. In addition, they must not match the name of
-        any let or procedure variable in their procedure.
-        </p>
-        <p>
-        Anonymous procedures are commonly used with the primitives
-        <a href="#foreach">foreach</a>, <a href="#map">map</a>, <a href="#reduce">reduce</a>,
-        <a href="#filter">filter</a>, <a href="#sort-by">sort-by</a>, and <a href="#n-values">n-values</a>. See
-        those entries for example usage.
-        </p>
-        <p>
-        See the <a href="programming.html#anonymous-procedures">Anonymous Procedures section</a> of the
-        Programming Guide for details.
-        </p>
-      </div>
-    </div>
-</body>
+					ask turtle 0 [ show sort my-links ]
+					;; prints [(street 0 1) (highway 0 1)]
+				</pre>
+				<p>
+					See also <a href="#breed">breed</a>, <a href="#directed-link-breed">directed-link-breed</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="untie">
+				<h3>
+					<a>untie<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">untie</span>
+					<img alt="Link Command" src="images/link.gif"/>
+				</h4>
+				<p>
+					Unties <i>end2</i> from <i>end1</i> (sets <a href="#tie-mode">tie-mode</a> to &quot;none&quot;) if they were
+					previously tied together. If the link is an undirected link, then
+					it will untie <i>end1</i> from <i>end2</i> as well. It does
+					<b>not</b> remove the link between the two turtles.
+				</p>
+				<p>
+					See also <a href="#tie">tie</a>
+				</p>
+				<p>
+					See the <a href="programming.html#tie">Tie</a> section of the
+					Programming Guide for more details.
+				</p>
+			</div>
+			<div class="dict_entry" id="up-to-n-of">
+				<h3>
+					<a>up-to-n-of<span class="since">6.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">up-to-n-of <i>size</i> <i>agentset</i></span>
+					<span class="prim_example">up-to-n-of <i>size</i> <i>list</i></span>
+				</h4>
+				<p>
+					From an agentset, reports an agentset of size <i>size</i>
+					randomly chosen from the input set, with no repeats.  If the
+					input does not have enough agents to satisfy the <i>size</i>,
+					reports the entire agentset.
+				</p>
+				<p>
+					From a list, reports a list of size <i>size</i> randomly chosen
+					from the input set, with no repeats. The items in the result
+					appear in the same order that they appeared in the input list.
+					(If you want them in random order, use shuffle on the result.)
+					If the input does not have enough items to satisfy the
+					<i>size</i>, reports the entire list.
+				</p>
+				<pre>
+					ask up-to-n-of 50 patches [ set pcolor green ]
+					;; 50 randomly chosen patches turn green
+					;; if less than 50 patches exist, they all turn green
+				</pre>
+				<p>
+					See also <a href="#n-of">n-of</a>, <a href="#one-of">one-of</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="update-plots">
+				<h3>
+					<a>update-plots<span class="since">5.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">update-plots</span>
+				</h4>
+				<p>
+					For each plot, runs that plot's update commands, including the
+					update code for any pens in the plot.
+				</p>
+				<p>
+					<a href="#tick">tick</a> has the same effect, so in models that use
+					the tick counter, this primitive is not normally used. Models that
+					use fractional ticks may need <code>update-plots</code>, since <a href="#tick-advance">tick-advance</a> does not update the plots.
+				</p>
+				<p>
+					See the <a href="programming.html#plotting">Plotting section</a> of
+					the Programming Guide for more details.
+				</p>
+				<p>
+					See also <a href="#setup-plots">setup-plots</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="uphill">
+				<h3>
+					<a>uphill<span class="since">1.0</span></a>
+					<a>uphill4<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">uphill <i>patch-variable</i></span>
+					<span class="prim_example">uphill4 <i>patch-variable</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Moves the turtle to the neighboring patch with the highest value
+					for <i>patch-variable</i>. If no neighboring patch has a higher
+					value than the current patch, the turtle stays put. If there are
+					multiple patches with the same highest value, the turtle picks one
+					randomly. Non-numeric values are ignored.
+				</p>
+				<p>
+					uphill considers the eight neighboring patches; uphill4 only
+					considers the four neighbors.
+				</p>
+				<p>
+					Equivalent to the following code (assumes variable values are
+					numeric):
+				</p>
+				<pre>
+					move-to patch-here  ;; go to patch center
+					let p max-one-of neighbors [<i>patch-variable</i>]  ;; or neighbors4
+					if [<i>patch-variable</i>] of p &gt; <i>patch-variable</i> [
+					face p
+					move-to p
+					]
+				</pre>
+				<p>
+					Note that the turtle always ends up on a patch center and has a
+					heading that is a multiple of 45 (uphill) or 90 (uphill4).
+				</p>
+				<p>
+					See also <a href="#downhill">downhill</a>, <a href="#downhill">downhill4</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="user-directory">
+				<h3>
+					<a>user-directory<span class="since">3.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">user-directory</span>
+				</h4>
+				<p>
+					Opens a dialog that allows the user to choose an existing directory
+					on the system.
+				</p>
+				<p>
+					It reports a string with the absolute path or false if the user
+					cancels.
+				</p>
+				<pre>
+					set-current-directory user-directory
+					;; Assumes the user will choose a directory
+				</pre>
+			</div>
+			<div class="dict_entry" id="user-file">
+				<h3>
+					<a>user-file<span class="since">3.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">user-file</span>
+				</h4>
+				<p>
+					Opens a dialog that allows the user to choose an existing file on
+					the system.
+				</p>
+				<p>
+					It reports a string with the absolute file path or false if the
+					user cancels.
+				</p>
+				<pre>
+					file-open user-file
+					;; Assumes the user will choose a file
+				</pre>
+			</div>
+			<div class="dict_entry" id="user-new-file">
+				<h3>
+					<a>user-new-file<span class="since">3.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">user-new-file</span>
+				</h4>
+				<p>
+					Opens a dialog that allows the user to choose a location and name
+					of a new file to be created. It reports a string with the absolute
+					file path or false if the user cancels.
+				</p>
+				<pre>
+					file-open user-new-file
+					;; Assumes the user will choose a file
+				</pre>
+				<p>
+					Note that this reporter doesn't actually create the file;
+					normally you would create the file using <code>file-open</code>, as in
+					the example.
+				</p>
+				<p>
+					If the user chooses an existing file, they will be asked if they
+					wish to replace it or not, but the reporter itself doesn't
+					cause the file to be replaced. To do that you would use
+					<code>file-delete</code>.
+				</p>
+			</div>
+			<div class="dict_entry" id="user-input">
+				<h3>
+					<a>user-input<span class="since">1.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">user-input <i>value</i></span>
+				</h4>
+				<p>
+					Reports the string that a user types into an entry field in a
+					dialog with title <i>value</i>.
+				</p>
+				<p>
+					<i>value</i> may be of any type, but is typically a string.
+				</p>
+				<pre>
+					show user-input &quot;What is your name?&quot;
+				</pre>
+				<p>
+					See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
+					Programming Guide for additional details.
+				</p>
+			</div>
+			<div class="dict_entry" id="user-message">
+				<h3>
+					<a>user-message<span class="since">1.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">user-message <i>value</i></span>
+				</h4>
+				<p>
+					Opens a dialog with <i>value</i> displayed as the message to the user.
+				</p>
+				<p>
+					<i>value</i> may be of any type, but is typically a string.
+				</p>
+				<pre>
+					user-message (word &quot;There are &quot; count turtles &quot; turtles.&quot;)
+				</pre>
+				<p>
+					Note that if a user closes the <code>user-message</code> dialog
+					with the &quot;X&quot; in the corner, the behavior will be the same as if they had clicked &quot;OK&quot;.
+				</p>
+				<p>
+					See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
+					Programming Guide for additional details.
+				</p>
+			</div>
+			<div class="dict_entry" id="user-one-of">
+				<h3>
+					<a>user-one-of<span class="since">3.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">user-one-of <i>value</i> <i>list-of-choices</i></span>
+				</h4>
+				<p>
+					Opens a dialog with <i>value</i> displayed as the message and
+					<i>list-of-choices</i> displayed as a popup menu for the user to
+					select from.
+				</p>
+				<p>
+					Reports the item in <i>list-of-choices</i> selected by the user.
+				</p>
+				<p>
+					<i>value</i> may be of any type, but is typically a string.
+				</p>
+				<pre>
+					if &quot;yes&quot; = user-one-of &quot;Set up the model?&quot; [&quot;yes&quot; &quot;no&quot;]
+					[ setup ]
+				</pre>
+				<p>
+					See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
+					Programming Guide for additional details.
+				</p>
+			</div>
+			<div class="dict_entry" id="user-yes-or-no">
+				<h3>
+					<a>user-yes-or-no?<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">user-yes-or-no? <i>value</i></span>
+				</h4>
+				<p>
+					Reports true or false based on the user's response to
+					<i>value</i>.
+				</p>
+				<p>
+					<i>value</i> may be of any type, but is typically a string.
+				</p>
+				<pre>
+					if user-yes-or-no? &quot;Set up the model?&quot;
+					[ setup ]
+				</pre>
+				<p>
+					See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
+					Programming Guide for additional details.
+				</p>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="V">
+			<a>V</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="variance">
+				<h3>
+					<a>variance<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">variance <i>list</i></span>
+				</h4>
+				<p>
+					Reports the sample variance of a <i>list</i> of numbers. Ignores
+					other types of items.
+				</p>
+				<p>
+					(Note that this computes an unbiased estimate of the variance for a
+					<i>sample</i>, rather than for a whole <i>population</i>, using
+					Bessel's correction.)
+				</p>
+				<p>
+					The sample variance is the sum of the squares of the deviations of
+					the numbers from their mean, divided by one less than the number of
+					numbers in the list.
+				</p>
+				<pre>
+					show variance [2 7 4 3 5]
+					=&gt; 3.7
+				</pre>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="W">
+			<a>W</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="wait">
+				<h3>
+					<a>wait<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">wait <i>number</i></span>
+				</h4>
+				<p>
+					Wait the given number of seconds. (This needn't be an integer;
+					you can specify fractions of seconds.) Note that you can't
+					expect complete precision; the agent will never wait less than the
+					given amount, but might wait slightly more.
+				</p>
+				<pre>
+					repeat 10 [ fd 1 wait 0.5 ]
+				</pre>
+				<p>
+					While the agent is waiting, no other agents can do anything.
+					Everything stops until the agent is done.
+				</p>
+				<p>
+					See also <a href="#every">every</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="watch">
+				<h3>
+					<a>watch<span class="since">3.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">watch <i>agent</i></span>
+					<img alt="Observer Command" src="images/observer.gif"/>
+				</h4>
+				<p>
+					Puts a spotlight on <i>agent</i>. In the 3D view the observer will
+					also turn to face the subject.
+				</p>
+				<p>
+					The observer may only watch or follow a single subject.
+					Calling <code>watch</code> will undo perspective changes caused
+					by prior calls to <code>follow</code>, <code>follow-me</code>,
+					<code>ride</code>, and <code>ride-me</code>.
+				</p>
+				<p>
+					See also <a href="#follow">follow</a>, <a href="#subject">subject</a>, <a href="#reset-perspective">reset-perspective</a>,
+					<a href="#ride">ride</a>, <a href="#ride-me">ride-me</a>, <a href="#watch-me">watch-me</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="watch-me">
+				<h3>
+					<a>watch-me<span class="since">3.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">watch-me</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+				</h4>
+				<p>
+					Asks the observer to watch this agent.
+				</p>
+				<p>
+					The observer may only watch or follow a single subject.
+					Calling <code>watch</code> will undo perspective changes caused
+					by prior calls to <code>follow</code>, <code>follow-me</code>,
+					<code>ride</code>, and <code>ride-me</code>.
+				</p>
+				<p>
+					See also <a href="#follow">follow</a>, <a href="#subject">subject</a>, <a href="#reset-perspective">reset-perspective</a>,
+					<a href="#ride">ride</a>, <a href="#ride-me">ride-me</a>, <a href="#watch">watch</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="while">
+				<h3>
+					<a>while<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">while [<i>reporter</i>] [ <i>commands</i> ]</span>
+				</h4>
+				<p>
+					If <i>reporter</i> reports false, exit the loop. Otherwise run
+					<i>commands</i> and repeat.
+				</p>
+				<p>
+					The reporter may have different values for different agents, so
+					some agents may run <i>commands</i> a different number of times
+					than other agents.
+				</p>
+				<pre>
+					while [any? other turtles-here]
+					[ fd 1 ]
+					;; turtle moves until it finds a patch that has
+					;; no other turtles on it
+				</pre>
+			</div>
+			<div class="dict_entry" id="who">
+				<h3>
+					<a>who</a>
+				</h3>
+				<h4>
+					<span class="prim_example">who</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					This is a built-in turtle variable. It holds the turtle's
+					&quot;who number&quot; or ID number, an integer greater than or
+					equal to zero. You cannot set this variable; a turtle's who
+					number never changes.
+				</p>
+				<p>
+					Who numbers start at 0. A dead turtle's number will not be
+					reassigned to a new turtle until you use the <a href="#clear-turtles">clear-turtles</a> or <a href="#clear-all">clear-all</a> commands, at which time who numbering
+					starts over again at 0.
+				</p>
+				<p>
+					Example:
+				</p>
+				<pre>
+					show [who] of turtles with [color = red]
+					;; prints a list of the who numbers of all red turtles
+					;; in the Command Center, in random order
+					crt 100
+					[ ifelse who &lt; 50
+					[ set color red ]
+					[ set color blue ] ]
+					;; turtles 0 through 49 are red, turtles 50
+					;; through 99 are blue
+				</pre>
+				<p>
+					You can use the turtle reporter to retrieve a turtle with a given
+					who number. See also <a href="#turtle">turtle</a>.
+				</p>
+				<p>
+					Note that who numbers aren't breed-specific. No two turtles can
+					have the same who number, even if they are different breeds:
+				</p>
+				<pre>
+					clear-turtles
+					create-frogs 1
+					create-mice 1
+					ask turtles [ print who ]
+					;; prints (in some random order):
+					;; (frog 0): 0
+					;; (mouse 1): 1
+				</pre>
+				<p>
+					Even though we only have one mouse, it is <code>mouse 1</code> not
+					<code>mouse 0</code>, because the who number 0 was already taken by the
+					frog.
+				</p>
+			</div>
+			<div class="dict_entry" id="with">
+				<h3>
+					<a>with<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example"><i>agentset</i> with [<i>reporter</i>]</span>
+				</h4>
+				<p>
+					Takes two inputs: on the left, an agentset (usually
+					&quot;turtles&quot; or &quot;patches&quot;). On the right, a
+					boolean reporter. Reports a new agentset containing only those
+					agents that reported true -- in other words, the agents satisfying
+					the given condition.
+				</p>
+				<pre>
+					show count patches with [pcolor = red]
+					;; prints the number of red patches
+				</pre>
+			</div>
+			<div class="dict_entry" id="link-with">
+				<h3>
+					<a>&lt;breed&gt;-with</a>
+					<a>link-with<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">&lt;breed&gt;-with <i>turtle</i></span>
+					<span class="prim_example">link-with <i>turtle</i></span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					Reports a link between <i>turtle</i> and the caller (directed or
+					undirected, incoming or outgoing). If no link exists then it reports
+					nobody. If more than one such link exists, reports a random one.
+				</p>
+				<pre>
+					crt 2
+					ask turtle 0 [
+					create-link-with turtle 1
+					show link-with turtle 1 ;; prints link 0 1
+					]
+				</pre>
+				<p>
+					See also: <a href="#in-link-from">in-link-from</a>, <a href="#out-link-to">out-link-to</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="with-max">
+				<h3>
+					<a>with-max<span class="since">2.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example"><i>agentset</i> with-max [<i>reporter</i>]</span>
+				</h4>
+				<p>
+					Takes two inputs: on the left, an agentset (usually
+					&quot;turtles&quot; or &quot;patches&quot;). On the right, a
+					reporter. Reports a new agentset containing all agents reporting
+					the maximum value of the given reporter.
+				</p>
+				<pre>
+					show count patches with-max [pxcor]
+					;; prints the number of patches on the right edge
+				</pre>
+				<p>
+					See also <a href="#max-one-of">max-one-of</a>, <a href="#max-n-of">max-n-of</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="with-min">
+				<h3>
+					<a>with-min<span class="since">2.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example"><i>agentset</i> with-min [<i>reporter</i>]</span>
+				</h4>
+				<p>
+					Takes two inputs: on the left, an agentset (usually
+					&quot;turtles&quot; or &quot;patches&quot;). On the right, a
+					reporter. Reports a new agentset containing only those agents that
+					have the minimum value of the given reporter.
+				</p>
+				<pre>
+					show count patches with-min [pycor]
+					;; prints the number of patches on the bottom edge
+				</pre>
+				<p>
+					See also <a href="#min-one-of">min-one-of</a>, <a href="#min-n-of">min-n-of</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="with-local-randomness">
+				<h3>
+					<a>with-local-randomness<span class="since">4.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">with-local-randomness [ <i>commands</i> ]</span>
+				</h4>
+				<p>
+					The commands are run without affecting subsequent random events.
+					This is useful for performing extra operations (such as output)
+					without changing the outcome of a model.
+				</p>
+				<p>
+					Example:
+				</p>
+				<pre>
+					;; Run #1:
+					random-seed 50 setup repeat 10 [ go ]
+					;; Run #2:
+					random-seed 50 setup
+					with-local-randomness [ watch one-of turtles ]
+					repeat 10 [ go ]
+				</pre>
+				<p>
+					Since <code>one-of</code> is used inside
+					<code>with-local-randomness</code>, both runs will be identical.
+				</p>
+				<p>
+					Specifically how it works is, the state of the random number
+					generator is remembered before the commands run, then restored
+					afterwards. (If you want to run the commands with a fresh random
+					state instead of the same random state that will be restored later,
+					you can begin the commands with <code>random-seed new-seed</code>.)
+				</p>
+				<p>
+					The following example demonstrates that the random number generator
+					state is the same both before the commands run and afterwards.
+				</p>
+				<pre>
+					random-seed 10
+					with-local-randomness [ print n-values 10 [random 10] ]
+					;; prints [8 9 8 4 2 4 5 4 7 9]
+					print n-values 10 [random 10]
+					;; prints [8 9 8 4 2 4 5 4 7 9]
+				</pre>
+			</div>
+			<div class="dict_entry" id="without-interruption">
+				<h3>
+					<a>without-interruption<span class="since">1.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">without-interruption [ <i>commands</i> ]</span>
+				</h4>
+				<p>
+					This primitive exists only for backwards compatibility. We
+					don't recommend using it in new models.
+				</p>
+				<p>
+					The agent runs all the commands in the block without allowing other
+					agents using <code>ask-concurrent</code> to &quot;interrupt&quot;. That
+					is, other agents are put &quot;on hold&quot; and do not run any
+					commands until the commands in the block are finished.
+				</p>
+				<p>
+					Note: This command is only useful in conjunction with
+					<code>ask-concurrent</code>.
+				</p>
+				<p>
+					See also <a href="#ask-concurrent">ask-concurrent</a>.
+				</p>
+			</div>
+			<div class="dict_entry" id="word">
+				<h3>
+					<a>word<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">word <i>value1</i> <i>value2</i></span>
+					<span class="prim_example">(word <i>value1</i> ...)</span>
+				</h4>
+				<p>
+					Concatenates the inputs together and reports the result as a
+					string.
+				</p>
+				<pre>
+					show word &quot;tur&quot; &quot;tle&quot;
+					=&gt; &quot;turtle&quot;
+					word &quot;a&quot; 6
+					=&gt; &quot;a6&quot;
+					set directory &quot;c:\\foo\\fish\\&quot;
+					show word directory &quot;bar.txt&quot;
+					=&gt; &quot;c:\foo\fish\bar.txt&quot;
+					show word [1 54 8] &quot;fishy&quot;
+					=&gt; &quot;[1 54 8]fishy&quot;
+					show (word 3)
+					=&gt; &quot;3&quot;
+					show (word &quot;a&quot; &quot;b&quot; &quot;c&quot; 1 23)
+					=&gt; &quot;abc123&quot;
+				</pre>
+			</div>
+			<div class="dict_entry" id="world-dim">
+				<h3>
+					<a>world-width<span class="since">3.1</span></a>
+					<a>world-height<span class="since">3.1</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">world-width</span>
+					<span class="prim_example">world-height</span>
+				</h4>
+				<p>
+					These reporters give the total width and height of the NetLogo
+					world.
+				</p>
+				<p>
+					The width equals max-pxcor - min-pxcor + 1 and the height equals
+					max-pycor - min-pycor + 1.
+				</p>
+				<p>
+					See also <a href="#max-pcor">max-pxcor</a>, <a href="#max-pcor">max-pycor</a>, <a href="#min-pcor">min-pxcor</a>, and
+					<a href="#min-pcor">min-pycor</a>
+				</p>
+			</div>
+			<div class="dict_entry" id="wrap-color">
+				<h3>
+					<a>wrap-color<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">wrap-color <i>number</i></span>
+				</h4>
+				<p>
+					wrap-color checks whether <i>number</i> is in the NetLogo color
+					range of 0 to 140 (not including 140 itself). If it is not,
+					wrap-color &quot;wraps&quot; the numeric input to the 0 to 140
+					range.
+				</p>
+				<p>
+					The wrapping is done by repeatedly adding or subtracting 140 from
+					the given number until it is in the 0 to 140 range. (This is the
+					same wrapping that is done automatically if you assign an
+					out-of-range number to the color turtle variable or pcolor patch
+					variable.)
+				</p>
+				<pre>
+					show wrap-color 150
+					=&gt; 10
+					show wrap-color -10
+					=&gt; 130
+				</pre>
+			</div>
+			<div class="dict_entry" id="write">
+				<h3>
+					<a>write<span class="since">2.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">write <i>value</i></span>
+				</h4>
+				<p>
+					This command will output <i>value</i>, which can be a number,
+					string, list, boolean, or nobody to the Command Center, <i>not</i>
+					followed by a carriage return (unlike <a href="#print">print</a>
+					and <a href="#show">show</a>).
+				</p>
+				<p>
+					This agent is <i>not</i> printed before the value, unlike <a href="#show">show</a>. Its output also includes quotes around strings
+					and is prepended with a space.
+				</p>
+				<pre>
+					write &quot;hello world&quot;
+					=&gt;  &quot;hello world&quot;
+				</pre>
+				<p>
+					See also <a href="#print">print</a>, <a href="#show">show</a>,
+					<a href="#type">type</a>, <a href="#output-cmds">output-write</a>,
+					and <a href="programming.html#output">Output (programming guide)</a>.
+				</p>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="X">
+			<a>X</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="xcor">
+				<h3>
+					<a>xcor</a>
+				</h3>
+				<h4>
+					<span class="prim_example">xcor</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					This is a built-in turtle variable. It holds the current x
+					coordinate of the turtle. You can set this variable to change the
+					turtle's location.
+				</p>
+				<p>
+					This variable is always greater than or equal to (min-pxcor - 0.5)
+					and strictly less than (max-pxcor + 0.5).
+				</p>
+				<p>
+					See also <a href="#setxy">setxy</a>, <a href="#ycor">ycor</a>,
+					<a href="#pcor">pxcor</a>, <a href="#pcor">pycor</a>,
+				</p>
+			</div>
+			<div class="dict_entry" id="xor">
+				<h3>
+					<a>xor<span class="since">1.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example"><i>boolean1</i> xor <i>boolean2</i></span>
+				</h4>
+				<p>
+					Reports true if either <i>boolean1</i> or <i>boolean2</i> is true,
+					but not when both are true.
+				</p>
+				<pre>
+					if (pxcor &gt; 0) xor (pycor &gt; 0)
+					[ set pcolor blue ]
+					;; upper-left and lower-right quadrants turn blue
+				</pre>
+			</div><!-- ======================================== -->
+		</div>
+		<h2 id="Y">
+			<a>Y</a>
+		</h2><!-- ======================================== -->
+		<div>
+			<div class="dict_entry" id="ycor">
+				<h3>
+					<a>ycor</a>
+				</h3>
+				<h4>
+					<span class="prim_example">ycor</span>
+					<img alt="Turtle Command" src="images/turtle.gif"/>
+				</h4>
+				<p>
+					This is a built-in turtle variable. It holds the current y
+					coordinate of the turtle. You can set this variable to change the
+					turtle's location.
+				</p>
+				<p>
+					This variable is always greater than or equal to (min-pycor - 0.5)
+					and strictly less than (max-pycor + 0.5).
+				</p>
+				<p>
+					See also <a href="#setxy">setxy</a>, <a href="#xcor">xcor</a>,
+					<a href="#pcor">pxcor</a>, <a href="#pcor">pycor</a>,
+				</p>
+			</div><!-- ======================================== -->
+		</div>
+		<h2>
+			<a>-&gt;</a>
+		</h2><!-- ======================================== -->
+		<div id="ops">
+			<div class="dict_entry" id="arrow">
+				<h3>
+					<a>-><span class="since">6.0</span></a>
+				</h3>
+				<h4>
+					<span class="prim_example">[ [<i>args</i>] -> <i>commands</i> ]</span>
+					<span class="prim_example">[ [<i>args</i>] -> <i>reporter</i> ]</span>
+				</h4>
+				<p>
+					Creates and reports an anonymous procedure - a command or reporter
+					- depending on the input. Within <i>commands</i> or <i>reporter</i> the listed
+					<i>args</i> may be used just as you would use <code>let</code> or procedure variables.
+					The variable names in <i>args</i> have the same restrictions
+					as variable names of commands and reporters. In addition, they must not match the name of
+					any let or procedure variable in their procedure.
+				</p>
+				<p>
+					Anonymous procedures are commonly used with the primitives
+					<a href="#foreach">foreach</a>, <a href="#map">map</a>, <a href="#reduce">reduce</a>,
+					<a href="#filter">filter</a>, <a href="#sort-by">sort-by</a>, and <a href="#n-values">n-values</a>. See
+					those entries for example usage.
+				</p>
+				<p>
+					See the <a href="programming.html#anonymous-procedures">Anonymous Procedures section</a> of the
+					Programming Guide for details.
+				</p>
+			</div>
+		</div>
+	</body>
 </html>

--- a/autogen/docs/dictionary.html.mustache
+++ b/autogen/docs/dictionary.html.mustache
@@ -864,11 +864,11 @@
           Reports the absolute value of <i>number</i>.
         </p>
         <pre>
-          show abs -7
-          =&gt; 7
-          show abs 5
-          =&gt; 5
-        </pre>
+show abs -7
+=&gt; 7
+show abs 5
+=&gt; 5
+</pre>
       </div>
       <div class="dict_entry" id="acos">
         <h3>
@@ -903,9 +903,9 @@
           true or false), otherwise an error occurs.
         </p>
         <pre>
-          if all? turtles [color = red]
-          [ show &quot;every turtle is red!&quot; ]
-        </pre>
+if all? turtles [color = red]
+[ show &quot;every turtle is red!&quot; ]
+</pre>
         <p>
           See also <a href="#any">any?</a>.
         </p>
@@ -926,10 +926,10 @@
           will not be run (since it can't affect the result).
         </p>
         <pre>
-          if (pxcor &gt; 0) and (pycor &gt; 0)
-          [ set pcolor blue ]  ;; the upper-right quadrant of
-          ;; patches turn blue
-        </pre>
+if (pxcor &gt; 0) and (pycor &gt; 0)
+[ set pcolor blue ]  ;; the upper-right quadrant of
+;; patches turn blue
+</pre>
       </div>
       <div class="dict_entry" id="any">
         <h3>
@@ -946,9 +946,9 @@
           efficient (and arguably more readable).
         </p>
         <pre>
-          if any? turtles with [color = red]
-          [ show &quot;at least one turtle is red!&quot; ]
-        </pre>
+if any? turtles with [color = red]
+[ show &quot;at least one turtle is red!&quot; ]
+</pre>
         <p>
           Note: nobody is not an agentset. You only get nobody back in
           situations where you were expecting a single agent, not a whole
@@ -979,11 +979,11 @@
           color space does not include all possible colors.
         </p>
         <pre>
-          show approximate-hsb 0 0 0
-          =&gt; 0  ;; (black)
-          show approximate-hsb 180 57.143 76.863
-          =&gt; 85 ;; (cyan)
-        </pre>
+show approximate-hsb 0 0 0
+=&gt; 0  ;; (black)
+show approximate-hsb 180 57.143 76.863
+=&gt; 85 ;; (cyan)
+</pre>
         <p>
           See also <a href="#extract-hsb">extract-hsb</a>, <a href="#approximate-rgb">approximate-rgb</a>, <a href="#extract-rgb">extract-rgb</a>.
         </p>
@@ -1010,11 +1010,11 @@
           difficult to characterize in RGB terms.)
         </p>
         <pre>
-          show approximate-rgb 0 0 0
-          =&gt; 0  ;; black
-          show approximate-rgb 0 255 255
-          =&gt; 85.2 ;; cyan
-        </pre>
+show approximate-rgb 0 0 0
+=&gt; 0  ;; black
+show approximate-rgb 0 255 255
+=&gt; 85.2 ;; cyan
+</pre>
         <p>
           See also <a href="#extract-rgb">extract-rgb</a>, <a href="#approximate-hsb">approximate-hsb</a>, and <a href="#extract-hsb">extract-hsb</a>.
         </p>
@@ -1076,11 +1076,11 @@
           should add parentheses.
         </p>
         <pre>
-          show 5 * 6 + 6 / 3
-          =&gt; 32
-          show 5 * (6 + 6) / 3
-          =&gt; 20
-        </pre>
+show 5 * 6 + 6 / 3
+=&gt; 32
+show 5 * (6 + 6) / 3
+=&gt; 20
+</pre>
         <p>
           Many extension objects may be tested for equality and inequality
           using = and !=.
@@ -1118,13 +1118,13 @@
           for more information.
         </p>
         <pre>
-          ask turtles [ fd 1 ]
-          ;; all turtles move forward one step
-          ask patches [ set pcolor red ]
-          ;; all patches turn red
-          ask turtle 4 [ rt 90 ]
-          ;; only the turtle with id 4 turns right
-        </pre>
+ask turtles [ fd 1 ]
+;; all turtles move forward one step
+ask patches [ set pcolor red ]
+;; all patches turn red
+ask turtle 4 [ rt 90 ]
+;; only the turtle with id 4 turns right
+</pre>
         <p>
           Note: only the observer can ask all turtles or all patches. This
           prevents you from inadvertently having all turtles ask all turtles
@@ -1186,11 +1186,11 @@
           under the turtle.
         </p>
         <pre>
-          ask turtles at-points [[2 4] [1 2] [10 15]]
-          [ fd 1 ]  ;; only the turtles on the patches at the
-          ;; coordinates (2,4), (1,2) and (10,15),
-          ;; relative to the caller, move
-        </pre>
+ask turtles at-points [[2 4] [1 2] [10 15]]
+[ fd 1 ]  ;; only the turtles on the patches at the
+;; coordinates (2,4), (1,2) and (10,15),
+;; relative to the caller, move
+</pre>
       </div>
       <div class="dict_entry" id="atan">
         <h3>
@@ -1216,13 +1216,13 @@
           reports 270; if x is zero, you get an error.
         </p>
         <pre>
-          show atan 1 -1
-          =&gt; 135
-          show atan -1 1
-          =&gt; 315
-          crt 1 [ set heading 30  fd 1  print atan xcor ycor ]
-          =&gt; 30
-        </pre>
+show atan 1 -1
+=&gt; 135
+show atan -1 1
+=&gt; 315
+crt 1 [ set heading 30  fd 1  print atan xcor ycor ]
+=&gt; 30
+</pre>
         <p>
           In the final example, note that the result of <code>atan</code> equals
           the turtle's heading.
@@ -1233,10 +1233,10 @@
           helpful:
         </p>
         <pre>
-          to-report heading-to-angle [ h ]
-          report (90 - h) mod 360
-          end
-        </pre>
+to-report heading-to-angle [ h ]
+report (90 - h) mod 360
+end
+</pre>
       </div>
       <div class="dict_entry" id="autoplot">
         <h3>
@@ -1312,13 +1312,13 @@
           Reports a list of the 14 basic NetLogo hues.
         </p>
         <pre>
-          print base-colors
-          =&gt; [5 15 25 35 45 55 65 75 85 95 105 115 125 135]
-          ask turtles [ set color one-of base-colors ]
-          ;; each turtle turns a random base color
-          ask turtles [ set color one-of remove gray base-colors ]
-          ;; each turtle turns a random base color except for gray
-        </pre>
+print base-colors
+=&gt; [5 15 25 35 45 55 65 75 85 95 105 115 125 135]
+ask turtles [ set color one-of base-colors ]
+;; each turtle turns a random base color
+ask turtles [ set color one-of remove gray base-colors ]
+;; each turtle turns a random base color except for gray
+</pre>
       </div>
       <div class="dict_entry" id="beep">
         <h3>
@@ -1336,12 +1336,12 @@
           Example:
         </p>
         <pre>
-          beep                       ;; emits one beep
-          repeat 3 [ beep ]          ;; emits 3 beeps at once,
-          ;; so you only hear one sound
-          repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
-          ;; separated by 1/10th of a second
-        </pre>
+beep                       ;; emits one beep
+repeat 3 [ beep ]          ;; emits 3 beeps at once,
+;; so you only hear one sound
+repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
+;; separated by 1/10th of a second
+</pre>
         <p>
           When running headless, this command has no effect.
         </p>
@@ -1387,12 +1387,12 @@
           Reports the agentset of the 2 nodes connected by this link.
         </p>
         <pre>
-          crt 2
-          ask turtle 0 [ create-link-with turtle 1 ]
-          ask link 0 1 [
-          ask both-ends [ set color red ] ;; turtles 0 and 1 both turn red
-          ]
-        </pre>
+crt 2
+ask turtle 0 [ create-link-with turtle 1 ]
+ask link 0 1 [
+ask both-ends [ set color red ] ;; turtles 0 and 1 both turn red
+]
+</pre>
       </div>
       <div class="dict_entry" id="breedvar">
         <h3>
@@ -1421,18 +1421,18 @@
           Example:
         </p>
         <pre>
-          breed [cats cat]
-          breed [dogs dog]
-          ;; turtle code:
-          if breed = cats [ show &quot;meow!&quot; ]
-          set breed dogs
-          show &quot;woof!&quot;
-        </pre>
+breed [cats cat]
+breed [dogs dog]
+;; turtle code:
+if breed = cats [ show &quot;meow!&quot; ]
+set breed dogs
+show &quot;woof!&quot;
+</pre>
         <pre>
-          directed-link-breed [ roads road ]
-          ;; link code
-          if breed = roads [ set color gray ]
-        </pre>
+directed-link-breed [ roads road ]
+;; link code
+if breed = roads [ set color gray ]
+</pre>
       </div>
       <div class="dict_entry" id="breed">
         <h3>
@@ -1460,25 +1460,25 @@
           commands to only the turtles of a particular breed.
         </p>
         <pre>
-          breed [mice mouse]
-          breed [frogs frog]
-          to setup
-          clear-all
-          create-mice 50
-          ask mice [ set color white ]
-          create-frogs 50
-          ask frogs [ set color green ]
-          show [breed] of one-of mice    ;; prints mice
-          show [breed] of one-of frogs   ;; prints frogs
-          end
+breed [mice mouse]
+breed [frogs frog]
+to setup
+clear-all
+create-mice 50
+ask mice [ set color white ]
+create-frogs 50
+ask frogs [ set color green ]
+show [breed] of one-of mice    ;; prints mice
+show [breed] of one-of frogs   ;; prints frogs
+end
 
-          show mouse 1
-          ;; prints (mouse 1)
-          show frog 51
-          ;; prints (frog 51)
-          show turtle 51
-          ;; prints (frog 51)
-        </pre>
+show mouse 1
+;; prints (mouse 1)
+show frog 51
+;; prints (frog 51)
+show turtle 51
+;; prints (frog 51)
+</pre>
         <p>
           See also <a href="#globals">globals</a>, <a href="#patches-own">patches-own</a>, <a href="#turtles-own">turtles-own</a>, <a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>, <a href="#create-turtles">create-<i>&lt;breeds&gt;</i></a>, <a href="#turtles-at"><i>&lt;breeds&gt;</i>-at</a>, <a href="#turtles-here"><i>&lt;breeds&gt;</i>-here</a>.
         </p>
@@ -1508,16 +1508,16 @@
           the first or last character of the original string.
         </p>
         <pre>
-          ;; mylist is [2 4 6 5 8 12]
-          set mylist but-first mylist
-          ;; mylist is now [4 6 5 8 12]
-          set mylist but-last mylist
-          ;; mylist is now [4 6 5 8]
-          show but-first &quot;string&quot;
-          ;; prints &quot;tring&quot;
-          show but-last &quot;string&quot;
-          ;; prints &quot;strin&quot;
-        </pre><!-- ======================================== -->
+;; mylist is [2 4 6 5 8 12]
+set mylist but-first mylist
+;; mylist is now [4 6 5 8 12]
+set mylist but-last mylist
+;; mylist is now [4 6 5 8]
+show but-first &quot;string&quot;
+;; prints &quot;tring&quot;
+show but-last &quot;string&quot;
+;; prints &quot;strin&quot;
+</pre><!-- ======================================== -->
       </div>
     </div>
     <h2 id="C">
@@ -1542,7 +1542,7 @@
         </p>
         <pre>
           patch-ahead <i>distance</i> != nobody
-        </pre>
+</pre>
       </div>
       <div class="dict_entry" id="carefully">
         <h3>
@@ -1562,11 +1562,11 @@
           out what error was suppressed in <i>commands1</i>. See <a href="#error-message">error-message</a>.
         </p>
         <pre>
-          carefully [ print one-of [1 2 3] ] [ print error-message ]
-          =&gt; 3
-          observer&gt; carefully [ print one-of [] ] [ print error-message ]
-          =&gt; ONE-OF got an empty list as input.
-        </pre>
+carefully [ print one-of [1 2 3] ] [ print error-message ]
+=&gt; 3
+observer&gt; carefully [ print one-of [] ] [ print error-message ]
+=&gt; ONE-OF got an empty list as input.
+</pre>
       </div>
       <div class="dict_entry" id="ceiling">
         <h3>
@@ -1580,11 +1580,11 @@
           <i>number</i>.
         </p>
         <pre>
-          show ceiling 4.5
-          =&gt; 5
-          show ceiling -4.5
-          =&gt; -4
-        </pre>
+show ceiling 4.5
+=&gt; 5
+show ceiling -4.5
+=&gt; -4
+</pre>
         <p>
           See also <a href="#floor">floor</a>, <a href="#round">round</a>,
           <a href="#precision">precision</a>.
@@ -1788,9 +1788,9 @@
         in degrees.
       </p>
       <pre>
-        show cos 180
-        =&gt; -1
-      </pre>
+show cos 180
+=&gt; -1
+</pre>
     </div>
     <div class="dict_entry" id="count">
       <h3>
@@ -1803,11 +1803,11 @@
         Reports the number of agents in the given agentset.
       </p>
       <pre>
-        show count turtles
-        ;; prints the total number of turtles
-        show count patches with [pcolor = red]
-        ;; prints the total number of red patches
-      </pre>
+show count turtles
+;; prints the total number of turtles
+show count patches with [pcolor = red]
+;; prints the total number of red patches
+</pre>
     </div>
     <div class="dict_entry" id="create-ordered-turtles">
       <h3>
@@ -1837,8 +1837,8 @@
         run one at a time, in random order.)
       </p>
       <pre>
-        cro 100 [ fd 10 ]  ;; makes an evenly spaced circle
-      </pre>
+cro 100 [ fd 10 ]  ;; makes an evenly spaced circle
+</pre>
     </div>
     <div class="dict_entry" id="create-link">
       <h3>
@@ -1913,37 +1913,37 @@
         to itself you get a runtime error.
       </p>
       <pre>
-        to setup
-        clear-all
-        create-turtles 5
-        ;; turtle 1 creates links with all other turtles
-        ;; the link between the turtle and itself is ignored
-        ask turtle 0 [ create-links-with other turtles ]
-        show count links ;; shows 4
-        ;; this does nothing since the link already exists
-        ask turtle 0 [ create-link-with turtle 1 ]
-        show count links ;; shows 4 since the previous link already existed
-        ask turtle 2 [ create-link-with turtle 1 ]
-        show count links ;; shows 5
-        end
-      </pre>
+to setup
+clear-all
+create-turtles 5
+;; turtle 1 creates links with all other turtles
+;; the link between the turtle and itself is ignored
+ask turtle 0 [ create-links-with other turtles ]
+show count links ;; shows 4
+;; this does nothing since the link already exists
+ask turtle 0 [ create-link-with turtle 1 ]
+show count links ;; shows 4 since the previous link already existed
+ask turtle 2 [ create-link-with turtle 1 ]
+show count links ;; shows 5
+end
+</pre>
       <pre>
-        directed-link-breed [red-links red-link]
-        undirected-link-breed [blue-links blue-link]
+directed-link-breed [red-links red-link]
+undirected-link-breed [blue-links blue-link]
 
-        to setup
-        clear-all
-        create-turtles 5
-        ;; create links in both directions between turtle 0
-        ;; and all other turtles
-        ask turtle 0 [ create-red-links-to other turtles ]
-        ask turtle 0 [ create-red-links-from other turtles ]
-        show count links ;; shows 8
-        ;; now create undirected links between turtle 0 and other turtles
-        ask turtle 0 [ create-blue-links-with other turtles ]
-        show count links ;; shows 12
-        end
-      </pre>
+to setup
+clear-all
+create-turtles 5
+;; create links in both directions between turtle 0
+;; and all other turtles
+ask turtle 0 [ create-red-links-to other turtles ]
+ask turtle 0 [ create-red-links-from other turtles ]
+show count links ;; shows 8
+;; now create undirected links between turtle 0 and other turtles
+ask turtle 0 [ create-blue-links-with other turtles ]
+show count links ;; shows 12
+end
+</pre>
     </div>
     <div class="dict_entry" id="create-turtles">
       <h3>
@@ -1973,17 +1973,17 @@
         run one at a time, in random order.)
       </p>
       <pre>
-        crt 100 [ fd 10 ]     ;; makes a randomly spaced circle
-      </pre>
+crt 100 [ fd 10 ]     ;; makes a randomly spaced circle
+</pre>
       <pre>
-        breed [canaries canary]
-        breed [snakes snake]
-        to setup
-        clear-all
-        create-canaries 50 [ set color yellow ]
-        create-snakes 50 [ set color green ]
-        end
-      </pre>
+breed [canaries canary]
+breed [snakes snake]
+to setup
+clear-all
+create-canaries 50 [ set color yellow ]
+create-snakes 50 [ set color green ]
+end
+</pre>
       <p>
         See also <a href="#hatch">hatch</a>, <a href="#sprout">sprout</a>.
       </p>
@@ -2044,9 +2044,9 @@
           capabilities of the underlying Java Virtual Machine.)
         </p>
         <pre>
-          show date-and-time
-          =&gt; &quot;01:19:36.685 PM 19-Sep-2002&quot;
-        </pre>
+show date-and-time
+=&gt; &quot;01:19:36.685 PM 19-Sep-2002&quot;
+</pre>
       </div>
       <div class="dict_entry" id="die">
         <h3>
@@ -2060,11 +2060,11 @@
           The turtle or link dies.
         </p>
         <pre>
-          if xcor &gt; 20 [ die ]
-          ;; all turtles with xcor greater than 20 die
-          ask links with [color = blue] [ die ]
-          ;; all the blue links will die
-        </pre>
+if xcor &gt; 20 [ die ]
+;; all turtles with xcor greater than 20 die
+ask links with [color = blue] [ die ]
+;; all the blue links will die
+</pre>
         <p>
           A dead agent ceases to exist. The effects of this include:
         </p>
@@ -2116,12 +2116,12 @@
           the patches at once -- patch commands act on individual patches.)
         </p>
         <pre>
-          diffuse chemical 0.5
-          ;; each patch diffuses 50% of its variable
-          ;; chemical to its neighboring 8 patches. Thus,
-          ;; each patch gets 1/8 of 50% of the chemical
-          ;; from each neighboring patch.)
-        </pre>
+diffuse chemical 0.5
+;; each patch diffuses 50% of its variable
+;; chemical to its neighboring 8 patches. Thus,
+;; each patch gets 1/8 of 50% of the chemical
+;; from each neighboring patch.)
+</pre>
       </div>
       <div class="dict_entry" id="diffuse4">
         <h3>
@@ -2136,12 +2136,12 @@
           the north, south, east, and west), not to the diagonal neighbors.
         </p>
         <pre>
-          diffuse4 chemical 0.5
-          ;; each patch diffuses 50% of its variable
-          ;; chemical to its neighboring 4 patches. Thus,
-          ;; each patch gets 1/4 of 50% of the chemical
-          ;; from each neighboring patch.)
-        </pre>
+diffuse4 chemical 0.5
+;; each patch diffuses 50% of its variable
+;; chemical to its neighboring 4 patches. Thus,
+;; each patch gets 1/4 of 50% of the chemical
+;; from each neighboring patch.)
+</pre>
       </div>
       <div class="dict_entry" id="directed-link-breed">
         <h3>
@@ -2173,22 +2173,22 @@
           commands to only the links of a particular breed.
         </p>
         <pre>
-          directed-link-breed [streets street]
-          directed-link-breed [highways highway]
-          to setup
-          clear-all
-          crt 2
-          ;; create a link from turtle 0 to turtle 1
-          ask turtle 0 [ create-street-to turtle 1 ]
-          ;; create a link from turtle 1 to turtle 0
-          ask turtle 0 [ create-highway-from turtle 1 ]
-          end
+directed-link-breed [streets street]
+directed-link-breed [highways highway]
+to setup
+clear-all
+crt 2
+;; create a link from turtle 0 to turtle 1
+ask turtle 0 [ create-street-to turtle 1 ]
+;; create a link from turtle 1 to turtle 0
+ask turtle 0 [ create-highway-from turtle 1 ]
+end
 
-          ask turtle 0 [ show one-of my-in-links ]
-          ;; prints (street 0 1)
-          ask turtle 0 [ show one-of my-out-links ]
-          ;; prints (highway 1 0)
-        </pre>
+ask turtle 0 [ show one-of my-in-links ]
+;; prints (street 0 1)
+ask turtle 0 [ show one-of my-out-links ]
+;; prints (highway 1 0)
+</pre>
         <p>
           See also <a href="#breed">breed</a>, <a href="#undirected-link-breed">undirected-link-breed</a>
         </p>
@@ -2210,13 +2210,13 @@
           updates were suspended by that command, they will resume.
         </p>
         <pre>
-          no-display
-          ask turtles [ jump 10 set color blue set size 5 ]
-          display
-          ;; turtles move, change color, and grow, with none of
-          ;; their intermediate states visible to the user, only
-          ;; their final state
-        </pre>
+no-display
+ask turtles [ jump 10 set color blue set size 5 ]
+display
+;; turtles move, change color, and grow, with none of
+;; their intermediate states visible to the user, only
+;; their final state
+</pre>
         <p>
           Even if no-display was not used, &quot;display&quot; can still be
           useful, because ordinarily NetLogo is free to skip some view
@@ -2225,12 +2225,12 @@
           changes have taken place in the world are visible to the user.
         </p>
         <pre>
-          ask turtles [ set color red ]
-          display
-          ask turtles [ set color blue]
-          ;; turtles turn red, then blue; use of &quot;display&quot; forces
-          ;; red turtles to appear briefly
-        </pre>
+ask turtles [ set color red ]
+display
+ask turtles [ set color blue]
+;; turtles turn red, then blue; use of &quot;display&quot; forces
+;; red turtles to appear briefly
+</pre>
         <p>
           Note that display and no-display operate independently of the
           switch in the view control strip that freezes the view.
@@ -2257,9 +2257,9 @@
           wrapped distance is shorter.
         </p>
         <pre>
-          ask turtles [ show max-one-of turtles [distance myself] ]
-          ;; each turtle prints the turtle farthest from itself
-        </pre>
+ask turtles [ show max-one-of turtles [distance myself] ]
+;; each turtle prints the turtle farthest from itself
+</pre>
       </div>
       <div class="dict_entry" id="distancexy">
         <h3>
@@ -2280,11 +2280,11 @@
           distance is shorter.
         </p>
         <pre>
-          if (distancexy 0 0) &gt; 10
-          [ set color green ]
-          ;; all turtles more than 10 units from
-          ;; the center of the world turn green.
-        </pre>
+if (distancexy 0 0) &gt; 10
+[ set color green ]
+;; all turtles more than 10 units from
+;; the center of the world turn green.
+</pre>
       </div>
       <div class="dict_entry" id="downhill">
         <h3>
@@ -2318,7 +2318,7 @@
           face p
           move-to p
           ]
-        </pre>
+</pre>
         <p>
           Note that the turtle always ends up on a patch center and has a
           heading that is a multiple of 45 (downhill) or 90 (downhill4).
@@ -2402,12 +2402,12 @@
           lower who number. You cannot set end1.
         </p>
         <pre>
-          crt 2
-          ask turtle 0
-          [ create-link-to turtle 1 ]
-          ask links
-          [ show end1 ] ;; shows turtle 0
-        </pre>
+crt 2
+ask turtle 0
+[ create-link-to turtle 1 ]
+ask links
+[ show end1 ] ;; shows turtle 0
+</pre>
       </div>
       <div class="dict_entry" id="end2">
         <h3>
@@ -2424,12 +2424,12 @@
           the higher who number. You cannot set end2.
         </p>
         <pre>
-          crt 2
-          ask turtle 1
-          [ create-link-with turtle 0 ]
-          ask links
-          [ show end2 ] ;; shows turtle 1
-        </pre>
+crt 2
+ask turtle 1
+[ create-link-with turtle 0 ]
+ask links
+[ show end2 ] ;; shows turtle 1
+</pre>
       </div>
       <div class="dict_entry" id="error">
         <h3>
@@ -2495,11 +2495,11 @@
           below.
         </p>
         <pre>
-          every 0.5 [ ask turtles [ fd 1 ] ]
-          ;; twice a second the turtles will move forward 1
-          every 2 [ set index index + 1 ]
-          ;; every 2 seconds index is incremented
-        </pre>
+every 0.5 [ ask turtles [ fd 1 ] ]
+;; twice a second the turtles will move forward 1
+every 2 [ set index index + 1 ]
+;; every 2 seconds index is incremented
+</pre>
         <p>
           See also <a href="#wait">wait</a>.
         </p>
@@ -2594,26 +2594,26 @@
           directly from NetLogo's File menu.
         </p>
         <pre>
-          export-world &quot;fire.csv&quot;
-          ;; exports the state of the model to the file fire.csv
-          ;; located in the NetLogo folder
-          export-plot &quot;Temperature&quot; &quot;c:/My Documents/plot.csv&quot;
-          ;; exports the plot named
-          ;; &quot;Temperature&quot; to the file plot.csv located in
-          ;; the C:\My Documents folder
-          export-all-plots &quot;c:/My Documents/plots.csv&quot;
-          ;; exports all plots to the file plots.csv
-          ;; located in the C:\My Documents folder
-        </pre>
+export-world &quot;fire.csv&quot;
+;; exports the state of the model to the file fire.csv
+;; located in the NetLogo folder
+export-plot &quot;Temperature&quot; &quot;c:/My Documents/plot.csv&quot;
+;; exports the plot named
+;; &quot;Temperature&quot; to the file plot.csv located in
+;; the C:\My Documents folder
+export-all-plots &quot;c:/My Documents/plots.csv&quot;
+;; exports all plots to the file plots.csv
+;; located in the C:\My Documents folder
+</pre>
         <p>
           If the file already exists, it is overwritten. To avoid this you
           may wish to use some method of generating fresh names. Examples:
         </p>
         <pre>
-          export-world user-new-file
-          export-world (word &quot;results &quot; date-and-time &quot;.csv&quot;) ;; Colon characters in the time cause errors on Windows
-          export-world (word &quot;results &quot; random-float 1.0 &quot;.csv&quot;)
-        </pre>
+export-world user-new-file
+export-world (word &quot;results &quot; date-and-time &quot;.csv&quot;) ;; Colon characters in the time cause errors on Windows
+export-world (word &quot;results &quot; random-float 1.0 &quot;.csv&quot;)
+</pre>
       </div>
       <div class="dict_entry" id="extensions">
         <h3>
@@ -2647,13 +2647,13 @@
           of red, green, and blue.
         </p>
         <pre>
-          show extract-hsb cyan
-          =&gt; [180 57.143 76.863]
-          show extract-hsb red
-          =&gt; [3.103 80.93 84.314]
-          show extract-hsb [255 0 0]
-          =&gt; [0 100 100]
-        </pre>
+show extract-hsb cyan
+=&gt; [180 57.143 76.863]
+show extract-hsb red
+=&gt; [3.103 80.93 84.314]
+show extract-hsb [255 0 0]
+=&gt; [0 100 100]
+</pre>
         <p>
           See also <a href="#approximate-hsb">approximate-hsb</a>, <a href="#approximate-rgb">approximate-rgb</a>, <a href="#extract-rgb">extract-rgb</a>.
         </p>
@@ -2672,11 +2672,11 @@
           itself.
         </p>
         <pre>
-          show extract-rgb red
-          =&gt; [215 50 41]
-          show extract-rgb cyan
-          =&gt; [84 196 196]
-        </pre>
+show extract-rgb red
+=&gt; [215 50 41]
+show extract-rgb cyan
+=&gt; [84 196 196]
+</pre>
         <p>
           See also <a href="#approximate-rgb">approximate-rgb</a>, <a href="#approximate-hsb">approximate-hsb</a>, <a href="#extract-hsb">extract-hsb</a>.
         </p>
@@ -2740,14 +2740,14 @@
           the current file (that was opened previously with <a href="#file-open">file-open</a>). Otherwise, reports false.
         </p>
         <pre>
-          file-open &quot;my-file.txt&quot;
-          print file-at-end?
-          =&gt; false ;; Can still read in more characters
-          print file-read-line
-          =&gt; This is the last line in file
-          print file-at-end?
-          =&gt; true ;; We reached the end of the file
-        </pre>
+file-open &quot;my-file.txt&quot;
+print file-at-end?
+=&gt; false ;; Can still read in more characters
+print file-read-line
+=&gt; This is the last line in file
+print file-at-end?
+=&gt; true ;; We reached the end of the file
+</pre>
         <p>
           See also <a href="#file-open">file-open</a>, <a href="#file-close-all">file-close-all</a>.
         </p>
@@ -2888,13 +2888,13 @@
           to the model's directory.
         </p>
         <pre>
-          file-open &quot;my-file-in.txt&quot;
-          print file-read-line
-          =&gt; First line in file ;; File is in reading mode
-          file-open &quot;C:\\NetLogo\\my-file-out.txt&quot;
-          ;; assuming Windows machine
-          file-print &quot;Hello World&quot; ;; File is in writing mode
-        </pre>
+file-open &quot;my-file-in.txt&quot;
+print file-read-line
+=&gt; First line in file ;; File is in reading mode
+file-open &quot;C:\\NetLogo\\my-file-out.txt&quot;
+;; assuming Windows machine
+file-print &quot;Hello World&quot; ;; File is in writing mode
+</pre>
         <p>
           Opening a file does not close previously opened files. You can use
           <code>file-open</code> to switch back and forth between multiple open
@@ -2956,14 +2956,14 @@
           of the file.
         </p>
         <pre>
-          file-open &quot;my-file.data&quot;
-          print file-read + 5
-          ;; Next value is the number 1
-          =&gt; 6
-          print length file-read
-          ;; Next value is the list [1 2 3 4]
-          =&gt; 4
-        </pre>
+file-open &quot;my-file.data&quot;
+print file-read + 5
+;; Next value is the number 1
+=&gt; 6
+print length file-read
+;; Next value is the list [1 2 3 4]
+=&gt; 4
+</pre>
         <p>
           See also <a href="#file-open">file-open</a> and <a href="#file-write">file-write</a>.
         </p>
@@ -2991,11 +2991,11 @@
           of the file.
         </p>
         <pre>
-          file-open &quot;my-file.txt&quot;
-          print file-read-characters 5
-          ;; Current line in file is &quot;Hello World&quot;
-          =&gt; Hello
-        </pre>
+file-open &quot;my-file.txt&quot;
+print file-read-characters 5
+;; Current line in file is &quot;Hello World&quot;
+=&gt; Hello
+</pre>
         <p>
           See also <a href="#file-open">file-open</a>.
         </p>
@@ -3020,10 +3020,10 @@
           of the file.
         </p>
         <pre>
-          file-open &quot;my-file.txt&quot;
-          print file-read-line
-          =&gt; Hello World
-        </pre>
+file-open &quot;my-file.txt&quot;
+print file-read-line
+=&gt; Hello World
+</pre>
         <p>
           See also <a href="#file-open">file-open</a>.
         </p>
@@ -3100,10 +3100,10 @@
           be called before this command can be used.
         </p>
         <pre>
-          file-open &quot;locations.txt&quot;
-          ask turtles
-          [ file-write xcor file-write ycor ]
-        </pre>
+file-open &quot;locations.txt&quot;
+ask turtles
+[ file-write xcor file-write ycor ]
+</pre>
         <p>
           See also <a href="#file-print">file-print</a>, <a href="#file-show">file-show</a>,
           <a href="#file-type">file-type</a>,
@@ -3124,13 +3124,13 @@
           name of a reporter.
         </p>
         <pre>
-          show filter is-number? [1 &quot;2&quot; 3]
-          =&gt; [1 3]
-          show filter [ i -&gt; i &lt; 3 ] [1 3 2]
-          =&gt; [1 2]
-          show filter [ s -&gt; first s != &quot;t&quot; ] [&quot;hi&quot; &quot;there&quot; &quot;everyone&quot;]
-          =&gt; [&quot;hi&quot; &quot;everyone&quot;]
-        </pre>
+show filter is-number? [1 &quot;2&quot; 3]
+=&gt; [1 3]
+show filter [ i -&gt; i &lt; 3 ] [1 3 2]
+=&gt; [1 2]
+show filter [ s -&gt; first s != &quot;t&quot; ] [&quot;hi&quot; &quot;there&quot; &quot;everyone&quot;]
+=&gt; [&quot;hi&quot; &quot;everyone&quot;]
+</pre>
         <p>
           See also <a href="#map">map</a>, <a href="#reduce">reduce</a>,
           <a href="#arrow">-> (anonymous procedure)</a>.
@@ -3163,11 +3163,11 @@
           Reports the largest integer less than or equal to <i>number</i>.
         </p>
         <pre>
-          show floor 4.5
-          =&gt; 4
-          show floor -4.5
-          =&gt; -5
-        </pre>
+show floor 4.5
+=&gt; 4
+show floor -4.5
+=&gt; -5
+</pre>
         <p>
           See also <a href="#ceiling">ceiling</a>, <a href="#round">round</a>, <a href="#precision">precision</a>.
         </p>
@@ -3230,15 +3230,15 @@
           created with <a href="#arrow">-&gt;</a>.
         </p>
         <pre>
-          foreach [1.1 2.2 2.6] show
-          =&gt; 1.1
-          =&gt; 2.2
-          =&gt; 2.6
-          foreach [1.1 2.2 2.6] [ x -&gt; show (word x &quot; -&gt; &quot; round x) ]
-          =&gt; 1.1 -&gt; 1
-          =&gt; 2.2 -&gt; 2
-          =&gt; 2.6 -&gt; 3
-        </pre>
+foreach [1.1 2.2 2.6] show
+=&gt; 1.1
+=&gt; 2.2
+=&gt; 2.6
+foreach [1.1 2.2 2.6] [ x -&gt; show (word x &quot; -&gt; &quot; round x) ]
+=&gt; 1.1 -&gt; 1
+=&gt; 2.2 -&gt; 2
+=&gt; 2.6 -&gt; 3
+</pre>
         <p>
           With multiple lists, runs <i>command</i> for each group of items
           from each list.
@@ -3249,16 +3249,16 @@
           Some examples make this clearer:
         </p>
         <pre>
-          (foreach [1 2 3] [2 4 6]
-          [ [a b] -&gt; show word &quot;the sum is: &quot; (a + b) ])
-          =&gt; &quot;the sum is: 3&quot;
-          =&gt; &quot;the sum is: 6&quot;
-          =&gt; &quot;the sum is: 9&quot;
-          (foreach list (turtle 1) (turtle 2) [3 4]
-          [ [the-turtle num-steps] -&gt; ask the-turtle [ fd num-steps ] ])
-          ;; turtle 1 moves forward 3 patches
-          ;; turtle 2 moves forward 4 patches
-        </pre>
+(foreach [1 2 3] [2 4 6]
+[ [a b] -&gt; show word &quot;the sum is: &quot; (a + b) ])
+=&gt; &quot;the sum is: 3&quot;
+=&gt; &quot;the sum is: 6&quot;
+=&gt; &quot;the sum is: 9&quot;
+(foreach list (turtle 1) (turtle 2) [3 4]
+[ [the-turtle num-steps] -&gt; ask the-turtle [ fd num-steps ] ])
+;; turtle 1 moves forward 3 patches
+;; turtle 2 moves forward 4 patches
+</pre>
         <p>
           See also <a href="#map">map</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>.
         </p>
@@ -3302,10 +3302,10 @@
           list.
         </p>
         <pre>
-          ;; suppose mylist is [5 7 10]
-          set mylist fput 2 mylist
-          ;; mylist is now [2 5 7 10]
-        </pre>
+;; suppose mylist is [5 7 10]
+set mylist fput 2 mylist
+;; mylist is now [2 5 7 10]
+</pre>
       </div><!-- ======================================== -->
     </div>
     <h2 id="G">
@@ -3365,13 +3365,13 @@
           turtles are the same breed as their parent.
         </p>
         <pre>
-          hatch 1 [ lt 45 fd 1 ]
-          ;; this turtle creates one new turtle,
-          ;; and the child turns and moves away
-          hatch-sheep 1 [ set color black ]
-          ;; this turtle creates a new turtle
-          ;; of the sheep breed
-        </pre>
+hatch 1 [ lt 45 fd 1 ]
+;; this turtle creates one new turtle,
+;; and the child turns and moves away
+hatch-sheep 1 [ set color black ]
+;; this turtle creates a new turtle
+;; of the sheep breed
+</pre>
         <p>
           See also <a href="#create-turtles">create-turtles</a>, <a href="#sprout">sprout</a>.
         </p>
@@ -3398,9 +3398,9 @@
           Example:
         </p>
         <pre>
-          set heading 45      ;; turtle is now facing northeast
-          set heading heading + 10 ;; same effect as &quot;rt 10&quot;
-        </pre>
+set heading 45      ;; turtle is now facing northeast
+set heading heading + 10 ;; same effect as &quot;rt 10&quot;
+</pre>
       </div>
       <div class="dict_entry" id="hidden">
         <h3>
@@ -3424,10 +3424,10 @@
           Example:
         </p>
         <pre>
-          set hidden? not hidden?
-          ;; if turtle was showing, it hides, and if it was hiding,
-          ;; it reappears
-        </pre>
+set hidden? not hidden?
+;; if turtle was showing, it hides, and if it was hiding,
+;; it reappears
+</pre>
       </div>
       <div class="dict_entry" id="hide-link">
         <h3>
@@ -3508,10 +3508,10 @@
           fall outside of the histogram's range.
         </p>
         <pre>
-          histogram [color] of turtles
-          ;; draws a histogram showing how many turtles there are
-          ;; of each color
-        </pre>
+histogram [color] of turtles
+;; draws a histogram showing how many turtles there are
+;; of each color
+</pre>
       </div>
       <div class="dict_entry" id="home">
         <h3>
@@ -3900,8 +3900,8 @@
           turtle:
         </p>
         <pre>
-          ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
-        </pre>
+ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
+</pre>
         <p>
           In this example assume that there is a turtles-own variable
           client-name which is associated with a logged in client, and all
@@ -3957,10 +3957,10 @@
           some agents may run <i>commands</i> and others don't.
         </p>
         <pre>
-          if xcor &gt; 0[ set color blue ]
-          ;; turtles in the right half of the world
-          ;; turn blue
-        </pre>
+if xcor &gt; 0[ set color blue ]
+;; turtles in the right half of the world
+;; turn blue
+</pre>
         <p>
           See also <a href="#ifelse">ifelse</a>, <a href="#ifelse-value">ifelse-value</a>.
         </p>
@@ -3985,41 +3985,41 @@
           you do not need to surround the entire <i>ifelse</i> primitive and its blocks in parentheses.
         </p>
         <pre>
-          ask patches
-          [ ifelse pxcor &gt; 0
-          [ set pcolor blue ]
-          [ set pcolor red ] ]
-          ;; the left half of the world turns red and
-          ;; the right half turns blue
-        </pre>
+ask patches
+[ ifelse pxcor &gt; 0
+[ set pcolor blue ]
+[ set pcolor red ] ]
+;; the left half of the world turns red and
+;; the right half turns blue
+</pre>
         <p>
           The reporters may report a different value for different agents, so
           some agents may run different command blocks.  When using more than one <i>reporter</i> you
           must surround the whole <i>ifelse</i> primitive and its blocks in parentheses.
         </p>
         <pre>
-          ask patches [
-          let choice random 4
-          (ifelse
-          choice = 0 [
-          set pcolor red
-          set plabel "r"
-          ]
-          choice = 1 [
-          set pcolor blue
-          set plabel "b"
-          ]
-          choice = 2 [
-          set pcolor green
-          set plabel "g"
-          ]
-          ; elsecommands
-          [
-          set pcolor yellow
-          set plabel "y"
-          ])
-          ]
-        </pre>
+ask patches [
+let choice random 4
+(ifelse
+choice = 0 [
+set pcolor red
+set plabel "r"
+]
+choice = 1 [
+set pcolor blue
+set plabel "b"
+]
+choice = 2 [
+set pcolor green
+set plabel "g"
+]
+; elsecommands
+[
+set pcolor yellow
+set plabel "y"
+])
+]
+</pre>
         <p>
           See also <a href="#if">if</a>, <a href="#ifelse-value">ifelse-value</a>.
         </p>
@@ -4051,43 +4051,43 @@
           not allowed.
         </p>
         <pre>
-          ask patches [
-          set pcolor ifelse-value (pxcor &gt; 0) [blue] [red]
-          ]
-          ;; the left half of the world turns red and
-          ;; the right half turns blue
-          show n-values 10 [ifelse-value (? &lt; 5) [0] [1]]
-          =&gt; [0 0 0 0 0 1 1 1 1 1]
-          show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
-          [1 3 2 5 3 8 3 2 1]
-          =&gt; 8
-        </pre>
+ask patches [
+set pcolor ifelse-value (pxcor &gt; 0) [blue] [red]
+]
+;; the left half of the world turns red and
+;; the right half turns blue
+show n-values 10 [ifelse-value (? &lt; 5) [0] [1]]
+=&gt; [0 0 0 0 0 1 1 1 1 1]
+show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
+[1 3 2 5 3 8 3 2 1]
+=&gt; 8
+</pre>
         <p>
           When using more than one <i>tfreporter</i> you
           must surround the whole <i>ifelse-value</i> primitive and its blocks in parentheses.
         </p>
         <pre>
-          ask patches [
-          let choice random 4
-          set pcolor (ifelse-value
-          choice = 0 [ red ]
-          choice = 1 [ blue ]
-          choice = 2 [ green ]
-          [ yellow ])
-          ]
-        </pre>
+ask patches [
+let choice random 4
+set pcolor (ifelse-value
+choice = 0 [ red ]
+choice = 1 [ blue ]
+choice = 2 [ green ]
+[ yellow ])
+]
+</pre>
         <p>
           A runtime error can occur if there is no <i>elsereporter</i>.
         </p>
         <pre>
-          ask patches [
-          let x = 2
-          set pcolor (ifelse-value
-          x = 0 [ red ]
-          x = 1 [ blue ]
-          ; no final else reporter is given, and x is 2 so there will be a runtime error
-          )
-        </pre>
+ask patches [
+let x = 2
+set pcolor (ifelse-value
+x = 0 [ red ]
+x = 1 [ blue ]
+; no final else reporter is given, and x is 2 so there will be a runtime error
+)
+</pre>
         <p>
           See also <a href="#if">if</a>, <a href="#ifelse">ifelse</a>.
         </p>
@@ -4237,12 +4237,12 @@
           The distance to a patch is measured from the center of the patch.
         </p>
         <pre>
-          ask turtles
-          [ ask patches in-cone 3 60
-          [ set pcolor red ] ]
-          ;; each turtle makes a red &quot;splotch&quot; of patches in a 60 degree
-          ;; cone of radius 3 ahead of itself
-        </pre>
+ask turtles
+[ ask patches in-cone 3 60
+[ set pcolor red ] ]
+;; each turtle makes a red &quot;splotch&quot; of patches in a 60 degree
+;; cone of radius 3 ahead of itself
+</pre>
       </div>
       <div class="dict_entry" id="in-link-neighbor">
         <h3>
@@ -4261,17 +4261,17 @@
           <i>turtle</i> to the caller?"
         </p>
         <pre>
-          crt 2
-          ask turtle 0 [
-          create-link-to turtle 1
-          show in-link-neighbor? turtle 1  ;; prints false
-          show out-link-neighbor? turtle 1 ;; prints true
-          ]
-          ask turtle 1 [
-          show in-link-neighbor? turtle 0  ;; prints true
-          show out-link-neighbor? turtle 0 ;; prints false
-          ]
-        </pre>
+crt 2
+ask turtle 0 [
+create-link-to turtle 1
+show in-link-neighbor? turtle 1  ;; prints false
+show out-link-neighbor? turtle 1 ;; prints true
+]
+ask turtle 1 [
+show in-link-neighbor? turtle 0  ;; prints true
+show out-link-neighbor? turtle 0 ;; prints false
+]
+</pre>
       </div>
       <div class="dict_entry" id="in-link-neighbors">
         <h3>
@@ -4290,10 +4290,10 @@
           turtles that can get to the caller using a link."
         </p>
         <pre>
-          crt 4
-          ask turtle 0 [ create-links-to other turtles ]
-          ask turtle 1 [ ask in-link-neighbors [ set color blue ] ] ;; turtle 0 turns blue
-        </pre>
+crt 4
+ask turtle 0 [ create-links-to other turtles ]
+ask turtle 1 [ ask in-link-neighbors [ set color blue ] ] ;; turtle 0 turns blue
+</pre>
       </div>
       <div class="dict_entry" id="in-link-from">
         <h3>
@@ -4313,11 +4313,11 @@
           to travel from <i>turtle</i> to the caller."
         </p>
         <pre>
-          crt 2
-          ask turtle 0 [ create-link-to turtle 1 ]
-          ask turtle 1 [ show in-link-from turtle 0 ] ;; shows link 0 1
-          ask turtle 0 [ show in-link-from turtle 1 ] ;; shows nobody
-        </pre>
+crt 2
+ask turtle 0 [ create-link-to turtle 1 ]
+ask turtle 1 [ show in-link-from turtle 0 ] ;; shows link 0 1
+ask turtle 0 [ show in-link-from turtle 1 ] ;; shows nobody
+</pre>
         <p>
           See also: <a href="#out-link-to">out-link-to</a> <a href="#link-with">link-with</a>
         </p>
@@ -4339,14 +4339,14 @@
           The file names must be strings, for example:
         </p>
         <pre>
-          __includes [ &quot;utils.nls&quot; ]
-        </pre>
+__includes [ &quot;utils.nls&quot; ]
+</pre>
         <p>
           Or, for multiple files:
         </p>
         <pre>
-          __includes [ &quot;utils1.nls&quot; &quot;utils2.nls&quot; ]
-        </pre>
+__includes [ &quot;utils1.nls&quot; &quot;utils2.nls&quot; ]
+</pre>
       </div>
       <div class="dict_entry" id="in-radius">
         <h3>
@@ -4366,11 +4366,11 @@
           the patch.
         </p>
         <pre>
-          ask turtles
-          [ ask patches in-radius 3
-          [ set pcolor red ] ]
-          ;; each turtle makes a red &quot;splotch&quot; around itself
-        </pre>
+ask turtles
+[ ask patches in-radius 3
+[ set pcolor red ] ]
+;; each turtle makes a red &quot;splotch&quot; around itself
+</pre>
       </div>
 
       <div class="dict_entry" id="insert-item">
@@ -4391,11 +4391,11 @@
           are inserted at <i>index</i>.
         </p>
         <pre>
-          show insert-item 2 [2 7 4 5] 15
-          =&gt; [2 7 15 4 5]
-          show insert-item 2 &quot;cat&quot; &quot;re&quot;
-          =&gt; &quot;caret&quot;
-        </pre>
+show insert-item 2 [2 7 4 5] 15
+=&gt; [2 7 15 4 5]
+show insert-item 2 &quot;cat&quot; &quot;re&quot;
+=&gt; &quot;caret&quot;
+</pre>
       </div>
 
 
@@ -4410,12 +4410,12 @@
           Opens an agent monitor for the given agent (turtle or patch).
         </p>
         <pre>
-          inspect patch 2 4
-          ;; an agent monitor opens for that patch
-          inspect one-of sheep
-          ;; an agent monitor opens for a random turtle from
-          ;; the &quot;sheep&quot; breed
-        </pre>
+inspect patch 2 4
+;; an agent monitor opens for that patch
+inspect one-of sheep
+;; an agent monitor opens for a random turtle from
+;; the &quot;sheep&quot; breed
+</pre>
         <p>
           See <a href="#stop-inspecting">stop-inspecting</a> and <a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>
         </p>
@@ -4432,11 +4432,11 @@
           discarded.
         </p>
         <pre>
-          show int 4.7
-          =&gt; 4
-          show int -3.5
-          =&gt; -3
-        </pre>
+show int 4.7
+=&gt; 4
+show int -3.5
+=&gt; -3
+</pre>
       </div>
       <div class="dict_entry" id="is-of-type">
         <h3>
@@ -4502,12 +4502,12 @@
           0, the second item is item 1, and so on.)
         </p>
         <pre>
-          ;; suppose mylist is [2 4 6 8 10]
-          show item 2 mylist
-          =&gt; 6
-          show item 3 &quot;my-shoe&quot;
-          =&gt; &quot;s&quot;
-        </pre>
+;; suppose mylist is [2 4 6 8 10]
+show item 2 mylist
+=&gt; 6
+show item 3 &quot;my-shoe&quot;
+=&gt; &quot;s&quot;
+</pre>
       </div><!-- ======================================== -->
     </div>
     <h2 id="J">
@@ -4559,12 +4559,12 @@
         Example:
       </p>
       <pre>
-        ask turtles [ set label who ]
-        ;; all the turtles now are labeled with their
-        ;; who numbers
-        ask turtles [ set label &quot;&quot; ]
-        ;; all turtles now are not labeled
-      </pre>
+ask turtles [ set label who ]
+;; all the turtles now are labeled with their
+;; who numbers
+ask turtles [ set label &quot;&quot; ]
+;; all turtles now are not labeled
+</pre>
     </div>
     <div class="dict_entry" id="label-color">
       <h3>
@@ -4589,9 +4589,9 @@
         Example:
       </p>
       <pre>
-        ask turtles [ set label-color red ]
-        ;; all the turtles now have red labels
-      </pre>
+ask turtles [ set label-color red ]
+;; all the turtles now have red labels
+</pre>
     </div>
     <div class="dict_entry" id="last">
       <h3>
@@ -4633,13 +4633,13 @@
         non-turtles in the list are ignored.)
       </p>
       <pre>
-        ;; in random order
-        layout-circle turtles 10
-        ;; in order by who number
-        layout-circle sort turtles 10
-        ;; in order by size
-        layout-circle sort-by [ [a b] -&gt; [size] of a &lt; [size] of b ] turtles 10
-      </pre>
+;; in random order
+layout-circle turtles 10
+;; in order by who number
+layout-circle sort turtles 10
+;; in order by size
+layout-circle sort-by [ [a b] -&gt; [size] of a &lt; [size] of b ] turtles 10
+</pre>
     </div>
     <div class="dict_entry" id="layout-radial">
       <h3>
@@ -4664,22 +4664,22 @@
         not always be pretty.
       </p>
       <pre>
-        to make-a-tree
-        set-default-shape turtles &quot;circle&quot;
-        crt 6
-        ask turtle 0 [
-        create-link-with turtle 1
-        create-link-with turtle 2
-        create-link-with turtle 3
-        ]
-        ask turtle 1 [
-        create-link-with turtle 4
-        create-link-with turtle 5
-        ]
-        ; do a radial tree layout, centered on turtle 0
-        layout-radial turtles links (turtle 0)
-        end
-      </pre>
+to make-a-tree
+set-default-shape turtles &quot;circle&quot;
+crt 6
+ask turtle 0 [
+create-link-with turtle 1
+create-link-with turtle 2
+create-link-with turtle 3
+]
+ask turtle 1 [
+create-link-with turtle 4
+create-link-with turtle 5
+]
+; do a radial tree layout, centered on turtle 0
+layout-radial turtles links (turtle 0)
+end
+</pre>
     </div>
     <div class="dict_entry" id="layout-spring">
       <h3>
@@ -4726,20 +4726,20 @@
         <a href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.13.8444" target="_blank">here</a>.
       </p>
       <pre>
-        to make-a-triangle
-        set-default-shape turtles &quot;circle&quot;
-        crt 3
-        ask turtle 0
-        [
-        create-links-with other turtles
-        ]
-        ask turtle 1
-        [
-        create-link-with turtle 2
-        ]
-        repeat 30 [ layout-spring turtles links 0.2 5 1 ] ;; lays the nodes in a triangle
-        end
-      </pre>
+to make-a-triangle
+set-default-shape turtles &quot;circle&quot;
+crt 3
+ask turtle 0
+[
+create-links-with other turtles
+]
+ask turtle 1
+[
+create-link-with turtle 2
+]
+repeat 30 [ layout-spring turtles links 0.2 5 1 ] ;; lays the nodes in a triangle
+end
+</pre>
     </div>
     <div class="dict_entry" id="layout-tutte">
       <h3>
@@ -4772,25 +4772,25 @@
         who proposed it as a method for graph layout.
       </p>
       <pre>
-        to make-a-tree
-        set-default-shape turtles &quot;circle&quot;
-        crt 6
-        ask turtle 0 [
-        create-link-with turtle 1
-        create-link-with turtle 2
-        create-link-with turtle 3
-        ]
-        ask turtle 1 [
-        create-link-with turtle 4
-        create-link-with turtle 5
-        ]
-        ; place all the turtles with just one
-        ; neighbor on the perimeter of a circle
-        ; and then place the remaining turtles inside
-        ; this circle, spread between their neighbors.
-        repeat 10 [ layout-tutte (turtles with [link-neighbors = 1]) links 12 ]
-        end
-      </pre>
+to make-a-tree
+set-default-shape turtles &quot;circle&quot;
+crt 6
+ask turtle 0 [
+create-link-with turtle 1
+create-link-with turtle 2
+create-link-with turtle 3
+]
+ask turtle 1 [
+create-link-with turtle 4
+create-link-with turtle 5
+]
+; place all the turtles with just one
+; neighbor on the perimeter of a circle
+; and then place the remaining turtles inside
+; this circle, spread between their neighbors.
+repeat 10 [ layout-tutte (turtles with [link-neighbors = 1]) links 12 ]
+end
+</pre>
     </div>
     <div class="dict_entry" id="left">
       <h3>
@@ -4838,10 +4838,10 @@
         Example:
       </p>
       <pre>
-        let prey one-of sheep-here
-        if prey != nobody
-        [ ask prey [ die ] ]
-      </pre>
+let prey one-of sheep-here
+if prey != nobody
+[ ask prey [ die ] ]
+</pre>
     </div>
     <div class="dict_entry" id="link">
       <h3>
@@ -4858,11 +4858,11 @@
         the endpoints.
       </p>
       <pre>
-        ask link 0 1 [ set color green ]
-        ;; unbreeded link connecting turtle 0 and turtle 1 will turn green
-        ask directed-link 0 1 [ set color red ]
-        ;; directed link connecting turtle 0 and turtle 1 will turn red
-      </pre>
+ask link 0 1 [ set color green ]
+;; unbreeded link connecting turtle 0 and turtle 1 will turn green
+ask directed-link 0 1 [ set color red ]
+;; directed link connecting turtle 0 and turtle 1 will turn red
+</pre>
       <p>
         See also <a href="#patch-at">patch-at</a>.
       </p>
@@ -4881,9 +4881,9 @@
         if the endpoints are at the same location.
       </p>
       <pre>
-        ask link 0 1 [ print link-heading ]
-        ;; prints [[towards other-end] of end1] of link 0 1
-      </pre>
+ask link 0 1 [ print link-heading ]
+;; prints [[towards other-end] of end1] of link 0 1
+</pre>
       <p>
         See also <a href="#link-length">link-length</a>
       </p>
@@ -4900,9 +4900,9 @@
         Reports the distance between the endpoints of the link.
       </p>
       <pre>
-        ask link 0 1 [ print link-length ]
-        ;; prints [[distance other-end] of end1] of link 0 1
-      </pre>
+ask link 0 1 [ print link-length ]
+;; prints [[distance other-end] of end1] of link 0 1
+</pre>
       <p>
         See also <a href="#link-heading">link-heading</a>
       </p>
@@ -4921,9 +4921,9 @@
         nobody, or lists (or nested lists) containing any of the above.
       </p>
       <pre>
-        link-set self
-        link-set [my-links] of nodes with [color = red]
-      </pre>
+link-set self
+link-set [my-links] of nodes with [color = red]
+</pre>
       <p>
         See also <a href="#turtle-set">turtle-set</a>, <a href="#patch-set">patch-set</a>.
       </p>
@@ -4944,9 +4944,9 @@
         <a href="shapes.html">Link Shapes Editor</a>.
       </p>
       <pre>
-        show link-shapes
-        =&gt; [&quot;default&quot;]
-      </pre>
+show link-shapes
+=&gt; [&quot;default&quot;]
+</pre>
     </div>
     <div class="dict_entry" id="links">
       <h3>
@@ -4959,9 +4959,9 @@
         Reports the agentset consisting of all links. This is a special agentset that can grow as links are added to the world, see <a href="programming.html#special-agentsets">the programming guide for more info</a>.
       </p>
       <pre>
-        show count links
-        ;; prints the number of links
-      </pre>
+show count links
+;; prints the number of links
+</pre>
     </div>
     <div class="dict_entry" id="links-own">
       <h3>
@@ -4983,12 +4983,12 @@
         list the same variable.)
       </p>
       <pre>
-        undirected-link-breed [sidewalks sidewalk]
-        directed-link-breed [streets street]
-        links-own [traffic]   ;; applies to all breeds
-        sidewalks-own [pedestrians]
-        streets-own [cars bikes]
-      </pre>
+undirected-link-breed [sidewalks sidewalk]
+directed-link-breed [streets street]
+links-own [traffic]   ;; applies to all breeds
+sidewalks-own [pedestrians]
+streets-own [cars bikes]
+</pre>
       <div class="dict_entry" id="list">
         <h3>
           <a>list<span class="since">1.0</span></a>
@@ -5002,13 +5002,13 @@
           any type, produced by any kind of reporter.
         </p>
         <pre>
-          show list (random 10) (random 10)
-          =&gt; [4 9]  ;; or similar list
-          show (list 5)
-          =&gt; [5]
-          show (list (random 10) 1 2 3 (random 10))
-          =&gt; [4 1 2 3 9]  ;; or similar list
-        </pre>
+show list (random 10) (random 10)
+=&gt; [4 9]  ;; or similar list
+show (list 5)
+=&gt; [5]
+show (list (random 10) 1 2 3 (random 10))
+=&gt; [4 1 2 3 9]  ;; or similar list
+</pre>
       </div>
       <div class="dict_entry" id="ln">
         <h3>
@@ -5036,9 +5036,9 @@
           Reports the logarithm of <i>number</i> in base <i>base</i>.
         </p>
         <pre>
-          show log 64 2
-          =&gt; 6
-        </pre>
+show log 64 2
+=&gt; 6
+</pre>
         <p>
           See also <a href="#ln">ln</a>.
         </p>
@@ -5082,10 +5082,10 @@
           Adds <i>value</i> to the end of a list and reports the new list.
         </p>
         <pre>
-          ;; suppose mylist is [2 7 10 &quot;Bob&quot;]
-          set mylist lput 42 mylist
-          ;; mylist now is [2 7 10 &quot;Bob&quot; 42]
-        </pre>
+;; suppose mylist is [2 7 10 &quot;Bob&quot;]
+set mylist lput 42 mylist
+;; mylist now is [2 7 10 &quot;Bob&quot; 42]
+</pre>
       </div><!-- ======================================== -->
     </div>
     <h2 id="M">
@@ -5106,11 +5106,11 @@
           <i>reporter</i> may be an anonymous reporter or the name of a reporter.
         </p>
         <pre>
-          show map round [1.1 2.2 2.7]
-          =&gt; [1 2 3]
-          show map [ i -&gt; i * i ] [1 2 3]
-          =&gt; [1 4 9]
-        </pre>
+show map round [1.1 2.2 2.7]
+=&gt; [1 2 3]
+show map [ i -&gt; i * i ] [1 2 3]
+=&gt; [1 4 9]
+</pre>
         <p>
           With multiple lists, the given reporter is run for each group of
           items from each list. So, it is run once for the first items,
@@ -5121,11 +5121,11 @@
           Some examples make this clearer:
         </p>
         <pre>
-          show (map + [1 2 3] [2 4 6])
-          =&gt; [3 6 9]
-          show (map [ [a b c] -&gt; a + b = c ] [1 2 3] [2 4 6] [3 5 9])
-          =&gt; [true false true]
-        </pre>
+show (map + [1 2 3] [2 4 6])
+=&gt; [3 6 9]
+show (map [ [a b c] -&gt; a + b = c ] [1 2 3] [2 4 6] [3 5 9])
+=&gt; [true false true]
+</pre>
         <p>
           See also <a href="#foreach">foreach</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>.
         </p>
@@ -5142,14 +5142,14 @@
           types of items.
         </p>
         <pre>
-          show max [xcor] of turtles
-          ;; prints the x coordinate of the turtle which is
-          ;; farthest right in the world
-          show max list a b
-          ;; prints the larger of the two variables a and b
-          show max (list a b c)
-          ;; prints the largest of the three variables a, b, and c
-        </pre>
+show max [xcor] of turtles
+;; prints the x coordinate of the turtle which is
+;; farthest right in the world
+show max list a b
+;; prints the larger of the two variables a and b
+show max (list a b c)
+;; prints the largest of the three variables a, b, and c
+</pre>
       </div>
       <div class="dict_entry" id="max-n-of">
         <h3>
@@ -5168,13 +5168,13 @@
           the resulting agentset too large, the tie is broken randomly.
         </p>
         <pre>
-          ;; assume the world is 11 x 11
-          show max-n-of 5 patches [pxcor]
-          ;; shows 5 patches with pxcor = max-pxcor
-          show max-n-of 5 patches with [pycor = 0] [pxcor]
-          ;; shows an agentset containing:
-          ;; (patch 1 0) (patch 2 0) (patch 3 0) (patch 4 0) (patch 5 0)
-        </pre>
+;; assume the world is 11 x 11
+show max-n-of 5 patches [pxcor]
+;; shows 5 patches with pxcor = max-pxcor
+show max-n-of 5 patches with [pycor = 0] [pxcor]
+;; shows an agentset containing:
+;; (patch 1 0) (patch 2 0) (patch 3 0) (patch 4 0) (patch 5 0)
+</pre>
         <p>
           See also <a href="#max-one-of">max-one-of</a>, <a href="#with-max">with-max</a>.
         </p>
@@ -5195,7 +5195,7 @@
         <pre>
           show max-one-of patches [count turtles-here]
           <br/>;; prints the first patch with the most turtles on it
-        </pre>
+</pre>
         <p>
           See also <a href="#max-n-of">max-n-of</a>, <a href="#with-max">with-max</a>.
         </p>
@@ -5224,11 +5224,11 @@
           -- these are reporters which cannot be set.
         </p>
         <pre>
-          crt 100 [ setxy random-float max-pxcor
-          random-float max-pycor ]
-          ;; distributes 100 turtles randomly in the
-          ;; first quadrant
-        </pre>
+crt 100 [ setxy random-float max-pxcor
+random-float max-pycor ]
+;; distributes 100 turtles randomly in the
+;; first quadrant
+</pre>
         <p>
           See also <a href="#min-pcor">min-pxcor</a>, <a href="#min-pcor">min-pycor</a>, <a href="#world-dim">world-width</a>, and <a href="#world-dim">world-height</a>
         </p>
@@ -5246,9 +5246,9 @@
           the sum of the items divided by the total number of items.
         </p>
         <pre>
-          show mean [xcor] of turtles
-          ;; prints the average of all the turtles' x coordinates
-        </pre>
+show mean [xcor] of turtles
+;; prints the average of all the turtles' x coordinates
+</pre>
       </div>
       <div class="dict_entry" id="median">
         <h3>
@@ -5265,9 +5265,9 @@
           of the two.)
         </p>
         <pre>
-          show median [xcor] of turtles
-          ;; prints the median of all the turtles' x coordinates
-        </pre>
+show median [xcor] of turtles
+;; prints the median of all the turtles' x coordinates
+</pre>
       </div>
       <div class="dict_entry" id="member">
         <h3>
@@ -5292,17 +5292,17 @@
           the given agentset, otherwise reports false.
         </p>
         <pre>
-          show member? 2 [1 2 3]
-          =&gt; true
-          show member? 4 [1 2 3]
-          =&gt; false
-          show member? &quot;bat&quot; &quot;abate&quot;
-          =&gt; true
-          show member? turtle 0 turtles
-          =&gt; true
-          show member? turtle 0 patches
-          =&gt; false
-        </pre>
+show member? 2 [1 2 3]
+=&gt; true
+show member? 4 [1 2 3]
+=&gt; false
+show member? &quot;bat&quot; &quot;abate&quot;
+=&gt; true
+show member? turtle 0 turtles
+=&gt; true
+show member? turtle 0 patches
+=&gt; false
+</pre>
         <p>
           See also <a href="#position">position</a>.
         </p>
@@ -5319,13 +5319,13 @@
           types of items.
         </p>
         <pre>
-          show min [xcor] of turtles
-          ;; prints the lowest x-coordinate of all the turtles
-          show min list a b
-          ;; prints the smaller of the two variables a and b
-          show min (list a b c)
-          ;; prints the smallest of the three variables a, b, and c
-        </pre>
+show min [xcor] of turtles
+;; prints the lowest x-coordinate of all the turtles
+show min list a b
+;; prints the smaller of the two variables a and b
+show min (list a b c)
+;; prints the smallest of the three variables a, b, and c
+</pre>
       </div>
       <div class="dict_entry" id="min-n-of">
         <h3>
@@ -5344,13 +5344,13 @@
           the resulting agentset too large, the tie is broken randomly.
         </p>
         <pre>
-          ;; assume the world is 11 x 11
-          show min-n-of 5 patches [pxcor]
-          ;; shows 5 patches with pxcor = min-pxcor
-          show min-n-of 5 patches with [pycor = 0] [pxcor]
-          ;; shows an agentset containing:
-          ;; (patch -5 0) (patch -4 0) (patch -3 0) (patch -2 0) (patch -1 0)
-        </pre>
+;; assume the world is 11 x 11
+show min-n-of 5 patches [pxcor]
+;; shows 5 patches with pxcor = min-pxcor
+show min-n-of 5 patches with [pycor = 0] [pxcor]
+;; shows an agentset containing:
+;; (patch -5 0) (patch -4 0) (patch -3 0) (patch -2 0) (patch -1 0)
+</pre>
         <p>
           See also <a href="#min-one-of">min-one-of</a>, <a href="#with-min">with-min</a>.
         </p>
@@ -5369,10 +5369,10 @@
           all such agents use with-min instead.
         </p>
         <pre>
-          show min-one-of turtles [xcor + ycor]
-          ;; reports the first turtle with the smallest sum of
-          ;; coordinates
-        </pre>
+show min-one-of turtles [xcor + ycor]
+;; reports the first turtle with the smallest sum of
+;; coordinates
+</pre>
         <p>
           See also <a href="#with-min">with-min</a>, <a href="#min-n-of">min-n-of</a>.
         </p>
@@ -5401,11 +5401,11 @@
           -- these are reporters which cannot be set.
         </p>
         <pre>
-          crt 100 [ setxy random-float min-pxcor
-          random-float min-pycor ]
-          ;; distributes 100 turtles randomly in the
-          ;; third quadrant
-        </pre>
+crt 100 [ setxy random-float min-pxcor
+random-float min-pycor ]
+;; distributes 100 turtles randomly in the
+;; third quadrant
+</pre>
         <p>
           See also <a href="#max-pcor">max-pxcor</a>, <a href="#max-pcor">max-pycor</a>, <a href="#world-dim">world-width</a>, and <a href="#world-dim">world-height</a>
         </p>
@@ -5424,17 +5424,17 @@
         </p>
         <pre>
           <i>number1</i> - (floor (<i>number1</i> / <i>number2</i>)) * <i>number2</i>
-        </pre>
+</pre>
         <p>
           Note that mod is &quot;infix&quot;, that is, it comes between its
           two inputs.
         </p>
         <pre>
-          show 62 mod 5
-          =&gt; 2
-          show -8 mod 3
-          =&gt; 1
-        </pre>
+show 62 mod 5
+=&gt; 2
+show -8 mod 3
+=&gt; 1
+</pre>
         <p>
           See also <a href="#remainder">remainder</a>. mod and remainder
           behave the same for positive numbers, but differently for
@@ -5458,16 +5458,16 @@
           If the input is an empty list, reports an empty list.
         </p>
         <pre>
-          show modes [1 2 2 3 4]
-          =&gt; [2]
-          show modes [1 2 2 3 3 4]
-          =&gt; [2 3]
-          show modes [ [1 2 [3]] [1 2 [3]] [2 3 4] ]
-          =&gt; [[1 2 [3]]]
-          show modes [pxcor] of turtles
-          ;; shows which columns of patches have the most
-          ;; turtles on them
-        </pre>
+show modes [1 2 2 3 4]
+=&gt; [2]
+show modes [1 2 2 3 3 4]
+=&gt; [2 3]
+show modes [ [1 2 [3]] [1 2 [3]] [2 3 4] ]
+=&gt; [[1 2 [3]]]
+show modes [pxcor] of turtles
+;; shows which columns of patches have the most
+;; turtles on them
+</pre>
       </div>
       <div class="dict_entry" id="mouse-down">
         <h3>
@@ -5516,10 +5516,10 @@
           from the last time it was inside.
         </p>
         <pre>
-          ;; to make the mouse &quot;draw&quot; in red:
-          if mouse-down?
-          [ ask patch mouse-xcor mouse-ycor [ set pcolor red ] ]
-        </pre>
+;; to make the mouse &quot;draw&quot; in red:
+if mouse-down?
+[ ask patch mouse-xcor mouse-ycor [ set pcolor red ] ]
+</pre>
       </div>
       <div class="dict_entry" id="move-to">
         <h3>
@@ -5538,13 +5538,13 @@
           the center of that patch.)
         </p>
         <pre>
-          move-to turtle 5
-          ;; turtle moves to same point as turtle 5
-          move-to one-of patches
-          ;; turtle moves to the center of a random patch
-          move-to max-one-of turtles [size]
-          ;; turtle moves to same point as biggest turtle
-        </pre>
+move-to turtle 5
+;; turtle moves to same point as turtle 5
+move-to one-of patches
+;; turtle moves to the center of a random patch
+move-to max-one-of turtles [size]
+;; turtle moves to same point as biggest turtle
+</pre>
         <p>
           Note that the turtle's heading is unaltered. You may want to
           use the <a href="#face">face</a> command first to orient the
@@ -5574,19 +5574,19 @@
           links).
         </p>
         <pre>
-          crt 5
-          ask turtle 0
-          [
-          create-links-with other turtles
-          show my-links ;; prints the agentset containing all links
-          ;; (since all the links we created were with turtle 0 )
-          ]
-          ask turtle 1
-          [
-          show my-links ;; shows an agentset containing the link 0 1
-          ]
-          end
-        </pre>
+crt 5
+ask turtle 0
+[
+create-links-with other turtles
+show my-links ;; prints the agentset containing all links
+;; (since all the links we created were with turtle 0 )
+]
+ask turtle 1
+[
+show my-links ;; shows an agentset containing the link 0 1
+]
+end
+</pre>
         If you only want the undirected links connected to a node, you
         can do <code>my-links with [ not is-directed-link? self ]</code>.
       </div>
@@ -5607,17 +5607,17 @@
           that you can use to travel <i>to</i> this node".
         </p>
         <pre>
-          crt 5
-          ask turtle 0
-          [
-          create-links-to other turtles
-          show my-in-links ;; shows an empty agentset
-          ]
-          ask turtle 1
-          [
-          show my-in-links ;; shows an agentset containing the link 0 1
-          ]
-        </pre>
+crt 5
+ask turtle 0
+[
+create-links-to other turtles
+show my-in-links ;; shows an empty agentset
+]
+ask turtle 1
+[
+show my-in-links ;; shows an agentset containing the link 0 1
+]
+</pre>
       </div>
       <div class="dict_entry" id="my-out-links">
         <h3>
@@ -5636,17 +5636,17 @@
           <i>from</i> this node".
         </p>
         <pre>
-          crt 5
-          ask turtle 0
-          [
-          create-links-to other turtles
-          show my-out-links ;; shows agentset containing all the links
-          ]
-          ask turtle 1
-          [
-          show my-out-links ;; shows an empty agentset
-          ]
-        </pre>
+crt 5
+ask turtle 0
+[
+create-links-to other turtles
+show my-out-links ;; shows agentset containing all the links
+]
+ask turtle 1
+[
+show my-out-links ;; shows an empty agentset
+]
+</pre>
       </div>
       <div class="dict_entry" id="myself">
         <h3>
@@ -5677,11 +5677,11 @@
           with-max, min-one-of, max-one-of, min-n-of, max-n-of.
         </p>
         <pre>
-          ask turtles
-          [ ask patches in-radius 3
-          [ set pcolor [color] of myself ] ]
-          ;; each turtle makes a colored &quot;splotch&quot; around itself
-        </pre>
+ask turtles
+[ ask patches in-radius 3
+[ set pcolor [color] of myself ] ]
+;; each turtle makes a colored &quot;splotch&quot; around itself
+</pre>
         <p>
           See the &quot;Myself Example&quot; code example for more
           examples.
@@ -5718,9 +5718,9 @@
           input.
         </p>
         <pre>
-          ask n-of 50 patches [ set pcolor green ]
-          ;; 50 randomly chosen patches turn green
-        </pre>
+ask n-of 50 patches [ set pcolor green ]
+;; 50 randomly chosen patches turn green
+</pre>
         <p>
           See also <a href="#one-of">one-of</a> and <a href="#up-to-n-of">up-to-n-of</a>,
           a version that does not error with a <i>size</i> greater than
@@ -5744,15 +5744,15 @@
           item currently being computed, starting from zero.
         </p>
         <pre>
-          show n-values 5 [1]
-          =&gt; [1 1 1 1 1]
-          show n-values 5 [ i -&gt; i ]
-          =&gt; [0 1 2 3 4]
-          show n-values 3 turtle
-          =&gt; [(turtle 0) (turtle 1) (turtle 2)]
-          show n-values 5 [ x -&gt; x * x ]
-          =&gt; [0 1 4 9 16]
-        </pre>
+show n-values 5 [1]
+=&gt; [1 1 1 1 1]
+show n-values 5 [ i -&gt; i ]
+=&gt; [0 1 2 3 4]
+show n-values 3 turtle
+=&gt; [(turtle 0) (turtle 1) (turtle 2)]
+show n-values 5 [ x -&gt; x * x ]
+=&gt; [0 1 4 9 16]
+</pre>
         <p>
           See also <a href="#reduce">reduce</a>, <a href="#filter">filter</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>, <a href="#range">range</a>.
         </p>
@@ -5772,14 +5772,14 @@
           (neighbors) or 4 surrounding patches (neighbors4).
         </p>
         <pre>
-          show sum [count turtles-here] of neighbors
-          ;; prints the total number of turtles on the eight
-          ;; patches around this turtle or patch
-          show count turtles-on neighbors
-          ;; a shorter way to say the same thing
-          ask neighbors4 [ set pcolor red ]
-          ;; turns the four neighboring patches red
-        </pre>
+show sum [count turtles-here] of neighbors
+;; prints the total number of turtles on the eight
+;; patches around this turtle or patch
+show count turtles-on neighbors
+;; a shorter way to say the same thing
+ask neighbors4 [ set pcolor red ]
+;; turns the four neighboring patches red
+</pre>
       </div>
       <div class="dict_entry" id="link-neighbors">
         <h3>
@@ -5797,18 +5797,18 @@
           connected to this turtle.
         </p>
         <pre>
-          crt 3
-          ask turtle 0
-          [
-          create-links-with other turtles
-          ask link-neighbors [ set color red ] ;; turtles 1 and 2 turn red
-          ]
-          ask turtle 1
-          [
-          ask link-neighbors [ set color blue ] ;; turtle 0 turns blue
-          ]
-          end
-        </pre>
+crt 3
+ask turtle 0
+[
+create-links-with other turtles
+ask link-neighbors [ set color red ] ;; turtles 1 and 2 turn red
+]
+ask turtle 1
+[
+ask link-neighbors [ set color blue ] ;; turtle 0 turns blue
+]
+end
+</pre>
       </div>
       <div class="dict_entry" id="link-neighbor">
         <h3>
@@ -5825,17 +5825,17 @@
           incoming or outgoing) between <i>turtle</i> and the caller.
         </p>
         <pre>
-          crt 2
-          ask turtle 0
-          [
-          create-link-with turtle 1
-          show link-neighbor? turtle 1  ;; prints true
-          ]
-          ask turtle 1
-          [
-          show link-neighbor? turtle 0     ;; prints true
-          ]
-        </pre>
+crt 2
+ask turtle 0
+[
+create-link-with turtle 1
+show link-neighbor? turtle 1  ;; prints true
+]
+ask turtle 1
+[
+show link-neighbor? turtle 0     ;; prints true
+]
+</pre>
       </div>
       <div class="dict_entry" id="netlogo-version">
         <h3>
@@ -5849,9 +5849,9 @@
           are running.
         </p>
         <pre>
-          show netlogo-version
-          =&gt; &quot;{{version}}&quot;
-        </pre>
+show netlogo-version
+=&gt; &quot;{{version}}&quot;
+</pre>
       </div>
       <div class="dict_entry" id="netlogo-web">
         <h3>
@@ -5939,10 +5939,10 @@
           not a whole agentset.
         </p>
         <pre>
-          set target one-of other turtles-here
-          if target != nobody
-          [ ask target [ set color red ] ]
-        </pre>
+set target one-of other turtles-here
+if target != nobody
+[ ask target [ set color red ] ]
+</pre>
       </div>
       <div class="dict_entry" id="no-links">
         <h3>
@@ -5977,8 +5977,8 @@
           Reports true if <i>boolean</i> is false, otherwise reports false.
         </p>
         <pre>
-          if not any? turtles [ crt 10 ]
-        </pre>
+if not any? turtles [ crt 10 ]
+</pre>
       </div>
       <div class="dict_entry" id="no-turtles">
         <h3>
@@ -6009,27 +6009,27 @@
           (turtle or patch).
         </p>
         <pre>
-          show [pxcor] of patch 3 5
-          ;; prints 3
-          show [pxcor] of one-of patches
-          ;; prints the value of a random patch's pxcor variable
-          show [who * who] of turtle 5
-          =&gt; 25
-          show [count turtles in-radius 3] of patch 0 0
-          ;; prints the number of turtles located within a
-          ;; three-patch radius of the origin
-        </pre>
+show [pxcor] of patch 3 5
+;; prints 3
+show [pxcor] of one-of patches
+;; prints the value of a random patch's pxcor variable
+show [who * who] of turtle 5
+=&gt; 25
+show [count turtles in-radius 3] of patch 0 0
+;; prints the number of turtles located within a
+;; three-patch radius of the origin
+</pre>
         <p>
           For an agentset, reports a list that contains the value of the
           reporter for each agent in the agentset (in random order).
         </p>
         <pre>
-          crt 4
-          show sort [who] of turtles
-          =&gt; [0 1 2 3]
-          show sort [who * who] of turtles
-          =&gt; [0 1 4 9]
-        </pre>
+crt 4
+show sort [who] of turtles
+=&gt; [0 1 2 3]
+show sort [who * who] of turtles
+=&gt; [0 1 4 9]
+</pre>
       </div>
       <div class="dict_entry" id="one-of">
         <h3>
@@ -6048,17 +6048,17 @@
           list to be empty.
         </p>
         <pre>
-          ask one-of patches [ set pcolor green ]
-          ;; a random patch turns green
-          ask patches with [any? turtles-here]
-          [ show one-of turtles-here ]
-          ;; for each patch containing turtles, prints one of
-          ;; those turtles
+ask one-of patches [ set pcolor green ]
+;; a random patch turns green
+ask patches with [any? turtles-here]
+[ show one-of turtles-here ]
+;; for each patch containing turtles, prints one of
+;; those turtles
 
-          ;; suppose mylist is [1 2 3 4 5 6]
-          show one-of mylist
-          ;; prints a value randomly chosen from the list
-        </pre>
+;; suppose mylist is [1 2 3 4 5 6]
+show one-of mylist
+;; prints a value randomly chosen from the list
+</pre>
         <p>
           See also <a href="#n-of">n-of</a>, <a href="#up-to-n-of">up-to-n-of</a>.
         </p>
@@ -6079,9 +6079,9 @@
           not be run (since it can't affect the result).
         </p>
         <pre>
-          if (pxcor &gt; 0) or (pycor &gt; 0) [ set pcolor red ]
-          ;; patches turn red except in lower-left quadrant
-        </pre>
+if (pxcor &gt; 0) or (pycor &gt; 0) [ set pcolor red ]
+;; patches turn red except in lower-left quadrant
+</pre>
       </div>
       <div class="dict_entry" id="other">
         <h3>
@@ -6096,11 +6096,11 @@
           omits this agent.
         </p>
         <pre>
-          show count turtles-here
-          =&gt; 10
-          show count other turtles-here
-          =&gt; 9
-        </pre>
+show count turtles-here
+=&gt; 10
+show count other turtles-here
+=&gt; 9
+</pre>
       </div>
       <div class="dict_entry" id="other-end">
         <h3>
@@ -6123,11 +6123,11 @@
           the following examples should help:
         </p>
         <pre>
-          ask turtle 0 [ create-link-with turtle 1 ]
-          ask turtle 0 [ ask link 0 1 [ show other-end ] ] ;; prints turtle 1
-          ask turtle 1 [ ask link 0 1 [ show other-end ] ] ;; prints turtle 0
-          ask link 0 1 [ ask turtle 0 [ show other-end ] ] ;; prints turtle 1
-        </pre>
+ask turtle 0 [ create-link-with turtle 1 ]
+ask turtle 0 [ ask link 0 1 [ show other-end ] ] ;; prints turtle 1
+ask turtle 1 [ ask link 0 1 [ show other-end ] ] ;; prints turtle 0
+ask link 0 1 [ ask turtle 0 [ show other-end ] ] ;; prints turtle 1
+</pre>
         <p>
           As these examples hopefully make plain, the &quot;other&quot; end
           is the end that is neither asking nor being asked.
@@ -6150,17 +6150,17 @@
           to <i>turtle</i> using a link?"
         </p>
         <pre>
-          crt 2
-          ask turtle 0 [
-          create-link-to turtle 1
-          show in-link-neighbor? turtle 1  ;; prints false
-          show out-link-neighbor? turtle 1 ;; prints true
-          ]
-          ask turtle 1 [
-          show in-link-neighbor? turtle 0  ;; prints true
-          show out-link-neighbor? turtle 0 ;; prints false
-          ]
-        </pre>
+crt 2
+ask turtle 0 [
+create-link-to turtle 1
+show in-link-neighbor? turtle 1  ;; prints false
+show out-link-neighbor? turtle 1 ;; prints true
+]
+ask turtle 1 [
+show in-link-neighbor? turtle 0  ;; prints true
+show out-link-neighbor? turtle 0 ;; prints false
+]
+</pre>
       </div>
       <div class="dict_entry" id="out-link-neighbors">
         <h3>
@@ -6178,19 +6178,19 @@
           of this as "who can I get to from the caller using a link?"
         </p>
         <pre>
-          crt 4
-          ask turtle 0
-          [
-          create-links-to other turtles
-          ask out-link-neighbors [ set color pink ] ;; turtles 1-3 turn pink
-          ]
-          ask turtle 1
-          [
-          ask out-link-neighbors [ set color orange ]  ;; no turtles change colors
-          ;; since turtle 1 only has in-links
-          ]
-          end
-        </pre>
+crt 4
+ask turtle 0
+[
+create-links-to other turtles
+ask out-link-neighbors [ set color pink ] ;; turtles 1-3 turn pink
+]
+ask turtle 1
+[
+ask out-link-neighbors [ set color orange ]  ;; no turtles change colors
+;; since turtle 1 only has in-links
+]
+end
+</pre>
       </div>
       <div class="dict_entry" id="out-link-to">
         <h3>
@@ -6210,16 +6210,16 @@
           to travel from the caller to <i>turtle</i>."
         </p>
         <pre>
-          crt 2
-          ask turtle 0 [
-          create-link-to turtle 1
-          show out-link-to turtle 1 ;; shows link 0 1
-          ]
-          ask turtle 1
-          [
-          show out-link-to turtle 0 ;; shows nobody
-          ]
-        </pre>
+crt 2
+ask turtle 0 [
+create-link-to turtle 1
+show out-link-to turtle 1 ;; shows link 0 1
+]
+ask turtle 1
+[
+show out-link-to turtle 0 ;; shows nobody
+]
+</pre>
         <p>
           See also: <a href="#in-link-from">in-link-from</a> <a href="#link-with">link-with</a>
         </p>
@@ -6273,16 +6273,16 @@
           the given coordinates are outside the world, reports nobody.
         </p>
         <pre>
-          ask patch 3 -4 [ set pcolor green ]
-          ;; patch with pxcor of 3 and pycor of -4 turns green
-          show patch 1.2 3.7
-          ;; prints (patch 1 4); note rounding
-          show patch 18 19
-          ;; supposing min-pxcor and min-pycor are -17
-          ;; and max-pxcor and max-pycor are 17,
-          ;; in a wrapping topology, prints (patch -17 -16);
-          ;; in a non-wrapping topology, prints nobody
-        </pre>
+ask patch 3 -4 [ set pcolor green ]
+;; patch with pxcor of 3 and pycor of -4 turns green
+show patch 1.2 3.7
+;; prints (patch 1 4); note rounding
+show patch 18 19
+;; supposing min-pxcor and min-pycor are -17
+;; and max-pxcor and max-pycor are 17,
+;; in a wrapping topology, prints (patch -17 -16);
+;; in a non-wrapping topology, prints nobody
+</pre>
         <p>
           See also <a href="#patch-at">patch-at</a>.
         </p>
@@ -6302,11 +6302,11 @@
           it is outside the world.
         </p>
         <pre>
-          ask patch-ahead 1 [ set pcolor green ]
-          ;; turns the patch 1 in front of this turtle
-          ;;   green; note that this might be the same patch
-          ;;   the turtle is standing on
-        </pre>
+ask patch-ahead 1 [ set pcolor green ]
+;; turns the patch 1 in front of this turtle
+;;   green; note that this might be the same patch
+;;   the turtle is standing on
+</pre>
         <p>
           See also <a href="#patch-at">patch-at</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
         </p>
@@ -6328,10 +6328,10 @@
           beyond a non-wrapping world boundary.
         </p>
         <pre>
-          ask patch-at 1 -1 [ set pcolor green ]
-          ;; if caller is a turtle or patch, turns the
-          ;;   patch just southeast of the caller green
-        </pre>
+ask patch-at 1 -1 [ set pcolor green ]
+;; if caller is a turtle or patch, turns the
+;;   patch just southeast of the caller green
+</pre>
         <p>
           See also <a href="#patch">patch</a>, <a href="#patch-ahead">patch-ahead</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
         </p>
@@ -6353,9 +6353,9 @@
           because it is outside the world.
         </p>
         <pre>
-          ask patch-at-heading-and-distance -90 1 [ set pcolor green ]
-          ;; turns the patch 1 to the west of this patch green
-        </pre>
+ask patch-at-heading-and-distance -90 1 [ set pcolor green ]
+;; turns the patch 1 to the west of this patch green
+</pre>
         <p>
           See also <a href="#patch">patch</a>, <a href="#patch-at">patch-at</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>.
         </p>
@@ -6398,12 +6398,12 @@
           patch-at-heading-and-distance instead.)
         </p>
         <pre>
-          ask patch-right-and-ahead 30 1 [ set pcolor green ]
-          ;; this turtle &quot;looks&quot; 30 degrees right of its
-          ;;   current heading at the patch 1 unit away, and turns
-          ;;   that patch green; note that this might be the same
-          ;;   patch the turtle is standing on
-        </pre>
+ask patch-right-and-ahead 30 1 [ set pcolor green ]
+;; this turtle &quot;looks&quot; 30 degrees right of its
+;;   current heading at the patch 1 unit away, and turns
+;;   that patch green; note that this might be the same
+;;   patch the turtle is standing on
+</pre>
         <p>
           See also <a href="#patch">patch</a>, <a href="#patch-at">patch-at</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
         </p>
@@ -6423,15 +6423,15 @@
           above.
         </p>
         <pre>
-          patch-set self
-          patch-set patch-here
-          (patch-set self neighbors)
-          (patch-set patch-here neighbors)
-          (patch-set patch 0 0 patch 1 3 patch 4 -2)
-          (patch-set patch-at -1 1 patch-at 0 1 patch-at 1 1)
-          patch-set [patch-here] of turtles
-          patch-set [neighbors] of turtles
-        </pre>
+patch-set self
+patch-set patch-here
+(patch-set self neighbors)
+(patch-set patch-here neighbors)
+(patch-set patch 0 0 patch 1 3 patch 4 -2)
+(patch-set patch-at -1 1 patch-at 0 1 patch-at 1 1)
+patch-set [patch-here] of turtles
+patch-set [neighbors] of turtles
+</pre>
         <p>
           See also <a href="#turtle-set">turtle-set</a>, <a href="#link-set">link-set</a>.
         </p>
@@ -6740,14 +6740,14 @@
           Note: The positions are numbered beginning with 0, not with 1.
         </p>
         <pre>
-          ;; suppose mylist is [2 7 4 7 &quot;Bob&quot;]
-          show position 7 mylist
-          =&gt; 1
-          show position 10 mylist
-          =&gt; false
-          show position &quot;in&quot; &quot;string&quot;
-          =&gt; 3
-        </pre>
+;; suppose mylist is [2 7 4 7 &quot;Bob&quot;]
+show position 7 mylist
+=&gt; 1
+show position 10 mylist
+=&gt; false
+show position &quot;in&quot; &quot;string&quot;
+=&gt; 3
+</pre>
         <p>
           See also <a href="#member">member?</a>.
         </p>
@@ -6767,11 +6767,11 @@
           of the decimal point.
         </p>
         <pre>
-          show precision 1.23456789 3
-          =&gt; 1.235
-          show precision 3834 -3
-          =&gt; 4000
-        </pre>
+show precision 1.23456789 3
+=&gt; 1.235
+show precision 3834 -3
+=&gt; 4000
+</pre>
         <p>
           See also <a href="#round">round</a>, <a href="#ceiling">ceiling</a>, <a href="#floor">floor</a>.
         </p>
@@ -6853,13 +6853,13 @@
           must now use <a href="#random-float">random-float</a> instead.
         </p>
         <pre>
-          show random 3
-          ;; prints 0, 1,  or 2
-          show random -3
-          ;; prints 0, -1, or -2
-          show random 3.5
-          ;; prints 0, 1, 2, or 3
-        </pre>
+show random 3
+;; prints 0, 1,  or 2
+show random -3
+;; prints 0, -1, or -2
+show random 3.5
+;; prints 0, 1, 2, or 3
+</pre>
         <p>
           See also <a href="#random-float">random-float</a>.
         </p>
@@ -6885,13 +6885,13 @@
           If <i>number</i> is zero, the result is always 0.
         </p>
         <pre>
-          show random-float 3
-          ;; prints a number at least 0 but less than 3,
-          ;; for example 2.589444906014774
-          show random-float 2.5
-          ;; prints a number at least 0 but less than 2.5,
-          ;; for example 1.0897423196760796
-        </pre>
+show random-float 3
+;; prints a number at least 0 but less than 3,
+;; for example 2.589444906014774
+show random-float 2.5
+;; prints a number at least 0 but less than 2.5,
+;; for example 1.0897423196760796
+</pre>
       </div>
       <div class="dict_entry" id="random-reporters">
         <h3>
@@ -6932,17 +6932,17 @@
           random-poisson reports a Poisson-distributed random integer.
         </p>
         <pre>
-          show random-exponential 2
-          ;; prints an exponentially distributed random floating
-          ;; point number with a mean of 2
-          show random-normal 10.1 5.2
-          ;; prints a normally distributed random floating point
-          ;; number with a mean of 10.1 and a standard deviation
-          ;; of 5.2
-          show random-poisson 3.4
-          ;; prints a Poisson-distributed random integer with a
-          ;; mean of 3.4
-        </pre>
+show random-exponential 2
+;; prints an exponentially distributed random floating
+;; point number with a mean of 2
+show random-normal 10.1 5.2
+;; prints a normally distributed random floating point
+;; number with a mean of 10.1 and a standard deviation
+;; of 5.2
+show random-poisson 3.4
+;; prints a Poisson-distributed random integer with a
+;; mean of 3.4
+</pre>
       </div>
       <div class="dict_entry" id="random-pcor">
         <h3>
@@ -6958,11 +6958,11 @@
           max-pxcor (or -y) inclusive.
         </p>
         <pre>
-          ask turtles [
-          ;; move each turtle to the center of a random patch
-          setxy random-pxcor random-pycor
-          ]
-        </pre>
+ask turtles [
+;; move each turtle to the center of a random patch
+setxy random-pxcor random-pycor
+]
+</pre>
         <p>
           See also <a href="#random-cor">random-xcor</a>, <a href="#random-cor">random-ycor</a>.
         </p>
@@ -6986,17 +6986,17 @@
           section of the Programming Guide for more details.
         </p>
         <pre>
-          random-seed 47822
-          show random 100
-          =&gt; 50
-          show random 100
-          =&gt; 35
-          random-seed 47822
-          show random 100
-          =&gt; 50
-          show random 100
-          =&gt; 35
-        </pre>
+random-seed 47822
+show random 100
+=&gt; 50
+show random 100
+=&gt; 35
+random-seed 47822
+show random 100
+=&gt; 50
+show random 100
+=&gt; 35
+</pre>
       </div>
       <div class="dict_entry" id="random-cor">
         <h3>
@@ -7017,11 +7017,11 @@
           for -x.
         </p>
         <pre>
-          ask turtles [
-          ;; move each turtle to a random point
-          setxy random-xcor random-ycor
-          ]
-        </pre>
+ask turtles [
+;; move each turtle to a random point
+setxy random-xcor random-ycor
+]
+</pre>
         <p>
           See also <a href="#random-pcor">random-pxcor</a>, <a href="#random-pcor">random-pycor</a>.
         </p>
@@ -7041,15 +7041,15 @@
           <i>step</i> defaults to 1.
         </p>
         <pre>
-          show range 5
-          =&gt; [0 1 2 3 4]
-          show (range 2 5)
-          =&gt; [2 3 4]
-          show (range 2 5 0.5)
-          =&gt; [2 2.5 3 3.5 4 4.5]
-          show (range 10 0 -1)
-          =&gt; [10 9 8 7 6 5 4 3 2 1]
-        </pre>
+show range 5
+=&gt; [0 1 2 3 4]
+show (range 2 5)
+=&gt; [2 3 4]
+show (range 2 5 0.5)
+=&gt; [2 2.5 3 3.5 4 4.5]
+show (range 10 0 -1)
+=&gt; [10 9 8 7 6 5 4 3 2 1]
+</pre>
         <p>
           See also <a href="#n-values">n-values</a>
         </p>
@@ -7072,14 +7072,14 @@
           primitive for converting the user's input into usable form.
         </p>
         <pre>
-          show read-from-string &quot;3&quot; + read-from-string &quot;5&quot;
-          =&gt; 8
-          show length read-from-string &quot;[1 2 3]&quot;
-          =&gt; 3
-          crt read-from-string user-input &quot;Make how many turtles?&quot;
-          ;; the number of turtles input by the user
-          ;; are created
-        </pre>
+show read-from-string &quot;3&quot; + read-from-string &quot;5&quot;
+=&gt; 8
+show length read-from-string &quot;[1 2 3]&quot;
+=&gt; 3
+crt read-from-string user-input &quot;Make how many turtles?&quot;
+;; the number of turtles input by the user
+;; are created
+</pre>
       </div>
       <div class="dict_entry" id="reduce">
         <h3>
@@ -7108,53 +7108,53 @@
           this primitive:
         </p>
         <pre>
-          show reduce + [1 2 3]
-          =&gt; 6
-          show reduce - [1 2 3]
-          =&gt; -4
-          show reduce [ [result-so-far next-item] -&gt; next-item - result-so-far ] [1 2 3]
-          =&gt; 2
-          show reduce [ [result-so-far ignored-item] -&gt; result-so-far ] [1 2 3]
-          =&gt; 1
-          show reduce [ [ignored next-item] -&gt; next-item ] [1 2 3]
-          =&gt; 3
-          show reduce sentence [[1 2] [3 [4]] 5]
-          =&gt; [1 2 3 [4] 5]
-          show reduce [ [result-so-far next-item] -&gt; fput next-item result-so-far ] (fput [] [1 2 3 4 5])
-          =&gt; [5 4 3 2 1]
-        </pre>
+show reduce + [1 2 3]
+=&gt; 6
+show reduce - [1 2 3]
+=&gt; -4
+show reduce [ [result-so-far next-item] -&gt; next-item - result-so-far ] [1 2 3]
+=&gt; 2
+show reduce [ [result-so-far ignored-item] -&gt; result-so-far ] [1 2 3]
+=&gt; 1
+show reduce [ [ignored next-item] -&gt; next-item ] [1 2 3]
+=&gt; 3
+show reduce sentence [[1 2] [3 [4]] 5]
+=&gt; [1 2 3 [4] 5]
+show reduce [ [result-so-far next-item] -&gt; fput next-item result-so-far ] (fput [] [1 2 3 4 5])
+=&gt; [5 4 3 2 1]
+</pre>
         <p>
           Here are some more useful examples:
         </p>
         <pre>
-          ;; find the longest string in a list
-          to-report longest-string [strings]
-          report reduce
-          [ [longest-so-far next-string] -&gt; ifelse-value (length longest-so-far &gt;= length next-string) [longest-so-far] [next-string] ]
-          strings
-          end
+;; find the longest string in a list
+to-report longest-string [strings]
+report reduce
+[ [longest-so-far next-string] -&gt; ifelse-value (length longest-so-far &gt;= length next-string) [longest-so-far] [next-string] ]
+strings
+end
 
-          show longest-string [&quot;hi&quot; &quot;there&quot; &quot;!&quot;]
-          =&gt; &quot;there&quot;
+show longest-string [&quot;hi&quot; &quot;there&quot; &quot;!&quot;]
+=&gt; &quot;there&quot;
 
-          ;; count the number of occurrences of an item in a list
-          to-report occurrences [x the-list]
-          report reduce
-          [ [occurrence-count next-item] -&gt; ifelse-value (next-item = x) [occurrence-count + 1] [occurrence-count] ] (fput 0 the-list)
-          end
+;; count the number of occurrences of an item in a list
+to-report occurrences [x the-list]
+report reduce
+[ [occurrence-count next-item] -&gt; ifelse-value (next-item = x) [occurrence-count + 1] [occurrence-count] ] (fput 0 the-list)
+end
 
-          show occurrences 1 [1 2 1 3 1 2 3 1 1 4 5 1]
-          =&gt; 6
+show occurrences 1 [1 2 1 3 1 2 3 1 1 4 5 1]
+=&gt; 6
 
-          ;; evaluate the polynomial, with given coefficients, at x
-          to-report evaluate-polynomial [coefficients x]
-          report reduce [ [value coefficient] -&gt; (x * value) + coefficient ] coefficients
-          end
+;; evaluate the polynomial, with given coefficients, at x
+to-report evaluate-polynomial [coefficients x]
+report reduce [ [value coefficient] -&gt; (x * value) + coefficient ] coefficients
+end
 
-          ;; evaluate 3x^2 + 2x + 1 at x = 4
-          show evaluate-polynomial [3 2 1] 4
-          =&gt; 57
-        </pre>
+;; evaluate 3x^2 + 2x + 1 at x = 4
+show evaluate-polynomial [3 2 1] 4
+=&gt; 57
+</pre>
         <p>
           See also <a href="#filter">filter</a>, <a href="#arrow">-&gt; (anonymous procedure</a>.
         </p>
@@ -7172,13 +7172,13 @@
         </p>
         <pre>
           <i>number1</i> - (int (<i>number1</i> / <i>number2</i>)) * <i>number2</i>
-        </pre>
+</pre>
         <pre>
-          show remainder 62 5
-          =&gt; 2
-          show remainder -8 3
-          =&gt; -2
-        </pre>
+show remainder 62 5
+=&gt; 2
+show remainder -8 3
+=&gt; -2
+</pre>
         <p>
           See also <a href="#mod">mod</a>. mod and remainder behave the same
           for positive numbers, but differently for negative numbers.
@@ -7201,12 +7201,12 @@
           appearances of <i>string1</i> as a substring removed.
         </p>
         <pre>
-          set mylist [2 7 4 7 &quot;Bob&quot;]
-          set mylist remove 7 mylist
-          ;; mylist is now [2 4 &quot;Bob&quot;]
-          show remove &quot;to&quot; &quot;phototonic&quot;
-          =&gt; &quot;phonic&quot;
-        </pre>
+set mylist [2 7 4 7 &quot;Bob&quot;]
+set mylist remove 7 mylist
+;; mylist is now [2 4 &quot;Bob&quot;]
+show remove &quot;to&quot; &quot;phototonic&quot;
+=&gt; &quot;phonic&quot;
+</pre>
       </div>
       <div class="dict_entry" id="remove-duplicates">
         <h3>
@@ -7220,10 +7220,10 @@
           first of each item remains in place.
         </p>
         <pre>
-          set mylist [2 7 4 7 &quot;Bob&quot; 7]
-          set mylist remove-duplicates mylist
-          ;; mylist is now [2 7 4 &quot;Bob&quot;]
-        </pre>
+set mylist [2 7 4 7 &quot;Bob&quot; 7]
+set mylist remove-duplicates mylist
+;; mylist is now [2 7 4 &quot;Bob&quot;]
+</pre>
       </div>
       <div class="dict_entry" id="remove-item">
         <h3>
@@ -7246,12 +7246,12 @@
           0, the second item is item 1, and so on.)
         </p>
         <pre>
-          set mylist [2 7 4 7 &quot;Bob&quot;]
-          set mylist remove-item 2 mylist
-          ;; mylist is now [2 7 7 &quot;Bob&quot;]
-          show remove-item 2 &quot;string&quot;
-          =&gt; &quot;sting&quot;
-        </pre>
+set mylist [2 7 4 7 &quot;Bob&quot;]
+set mylist remove-item 2 mylist
+;; mylist is now [2 7 7 &quot;Bob&quot;]
+show remove-item 2 &quot;string&quot;
+=&gt; &quot;sting&quot;
+</pre>
       </div>
       <div class="dict_entry" id="repeat">
         <h3>
@@ -7265,10 +7265,10 @@
         </p>
         <pre>
 
-          pd repeat 36 [ fd 1 rt 10 ]
-          ;; the turtle draws a circle
+pd repeat 36 [ fd 1 rt 10 ]
+;; the turtle draws a circle
 
-        </pre>
+</pre>
       </div>
       <div class="dict_entry" id="replace-item">
         <h3>
@@ -7289,11 +7289,11 @@
           removed and the contents of <i>string2</i> spliced in instead.
         </p>
         <pre>
-          show replace-item 2 [2 7 4 5] 15
-          =&gt; [2 7 15 5]
-          show replace-item 1 &quot;cat&quot; &quot;are&quot;
-          =&gt; &quot;caret&quot;
-        </pre>
+show replace-item 2 [2 7 4 5] 15
+=&gt; [2 7 15 5]
+show replace-item 1 &quot;cat&quot; &quot;are&quot;
+=&gt; &quot;caret&quot;
+</pre>
       </div>
       <div class="dict_entry" id="report">
         <h3>
@@ -7400,13 +7400,13 @@
           Reports a reversed copy of the given list or string.
         </p>
         <pre>
-          show mylist
-          ;; mylist is [2 7 4 &quot;Bob&quot;]
-          set mylist reverse mylist
-          ;; mylist now is [&quot;Bob&quot; 4 7 2]
-          show reverse &quot;live&quot;
-          =&gt; &quot;evil&quot;
-        </pre>
+show mylist
+;; mylist is [2 7 4 &quot;Bob&quot;]
+set mylist reverse mylist
+;; mylist now is [&quot;Bob&quot; 4 7 2]
+show reverse &quot;live&quot;
+=&gt; &quot;evil&quot;
+</pre>
       </div>
       <div class="dict_entry" id="rgb">
         <h3>
@@ -7514,13 +7514,13 @@
           towards the positive numbers.
         </p>
         <pre>
-          show round 4.2
-          =&gt; 4
-          show round 4.5
-          =&gt; 5
-          show round -4.5
-          =&gt; -4
-        </pre>
+show round 4.2
+=&gt; 4
+show round 4.5
+=&gt; 5
+show round -4.5
+=&gt; -4
+</pre>
         <p>
           See also <a href="#precision">precision</a>, <a href="#ceiling">ceiling</a>, <a href="#floor">floor</a>.
         </p>
@@ -7570,12 +7570,12 @@
           if you surround the entire call with parentheses. For example:
         </p>
         <pre>
-          (run [ [turtle-count step-count] -&gt; crt turtle-count [ fd step-count ] ] 10 5)
-          ;; creates 10 turtles and move them forward 5 steps
-          show (runresult [ [a b] -&gt; a + b ] 10 5)
-          =&gt; 15
-          ;; adds 10 and 5
-        </pre>
+(run [ [turtle-count step-count] -&gt; crt turtle-count [ fd step-count ] ] 10 5)
+;; creates 10 turtles and move them forward 5 steps
+show (runresult [ [a b] -&gt; a + b ] 10 5)
+=&gt; 15
+;; adds 10 and 5
+</pre>
         <p>
           See also <a href="#foreach">foreach</a>, <a href="#arrow">-> (anonymous procedure)</a>.
         </p>
@@ -7614,10 +7614,10 @@
           2 are equivalent, and the same spectrum of colors will be used.
         </p>
         <pre>
-          ask turtles [ set color scale-color red age 0 50 ]
-          ;; colors each turtle a shade of red proportional
-          ;; to its value for the age variable
-        </pre>
+ask turtles [ set color scale-color red age 0 50 ]
+;; colors each turtle a shade of red proportional
+;; to its value for the age variable
+</pre>
       </div>
       <div class="dict_entry" id="self">
         <h3>
@@ -7677,19 +7677,19 @@
           a sublist. Examples make this clearer:
         </p>
         <pre>
-          show sentence 1 2
-          =&gt; [1 2]
-          show sentence [1 2] 3
-          =&gt; [1 2 3]
-          show sentence 1 [2 3]
-          =&gt; [1 2 3]
-          show sentence [1 2] [3 4]
-          =&gt; [1 2 3 4]
-          show sentence [[1 2]] [[3 4]]
-          =&gt; [[1 2] [3 4]]
-          show (sentence [1 2] 3 [4 5] (3 + 3) 7)
-          =&gt; [1 2 3 4 5 6 7]
-        </pre>
+show sentence 1 2
+=&gt; [1 2]
+show sentence [1 2] 3
+=&gt; [1 2 3]
+show sentence 1 [2 3]
+=&gt; [1 2 3]
+show sentence [1 2] [3 4]
+=&gt; [1 2 3 4]
+show sentence [[1 2]] [[3 4]]
+=&gt; [[1 2] [3 4]]
+show (sentence [1 2] 3 [4 5] (3 + 3) 7)
+=&gt; [1 2 3 4 5 6 7]
+</pre>
       </div>
       <div class="dict_entry" id="set">
         <h3>
@@ -7739,11 +7739,11 @@
           The change is temporary and is not saved with the model.
         </p>
         <pre>
-          set-current-directory &quot;C:\\NetLogo&quot;
-          ;; Assume it is a Windows Machine
-          file-open &quot;my-file.txt&quot;
-          ;; Opens file &quot;C:\\NetLogo\\my-file.txt&quot;
-        </pre>
+set-current-directory &quot;C:\\NetLogo&quot;
+;; Assume it is a Windows Machine
+file-open &quot;my-file.txt&quot;
+;; Opens file &quot;C:\\NetLogo\\my-file.txt&quot;
+</pre>
       </div>
       <div class="dict_entry" id="set-current-plot">
         <h3>
@@ -7804,20 +7804,20 @@
           stuck with their breed's default shape.
         </p>
         <pre>
-          create-turtles 1 ;; new turtle's shape is &quot;default&quot;
-          create-cats 1    ;; new turtle's shape is &quot;default&quot;
+create-turtles 1 ;; new turtle's shape is &quot;default&quot;
+create-cats 1    ;; new turtle's shape is &quot;default&quot;
 
-          set-default-shape turtles &quot;circle&quot;
-          create-turtles 1 ;; new turtle's shape is &quot;circle&quot;
-          create-cats 1    ;; new turtle's shape is &quot;circle&quot;
+set-default-shape turtles &quot;circle&quot;
+create-turtles 1 ;; new turtle's shape is &quot;circle&quot;
+create-cats 1    ;; new turtle's shape is &quot;circle&quot;
 
-          set-default-shape cats &quot;cat&quot;
-          set-default-shape dogs &quot;dog&quot;
-          create-cats 1   ;; new turtle's shape is &quot;cat&quot;
-          ask cats [ set breed dogs ]
-          ;; all cats become dogs, and automatically
-          ;; change their shape to &quot;dog&quot;
-        </pre>
+set-default-shape cats &quot;cat&quot;
+set-default-shape dogs &quot;dog&quot;
+create-cats 1   ;; new turtle's shape is &quot;cat&quot;
+ask cats [ set breed dogs ]
+;; all cats become dogs, and automatically
+;; change their shape to &quot;dog&quot;
+</pre>
         <p>
           See also <a href="#shape">shape</a>.
         </p>
@@ -8020,13 +8020,13 @@
           the center of patch (-16, -16).
         </p>
         <pre>
-          setxy 0 0
-          ;; turtle moves to the middle of the center patch
-          setxy random-xcor random-ycor
-          ;; turtle moves to a random point
-          setxy random-pxcor random-pycor
-          ;; turtle moves to the center of a random patch
-        </pre>
+setxy 0 0
+;; turtle moves to the middle of the center patch
+setxy random-xcor random-ycor
+;; turtle moves to a random point
+setxy random-pxcor random-pycor
+;; turtle moves to the center of a random patch
+</pre>
         <p>
           See also <a href="#move-to">move-to</a>.
         </p>
@@ -8043,13 +8043,13 @@
           otherwise.
         </p>
         <pre>
-          show shade-of? blue red
-          =&gt; false
-          show shade-of? blue (blue + 1)
-          =&gt; true
-          show shade-of? gray white
-          =&gt; true
-        </pre>
+show shade-of? blue red
+=&gt; false
+show shade-of? blue (blue + 1)
+=&gt; true
+show shade-of? gray white
+=&gt; true
+</pre>
       </div>
       <div class="dict_entry" id="shape">
         <h3>
@@ -8077,7 +8077,7 @@
           ask links [ set shape &quot;link 1&quot; ]
           ;; assumes you have made a &quot;link 1&quot; shape in
           ;; the Link Shapes Editor
-        </pre>
+</pre>
         <p>
           See also <a href="#set-default-shape">set-default-shape</a>,
           <a href="#shapes">shapes</a>.
@@ -8099,10 +8099,10 @@
           from other models, in the <a href="shapes.html">Shapes Editor</a>.
         </p>
         <pre>
-          show shapes
-          =&gt; [&quot;default&quot; &quot;airplane&quot; &quot;arrow&quot; &quot;box&quot; &quot;bug&quot; ...
-          ask turtles [ set shape one-of shapes ]
-        </pre>
+show shapes
+=&gt; [&quot;default&quot; &quot;airplane&quot; &quot;arrow&quot; &quot;box&quot; &quot;bug&quot; ...
+ask turtles [ set shape one-of shapes ]
+</pre>
       </div>
       <div class="dict_entry" id="show">
         <h3>
@@ -8174,11 +8174,11 @@
           in randomized order.
         </p>
         <pre>
-          show shuffle [1 2 3 4 5]
-          =&gt; [5 2 4 1 3]
-          show shuffle [1 2 3 4 5]
-          =&gt; [1 3 5 2 4]
-        </pre>
+show shuffle [1 2 3 4 5]
+=&gt; [5 2 4 1 3]
+show shuffle [1 2 3 4 5]
+=&gt; [1 3 5 2 4]
+</pre>
       </div>
       <div class="dict_entry" id="sin">
         <h3>
@@ -8192,9 +8192,9 @@
           degrees.
         </p>
         <pre>
-          show sin 270
-          =&gt; -1
-        </pre>
+show sin 270
+=&gt; -1
+</pre>
       </div>
       <div class="dict_entry" id="size">
         <h3>
@@ -8245,32 +8245,32 @@
           number).
         </p>
         <pre>
-          show sort [3 1 4 2]
-          =&gt; [1 2 3 4]
-          show sort [2 1 "a"]
-          =&gt; [1 2]
-          show sort (list "a" "c" "b" (patch 0 0))
-          =&gt; ["a" "b" "c"]
-          show sort (list (patch 0 0) (patch 0 1) (patch 1 0))
-          =&gt; [(patch 0 1) (patch 0 0) (patch 1 0)]
+show sort [3 1 4 2]
+=&gt; [1 2 3 4]
+show sort [2 1 "a"]
+=&gt; [1 2]
+show sort (list "a" "c" "b" (patch 0 0))
+=&gt; ["a" "b" "c"]
+show sort (list (patch 0 0) (patch 0 1) (patch 1 0))
+=&gt; [(patch 0 1) (patch 0 0) (patch 1 0)]
 
-          ;; label patches with numbers in left-to-right, top-to-bottom order
-          let n 0
-          foreach sort patches [ the-patch -&gt;
-          ask the-patch [
-          set plabel n
-          set n n + 1
-          ]
-          ]
+;; label patches with numbers in left-to-right, top-to-bottom order
+let n 0
+foreach sort patches [ the-patch -&gt;
+ask the-patch [
+set plabel n
+set n n + 1
+]
+]
 
-          ;; some additional examples to clarify behavior in strange cases
-          show sort (list patch 0 0 patch 0 1 patch 1 0 turtle 0 turtle 1) ; turtles are always sorted lower than patches
-          =&gt; [(turtle 0) (turtle 1) (patch 0 1) (patch 0 0) (patch 1 0)]
-          show sort (list nobody false true) ; booleans and nobody cannot be sorted
-          =&gt; []
-          show sort (list [1 2 3] turtles) ; lists and agentsets are not included if they are inside a list passed to sort
-          =&gt; []
-        </pre>
+;; some additional examples to clarify behavior in strange cases
+show sort (list patch 0 0 patch 0 1 patch 1 0 turtle 0 turtle 1) ; turtles are always sorted lower than patches
+=&gt; [(turtle 0) (turtle 1) (patch 0 1) (patch 0 0) (patch 1 0)]
+show sort (list nobody false true) ; booleans and nobody cannot be sorted
+=&gt; []
+show sort (list [1 2 3] turtles) ; lists and agentsets are not included if they are inside a list passed to sort
+=&gt; []
+</pre>
         <p>
           See also <a href="#sort-by">sort-by</a>, <a href="#sort-on">sort-on</a>.
         </p>
@@ -8304,13 +8304,13 @@
           input is an agentset, ties are broken randomly.
         </p>
         <pre>
-          show sort-by &lt; [3 1 4 2]
-          =&gt; [1 2 3 4]
-          show sort-by &gt; [3 1 4 2]
-          =&gt; [4 3 2 1]
-          show sort-by [ [string1 string2] -&gt; length string1 &lt; length string2 ] [&quot;Grumpy&quot; &quot;Doc&quot; &quot;Happy&quot;]
-          =&gt; [&quot;Doc&quot; &quot;Happy&quot; &quot;Grumpy&quot;]
-        </pre>
+show sort-by &lt; [3 1 4 2]
+=&gt; [1 2 3 4]
+show sort-by &gt; [3 1 4 2]
+=&gt; [4 3 2 1]
+show sort-by [ [string1 string2] -&gt; length string1 &lt; length string2 ] [&quot;Grumpy&quot; &quot;Doc&quot; &quot;Happy&quot;]
+=&gt; [&quot;Doc&quot; &quot;Happy&quot; &quot;Grumpy&quot;]
+</pre>
         <p>
           See also <a href="#sort">sort</a>, <a href="#sort-on">sort-on</a>, <a href="#arrow">-> (anonymous procedure)</a>.
         </p>
@@ -8331,16 +8331,16 @@
           same type.
         </p>
         <pre>
-          crt 3
-          show sort-on [who] turtles
-          =&gt; [(turtle 0) (turtle 1) (turtle 2)]
-          show sort-on [(- who)] turtles
-          =&gt; [(turtle 2) (turtle 1) (turtle 0)]
-          foreach sort-on [size] turtles
-          [ the-turtle -&gt; ask the-turtle [ do-something ] ]
-          ;; turtles run &quot;do-something&quot; one at a time, in
-          ;; ascending order by size
-        </pre>
+crt 3
+show sort-on [who] turtles
+=&gt; [(turtle 0) (turtle 1) (turtle 2)]
+show sort-on [(- who)] turtles
+=&gt; [(turtle 2) (turtle 1) (turtle 0)]
+foreach sort-on [size] turtles
+[ the-turtle -&gt; ask the-turtle [ do-something ] ]
+;; turtles run &quot;do-something&quot; one at a time, in
+;; ascending order by size
+</pre>
         <p>
           See also <a href="#sort">sort</a>, <a href="#sort-by">sort-by</a>.
         </p>
@@ -8367,11 +8367,11 @@
           are created as members of the given breed.
         </p>
         <pre>
-          sprout 5
-          sprout-wolves 10
-          sprout 1 [ set color red ]
-          sprout-sheep 1 [ set color black ]
-        </pre>
+sprout 5
+sprout-wolves 10
+sprout 1 [ set color red ]
+sprout-sheep 1 [ set color black ]
+</pre>
         <p>
           See also <a href="#create-turtles">create-turtles</a>, <a href="#hatch">hatch</a>.
         </p>
@@ -8438,12 +8438,12 @@
           Bessel's correction.)
         </p>
         <pre>
-          show standard-deviation [1 2 3 4 5 6]
-          =&gt; 1.8708286933869707
-          show standard-deviation [energy] of turtles
-          ;; prints the standard deviation of the variable &quot;energy&quot;
-          ;; from all the turtles
-        </pre>
+show standard-deviation [1 2 3 4 5 6]
+=&gt; 1.8708286933869707
+show standard-deviation [energy] of turtles
+;; prints the standard deviation of the variable &quot;energy&quot;
+;; from all the turtles
+</pre>
       </div>
       <div class="dict_entry" id="startup">
         <h3>
@@ -8458,10 +8458,10 @@
           model is first loaded in the NetLogo application.
         </p>
         <pre>
-          to startup
-          setup
-          end
-        </pre>
+to startup
+setup
+end
+</pre>
         <p>
           <code>startup</code> does not run when a model is run headless from the
           command line, or by parallel BehaviorSpace.
@@ -8480,9 +8480,9 @@
           procedure or construct stops, not all execution for the agent.
         </p>
         <pre>
-          if not any? turtles [ stop ]
-          ;; exits if there are no more turtles
-        </pre>
+if not any? turtles [ stop ]
+;; exits if there are no more turtles
+</pre>
         <p>
           Note: <code>stop</code> can also be used to stop a forever button. See
           <a href="programming.html#buttons">Buttons</a> in the
@@ -8507,11 +8507,11 @@
           nothing.
         </p>
         <pre>
-          stop-inspecting patch 2 4
-          ;; the agent monitor for that patch closes
-          ask sheep [ stop-inspecting self ]
-          ;; close all agent monitors for sheep
-        </pre>
+stop-inspecting patch 2 4
+;; the agent monitor for that patch closes
+ask sheep [ stop-inspecting self ]
+;; close all agent monitors for sheep
+</pre>
         <p>
           See <a href="#inspect">inspect</a> and <a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>.
         </p>
@@ -8561,11 +8561,11 @@
           Note: The positions are numbered beginning with 0, not with 1.
         </p>
         <pre>
-          show sublist [99 88 77 66] 1 3
-          =&gt; [88 77]
-          show substring &quot;apartment&quot; 1 5
-          =&gt; &quot;part&quot;
-        </pre>
+show sublist [99 88 77 66] 1 3
+=&gt; [88 77]
+show substring &quot;apartment&quot; 1 5
+=&gt; &quot;part&quot;
+</pre>
       </div>
       <div class="dict_entry" id="subtract-headings">
         <h3>
@@ -8589,19 +8589,19 @@
           between 5 degrees and 355 degrees is 10 degrees, not -350 degrees.
         </p>
         <pre>
-          show subtract-headings 80 60
-          =&gt; 20
-          show subtract-headings 60 80
-          =&gt; -20
-          show subtract-headings 5 355
-          =&gt; 10
-          show subtract-headings 355 5
-          =&gt; -10
-          show subtract-headings 180 0
-          =&gt; 180
-          show subtract-headings 0 180
-          =&gt; 180
-        </pre>
+show subtract-headings 80 60
+=&gt; 20
+show subtract-headings 60 80
+=&gt; -20
+show subtract-headings 5 355
+=&gt; 10
+show subtract-headings 355 5
+=&gt; -10
+show subtract-headings 180 0
+=&gt; 180
+show subtract-headings 0 180
+=&gt; 180
+</pre>
       </div>
       <div class="dict_entry" id="sum">
         <h3>
@@ -8614,10 +8614,10 @@
           Reports the sum of the items in the list.
         </p>
         <pre>
-          show sum [energy] of turtles
-          ;; prints the total of the variable &quot;energy&quot;
-          ;; from all the turtles
-        </pre>
+show sum [energy] of turtles
+;; prints the total of the variable &quot;energy&quot;
+;; from all the turtles
+</pre>
       </div><!-- ======================================== -->
     </div>
     <h2 id="T">
@@ -8764,10 +8764,10 @@
           If the link dies, the tie relation is removed.
         </p>
         <pre>
-          crt 2 [ fd 3 ]
-          ;; creates a link and ties turtle 1 to turtle 0
-          ask turtle 0 [ create-link-to turtle 1 [ tie ] ]
-        </pre>
+crt 2 [ fd 3 ]
+;; creates a link and ties turtle 1 to turtle 0
+ask turtle 0 [ create-link-to turtle 1 [ tie ] ]
+</pre>
         <p>
           See also <a href="#untie">untie</a>
         </p>
@@ -8826,15 +8826,15 @@
           Used to begin a command procedure.
         </p>
         <pre>
-          to setup
-          clear-all
-          crt 500
-          end
+to setup
+clear-all
+crt 500
+end
 
-          to circle [radius]
-          crt 100 [ fd radius ]
-          end
-        </pre>
+to circle [radius]
+crt 100 [ fd radius ]
+end
+</pre>
       </div>
       <div class="dict_entry" id="to-report">
         <h3>
@@ -8852,20 +8852,20 @@
           value for the procedure. See <a href="#report">report</a>.
         </p>
         <pre>
-          to-report average [a b]
-          report (a + b) / 2
-          end
+to-report average [a b]
+report (a + b) / 2
+end
 
-          to-report absolute-value [number]
-          ifelse number &gt;= 0
-          [ report number ]
-          [ report (- number) ]
-          end
+to-report absolute-value [number]
+ifelse number &gt;= 0
+[ report number ]
+[ report (- number) ]
+end
 
-          to-report first-turtle?
-          report who = 0  ;; reports true or false
-          end
-        </pre>
+to-report first-turtle?
+report who = 0  ;; reports true or false
+end
+</pre>
       </div>
       <div class="dict_entry" id="towards">
         <h3>
@@ -8888,9 +8888,9 @@
           on the same location, will cause a runtime error.
         </p>
         <pre>
-          set heading towards turtle 1
-          ;; same as &quot;face turtle 1&quot;
-        </pre>
+set heading towards turtle 1
+;; same as &quot;face turtle 1&quot;
+</pre>
         <p>
           See also <a href="#face">face</a>.
         </p>
@@ -8933,9 +8933,9 @@
           turtles you may also use the single breed form to refer to them.
         </p>
         <pre>
-          ask turtle 5 [ set color red ]
-          ;; turtle with who number 5 turns red
-        </pre>
+ask turtle 5 [ set color red ]
+;; turtle with who number 5 turns red
+</pre>
       </div>
       <div class="dict_entry" id="turtle-set">
         <h3>
@@ -8952,11 +8952,11 @@
           above.
         </p>
         <pre>
-          turtle-set self
-          (turtle-set self turtles-on neighbors)
-          (turtle-set turtle 0 turtle 2 turtle 9)
-          (turtle-set frogs mice)
-        </pre>
+turtle-set self
+(turtle-set self turtles-on neighbors)
+(turtle-set turtle 0 turtle 2 turtle 9)
+(turtle-set frogs mice)
+</pre>
         <p>
           See also <a href="#patch-set">patch-set</a>, <a href="#link-set">link-set</a>.
         </p>
@@ -8972,9 +8972,9 @@
           Reports the agentset consisting of all turtles. This is a special agentset that can grow as turtles are added to the world, see <a href="programming.html#special-agentsets">the programming guide for more info</a>.
         </p>
         <pre>
-          show count turtles
-          ;; prints the number of turtles
-        </pre>
+show count turtles
+;; prints the number of turtles
+</pre>
       </div>
       <div class="dict_entry" id="turtles-at">
         <h3>
@@ -8991,10 +8991,10 @@
           caller is a turtle.)
         </p>
         <pre>
-          create-turtles 5 [ setxy 2 3 ]
-          show count [turtles-at 1 1] of patch 1 2
-          =&gt; 5
-        </pre>
+create-turtles 5 [ setxy 2 3 ]
+show count [turtles-at 1 1] of patch 1 2
+=&gt; 5
+</pre>
         <p>
           If the name of a breed is substituted for &quot;turtles&quot;, then
           only turtles of that breed are included.
@@ -9014,22 +9014,22 @@
           patch (including the caller itself if it's a turtle).
         </p>
         <pre>
-          crt 10
-          ask turtle 0 [ show count turtles-here ]
-          =&gt; 10
-        </pre>
+crt 10
+ask turtle 0 [ show count turtles-here ]
+=&gt; 10
+</pre>
         <p>
           If the name of a breed is substituted for &quot;turtles&quot;, then
           only turtles of that breed are included.
         </p>
         <pre>
-          breed [cats cat]
-          breed [dogs dog]
-          create-cats 5
-          create-dogs 1
-          ask dogs [ show count cats-here ]
-          =&gt; 5
-        </pre>
+breed [cats cat]
+breed [dogs dog]
+create-cats 5
+create-dogs 1
+ask dogs [ show count cats-here ]
+=&gt; 5
+</pre>
       </div>
       <div class="dict_entry" id="turtles-on">
         <h3>
@@ -9048,16 +9048,16 @@
           turtle or turtles.
         </p>
         <pre>
-          ask turtles [
-          if not any? turtles-on patch-ahead 1
-          [ fd 1 ]
-          ]
-          ask turtles [
-          if not any? turtles-on neighbors [
-          die-of-loneliness
-          ]
-          ]
-        </pre>
+ask turtles [
+if not any? turtles-on patch-ahead 1
+[ fd 1 ]
+]
+ask turtles [
+if not any? turtles-on neighbors [
+die-of-loneliness
+]
+]
+</pre>
         <p>
           If the name of a breed is substituted for &quot;turtles&quot;, then
           only turtles of that breed are included.
@@ -9083,14 +9083,14 @@
           breed may list the same variable.)
         </p>
         <pre>
-          breed [cats cat ]
-          breed [dogs dog]
-          breed [hamsters hamster]
-          turtles-own [eyes legs]   ;; applies to all breeds
-          cats-own [fur kittens]
-          hamsters-own [fur cage]
-          dogs-own [hair puppies]
-        </pre>
+breed [cats cat ]
+breed [dogs dog]
+breed [hamsters hamster]
+turtles-own [eyes legs]   ;; applies to all breeds
+cats-own [fur kittens]
+hamsters-own [fur cage]
+dogs-own [hair puppies]
+</pre>
         <p>
           See also <a href="#globals">globals</a>, <a href="#patches-own">patches-own</a>, <a href="#breed">breed</a>,
           <a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>.
@@ -9112,9 +9112,9 @@
           This agent is <i>not</i> printed before the value. unlike <a href="#show">show</a>.
         </p>
         <pre>
-          type 3 type &quot; &quot; print 4
-          =&gt; 3 4
-        </pre>
+type 3 type &quot; &quot; print 4
+=&gt; 3 4
+</pre>
         <p>
           See also <a href="#print">print</a>, <a href="#show">show</a>,
           <a href="#write">write</a>, <a href="#output-cmds">output-type</a>, and
@@ -9155,18 +9155,18 @@
           commands to only the links of a particular breed.
         </p>
         <pre>
-          undirected-link-breed [streets street]
-          undirected-link-breed [highways highway]
-          to setup
-          clear-all
-          crt 2
-          ask turtle 0 [ create-street-with turtle 1 ]
-          ask turtle 0 [ create-highway-with turtle 1 ]
-          end
+undirected-link-breed [streets street]
+undirected-link-breed [highways highway]
+to setup
+clear-all
+crt 2
+ask turtle 0 [ create-street-with turtle 1 ]
+ask turtle 0 [ create-highway-with turtle 1 ]
+end
 
-          ask turtle 0 [ show sort my-links ]
-          ;; prints [(street 0 1) (highway 0 1)]
-        </pre>
+ask turtle 0 [ show sort my-links ]
+;; prints [(street 0 1) (highway 0 1)]
+</pre>
         <p>
           See also <a href="#breed">breed</a>, <a href="#directed-link-breed">directed-link-breed</a>
         </p>
@@ -9216,10 +9216,10 @@
           <i>size</i>, reports the entire list.
         </p>
         <pre>
-          ask up-to-n-of 50 patches [ set pcolor green ]
-          ;; 50 randomly chosen patches turn green
-          ;; if less than 50 patches exist, they all turn green
-        </pre>
+ask up-to-n-of 50 patches [ set pcolor green ]
+;; 50 randomly chosen patches turn green
+;; if less than 50 patches exist, they all turn green
+</pre>
         <p>
           See also <a href="#n-of">n-of</a>, <a href="#one-of">one-of</a>.
         </p>
@@ -9280,7 +9280,7 @@
           face p
           move-to p
           ]
-        </pre>
+</pre>
         <p>
           Note that the turtle always ends up on a patch center and has a
           heading that is a multiple of 45 (uphill) or 90 (uphill4).
@@ -9305,9 +9305,9 @@
           cancels.
         </p>
         <pre>
-          set-current-directory user-directory
-          ;; Assumes the user will choose a directory
-        </pre>
+set-current-directory user-directory
+;; Assumes the user will choose a directory
+</pre>
       </div>
       <div class="dict_entry" id="user-file">
         <h3>
@@ -9325,9 +9325,9 @@
           user cancels.
         </p>
         <pre>
-          file-open user-file
-          ;; Assumes the user will choose a file
-        </pre>
+file-open user-file
+;; Assumes the user will choose a file
+</pre>
       </div>
       <div class="dict_entry" id="user-new-file">
         <h3>
@@ -9342,9 +9342,9 @@
           file path or false if the user cancels.
         </p>
         <pre>
-          file-open user-new-file
-          ;; Assumes the user will choose a file
-        </pre>
+file-open user-new-file
+;; Assumes the user will choose a file
+</pre>
         <p>
           Note that this reporter doesn't actually create the file;
           normally you would create the file using <code>file-open</code>, as in
@@ -9372,8 +9372,8 @@
           <i>value</i> may be of any type, but is typically a string.
         </p>
         <pre>
-          show user-input &quot;What is your name?&quot;
-        </pre>
+show user-input &quot;What is your name?&quot;
+</pre>
         <p>
           See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
           Programming Guide for additional details.
@@ -9393,8 +9393,8 @@
           <i>value</i> may be of any type, but is typically a string.
         </p>
         <pre>
-          user-message (word &quot;There are &quot; count turtles &quot; turtles.&quot;)
-        </pre>
+user-message (word &quot;There are &quot; count turtles &quot; turtles.&quot;)
+</pre>
         <p>
           Note that if a user closes the <code>user-message</code> dialog
           with the &quot;X&quot; in the corner, the behavior will be the same as if they had clicked &quot;OK&quot;.
@@ -9423,9 +9423,9 @@
           <i>value</i> may be of any type, but is typically a string.
         </p>
         <pre>
-          if &quot;yes&quot; = user-one-of &quot;Set up the model?&quot; [&quot;yes&quot; &quot;no&quot;]
-          [ setup ]
-        </pre>
+if &quot;yes&quot; = user-one-of &quot;Set up the model?&quot; [&quot;yes&quot; &quot;no&quot;]
+[ setup ]
+</pre>
         <p>
           See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
           Programming Guide for additional details.
@@ -9446,9 +9446,9 @@
           <i>value</i> may be of any type, but is typically a string.
         </p>
         <pre>
-          if user-yes-or-no? &quot;Set up the model?&quot;
-          [ setup ]
-        </pre>
+if user-yes-or-no? &quot;Set up the model?&quot;
+[ setup ]
+</pre>
         <p>
           See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
           Programming Guide for additional details.
@@ -9481,9 +9481,9 @@
           numbers in the list.
         </p>
         <pre>
-          show variance [2 7 4 3 5]
-          =&gt; 3.7
-        </pre>
+show variance [2 7 4 3 5]
+=&gt; 3.7
+</pre>
       </div><!-- ======================================== -->
     </div>
     <h2 id="W">
@@ -9504,8 +9504,8 @@
           given amount, but might wait slightly more.
         </p>
         <pre>
-          repeat 10 [ fd 1 wait 0.5 ]
-        </pre>
+repeat 10 [ fd 1 wait 0.5 ]
+</pre>
         <p>
           While the agent is waiting, no other agents can do anything.
           Everything stops until the agent is done.
@@ -9576,11 +9576,11 @@
           than other agents.
         </p>
         <pre>
-          while [any? other turtles-here]
-          [ fd 1 ]
-          ;; turtle moves until it finds a patch that has
-          ;; no other turtles on it
-        </pre>
+while [any? other turtles-here]
+[ fd 1 ]
+;; turtle moves until it finds a patch that has
+;; no other turtles on it
+</pre>
       </div>
       <div class="dict_entry" id="who">
         <h3>
@@ -9605,16 +9605,16 @@
           Example:
         </p>
         <pre>
-          show [who] of turtles with [color = red]
-          ;; prints a list of the who numbers of all red turtles
-          ;; in the Command Center, in random order
-          crt 100
-          [ ifelse who &lt; 50
-          [ set color red ]
-          [ set color blue ] ]
-          ;; turtles 0 through 49 are red, turtles 50
-          ;; through 99 are blue
-        </pre>
+show [who] of turtles with [color = red]
+;; prints a list of the who numbers of all red turtles
+;; in the Command Center, in random order
+crt 100
+[ ifelse who &lt; 50
+[ set color red ]
+[ set color blue ] ]
+;; turtles 0 through 49 are red, turtles 50
+;; through 99 are blue
+</pre>
         <p>
           You can use the turtle reporter to retrieve a turtle with a given
           who number. See also <a href="#turtle">turtle</a>.
@@ -9624,14 +9624,14 @@
           have the same who number, even if they are different breeds:
         </p>
         <pre>
-          clear-turtles
-          create-frogs 1
-          create-mice 1
-          ask turtles [ print who ]
-          ;; prints (in some random order):
-          ;; (frog 0): 0
-          ;; (mouse 1): 1
-        </pre>
+clear-turtles
+create-frogs 1
+create-mice 1
+ask turtles [ print who ]
+;; prints (in some random order):
+;; (frog 0): 0
+;; (mouse 1): 1
+</pre>
         <p>
           Even though we only have one mouse, it is <code>mouse 1</code> not
           <code>mouse 0</code>, because the who number 0 was already taken by the
@@ -9653,9 +9653,9 @@
           the given condition.
         </p>
         <pre>
-          show count patches with [pcolor = red]
-          ;; prints the number of red patches
-        </pre>
+show count patches with [pcolor = red]
+;; prints the number of red patches
+</pre>
       </div>
       <div class="dict_entry" id="link-with">
         <h3>
@@ -9673,12 +9673,12 @@
           nobody. If more than one such link exists, reports a random one.
         </p>
         <pre>
-          crt 2
-          ask turtle 0 [
-          create-link-with turtle 1
-          show link-with turtle 1 ;; prints link 0 1
-          ]
-        </pre>
+crt 2
+ask turtle 0 [
+create-link-with turtle 1
+show link-with turtle 1 ;; prints link 0 1
+]
+</pre>
         <p>
           See also: <a href="#in-link-from">in-link-from</a>, <a href="#out-link-to">out-link-to</a>
         </p>
@@ -9697,9 +9697,9 @@
           the maximum value of the given reporter.
         </p>
         <pre>
-          show count patches with-max [pxcor]
-          ;; prints the number of patches on the right edge
-        </pre>
+show count patches with-max [pxcor]
+;; prints the number of patches on the right edge
+</pre>
         <p>
           See also <a href="#max-one-of">max-one-of</a>, <a href="#max-n-of">max-n-of</a>.
         </p>
@@ -9718,9 +9718,9 @@
           have the minimum value of the given reporter.
         </p>
         <pre>
-          show count patches with-min [pycor]
-          ;; prints the number of patches on the bottom edge
-        </pre>
+show count patches with-min [pycor]
+;; prints the number of patches on the bottom edge
+</pre>
         <p>
           See also <a href="#min-one-of">min-one-of</a>, <a href="#min-n-of">min-n-of</a>.
         </p>
@@ -9741,13 +9741,13 @@
           Example:
         </p>
         <pre>
-          ;; Run #1:
-          random-seed 50 setup repeat 10 [ go ]
-          ;; Run #2:
-          random-seed 50 setup
-          with-local-randomness [ watch one-of turtles ]
-          repeat 10 [ go ]
-        </pre>
+;; Run #1:
+random-seed 50 setup repeat 10 [ go ]
+;; Run #2:
+random-seed 50 setup
+with-local-randomness [ watch one-of turtles ]
+repeat 10 [ go ]
+</pre>
         <p>
           Since <code>one-of</code> is used inside
           <code>with-local-randomness</code>, both runs will be identical.
@@ -9764,12 +9764,12 @@
           state is the same both before the commands run and afterwards.
         </p>
         <pre>
-          random-seed 10
-          with-local-randomness [ print n-values 10 [random 10] ]
-          ;; prints [8 9 8 4 2 4 5 4 7 9]
-          print n-values 10 [random 10]
-          ;; prints [8 9 8 4 2 4 5 4 7 9]
-        </pre>
+random-seed 10
+with-local-randomness [ print n-values 10 [random 10] ]
+;; prints [8 9 8 4 2 4 5 4 7 9]
+print n-values 10 [random 10]
+;; prints [8 9 8 4 2 4 5 4 7 9]
+</pre>
       </div>
       <div class="dict_entry" id="without-interruption">
         <h3>
@@ -9809,20 +9809,20 @@
           string.
         </p>
         <pre>
-          show word &quot;tur&quot; &quot;tle&quot;
-          =&gt; &quot;turtle&quot;
-          word &quot;a&quot; 6
-          =&gt; &quot;a6&quot;
-          set directory &quot;c:\\foo\\fish\\&quot;
-          show word directory &quot;bar.txt&quot;
-          =&gt; &quot;c:\foo\fish\bar.txt&quot;
-          show word [1 54 8] &quot;fishy&quot;
-          =&gt; &quot;[1 54 8]fishy&quot;
-          show (word 3)
-          =&gt; &quot;3&quot;
-          show (word &quot;a&quot; &quot;b&quot; &quot;c&quot; 1 23)
-          =&gt; &quot;abc123&quot;
-        </pre>
+show word &quot;tur&quot; &quot;tle&quot;
+=&gt; &quot;turtle&quot;
+word &quot;a&quot; 6
+=&gt; &quot;a6&quot;
+set directory &quot;c:\\foo\\fish\\&quot;
+show word directory &quot;bar.txt&quot;
+=&gt; &quot;c:\foo\fish\bar.txt&quot;
+show word [1 54 8] &quot;fishy&quot;
+=&gt; &quot;[1 54 8]fishy&quot;
+show (word 3)
+=&gt; &quot;3&quot;
+show (word &quot;a&quot; &quot;b&quot; &quot;c&quot; 1 23)
+=&gt; &quot;abc123&quot;
+</pre>
       </div>
       <div class="dict_entry" id="world-dim">
         <h3>
@@ -9867,11 +9867,11 @@
           variable.)
         </p>
         <pre>
-          show wrap-color 150
-          =&gt; 10
-          show wrap-color -10
-          =&gt; 130
-        </pre>
+show wrap-color 150
+=&gt; 10
+show wrap-color -10
+=&gt; 130
+</pre>
       </div>
       <div class="dict_entry" id="write">
         <h3>
@@ -9891,9 +9891,9 @@
           and is prepended with a space.
         </p>
         <pre>
-          write &quot;hello world&quot;
-          =&gt;  &quot;hello world&quot;
-        </pre>
+write &quot;hello world&quot;
+=&gt;  &quot;hello world&quot;
+</pre>
         <p>
           See also <a href="#print">print</a>, <a href="#show">show</a>,
           <a href="#type">type</a>, <a href="#output-cmds">output-write</a>,
@@ -9939,10 +9939,10 @@
           but not when both are true.
         </p>
         <pre>
-          if (pxcor &gt; 0) xor (pycor &gt; 0)
-          [ set pcolor blue ]
-          ;; upper-left and lower-right quadrants turn blue
-        </pre>
+if (pxcor &gt; 0) xor (pycor &gt; 0)
+[ set pcolor blue ]
+;; upper-left and lower-right quadrants turn blue
+</pre>
       </div><!-- ======================================== -->
     </div>
     <h2 id="Y">

--- a/autogen/docs/dictionary.html.mustache
+++ b/autogen/docs/dictionary.html.mustache
@@ -68,19 +68,6 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
         </div>
       </div>
     </div>
-<!--
-NOTE!
-</div>
-The reason the h2 headers have an extra &nbsp; in them, like this:
-<h2><a name="A">A&nbsp;</a></h2>
-instead of just:
-<h2><a name="A">A</a></h2>
-is to work around an extremely obscure bug in Internet Explorer
-where without the extra stuff, some of the links from primitives.html
-don't always work on every computer.  (On one computer it was just
-the "I" link that didn't work; on other computers it was more.)
-Go figure! - ST 12/2/04
--->
     <h2>
       Categories
     </h2>
@@ -833,7 +820,7 @@ Go figure! - ST 12/2/04
       <!-- ======================================== -->
     </div>
     <h2>
-      <a>A&nbsp;</a>
+      <a>A</a>
     </h2><!-- ======================================== -->
     <div id="A">
     <div class="dict_entry" id="abs">

--- a/autogen/docs/dictionary.html.mustache
+++ b/autogen/docs/dictionary.html.mustache
@@ -7266,10 +7266,8 @@ show remove-item 2 &quot;string&quot;
           Runs <i>commands</i> <i>number</i> times.
         </p>
         <pre>
-
 pd repeat 36 [ fd 1 rt 10 ]
 ;; the turtle draws a circle
-
 </pre>
       </div>
       <div class="dict_entry" id="replace-item">

--- a/autogen/docs/dictionary.html.mustache
+++ b/autogen/docs/dictionary.html.mustache
@@ -77,10 +77,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       versa. To see which agents (turtles, patches, links, observer) can
       actually run a primitive, consult its dictionary entry.
       <!-- ======================================== -->
-    <h3>
+    <h3 id="turtlegroup">
       Turtle-related
     </h3>
-    <p id="turtlegroup">
+    <p>
       <a href="#back">back</a> (<a href="#back">bk</a>)
       <a href="#turtles-at"><i>&lt;breeds&gt;</i>-at</a>
       <a href="#turtles-here"><i>&lt;breeds&gt;</i>-here</a>
@@ -156,10 +156,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#uphill">uphill</a>
       <a href="#uphill">uphill4</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="patchgroup">
       Patch-related
     </h3>
-    <p id="patchgroup">
+    <p>
       <a href="#clear-patches">clear-patches</a> (<a href="#clear-patches">cp</a>)
       <a href="#diffuse">diffuse</a>
       <a href="#diffuse4">diffuse4</a>
@@ -195,10 +195,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#subject">subject</a>
       <a href="#turtles-here">turtles-here</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="linkgroup">
       Link-related
     </h3>
-    <p id="linkgroup">
+    <p>
       <a href="#both-ends">both-ends</a>
       <a href="#clear-links">clear-links</a>
       <a href="#create-link">create-&lt;breed&gt;-from</a>
@@ -261,10 +261,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#undirected-link-breed">undirected-link-breed</a>
       <a href="#untie">untie</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="agentsetgroup">
       <a>Agentset</a>
     </h3>
-    <p id="agentsetgroup">
+    <p>
       <a href="#all">all?</a>
       <a href="#any">any?</a>
       <a href="#ask">ask</a>
@@ -310,10 +310,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#with-max">with-max</a>
       <a href="#with-min">with-min</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="colorgroup">
       Color
     </h3>
-    <p id="colorgroup">
+    <p>
       <a href="#approximate-hsb">approximate-hsb</a>
       <a href="#approximate-rgb">approximate-rgb</a>
       <a href="#base-colors">base-colors</a>
@@ -329,10 +329,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#shade-of">shade-of?</a>
       <a href="#wrap-color">wrap-color</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="controlgroup">
       Control flow and logic
     </h3>
-    <p id="controlgroup">
+    <p>
       <a href="#and">and</a>
       <a href="#ask">ask</a>
       <a href="#ask-concurrent">ask-concurrent</a>
@@ -364,10 +364,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#without-interruption">without-interruption</a>
       <a href="#xor">xor</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="anonproceduresgroup">
       Anonymous Procedures
     </h3>
-    <p id="anonproceduresgroup">
+    <p>
       <a href="#arrow">-&gt; (anonymous procedure)</a>
       <a href="#filter">filter</a>
       <a href="#foreach">foreach</a>
@@ -380,10 +380,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#run">runresult</a>
       <a href="#sort-by">sort-by</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="worldgroup">
       World
     </h3>
-    <p id="worldgroup">
+    <p>
       <a href="#clear-all">clear-all</a> (<a href="#clear-all">ca</a>)
       <a href="#clear-drawing">clear-drawing</a> (<a href="#clear-drawing">cd</a>)
       <a href="#clear-globals">clear-globals</a>
@@ -410,10 +410,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#world-dim">world-width</a>
       <a href="#world-dim">world-height</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="perspectivegroup">
       Perspective
     </h3>
-    <p id="perspectivegroup">
+    <p>
       <a href="#follow">follow</a>
       <a href="#follow-me">follow-me</a>
       <a href="#reset-perspective">reset-perspective</a> (<a href="#reset-perspective">rp</a>)
@@ -423,10 +423,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#watch">watch</a>
       <a href="#watch-me">watch-me</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="hubnetgroup">
       <a>HubNet</a>
     </h3>
-    <p id="hubnetgroup">
+    <p>
       <a href="#hubnet-broadcast">hubnet-broadcast</a>
       <a href="#hubnet-broadcast-clear-output">hubnet-broadcast-clear-output</a>
       <a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>
@@ -451,10 +451,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#hubnet-send-override">hubnet-send-override</a>
       <a href="#hubnet-send-watch">hubnet-send-watch</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="iogroup">
       Input/output
     </h3>
-    <p id="iogroup">
+    <p>
       <a href="#beep">beep</a>
       <a href="#clear-output">clear-output</a>
       <a href="#date-and-time">date-and-time</a>
@@ -492,10 +492,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#user-yes-or-no">user-yes-or-no?</a>
       <a href="#write">write</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="fileiogroup">
       File
     </h3>
-    <p id="fileiogroup">
+    <p>
       <a href="#file-at-end">file-at-end?</a>
       <a href="#file-close">file-close</a>
       <a href="#file-close-all">file-close-all</a>
@@ -514,10 +514,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#user-file">user-file</a>
       <a href="#user-new-file">user-new-file</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="listsgroup">
       List
     </h3>
-    <p id="listsgroup">
+    <p>
       <a href="#but-first-and-last">but-first</a>
       <a href="#but-first-and-last">but-last</a>
       <a href="#empty">empty?</a>
@@ -558,10 +558,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#subliststring">sublist</a>
       <a href="#up-to-n-of">up-to-n-of</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="stringgroup">
       String
     </h3>
-    <p id="stringgroup">
+    <p>
       <a href="#Symbols">Operators (&lt;, &gt;, =, !=, &lt;=, &gt;=)</a>
       <a href="#but-first-and-last">but-first</a>
       <a href="#but-first-and-last">but-last</a>
@@ -582,10 +582,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#subliststring">substring</a>
       <a href="#word">word</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="mathematicalgroup">
       Mathematical
     </h3>
-    <p id="mathematicalgroup">
+    <p>
       <a href="#Symbols">Arithmetic Operators (+, *, -, /, ^, &lt;, &gt;, =, !=, &lt;=, &gt;=)</a>
       <a href="#abs">abs</a>
       <a href="#acos">acos</a>
@@ -626,10 +626,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#tan">tan</a>
       <a href="#variance">variance</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="plottinggroup">
       Plotting
     </h3>
-    <p id="plottinggroup">
+    <p>
       <a href="#autoplot">autoplot?</a>
       <a href="#auto-plot-status">auto-plot-off</a>
       <a href="#auto-plot-status">auto-plot-on</a>
@@ -662,30 +662,30 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#setup-plots">setup-plots</a>
       <a href="#update-plots">update-plots</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="behaviorspacegroup">
       BehaviorSpace
     </h3>
-    <p id="behaviorspacegroup">
+    <p>
       <a href="#behaviorspace-experiment-name">behaviorspace-experiment-name</a>
       <a href="#behaviorspace-run-number">behaviorspace-run-number</a>
       <!-- ======================================== -->
-    <h3>
+    <h3 id="systemgroup">
       System
     </h3>
-    <p id="systemgroup">
+    <p>
       <a href="#netlogo-version">netlogo-version</a>
       <a href="#netlogo-web">netlogo-web?</a>
       <!-- ======================================== -->
        <!-- ======================================== -->
        <!-- ======================================== -->
-    <h2>
+    <h2 id="builtinvariables">
       <a>Built-In Variables</a>
     </h2><!-- ======================================== -->
-    <div id="builtinvariables">
-      <h3>
+    <div>
+      <h3 id="turtle-variables">
         <a>Turtles</a>
       </h3>
-      <p id="turtle-variables">
+      <p>
       <a href="#breedvar">breed</a>
       <a href="#color">color</a>
       <a href="#heading">heading</a>
@@ -700,20 +700,20 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#xcor">xcor</a>
       <a href="#ycor">ycor</a>
       <!-- ======================================== -->
-      <h3>
+      <h3 id="patch-variables">
         <a>Patches</a>
       </h3>
-      <p id="patch-variables">
+      <p>
       <a href="#pcolor">pcolor</a>
       <a href="#plabel">plabel</a>
       <a href="#plabel-color">plabel-color</a>
       <a href="#pcor">pxcor</a>
       <a href="#pcor">pycor</a>
       <!-- ======================================== -->
-      <h3>
+      <h3 id="link-variables">
         <a>Links</a>
       </h3>
-      <p id="link-variables">
+      <p>
       <a href="#breed">breed</a>
       <a href="#color">color</a>
       <a href="#end1">end1</a>
@@ -725,19 +725,19 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <a href="#thickness">thickness</a>
       <a href="#tie-mode">tie-mode</a>
       <!-- ======================================== -->
-      <h3>
+      <h3 id="other-variables">
         <a>Other</a>
       </h3>
-      <p id="other-variables">
+      <p>
       <a href="#arrow">-&gt;</a>
       <!-- ======================================== -->
       <!-- ======================================== -->
       <!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="Keywords">
       <a>Keywords</a>
     </h2>
-    <p id="Keywords">
+    <p>
       <a href="#breed">breed</a>
       <a href="#directed-link-breed">directed-link-breed</a>
       <a href="#end">end</a>
@@ -753,10 +753,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <!-- ======================================== -->
        <!-- ======================================== -->
        <!-- ======================================== -->
-    <h2>
+    <h2 id="Constants">
       <a>Constants</a>
     </h2><!-- ======================================== -->
-    <div id="Constants">
+    <div>
       <div class="dict_entry" id="mathconstants" data-constants="e pi">
         <h3>
           Mathematical Constants
@@ -819,10 +819,10 @@ h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
       <!-- ======================================== -->
       <!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="A">
       <a>A</a>
     </h2><!-- ======================================== -->
-    <div id="A">
+    <div>
     <div class="dict_entry" id="abs">
       <h3>
         <a>abs<span class="since">1.0</span></a>
@@ -1193,10 +1193,10 @@ end
         ranges.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="B">
       <a>B</a>
     </h2><!-- ======================================== -->
-    <div id="B">
+    <div>
     <div class="dict_entry" id="back">
       <h3>
         <a>back<span class="since">1.0</span></a>
@@ -1421,10 +1421,10 @@ show but-last &quot;string&quot;
 </pre><!-- ======================================== -->
     </div>
   </div>
-    <h2>
+    <h2 id="C">
       <a>C</a>
     </h2><!-- ======================================== -->
-    <div id="C">
+    <div>
     <div class="dict_entry" id="can-move">
       <h3>
         <a>can-move?<span class="since">3.1</span></a>
@@ -1882,10 +1882,10 @@ end
         <!-- ======================================== -->
       </div>
     </div>
-    <h2>
+    <h2 id="D">
       <a>D</a>
     </h2><!-- ======================================== -->
-    <div id="D">
+    <div>
     <div class="dict_entry" id="date-and-time">
       <h3>
         <a>date-and-time<span class="since">3.0</span></a>
@@ -2181,10 +2181,10 @@ if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
         more appropriate. <!-- ======================================== -->
       </div>
     </div>
-    <h2>
+    <h2 id="E">
       <a>E</a>
     </h2><!-- ======================================== -->
-    <div id="E">
+    <div>
     <div class="dict_entry" id="empty">
       <h3>
         <a>empty?<span class="since">1.0</span></a>
@@ -2473,10 +2473,10 @@ show extract-rgb cyan
         See also <a href="#approximate-rgb">approximate-rgb</a>, <a href="#approximate-hsb">approximate-hsb</a>, <a href="#extract-hsb">extract-hsb</a>.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="F">
       <a>F</a>
     </h2><!-- ======================================== -->
-    <div id="F">
+    <div>
     <div class="dict_entry" id="face">
       <h3>
         <a>face<span class="since">3.0</span></a>
@@ -3023,10 +3023,10 @@ set mylist fput 2 mylist
 </pre>
     </div><!-- ======================================== -->
   </div>
-    <h2>
+    <h2 id="G">
       <a>G</a>
     </h2><!-- ======================================== -->
-    <div id="G">
+    <div>
     <div class="dict_entry" id="globals">
       <h3>
         <a>globals</a>
@@ -3046,10 +3046,10 @@ set mylist fput 2 mylist
         need to be used in many parts of the program.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="H">
       <a>H</a>
     </h2><!-- ======================================== -->
-    <div id="H">
+    <div>
     <div class="dict_entry" id="hatch">
       <h3>
         <a>hatch<span class="since">1.0</span></a>
@@ -3576,10 +3576,10 @@ ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
         <a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
       </div>
     </div> <!-- ======================================== -->
-    <h2>
+    <h2 id="I">
       <a>I</a>
     </h2><!-- ======================================== -->
-    <div id="I">
+    <div>
     <div class="dict_entry" id="if">
       <h3>
         <a>if<span class="since">1.0</span></a>
@@ -4101,10 +4101,10 @@ show item 3 &quot;my-shoe&quot;
 </pre>
     </div><!-- ======================================== -->
   </div>
-    <h2>
+    <h2 id="J">
       <a>J</a>
     </h2><!-- ======================================== -->
-    <div id="J">
+    <div>
     <div class="dict_entry" id="jump">
       <h3>
         <a>jump<span class="since">1.0</span></a>
@@ -4123,10 +4123,10 @@ show item 3 &quot;my-shoe&quot;
         See also <a href="#forward">forward</a>, <a href="#can-move">can-move?</a>.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="L">
       <a>L</a>
     </h2><!-- ======================================== -->
-    <div id="L">
+    <div>
     <div class="dict_entry" id="label">
       <h3>
         <a>label</a>
@@ -4625,10 +4625,10 @@ set mylist lput 42 mylist
 </pre>
       </div><!-- ======================================== -->
     </div>
-      <h2>
+      <h2 id="M">
         <a>M</a>
       </h2><!-- ======================================== -->
-      <div id="M">
+      <div>
       <div class="dict_entry" id="map">
         <h3>
           <a>map<span class="since">1.3</span></a>
@@ -5176,10 +5176,10 @@ ask turtles
           See also <a href="#self">self</a>.
         </div><!-- ======================================== -->
       </div>
-      <h2>
+      <h2 id="N">
         <a>N</a>
       </h2><!-- ======================================== -->
-      <div id="N">
+      <div>
       <div class="dict_entry" id="n-of">
         <h3>
           <a>n-of<span class="since">3.1</span></a>
@@ -5450,10 +5450,10 @@ if not any? turtles [ crt 10 ]
         Reports an empty turtle agentset.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="O">
       <a>O</a>
     </h2><!-- ======================================== -->
-    <div id="O">
+    <div>
     <div class="dict_entry" id="of">
       <h3>
         <a>of<span class="since">4.0</span></a>
@@ -5687,10 +5687,10 @@ ask turtle 1
         Center is used.) See also <a href="programming.html#output">Output (programming guide)</a>.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="P">
       <a>P</a>
     </h2><!-- ======================================== -->
-    <div id="P">
+    <div>
     <div class="dict_entry" id="patch">
       <h3>
         <a>patch<span class="since">1.0</span></a>
@@ -6203,10 +6203,10 @@ show precision 3834 -3
         See also <a href="#xcor">xcor</a>, <a href="#ycor">ycor</a>.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="R">
       <a>R</a>
     </h2><!-- ======================================== -->
-    <div id="R">
+    <div>
     <div class="dict_entry" id="random">
       <h3>
         <a>random<span class="since">1.0</span></a>
@@ -6886,10 +6886,10 @@ show (runresult [ [a b] -&gt; a + b ] 10 5)
         See also <a href="#foreach">foreach</a>, <a href="#arrow">-> (anonymous procedure)</a>.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="S">
       <a>S</a>
     </h2><!-- ======================================== -->
-    <div id="S">
+    <div>
     <div class="dict_entry" id="scale-color">
       <h3>
         <a>scale-color<span class="since">1.0</span></a>
@@ -7815,10 +7815,10 @@ show sum [energy] of turtles
 </pre>
     </div><!-- ======================================== -->
   </div>
-    <h2>
+    <h2 id="T">
       <a>T</a>
     </h2><!-- ======================================== -->
-    <div id="T">
+    <div>
     <div class="dict_entry" id="tan">
       <h3>
         <a>tan<span class="since">1.0</span></a>
@@ -8265,10 +8265,10 @@ type 3 type &quot; &quot; print 4
         <a href="programming.html#output">Output (programming guide)</a>.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="U">
       <a>U</a>
     </h2><!-- ======================================== -->
-    <div id="U">
+    <div>
     <div class="dict_entry" id="undirected-link-breed">
       <h3>
         <a>undirected-link-breed</a>
@@ -8558,10 +8558,10 @@ if user-yes-or-no? &quot;Set up the model?&quot;
         Programming Guide for additional details.
     </div><!-- ======================================== -->
   </div>
-    <h2>
+    <h2 id="V">
       <a>V</a>
     </h2><!-- ======================================== -->
-    <div id="V">
+    <div>
     <div class="dict_entry" id="variance">
       <h3>
         <a>variance<span class="since">1.0</span></a>
@@ -8586,10 +8586,10 @@ show variance [2 7 4 3 5]
 </pre>
     </div><!-- ======================================== -->
   </div>
-    <h2>
+    <h2 id="W">
       <a>W</a>
     </h2><!-- ======================================== -->
-    <div id="W">
+    <div>
     <div class="dict_entry" id="wait">
       <h3>
         <a>wait<span class="since">1.0</span></a>
@@ -8959,10 +8959,10 @@ write &quot;hello world&quot;
         and <a href="programming.html#output">Output (programming guide)</a>.
       </div><!-- ======================================== -->
     </div>
-    <h2>
+    <h2 id="X">
       <a>X</a>
     </h2><!-- ======================================== -->
-    <div id="X">
+    <div>
     <div class="dict_entry" id="xcor">
       <h3>
         <a>xcor</a>
@@ -8999,10 +8999,10 @@ if (pxcor &gt; 0) xor (pycor &gt; 0)
 </pre>
     </div><!-- ======================================== -->
   </div>
-    <h2>
+    <h2 id="Y">
       <a>Y</a>
     </h2><!-- ======================================== -->
-    <div id="Y">
+    <div>
     <div class="dict_entry" id="ycor">
       <h3>
         <a>ycor</a>

--- a/autogen/docs/dictionary.html.mustache
+++ b/autogen/docs/dictionary.html.mustache
@@ -7815,8 +7815,8 @@ set-default-shape cats &quot;cat&quot;
 set-default-shape dogs &quot;dog&quot;
 create-cats 1   ;; new turtle's shape is &quot;cat&quot;
 ask cats [ set breed dogs ]
-;; all cats become dogs, and automatically
-;; change their shape to &quot;dog&quot;
+  ;; all cats become dogs, and automatically
+  ;; change their shape to &quot;dog&quot;
 </pre>
         <p>
           See also <a href="#shape">shape</a>.
@@ -8257,10 +8257,10 @@ show sort (list (patch 0 0) (patch 0 1) (patch 1 0))
 ;; label patches with numbers in left-to-right, top-to-bottom order
 let n 0
 foreach sort patches [ the-patch -&gt;
-ask the-patch [
-set plabel n
-set n n + 1
-]
+  ask the-patch [
+    set plabel n
+    set n n + 1
+  ]
 ]
 
 ;; some additional examples to clarify behavior in strange cases
@@ -8337,7 +8337,7 @@ show sort-on [who] turtles
 show sort-on [(- who)] turtles
 =&gt; [(turtle 2) (turtle 1) (turtle 0)]
 foreach sort-on [size] turtles
-[ the-turtle -&gt; ask the-turtle [ do-something ] ]
+  [ the-turtle -&gt; ask the-turtle [ do-something ] ]
 ;; turtles run &quot;do-something&quot; one at a time, in
 ;; ascending order by size
 </pre>
@@ -8459,7 +8459,7 @@ show standard-deviation [energy] of turtles
         </p>
         <pre>
 to startup
-setup
+  setup
 end
 </pre>
         <p>
@@ -8827,12 +8827,12 @@ ask turtle 0 [ create-link-to turtle 1 [ tie ] ]
         </p>
         <pre>
 to setup
-clear-all
-crt 500
+  clear-all
+  crt 500
 end
 
 to circle [radius]
-crt 100 [ fd radius ]
+  crt 100 [ fd radius ]
 end
 </pre>
       </div>
@@ -8853,17 +8853,17 @@ end
         </p>
         <pre>
 to-report average [a b]
-report (a + b) / 2
+  report (a + b) / 2
 end
 
 to-report absolute-value [number]
-ifelse number &gt;= 0
-[ report number ]
-[ report (- number) ]
+  ifelse number &gt;= 0
+    [ report number ]
+    [ report (- number) ]
 end
 
 to-report first-turtle?
-report who = 0  ;; reports true or false
+  report who = 0  ;; reports true or false
 end
 </pre>
       </div>
@@ -9049,13 +9049,13 @@ ask dogs [ show count cats-here ]
         </p>
         <pre>
 ask turtles [
-if not any? turtles-on patch-ahead 1
-[ fd 1 ]
+  if not any? turtles-on patch-ahead 1
+    [ fd 1 ]
 ]
 ask turtles [
-if not any? turtles-on neighbors [
-die-of-loneliness
-]
+  if not any? turtles-on neighbors [
+    die-of-loneliness
+  ]
 ]
 </pre>
         <p>
@@ -9158,10 +9158,10 @@ type 3 type &quot; &quot; print 4
 undirected-link-breed [streets street]
 undirected-link-breed [highways highway]
 to setup
-clear-all
-crt 2
-ask turtle 0 [ create-street-with turtle 1 ]
-ask turtle 0 [ create-highway-with turtle 1 ]
+  clear-all
+  crt 2
+  ask turtle 0 [ create-street-with turtle 1 ]
+  ask turtle 0 [ create-highway-with turtle 1 ]
 end
 
 ask turtle 0 [ show sort my-links ]
@@ -9424,7 +9424,7 @@ user-message (word &quot;There are &quot; count turtles &quot; turtles.&quot;)
         </p>
         <pre>
 if &quot;yes&quot; = user-one-of &quot;Set up the model?&quot; [&quot;yes&quot; &quot;no&quot;]
-[ setup ]
+  [ setup ]
 </pre>
         <p>
           See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
@@ -9447,7 +9447,7 @@ if &quot;yes&quot; = user-one-of &quot;Set up the model?&quot; [&quot;yes&quot; 
         </p>
         <pre>
 if user-yes-or-no? &quot;Set up the model?&quot;
-[ setup ]
+  [ setup ]
 </pre>
         <p>
           See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
@@ -9577,7 +9577,7 @@ repeat 10 [ fd 1 wait 0.5 ]
         </p>
         <pre>
 while [any? other turtles-here]
-[ fd 1 ]
+  [ fd 1 ]
 ;; turtle moves until it finds a patch that has
 ;; no other turtles on it
 </pre>
@@ -9609,9 +9609,9 @@ show [who] of turtles with [color = red]
 ;; prints a list of the who numbers of all red turtles
 ;; in the Command Center, in random order
 crt 100
-[ ifelse who &lt; 50
-[ set color red ]
-[ set color blue ] ]
+  [ ifelse who &lt; 50
+      [ set color red ]
+      [ set color blue ] ]
 ;; turtles 0 through 49 are red, turtles 50
 ;; through 99 are blue
 </pre>
@@ -9675,8 +9675,8 @@ show count patches with [pcolor = red]
         <pre>
 crt 2
 ask turtle 0 [
-create-link-with turtle 1
-show link-with turtle 1 ;; prints link 0 1
+  create-link-with turtle 1
+  show link-with turtle 1 ;; prints link 0 1
 ]
 </pre>
         <p>
@@ -9940,7 +9940,7 @@ write &quot;hello world&quot;
         </p>
         <pre>
 if (pxcor &gt; 0) xor (pycor &gt; 0)
-[ set pcolor blue ]
+  [ set pcolor blue ]
 ;; upper-left and lower-right quadrants turn blue
 </pre>
       </div><!-- ======================================== -->

--- a/autogen/docs/dictionary.html.mustache
+++ b/autogen/docs/dictionary.html.mustache
@@ -1,10008 +1,10008 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<title>
-			NetLogo {{version}} User Manual: NetLogo Dictionary
-		</title>
-		<link rel="stylesheet" href="netlogo.css" type="text/css"/>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-		<style>
-			p  { margin-left: 1.5em ; }
-			h3 { font-size: 115% ; }
-			h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
-		</style>
-	</head>
-	<body>
-		<h1>
-			NetLogo Dictionary
-		</h1>
-		<div class="version">
-			NetLogo {{version}} User Manual
-		</div>
-		<div class="centertext">
-			<div class="block">
-				<div class="smallfont centertext tocborder inlineblock">
-					Alphabetical:
-					<span class="bold">
-						<a href="#A">A</a>
-						<a href="#B">B</a>
-						<a href="#C">C</a>
-						<a href="#D">D</a>
-						<a href="#E">E</a>
-						<a href="#F">F</a>
-						<a href="#G">G</a>
-						<a href="#H">H</a>
-						<a href="#I">I</a>
-						<a href="#J">J</a>
-						<!--<a href="#K">K</a>-->
-						<a href="#L">L</a>
-						<a href="#M">M</a>
-						<a href="#N">N</a>
-						<a href="#O">O</a>
-						<a href="#P">P</a>
-						<!--<a href="#Q">Q</a>-->
-						<a href="#R">R</a>
-						<a href="#S">S</a>
-						<a href="#T">T</a>
-						<a href="#U">U</a>
-						<a href="#V">V</a>
-						<a href="#W">W</a>
-						<a href="#X">X</a>
-						<a href="#Y">Y</a>
-						<!--<a href="#Z">Z</a>-->
-						<a href="#ops">-></a>
-					</span>
-				</div>
-			</div>
-			<div class="block">
-				<div class="smallfont centertext tocborder inlineblock">
-					Categories: <a href="#turtlegroup">Turtle</a> - <a href="#patchgroup">Patch</a> - <a href="#linkgroup">Links</a>
-					- <a href="#agentsetgroup">Agentset</a> - <a href="#colorgroup">Color</a>
-					- <a href="#anonproceduresgroup">Anonymous Procedures</a> - <a href="#controlgroup">Control/Logic</a> - <a href="#worldgroup">World</a>
-					<br/>
-					<a href="#perspectivegroup">Perspective</a> -
-					<a href="#iogroup">Input/Output</a> - <a href="#fileiogroup">File</a> - <a href="#listsgroup">List</a> -
-					<a href="#stringgroup">String</a> - <a href="#mathematicalgroup">Math</a> - <a href="#plottinggroup">Plotting</a>
-					- <a href="#systemgroup">System</a> - <a href="#hubnetgroup">HubNet</a>
-				</div>
-			</div>
-			<div class="block">
-				<div class="smallfont centertext tocborder inlineblock">
-					Special: <a href="#builtinvariables">Variables</a> - <a href="#Keywords">Keywords</a> - <a href="#Constants">Constants</a>
-				</div>
-			</div>
-		</div>
-		<h2>
-			Categories
-		</h2>
-		<p>
-			This is an approximate grouping. Remember that a turtle-related
-			primitive might still be used by patches or the observer, and vice
-			versa. To see which agents (turtles, patches, links, observer) can
-			actually run a primitive, consult its dictionary entry.
-		</p>
-		<!-- ======================================== -->
-		<h3 id="turtlegroup">
-			Turtle-related
-		</h3>
-		<p>
-			<a href="#back">back</a> (<a href="#back">bk</a>)
-			<a href="#turtles-at"><i>&lt;breeds&gt;</i>-at</a>
-			<a href="#turtles-here"><i>&lt;breeds&gt;</i>-here</a>
-			<a href="#turtles-on"><i>&lt;breeds&gt;</i>-on</a>
-			<a href="#can-move">can-move?</a>
-			<a href="#clear-turtles">clear-turtles</a> (<a href="#clear-turtles">ct</a>)
-			<a href="#create-turtles">create-<i>&lt;breeds&gt;</i></a>
-			<a href="#create-ordered-turtles">create-ordered-<i>&lt;breeds&gt;</i></a>
-			<a href="#create-ordered-turtles">create-ordered-turtles</a> (<a href="#create-ordered-turtles">cro</a>)
-			<a href="#create-turtles">create-turtles</a> (<a href="#create-turtles">crt</a>)
-			<a href="#die">die</a>
-			<a href="#distance">distance</a>
-			<a href="#distancexy">distancexy</a>
-			<a href="#downhill">downhill</a>
-			<a href="#downhill">downhill4</a>
-			<a href="#dxy">dx</a>
-			<a href="#dxy">dy</a>
-			<a href="#face">face</a>
-			<a href="#facexy">facexy</a>
-			<a href="#forward">forward</a> (<a href="#forward">fd</a>)
-			<a href="#hatch">hatch</a>
-			<a href="#hatch">hatch-<i>&lt;breeds&gt;</i></a>
-			<a href="#hide-turtle">hide-turtle</a> (<a href="#hide-turtle">ht</a>)
-			<a href="#home">home</a>
-			<a href="#inspect">inspect</a>
-			<a href="#is-of-type">is-<i>&lt;breed&gt;</i>?</a>
-			<a href="#is-of-type">is-turtle?</a>
-			<a href="#jump">jump</a>
-			<a href="#layout-circle">layout-circle</a>
-			<a href="#left">left</a> (<a href="#left">lt</a>)
-			<a href="#move-to">move-to</a>
-			<a href="#myself">myself</a>
-			<a href="#nobody">nobody</a>
-			<a href="#no-turtles">no-turtles</a>
-			<a href="#of">of</a>
-			<a href="#other">other</a>
-			<a href="#patch-ahead">patch-ahead</a>
-			<a href="#patch-at">patch-at</a>
-			<a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>
-			<a href="#patch-here">patch-here</a>
-			<a href="#patch-lr-and-ahead">patch-left-and-ahead</a>
-			<a href="#patch-lr-and-ahead">patch-right-and-ahead</a>
-			<a href="#pen-switch-status">pen-down</a>  (<a href="#pen-switch-status">pd</a>)
-			<a href="#pen-switch-status">pen-erase</a> (<a href="#pen-switch-status">pe</a>)
-			<a href="#pen-switch-status">pen-up</a>    (<a href="#pen-switch-status">pu</a>)
-			<a href="#random-cor">random-xcor</a>
-			<a href="#random-cor">random-ycor</a>
-			<a href="#right">right</a> (<a href="#right">rt</a>)
-			<a href="#self">self</a>
-			<a href="#set-default-shape">set-default-shape</a>
-			<a href="#set-line-thickness">__set-line-thickness</a>
-			<a href="#setxy">setxy</a>
-			<a href="#shapes">shapes</a>
-			<a href="#show-turtle">show-turtle</a> (<a href="#show-turtle">st</a>)
-			<a href="#sprout">sprout</a>
-			<a href="#sprout">sprout-<i>&lt;breeds&gt;</i></a>
-			<a href="#stamp">stamp</a>
-			<a href="#stamp-erase">stamp-erase</a>
-			<a href="#stop-inspecting">stop-inspecting</a>
-			<a href="#subject">subject</a>
-			<a href="#subtract-headings">subtract-headings</a>
-			<a href="#tie">tie</a>
-			<a href="#towards">towards</a>
-			<a href="#towardsxy">towardsxy</a>
-			<a href="#turtle">turtle</a>
-			<a href="#turtle-set">turtle-set</a>
-			<a href="#turtles">turtles</a>
-			<a href="#turtles-at">turtles-at</a>
-			<a href="#turtles-here">turtles-here</a>
-			<a href="#turtles-on">turtles-on</a>
-			<a href="#turtles-own">turtles-own</a>
-			<a href="#untie">untie</a>
-			<a href="#uphill">uphill</a>
-			<a href="#uphill">uphill4</a>
-		</p>
-		<!-- ======================================== -->
-		<h3 id="patchgroup">
-			Patch-related
-		</h3>
-		<p>
-			<a href="#clear-patches">clear-patches</a> (<a href="#clear-patches">cp</a>)
-			<a href="#diffuse">diffuse</a>
-			<a href="#diffuse4">diffuse4</a>
-			<a href="#distance">distance</a>
-			<a href="#distancexy">distancexy</a>
-			<a href="#import-pcolors">import-pcolors</a>
-			<a href="#import-pcolors-rgb">import-pcolors-rgb</a>
-			<a href="#inspect">inspect</a>
-			<a href="#is-of-type">is-patch?</a>
-			<a href="#myself">myself</a>
-			<a href="#neighbors">neighbors</a>
-			<a href="#neighbors">neighbors4</a>
-			<a href="#nobody">nobody</a>
-			<a href="#no-patches">no-patches</a>
-			<a href="#of">of</a>
-			<a href="#other">other</a>
-			<a href="#patch">patch</a>
-			<a href="#patch-at">patch-at</a>
-			<a href="#patch-ahead">patch-ahead</a>
-			<a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>
-			<a href="#patch-here">patch-here</a>
-			<a href="#patch-lr-and-ahead">patch-left-and-ahead</a>
-			<a href="#patch-lr-and-ahead">patch-right-and-ahead</a>
-			<a href="#patch-set">patch-set</a>
-			<a href="#patches">patches</a>
-			<a href="#patches-own">patches-own</a>
-			<a href="#random-pcor">random-pxcor</a>
-			<a href="#random-pcor">random-pycor</a>
-			<a href="#self">self</a>
-			<a href="#sprout">sprout</a>
-			<a href="#sprout">sprout-<i>&lt;breeds&gt;</i></a>
-			<a href="#stop-inspecting">stop-inspecting</a>
-			<a href="#subject">subject</a>
-			<a href="#turtles-here">turtles-here</a>
-		</p>
-		<!-- ======================================== -->
-		<h3 id="linkgroup">
-			Link-related
-		</h3>
-		<p>
-			<a href="#both-ends">both-ends</a>
-			<a href="#clear-links">clear-links</a>
-			<a href="#create-link">create-&lt;breed&gt;-from</a>
-			<a href="#create-link">create-&lt;breeds&gt;-from</a>
-			<a href="#create-link">create-&lt;breed&gt;-to</a>
-			<a href="#create-link">create-&lt;breeds&gt;-to</a>
-			<a href="#create-link">create-&lt;breed&gt;-with</a>
-			<a href="#create-link">create-&lt;breeds&gt;-with</a>
-			<a href="#create-link">create-link-from</a>
-			<a href="#create-link">create-links-from</a>
-			<a href="#create-link">create-link-to</a>
-			<a href="#create-link">create-links-to</a>
-			<a href="#create-link">create-link-with</a>
-			<a href="#create-link">create-links-with</a>
-			<a href="#die">die</a>
-			<a href="#directed-link-breed">directed-link-breed</a>
-			<a href="#hide-link">hide-link</a>
-			<a href="#in-link-neighbor">in-&lt;breed&gt;-neighbor?</a>
-			<a href="#in-link-neighbors">in-&lt;breed&gt;-neighbors</a>
-			<a href="#in-link-from">in-&lt;breed&gt;-from</a>
-			<a href="#in-link-neighbor">in-link-neighbor?</a>
-			<a href="#in-link-neighbors">in-link-neighbors</a>
-			<a href="#in-link-from">in-link-from</a>
-			<a href="#is-of-type">is-directed-link?</a>
-			<a href="#is-of-type">is-link?</a>
-			<a href="#is-of-type">is-link-set?</a>
-			<a href="#is-of-type">is-<i>&lt;link-breed&gt;</i>?</a>
-			<a href="#is-of-type">is-undirected-link?</a>
-			<a href="#layout-radial">layout-radial</a>
-			<a href="#layout-spring">layout-spring</a>
-			<a href="#layout-tutte">layout-tutte</a>
-			<a href="#link-neighbor">&lt;breed&gt;-neighbor?</a>
-			<a href="#link-neighbors">&lt;breed&gt;-neighbors</a>
-			<a href="#link-with">&lt;breed&gt;-with</a>
-			<a href="#link-heading">link-heading</a>
-			<a href="#link-length">link-length</a>
-			<a href="#link-neighbor">link-neighbor?</a>
-			<a href="#link">link</a>
-			<a href="#links">links</a>
-			<a href="#links-own">links-own</a>
-			<a href="#links-own">&lt;link-breeds&gt;-own</a>
-			<a href="#link-neighbors">link-neighbors</a>
-			<a href="#link-with">link-with</a>
-			<a href="#my-links">my-&lt;breeds&gt;</a>
-			<a href="#my-in-links">my-in-&lt;breeds&gt;</a>
-			<a href="#my-in-links">my-in-links</a>
-			<a href="#my-links">my-links</a>
-			<a href="#my-out-links">my-out-&lt;breeds&gt;</a>
-			<a href="#my-out-links">my-out-links</a>
-			<a href="#no-links">no-links</a>
-			<a href="#other-end">other-end</a>
-			<a href="#out-link-neighbor">out-&lt;breed&gt;-neighbor?</a>
-			<a href="#out-link-neighbors">out-&lt;breed&gt;-neighbors</a>
-			<a href="#out-link-to">out-&lt;breed&gt;-to</a>
-			<a href="#out-link-neighbor">out-link-neighbor?</a>
-			<a href="#out-link-neighbors">out-link-neighbors</a>
-			<a href="#out-link-to">out-link-to</a>
-			<a href="#show-link">show-link</a>
-			<a href="#tie">tie</a>
-			<a href="#undirected-link-breed">undirected-link-breed</a>
-			<a href="#untie">untie</a>
-		</p>
-		<!-- ======================================== -->
-		<h3 id="agentsetgroup">
-			<a>Agentset</a>
-		</h3>
-		<p>
-			<a href="#all">all?</a>
-			<a href="#any">any?</a>
-			<a href="#ask">ask</a>
-			<a href="#ask-concurrent">ask-concurrent</a>
-			<a href="#at-points">at-points</a>
-			<a href="#turtles-at"><i>&lt;breeds&gt;</i>-at</a>
-			<a href="#turtles-here"><i>&lt;breeds&gt;</i>-here</a>
-			<a href="#turtles-on"><i>&lt;breeds&gt;</i>-on</a>
-			<a href="#count">count</a>
-			<a href="#in-cone">in-cone</a>
-			<a href="#in-radius">in-radius</a>
-			<a href="#is-of-type">is-agent?</a>
-			<a href="#is-of-type">is-agentset?</a>
-			<a href="#is-of-type">is-patch-set?</a>
-			<a href="#is-of-type">is-turtle-set?</a>
-			<a href="#link-set">link-set</a>
-			<a href="#max-n-of">max-n-of</a>
-			<a href="#max-one-of">max-one-of</a>
-			<a href="#member">member?</a>
-			<a href="#min-n-of">min-n-of</a>
-			<a href="#min-one-of">min-one-of</a>
-			<a href="#n-of">n-of</a>
-			<a href="#neighbors">neighbors</a>
-			<a href="#neighbors">neighbors4</a>
-			<a href="#no-links">no-links</a>
-			<a href="#no-patches">no-patches</a>
-			<a href="#no-turtles">no-turtles</a>
-			<a href="#of">of</a>
-			<a href="#one-of">one-of</a>
-			<a href="#other">other</a>
-			<a href="#patch-set">patch-set</a>
-			<a href="#patches">patches</a>
-			<a href="#sort">sort</a>
-			<a href="#sort-by">sort-by</a>
-			<a href="#sort-on">sort-on</a>
-			<a href="#turtle-set">turtle-set</a>
-			<a href="#turtles">turtles</a>
-			<a href="#turtles-at">turtles-at</a>
-			<a href="#turtles-here">turtles-here</a>
-			<a href="#turtles-on">turtles-on</a>
-			<a href="#up-to-n-of">up-to-n-of</a>
-			<a href="#with">with</a>
-			<a href="#with-max">with-max</a>
-			<a href="#with-min">with-min</a>
-		</p>
-		<!-- ======================================== -->
-		<h3 id="colorgroup">
-			Color
-		</h3>
-		<p>
-			<a href="#approximate-hsb">approximate-hsb</a>
-			<a href="#approximate-rgb">approximate-rgb</a>
-			<a href="#base-colors">base-colors</a>
-			<a href="#color">color</a>
-			<a href="#extract-hsb">extract-hsb</a>
-			<a href="#extract-rgb">extract-rgb</a>
-			<a href="#hsb">hsb</a>
-			<a href="#import-pcolors">import-pcolors</a>
-			<a href="#import-pcolors-rgb">import-pcolors-rgb</a>
-			<a href="#pcolor">pcolor</a>
-			<a href="#rgb">rgb</a>
-			<a href="#scale-color">scale-color</a>
-			<a href="#shade-of">shade-of?</a>
-			<a href="#wrap-color">wrap-color</a>
-		</p>
-		<!-- ======================================== -->
-		<h3 id="controlgroup">
-			Control flow and logic
-		</h3>
-		<p>
-			<a href="#and">and</a>
-			<a href="#ask">ask</a>
-			<a href="#ask-concurrent">ask-concurrent</a>
-			<a href="#carefully">carefully</a>
-			<a href="#end">end</a>
-			<a href="#error">error</a>
-			<a href="#error-message">error-message</a>
-			<a href="#every">every</a>
-			<a href="#if">if</a>
-			<a href="#ifelse">ifelse</a>
-			<a href="#ifelse-value">ifelse-value</a>
-			<a href="#let">let</a>
-			<a href="#loop">loop</a>
-			<a href="#not">not</a>
-			<a href="#or">or</a>
-			<a href="#repeat">repeat</a>
-			<a href="#report">report</a>
-			<a href="#run">run</a>
-			<a href="#run">runresult</a>
-			<a href="#semicolon">; (semicolon)</a>
-			<a href="#set">set</a>
-			<a href="#stop">stop</a>
-			<a href="#startup">startup</a>
-			<a href="#to">to</a>
-			<a href="#to-report">to-report</a>
-			<a href="#wait">wait</a>
-			<a href="#while">while</a>
-			<a href="#with-local-randomness">with-local-randomness</a>
-			<a href="#without-interruption">without-interruption</a>
-			<a href="#xor">xor</a>
-		</p>
-		<!-- ======================================== -->
-		<h3 id="anonproceduresgroup">
-			Anonymous Procedures
-		</h3>
-		<p>
-			<a href="#arrow">-&gt; (anonymous procedure)</a>
-			<a href="#filter">filter</a>
-			<a href="#foreach">foreach</a>
-			<a href="#is-of-type">is-anonymous-command?</a>
-			<a href="#is-of-type">is-anonymous-reporter?</a>
-			<a href="#map">map</a>
-			<a href="#n-values">n-values</a>
-			<a href="#reduce">reduce</a>
-			<a href="#run">run</a>
-			<a href="#run">runresult</a>
-			<a href="#sort-by">sort-by</a>
-		</p>
-		<!-- ======================================== -->
-		<h3 id="worldgroup">
-			World
-		</h3>
-		<p>
-			<a href="#clear-all">clear-all</a> (<a href="#clear-all">ca</a>)
-			<a href="#clear-drawing">clear-drawing</a> (<a href="#clear-drawing">cd</a>)
-			<a href="#clear-globals">clear-globals</a>
-			<a href="#clear-patches">clear-patches</a> (<a href="#clear-patches">cp</a>)
-			<a href="#clear-ticks">clear-ticks</a>
-			<a href="#clear-turtles">clear-turtles</a> (<a href="#clear-turtles">ct</a>)
-			<a href="#display">display</a>
-			<a href="#import-drawing">import-drawing</a>
-			<a href="#import-pcolors">import-pcolors</a>
-			<a href="#import-pcolors-rgb">import-pcolors-rgb</a>
-			<a href="#no-display">no-display</a>
-			<a href="#max-pcor">max-pxcor</a>
-			<a href="#max-pcor">max-pycor</a>
-			<a href="#min-pcor">min-pxcor</a>
-			<a href="#min-pcor">min-pycor</a>
-			<a href="#patch-size">patch-size</a>
-			<a href="#reset-ticks">reset-ticks</a>
-			<a href="#resize-world">resize-world</a>
-			<a href="#set-patch-size">set-patch-size</a>
-			<a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>
-			<a href="#tick">tick</a>
-			<a href="#tick-advance">tick-advance</a>
-			<a href="#ticks">ticks</a>
-			<a href="#world-dim">world-width</a>
-			<a href="#world-dim">world-height</a>
-		</p>
-		<!-- ======================================== -->
-		<h3 id="perspectivegroup">
-			Perspective
-		</h3>
-		<p>
-			<a href="#follow">follow</a>
-			<a href="#follow-me">follow-me</a>
-			<a href="#reset-perspective">reset-perspective</a> (<a href="#reset-perspective">rp</a>)
-			<a href="#ride">ride</a>
-			<a href="#ride-me">ride-me</a>
-			<a href="#subject">subject</a>
-			<a href="#watch">watch</a>
-			<a href="#watch-me">watch-me</a>
-		</p>
-		<!-- ======================================== -->
-		<h3 id="hubnetgroup">
-			<a>HubNet</a>
-		</h3>
-		<p>
-			<a href="#hubnet-broadcast">hubnet-broadcast</a>
-			<a href="#hubnet-broadcast-clear-output">hubnet-broadcast-clear-output</a>
-			<a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>
-			<a href="#hubnet-clear-override">hubnet-clear-override</a>
-			<a href="#hubnet-clear-override">hubnet-clear-overrides</a>
-			<a href="#hubnet-clients-list">hubnet-clients-list</a>
-			<a href="#hubnet-enter-message">hubnet-enter-message?</a>
-			<a href="#hubnet-exit-message">hubnet-exit-message?</a>
-			<a href="#hubnet-kick-all-clients">hubnet-kick-all-clients</a>
-			<a href="#hubnet-kick-client">hubnet-kick-client</a>
-			<a href="#hubnet-fetch-message">hubnet-fetch-message</a>
-			<a href="#hubnet-message">hubnet-message</a>
-			<a href="#hubnet-message-source">hubnet-message-source</a>
-			<a href="#hubnet-message-tag">hubnet-message-tag</a>
-			<a href="#hubnet-message-waiting">hubnet-message-waiting?</a>
-			<a href="#hubnet-reset">hubnet-reset</a>
-			<a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
-			<a href="#hubnet-send">hubnet-send</a>
-			<a href="#hubnet-send-clear-output">hubnet-send-clear-output</a>
-			<a href="#hubnet-send-follow">hubnet-send-follow</a>
-			<a href="#hubnet-send-message">hubnet-send-message</a>
-			<a href="#hubnet-send-override">hubnet-send-override</a>
-			<a href="#hubnet-send-watch">hubnet-send-watch</a>
-		</p>
-		<!-- ======================================== -->
-		<h3 id="iogroup">
-			Input/output
-		</h3>
-		<p>
-			<a href="#beep">beep</a>
-			<a href="#clear-output">clear-output</a>
-			<a href="#date-and-time">date-and-time</a>
-			<a href="#export-cmds">export-view</a>
-			<a href="#export-cmds">export-interface</a>
-			<a href="#export-cmds">export-output</a>
-			<a href="#export-cmds">export-plot</a>
-			<a href="#export-cmds">export-all-plots</a>
-			<a href="#export-cmds">export-world</a>
-			<a href="#import-drawing">import-drawing</a>
-			<a href="#import-pcolors">import-pcolors</a>
-			<a href="#import-pcolors-rgb">import-pcolors-rgb</a>
-			<a href="#import-world">import-world</a>
-			<a href="#mouse-down">mouse-down?</a>
-			<a href="#mouse-inside">mouse-inside?</a>
-			<a href="#mouse-cor">mouse-xcor</a>
-			<a href="#mouse-cor">mouse-ycor</a>
-			<a href="#output-cmds">output-print</a>
-			<a href="#output-cmds">output-show</a>
-			<a href="#output-cmds">output-type</a>
-			<a href="#output-cmds">output-write</a>
-			<a href="#print">print</a>
-			<a href="#read-from-string">read-from-string</a>
-			<a href="#reset-timer">reset-timer</a>
-			<a href="#set-current-directory">set-current-directory</a>
-			<a href="#show">show</a>
-			<a href="#timer">timer</a>
-			<a href="#type">type</a>
-			<a href="#user-directory">user-directory</a>
-			<a href="#user-file">user-file</a>
-			<a href="#user-new-file">user-new-file</a>
-			<a href="#user-input">user-input</a>
-			<a href="#user-message">user-message</a>
-			<a href="#user-one-of">user-one-of</a>
-			<a href="#user-yes-or-no">user-yes-or-no?</a>
-			<a href="#write">write</a>
-		</p>
-		<!-- ======================================== -->
-		<h3 id="fileiogroup">
-			File
-		</h3>
-		<p>
-			<a href="#file-at-end">file-at-end?</a>
-			<a href="#file-close">file-close</a>
-			<a href="#file-close-all">file-close-all</a>
-			<a href="#file-delete">file-delete</a>
-			<a href="#file-exists">file-exists?</a>
-			<a href="#file-flush">file-flush</a>
-			<a href="#file-open">file-open</a>
-			<a href="#file-print">file-print</a>
-			<a href="#file-read">file-read</a>
-			<a href="#file-read-characters">file-read-characters</a>
-			<a href="#file-read-line">file-read-line</a>
-			<a href="#file-show">file-show</a>
-			<a href="#file-type">file-type</a>
-			<a href="#file-write">file-write</a>
-			<a href="#user-directory">user-directory</a>
-			<a href="#user-file">user-file</a>
-			<a href="#user-new-file">user-new-file</a>
-		</p>
-		<!-- ======================================== -->
-		<h3 id="listsgroup">
-			List
-		</h3>
-		<p>
-			<a href="#but-first-and-last">but-first</a>
-			<a href="#but-first-and-last">but-last</a>
-			<a href="#empty">empty?</a>
-			<a href="#filter">filter</a>
-			<a href="#first">first</a>
-			<a href="#foreach">foreach</a>
-			<a href="#fput">fput</a>
-			<a href="#histogram">histogram</a>
-			<a href="#insert-item">insert-item</a>
-			<a href="#is-of-type">is-list?</a>
-			<a href="#item">item</a>
-			<a href="#last">last</a>
-			<a href="#length">length</a>
-			<a href="#list">list</a>
-			<a href="#lput">lput</a>
-			<a href="#map">map</a>
-			<a href="#max">max</a>
-			<a href="#member">member?</a>
-			<a href="#min">min</a>
-			<a href="#modes">modes</a>
-			<a href="#n-of">n-of</a>
-			<a href="#n-values">n-values</a>
-			<a href="#of">of</a>
-			<a href="#position">position</a>
-			<a href="#one-of">one-of</a>
-			<a href="#range">range</a>
-			<a href="#reduce">reduce</a>
-			<a href="#remove">remove</a>
-			<a href="#remove-duplicates">remove-duplicates</a>
-			<a href="#remove-item">remove-item</a>
-			<a href="#replace-item">replace-item</a>
-			<a href="#reverse">reverse</a>
-			<a href="#sentence">sentence</a>
-			<a href="#shuffle">shuffle</a>
-			<a href="#sort">sort</a>
-			<a href="#sort-by">sort-by</a>
-			<a href="#sort-on">sort-on</a>
-			<a href="#subliststring">sublist</a>
-			<a href="#up-to-n-of">up-to-n-of</a>
-		</p>
-		<!-- ======================================== -->
-		<h3 id="stringgroup">
-			String
-		</h3>
-		<p>
-			<a href="#Symbols">Operators (&lt;, &gt;, =, !=, &lt;=, &gt;=)</a>
-			<a href="#but-first-and-last">but-first</a>
-			<a href="#but-first-and-last">but-last</a>
-			<a href="#empty">empty?</a>
-			<a href="#first">first</a>
-			<a href="#insert-item">insert-item</a>
-			<a href="#is-of-type">is-string?</a>
-			<a href="#item">item</a>
-			<a href="#last">last</a>
-			<a href="#length">length</a>
-			<a href="#member">member?</a>
-			<a href="#position">position</a>
-			<a href="#remove">remove</a>
-			<a href="#remove-item">remove-item</a>
-			<a href="#read-from-string">read-from-string</a>
-			<a href="#replace-item">replace-item</a>
-			<a href="#reverse">reverse</a>
-			<a href="#subliststring">substring</a>
-			<a href="#word">word</a>
-		</p>
-		<!-- ======================================== -->
-		<h3 id="mathematicalgroup">
-			Mathematical
-		</h3>
-		<p>
-			<a href="#Symbols">Arithmetic Operators (+, *, -, /, ^, &lt;, &gt;, =, !=, &lt;=, &gt;=)</a>
-			<a href="#abs">abs</a>
-			<a href="#acos">acos</a>
-			<a href="#asin">asin</a>
-			<a href="#atan">atan</a>
-			<a href="#ceiling">ceiling</a>
-			<a href="#cos">cos</a>
-			<a href="#num-e">e</a>
-			<a href="#exp">exp</a>
-			<a href="#floor">floor</a>
-			<a href="#int">int</a>
-			<a href="#is-of-type">is-number?</a>
-			<a href="#ln">ln</a>
-			<a href="#log">log</a>
-			<a href="#max">max</a>
-			<a href="#mean">mean</a>
-			<a href="#median">median</a>
-			<a href="#min">min</a>
-			<a href="#mod">mod</a>
-			<a href="#modes">modes</a>
-			<a href="#new-seed">new-seed</a>
-			<a href="#pi">pi</a>
-			<a href="#precision">precision</a>
-			<a href="#random">random</a>
-			<a href="#random-reporters">random-exponential</a>
-			<a href="#random-float">random-float</a>
-			<a href="#random-reporters">random-gamma</a>
-			<a href="#random-reporters">random-normal</a>
-			<a href="#random-reporters">random-poisson</a>
-			<a href="#random-seed">random-seed</a>
-			<a href="#remainder">remainder</a>
-			<a href="#round">round</a>
-			<a href="#sin">sin</a>
-			<a href="#sqrt">sqrt</a>
-			<a href="#standard-deviation">standard-deviation</a>
-			<a href="#subtract-headings">subtract-headings</a>
-			<a href="#sum">sum</a>
-			<a href="#tan">tan</a>
-			<a href="#variance">variance</a>
-		</p>
-		<!-- ======================================== -->
-		<h3 id="plottinggroup">
-			Plotting
-		</h3>
-		<p>
-			<a href="#autoplot">autoplot?</a>
-			<a href="#auto-plot-status">auto-plot-off</a>
-			<a href="#auto-plot-status">auto-plot-on</a>
-			<a href="#clear-all-plots">clear-all-plots</a>
-			<a href="#clear-plot">clear-plot</a>
-			<a href="#create-temporary-plot-pen">create-temporary-plot-pen</a>
-			<a href="#export-cmds">export-plot</a>
-			<a href="#export-cmds">export-all-plots</a>
-			<a href="#histogram">histogram</a>
-			<a href="#plot">plot</a>
-			<a href="#plot-name">plot-name</a>
-			<a href="#plot-pen-exists">plot-pen-exists?</a>
-			<a href="#plot-pen-switch-status">plot-pen-down</a>
-			<a href="#plot-pen-reset">plot-pen-reset</a>
-			<a href="#plot-pen-switch-status">plot-pen-up</a>
-			<a href="#plot-cor-max-or-min">plot-x-max</a>
-			<a href="#plot-cor-max-or-min">plot-x-min</a>
-			<a href="#plot-cor-max-or-min">plot-y-max</a>
-			<a href="#plot-cor-max-or-min">plot-y-min</a>
-			<a href="#plotxy">plotxy</a>
-			<a href="#set-current-plot">set-current-plot</a>
-			<a href="#set-current-plot-pen">set-current-plot-pen</a>
-			<a href="#set-histogram-num-bars">set-histogram-num-bars</a>
-			<a href="#set-plot-background-color">set-plot-background-color</a>
-			<a href="#set-plot-pen-color">set-plot-pen-color</a>
-			<a href="#set-plot-pen-interval">set-plot-pen-interval</a>
-			<a href="#set-plot-pen-mode">set-plot-pen-mode</a>
-			<a href="#set-plot--range">set-plot-x-range</a>
-			<a href="#set-plot--range">set-plot-y-range</a>
-			<a href="#setup-plots">setup-plots</a>
-			<a href="#update-plots">update-plots</a>
-		</p>
-		<!-- ======================================== -->
-		<h3 id="behaviorspacegroup">
-			BehaviorSpace
-		</h3>
-		<p>
-			<a href="#behaviorspace-experiment-name">behaviorspace-experiment-name</a>
-			<a href="#behaviorspace-run-number">behaviorspace-run-number</a>
-		</p>
-		<!-- ======================================== -->
-		<h3 id="systemgroup">
-			System
-		</h3>
-		<p>
-			<a href="#netlogo-version">netlogo-version</a>
-			<a href="#netlogo-web">netlogo-web?</a>
-		</p>
-		<!-- ======================================== -->
-		<!-- ======================================== -->
-		<!-- ======================================== -->
-		<h2 id="builtinvariables">
-			<a>Built-In Variables</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<h3 id="turtle-variables">
-				<a>Turtles</a>
-			</h3>
-			<p>
-				<a href="#breedvar">breed</a>
-				<a href="#color">color</a>
-				<a href="#heading">heading</a>
-				<a href="#hidden">hidden?</a>
-				<a href="#label">label</a>
-				<a href="#label-color">label-color</a>
-				<a href="#pen-mode">pen-mode</a>
-				<a href="#pen-size">pen-size</a>
-				<a href="#shape">shape</a>
-				<a href="#size">size</a>
-				<a href="#who">who</a>
-				<a href="#xcor">xcor</a>
-				<a href="#ycor">ycor</a>
-			</p>
-			<!-- ======================================== -->
-			<h3 id="patch-variables">
-				<a>Patches</a>
-			</h3>
-			<p>
-				<a href="#pcolor">pcolor</a>
-				<a href="#plabel">plabel</a>
-				<a href="#plabel-color">plabel-color</a>
-				<a href="#pcor">pxcor</a>
-				<a href="#pcor">pycor</a>
-			</p>
-			<!-- ======================================== -->
-			<h3 id="link-variables">
-				<a>Links</a>
-			</h3>
-			<p>
-				<a href="#breed">breed</a>
-				<a href="#color">color</a>
-				<a href="#end1">end1</a>
-				<a href="#end2">end2</a>
-				<a href="#hidden">hidden?</a>
-				<a href="#label">label</a>
-				<a href="#label-color">label-color</a>
-				<a href="#shape">shape</a>
-				<a href="#thickness">thickness</a>
-				<a href="#tie-mode">tie-mode</a>
-			</p>
-			<!-- ======================================== -->
-			<h3 id="other-variables">
-				<a>Other</a>
-			</h3>
-			<p>
-				<a href="#arrow">-&gt;</a>
-			</p>
-			<!-- ======================================== -->
-			<!-- ======================================== -->
-			<!-- ======================================== -->
-		</div>
-		<h2 id="Keywords">
-			<a>Keywords</a>
-		</h2>
-		<p>
-			<a href="#breed">breed</a>
-			<a href="#directed-link-breed">directed-link-breed</a>
-			<a href="#end">end</a>
-			<a href="#extensions">extensions</a>
-			<a href="#globals">globals</a>
-			<a href="#includes">__includes</a>
-			<a href="#links-own">links-own</a>
-			<a href="#patches-own">patches-own</a>
-			<a href="#to">to</a>
-			<a href="#to-report">to-report</a>
-			<a href="#turtles-own">turtles-own</a>
-			<a href="#undirected-link-breed">undirected-link-breed</a>
-		</p>
-		<!-- ======================================== -->
-		<!-- ======================================== -->
-		<!-- ======================================== -->
-		<h2 id="Constants">
-			<a>Constants</a>
-		</h2><!-- ======================================== -->
-		<div class="dict_entry" id="mathconstants" data-constants="e pi">
-			<h3>
-				Mathematical Constants
-			</h3>
-			<p>
-				<b id="num-e"><a>e</a></b> = 2.718281828459045
-				<br/>
-				<b id="pi"><a>pi</a></b> = 3.141592653589793
-			</p>
-		</div><!-- ======================================== -->
-		<div class="dict_entry" id="boolconstants" data-constants="false true">
-			<h3>
-				<a>Boolean Constants</a>
-			</h3>
-			<p id="false_true">
-				<b><a>false</a></b>
-				<br/>
-				<b><a>true</a></b>
-			</p>
-		</div><!-- ======================================== -->
-		<div class="dict_entry" id="colorconstants" data-constants="black gray white red orange brown yellow green lime turquoise cyan sky blue violet magenta pink">
-			<h3>
-				<a>Color Constants</a>
-			</h3>
-			<p>
-				<b>black</b> = 0
-				<br/>
-				<b>gray</b> = 5
-				<br/>
-				<b>white</b> = 9.9
-				<br/>
-				<b>red</b> = 15
-				<br/>
-				<b>orange</b> = 25
-				<br/>
-				<b>brown</b> = 35
-				<br/>
-				<b>yellow</b> = 45
-				<br/>
-				<b>green</b> = 55
-				<br/>
-				<b>lime</b> = 65
-				<br/>
-				<b>turquoise</b> = 75
-				<br/>
-				<b>cyan</b> = 85
-				<br/>
-				<b>sky</b> = 95
-				<br/>
-				<b>blue</b> = 105
-				<br/>
-				<b>violet</b> = 115
-				<br/>
-				<b>magenta</b> = 125
-				<br/>
-				<b>pink</b> = 135
-			</p>
-			<p>
-				See the <a href="programming.html#colors">Colors</a> section of the
-				Programming Guide for more details.
-			</p>
-		</div><!-- ======================================== -->
-		<!-- ======================================== -->
-		<!-- ======================================== -->
-		<!-- ======================================== -->
-		<h2 id="A">
-			<a>A</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="abs">
-				<h3>
-					<a>abs<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">abs <i>number</i></span>
-				</h4>
-				<p>
-					Reports the absolute value of <i>number</i>.
-				</p>
-				<pre>
-					show abs -7
-					=&gt; 7
-					show abs 5
-					=&gt; 5
-				</pre>
-			</div>
-			<div class="dict_entry" id="acos">
-				<h3>
-					<a>acos<span class="since">1.3</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">acos <i>number</i></span>
-				</h4>
-				<p>
-					Reports the arc cosine (inverse cosine) of the given number. The
-					input must be in the range -1 to 1. The result is in degrees, and
-					lies in the range 0 to 180.
-				</p>
-			</div>
-			<div class="dict_entry" id="all">
-				<h3>
-					<a>all?<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">all? <i>agentset</i> [<i>reporter</i>]</span>
-				</h4>
-				<p>
-					Reports true if all of the agents in the agentset report true for
-					the given reporter. Otherwise reports false as soon as a
-					counterexample is found.
-				</p>
-				<p>
-					If the agentset is empty, reports true.
-				</p>
-				<p>
-					The reporter must report a boolean value for every agent (either
-					true or false), otherwise an error occurs.
-				</p>
-				<pre>
-					if all? turtles [color = red]
-					[ show &quot;every turtle is red!&quot; ]
-				</pre>
-				<p>
-					See also <a href="#any">any?</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="and">
-				<h3>
-					<a>and<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example"><i>condition1</i> and <i>condition2</i></span>
-				</h4>
-				<p>
-					Reports true if both <i>condition1</i> and <i>condition2</i> are
-					true.
-				</p>
-				<p>
-					Note that if <i>condition1</i> is false, then <i>condition2</i>
-					will not be run (since it can't affect the result).
-				</p>
-				<pre>
-					if (pxcor &gt; 0) and (pycor &gt; 0)
-					[ set pcolor blue ]  ;; the upper-right quadrant of
-					;; patches turn blue
-				</pre>
-			</div>
-			<div class="dict_entry" id="any">
-				<h3>
-					<a>any?<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">any? <i>agentset</i></span>
-				</h4>
-				<p>
-					Reports true if the given agentset is non-empty, false otherwise.
-				</p>
-				<p>
-					Equivalent to &quot;count <i>agentset</i> &gt; 0&quot;, but more
-					efficient (and arguably more readable).
-				</p>
-				<pre>
-					if any? turtles with [color = red]
-					[ show &quot;at least one turtle is red!&quot; ]
-				</pre>
-				<p>
-					Note: nobody is not an agentset. You only get nobody back in
-					situations where you were expecting a single agent, not a whole
-					agentset. If any? gets nobody as input, an error results.
-				</p>
-				<p>
-					See also <a href="#all">all?</a>, <a href="#nobody">nobody</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="approximate-hsb">
-				<h3>
-					<a>approximate-hsb<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">approximate-hsb <i>hue saturation brightness</i></span>
-				</h4>
-				<p>
-					Reports a number in the range 0 to 140, not including 140 itself,
-					that represents the given color, specified in the HSB spectrum, in
-					NetLogo's color space.
-				</p>
-				<p>
-					The first value (hue) should be in the range of 0 to 360, the second
-					and third (saturation and brightness) in the range between 0 and 100.
-				</p>
-				<p>
-					The color reported may be only an approximation, since the NetLogo
-					color space does not include all possible colors.
-				</p>
-				<pre>
-					show approximate-hsb 0 0 0
-					=&gt; 0  ;; (black)
-					show approximate-hsb 180 57.143 76.863
-					=&gt; 85 ;; (cyan)
-				</pre>
-				<p>
-					See also <a href="#extract-hsb">extract-hsb</a>, <a href="#approximate-rgb">approximate-rgb</a>, <a href="#extract-rgb">extract-rgb</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="approximate-rgb">
-				<h3>
-					<a>approximate-rgb<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">approximate-rgb <i>red green blue</i></span>
-				</h4>
-				<p>
-					Reports a number in the range 0 to 140, not including 140 itself,
-					that represents the given color, specified in the RGB spectrum, in
-					NetLogo's color space.
-				</p>
-				<p>
-					All three inputs should be in the range 0 to 255.
-				</p>
-				<p>
-					The color reported may be only an approximation, since the NetLogo
-					color space does not include all possible colors. (See <a href="#approximate-hsb">approximate-hsb</a> for a description of what
-					parts of the HSB color space NetLogo colors cover; this is
-					difficult to characterize in RGB terms.)
-				</p>
-				<pre>
-					show approximate-rgb 0 0 0
-					=&gt; 0  ;; black
-					show approximate-rgb 0 255 255
-					=&gt; 85.2 ;; cyan
-				</pre>
-				<p>
-					See also <a href="#extract-rgb">extract-rgb</a>, <a href="#approximate-hsb">approximate-hsb</a>, and <a href="#extract-hsb">extract-hsb</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="Symbols">
-				<h3>
-					<a>Arithmetic Operators</a>
-					<a>+<span class="since">1.0</span></a>
-					<a>*<span class="since">1.0</span></a>
-					<a>-<span class="since">1.0</span></a>
-					<a>/<span class="since">1.0</span></a>
-					<a>^<span class="since">1.0</span></a>
-					<a>&lt;<span class="since">1.0</span></a>
-					<a>&gt;<span class="since">1.0</span></a>
-					<a>=<span class="since">1.0</span></a>
-					<a>!=<span class="since">1.0</span></a>
-					<a>&lt;=<span class="since">1.0</span></a>
-					<a>&gt;=<span class="since">1.0</span></a>
-				</h3>
-				<p>
-					All of these operators take two inputs, and all act as &quot;infix
-					operators&quot; (going between the two inputs, as in standard
-					mathematical use). NetLogo correctly supports order of operations
-					for infix operators.
-				</p>
-				<p>
-					The operators work as follows: + is addition, * is multiplication,
-					- is subtraction, / is division, ^ is exponentiation, &lt; is less
-					than, &gt; is greater than, = is equal to, != is not equal to,
-					&lt;= is less than or equal, &gt;= is greater than or equal.
-				</p>
-				<p>
-					Note that the subtraction operator (-) always takes two inputs
-					unless you put parentheses around it, in which case it can take one
-					input. For example, to take the negative of x, write (- x), with
-					the parentheses.
-				</p>
-				<p>
-					All of the comparison operators also work on strings.
-				</p>
-				<p>
-					All of the comparison operators work on agents. Turtles are
-					compared by who number. Patches are compared top to bottom left to
-					right, so patch 0 10 is less than patch 0 9 and patch 9 0 is less
-					than patch 10 0. Links are ordered by end points and in case of a
-					tie by breed. So link 0 9 is before link 1 10 as the end1 is
-					smaller, and link 0 8 is less than link 0 9. If there are multiple
-					breeds of links unbreeded links will come before breeded links of
-					the same end points and breeded links will be sorted in the order
-					they are declared in the Code tab.
-				</p>
-				<p>
-					Agentsets can be tested for equality or inequality. Two agentsets
-					are equal if they are the same type (turtle or patch) and contain
-					the same agents.
-				</p>
-				<p>
-					If you are not sure how NetLogo will interpret your code, you
-					should add parentheses.
-				</p>
-				<pre>
-					show 5 * 6 + 6 / 3
-					=&gt; 32
-					show 5 * (6 + 6) / 3
-					=&gt; 20
-				</pre>
-				<p>
-					Many extension objects may be tested for equality and inequality
-					using = and !=.
-					For instance, the array, matrix, and table objects returned by their
-					respective extensions may be compared for equality / inequality.
-					Extension objects may not be tested using &lt;, &gt;, &lt;=, or &gt;=.
-				</p>
-			</div>
-			<div class="dict_entry" id="asin">
-				<h3>
-					<a>asin<span class="since">1.3</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">asin <i>number</i></span>
-				</h4>
-				<p>
-					Reports the arc sine (inverse sine) of the given number. The input
-					must be in the range -1 to 1. The result is in degrees, and lies in
-					the range -90 to 90.
-				</p>
-			</div>
-			<div class="dict_entry" id="ask">
-				<h3>
-					<a>ask<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">ask <i>agentset</i> [<i>commands</i>]</span>
-					<span class="prim_example">ask <i>agent</i> [<i>commands</i>]</span>
-				</h4>
-				<p>
-					The specified agent or agentset runs the given commands.  Because
-					agentset members are always read in a random order, when ask is
-					used with an agentset each agent will take its turn in a random
-					order.  See <a href="programming.html#agentsets">Agentsets</a>
-					for more information.
-				</p>
-				<pre>
-					ask turtles [ fd 1 ]
-					;; all turtles move forward one step
-					ask patches [ set pcolor red ]
-					;; all patches turn red
-					ask turtle 4 [ rt 90 ]
-					;; only the turtle with id 4 turns right
-				</pre>
-				<p>
-					Note: only the observer can ask all turtles or all patches. This
-					prevents you from inadvertently having all turtles ask all turtles
-					or all patches ask all patches, which is a common mistake to make
-					if you're not careful about which agents will run the code you
-					are writing.
-				</p>
-				<p>
-					Note: Only the agents that are in the agentset <i>at the time the
-						ask begins</i> run the commands.
-				</p>
-			</div>
-			<div class="dict_entry" id="ask-concurrent">
-				<h3>
-					<a>ask-concurrent<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">ask-concurrent <i>agentset</i> [<i>commands</i>]</span>
-				</h4>
-				<p>
-					This primitive exists only for backwards compatibility. We
-					don't recommend using it new models.
-				</p>
-				<p>
-					The agents in the given agentset run the given commands, using a
-					turn-taking mechanism to produce simulated concurrency. See the
-					<a href="programming.html#ask-concurrent">Ask-Concurrent</a>
-					section of the Programming Guide for details on how this works.
-				</p>
-				<p>
-					Note: Only the agents that are in the agentset <i>at the time the
-						ask begins</i> run the commands.
-				</p>
-				<p>
-					See also <a href="#without-interruption">without-interruption</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="at-points">
-				<h3>
-					<a>at-points<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example"><i>agentset</i> at-points [[<i>x1 y1</i>] [<i>x2 y2</i>] ...]</span>
-				</h4>
-				<p>
-					Reports a subset of the given agentset that includes only the
-					agents on the patches at the given coordinates (relative to this
-					agent). The coordinates are specified as a list of two-item lists,
-					where the two items are the x and y offsets.
-				</p>
-				<p>
-					If the caller is the observer, then the points are measured
-					relative to the origin, in other words, the points are taken as
-					absolute patch coordinates.
-				</p>
-				<p>
-					If the caller is a turtle, the points are measured relative to the
-					turtle's exact location, and not from the center of the patch
-					under the turtle.
-				</p>
-				<pre>
-					ask turtles at-points [[2 4] [1 2] [10 15]]
-					[ fd 1 ]  ;; only the turtles on the patches at the
-					;; coordinates (2,4), (1,2) and (10,15),
-					;; relative to the caller, move
-				</pre>
-			</div>
-			<div class="dict_entry" id="atan">
-				<h3>
-					<a>atan<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">atan <i>x y</i></span>
-				</h4>
-				<p>
-					Converts x and y offsets to a turtle heading in degrees (from 0 to
-					360).
-				</p>
-				<p>
-					Note that this version of atan is designed to conform to the
-					geometry of the NetLogo world, where a heading of 0 is straight up,
-					90 is to the right, and so on clockwise around the circle.
-					(Normally in geometry an angle of 0 is right, 90 is up, and so on,
-					counterclockwise around the circle, and atan would be defined
-					accordingly.)
-				</p>
-				<p>
-					When y is 0: if x is positive, it reports 90; if x is negative, it
-					reports 270; if x is zero, you get an error.
-				</p>
-				<pre>
-					show atan 1 -1
-					=&gt; 135
-					show atan -1 1
-					=&gt; 315
-					crt 1 [ set heading 30  fd 1  print atan xcor ycor ]
-					=&gt; 30
-				</pre>
-				<p>
-					In the final example, note that the result of <code>atan</code> equals
-					the turtle's heading.
-				</p>
-				<p>
-					If you ever need to convert a turtle heading (obtained with atan or
-					otherwise) to a normal mathematical angle, the following should be
-					helpful:
-				</p>
-				<pre>
-					to-report heading-to-angle [ h ]
-					report (90 - h) mod 360
-					end
-				</pre>
-			</div>
-			<div class="dict_entry" id="autoplot">
-				<h3>
-					<a>autoplot?<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">autoplot?</span>
-				</h4>
-				<p>
-					Reports true if auto-plotting is on for the current plot, false
-					otherwise.
-				</p>
-			</div>
-			<div class="dict_entry" id="auto-plot-status">
-				<h3>
-					<a>auto-plot-off<span class="since">1.0</span></a>
-					<a>auto-plot-on<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">auto-plot-off</span>
-					<span class="prim_example">auto-plot-on</span>
-				</h4>
-				<p>
-					This pair of commands is used to control the NetLogo feature of
-					auto-plotting in the current plot. Auto-plotting will automatically
-					update the x and y axes of the plot whenever the current pen
-					exceeds these boundaries. It is useful when wanting to show all
-					plotted values in the current plot, regardless of the current plot
-					ranges.
-				</p>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="B">
-			<a>B</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="back">
-				<h3>
-					<a>back<span class="since">1.0</span></a>
-					<a>bk<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">back <i>number</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					The turtle moves backward by <i>number</i> steps. (If <i>number</i>
-					is negative, the turtle moves forward.)
-				</p>
-				<p>
-					Turtles using this primitive can move a maximum of one unit per
-					time increment. So <code>bk 0.5</code> and <code>bk 1</code> both take one
-					unit of time, but <code>bk 3</code> takes three.
-				</p>
-				<p>
-					If the turtle cannot move backward <i>number</i> steps because it
-					is not permitted by the current topology the turtle will complete
-					as many steps of 1 as it can and stop.
-				</p>
-				<p>
-					See also <a href="#forward">forward</a>, <a href="#jump">jump</a>,
-					<a href="#can-move">can-move?</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="base-colors">
-				<h3>
-					<a>base-colors<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">base-colors</span>
-				</h4>
-				<p>
-					Reports a list of the 14 basic NetLogo hues.
-				</p>
-				<pre>
-					print base-colors
-					=&gt; [5 15 25 35 45 55 65 75 85 95 105 115 125 135]
-					ask turtles [ set color one-of base-colors ]
-					;; each turtle turns a random base color
-					ask turtles [ set color one-of remove gray base-colors ]
-					;; each turtle turns a random base color except for gray
-				</pre>
-			</div>
-			<div class="dict_entry" id="beep">
-				<h3>
-					<a>beep<span class="since">2.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">beep</span>
-				</h4>
-				<p>
-					Emits a beep. Note that the beep sounds immediately, so several
-					beep commands in close succession may produce only one audible
-					sound.
-				</p>
-				<p>
-					Example:
-				</p>
-				<pre>
-					beep                       ;; emits one beep
-					repeat 3 [ beep ]          ;; emits 3 beeps at once,
-					;; so you only hear one sound
-					repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
-					;; separated by 1/10th of a second
-				</pre>
-				<p>
-					When running headless, this command has no effect.
-				</p>
-			</div>
-			<div class="dict_entry" id="behaviorspace-experiment-name">
-				<h3>
-					<a>behaviorspace-experiment-name<span class="since">5.2</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">behaviorspace-experiment-name</span>
-				</h4>
-				<p>
-					Reports the current experiment name in the current experiment.
-				</p>
-				<p>
-					If no BehaviorSpace experiment is running, reports &quot;&quot;.
-				</p>
-			</div>
-			<div class="dict_entry" id="behaviorspace-run-number">
-				<h3>
-					<a>behaviorspace-run-number<span class="since">4.1.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">behaviorspace-run-number</span>
-				</h4>
-				<p>
-					Reports the current run number in the current BehaviorSpace
-					experiment, starting at 1.
-				</p>
-				<p>
-					If no BehaviorSpace experiment is running, reports 0.
-				</p>
-			</div>
-			<div class="dict_entry" id="both-ends">
-				<h3>
-					<a>both-ends<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">both-ends</span>
-					<img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					Reports the agentset of the 2 nodes connected by this link.
-				</p>
-				<pre>
-					crt 2
-					ask turtle 0 [ create-link-with turtle 1 ]
-					ask link 0 1 [
-					ask both-ends [ set color red ] ;; turtles 0 and 1 both turn red
-					]
-				</pre>
-			</div>
-			<div class="dict_entry" id="breedvar">
-				<h3>
-					<a>breed</a>
-				</h3>
-				<h4>
-					<span class="prim_example">breed</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					This is a built-in turtle and link variable. It holds the agentset
-					of all turtles or links of the same breed as this turtle or link.
-					(For turtles or links that do not have any particular breed, this
-					is the <a href="#turtles">turtles</a> agentset of all turtles or
-					the <a href="#links">links</a> agentset of all links respectively.)
-				</p>
-				<p>
-					You can set this variable to change a turtle or link's breed.
-					(When a turtle changes breeds, its shape is reset to the default
-					shape for that breed. See <a href="#set-default-shape">set-default-shape</a>.)
-				</p>
-				<p>
-					See also <a href="#breed">breed</a>, <a href="#directed-link-breed">directed-link-breed</a>, <a href="#undirected-link-breed">undirected-link-breed</a>
-				</p>
-				<p>
-					Example:
-				</p>
-				<pre>
-					breed [cats cat]
-					breed [dogs dog]
-					;; turtle code:
-					if breed = cats [ show &quot;meow!&quot; ]
-					set breed dogs
-					show &quot;woof!&quot;
-				</pre>
-				<pre>
-					directed-link-breed [ roads road ]
-					;; link code
-					if breed = roads [ set color gray ]
-				</pre>
-			</div>
-			<div class="dict_entry" id="breed">
-				<h3>
-					<a>breed</a>
-				</h3>
-				<h4>
-					<span class="prim_example">breed [<i>&lt;breeds&gt;</i> <i>&lt;breed&gt;</i>]</span>
-				</h4>
-				<p>
-					This keyword, like the globals, turtles-own, and patches-own
-					keywords, can only be used at the beginning of the Code tab, before
-					any procedure definitions. It defines a breed. The first input
-					defines the name of the agentset associated with the breed. The
-					second input defines the name of a single member of the breed.
-				</p>
-				<p>
-					Any turtle of the given breed:
-				</p>
-				<ul>
-					<li>is part of the agentset named by the breed name</li>
-					<li>has its breed built-in variable set to that agentset</li>
-				</ul>
-				<p>
-					Most often, the agentset is used in conjunction with ask to give
-					commands to only the turtles of a particular breed.
-				</p>
-				<pre>
-					breed [mice mouse]
-					breed [frogs frog]
-					to setup
-					clear-all
-					create-mice 50
-					ask mice [ set color white ]
-					create-frogs 50
-					ask frogs [ set color green ]
-					show [breed] of one-of mice    ;; prints mice
-					show [breed] of one-of frogs   ;; prints frogs
-					end
+  <head>
+    <title>
+      NetLogo {{version}} User Manual: NetLogo Dictionary
+    </title>
+    <link rel="stylesheet" href="netlogo.css" type="text/css"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <style>
+      p  { margin-left: 1.5em ; }
+      h3 { font-size: 115% ; }
+      h4 { font-size: 100% ; margin-left: 1.5em ; background: white ; }
+    </style>
+  </head>
+  <body>
+    <h1>
+      NetLogo Dictionary
+    </h1>
+    <div class="version">
+      NetLogo {{version}} User Manual
+    </div>
+    <div class="centertext">
+      <div class="block">
+        <div class="smallfont centertext tocborder inlineblock">
+          Alphabetical:
+          <span class="bold">
+            <a href="#A">A</a>
+            <a href="#B">B</a>
+            <a href="#C">C</a>
+            <a href="#D">D</a>
+            <a href="#E">E</a>
+            <a href="#F">F</a>
+            <a href="#G">G</a>
+            <a href="#H">H</a>
+            <a href="#I">I</a>
+            <a href="#J">J</a>
+            <!--<a href="#K">K</a>-->
+            <a href="#L">L</a>
+            <a href="#M">M</a>
+            <a href="#N">N</a>
+            <a href="#O">O</a>
+            <a href="#P">P</a>
+            <!--<a href="#Q">Q</a>-->
+            <a href="#R">R</a>
+            <a href="#S">S</a>
+            <a href="#T">T</a>
+            <a href="#U">U</a>
+            <a href="#V">V</a>
+            <a href="#W">W</a>
+            <a href="#X">X</a>
+            <a href="#Y">Y</a>
+            <!--<a href="#Z">Z</a>-->
+            <a href="#ops">-></a>
+          </span>
+        </div>
+      </div>
+      <div class="block">
+        <div class="smallfont centertext tocborder inlineblock">
+          Categories: <a href="#turtlegroup">Turtle</a> - <a href="#patchgroup">Patch</a> - <a href="#linkgroup">Links</a>
+          - <a href="#agentsetgroup">Agentset</a> - <a href="#colorgroup">Color</a>
+          - <a href="#anonproceduresgroup">Anonymous Procedures</a> - <a href="#controlgroup">Control/Logic</a> - <a href="#worldgroup">World</a>
+          <br/>
+          <a href="#perspectivegroup">Perspective</a> -
+          <a href="#iogroup">Input/Output</a> - <a href="#fileiogroup">File</a> - <a href="#listsgroup">List</a> -
+          <a href="#stringgroup">String</a> - <a href="#mathematicalgroup">Math</a> - <a href="#plottinggroup">Plotting</a>
+          - <a href="#systemgroup">System</a> - <a href="#hubnetgroup">HubNet</a>
+        </div>
+      </div>
+      <div class="block">
+        <div class="smallfont centertext tocborder inlineblock">
+          Special: <a href="#builtinvariables">Variables</a> - <a href="#Keywords">Keywords</a> - <a href="#Constants">Constants</a>
+        </div>
+      </div>
+    </div>
+    <h2>
+      Categories
+    </h2>
+    <p>
+      This is an approximate grouping. Remember that a turtle-related
+      primitive might still be used by patches or the observer, and vice
+      versa. To see which agents (turtles, patches, links, observer) can
+      actually run a primitive, consult its dictionary entry.
+    </p>
+    <!-- ======================================== -->
+    <h3 id="turtlegroup">
+      Turtle-related
+    </h3>
+    <p>
+      <a href="#back">back</a> (<a href="#back">bk</a>)
+      <a href="#turtles-at"><i>&lt;breeds&gt;</i>-at</a>
+      <a href="#turtles-here"><i>&lt;breeds&gt;</i>-here</a>
+      <a href="#turtles-on"><i>&lt;breeds&gt;</i>-on</a>
+      <a href="#can-move">can-move?</a>
+      <a href="#clear-turtles">clear-turtles</a> (<a href="#clear-turtles">ct</a>)
+      <a href="#create-turtles">create-<i>&lt;breeds&gt;</i></a>
+      <a href="#create-ordered-turtles">create-ordered-<i>&lt;breeds&gt;</i></a>
+      <a href="#create-ordered-turtles">create-ordered-turtles</a> (<a href="#create-ordered-turtles">cro</a>)
+      <a href="#create-turtles">create-turtles</a> (<a href="#create-turtles">crt</a>)
+      <a href="#die">die</a>
+      <a href="#distance">distance</a>
+      <a href="#distancexy">distancexy</a>
+      <a href="#downhill">downhill</a>
+      <a href="#downhill">downhill4</a>
+      <a href="#dxy">dx</a>
+      <a href="#dxy">dy</a>
+      <a href="#face">face</a>
+      <a href="#facexy">facexy</a>
+      <a href="#forward">forward</a> (<a href="#forward">fd</a>)
+      <a href="#hatch">hatch</a>
+      <a href="#hatch">hatch-<i>&lt;breeds&gt;</i></a>
+      <a href="#hide-turtle">hide-turtle</a> (<a href="#hide-turtle">ht</a>)
+      <a href="#home">home</a>
+      <a href="#inspect">inspect</a>
+      <a href="#is-of-type">is-<i>&lt;breed&gt;</i>?</a>
+      <a href="#is-of-type">is-turtle?</a>
+      <a href="#jump">jump</a>
+      <a href="#layout-circle">layout-circle</a>
+      <a href="#left">left</a> (<a href="#left">lt</a>)
+      <a href="#move-to">move-to</a>
+      <a href="#myself">myself</a>
+      <a href="#nobody">nobody</a>
+      <a href="#no-turtles">no-turtles</a>
+      <a href="#of">of</a>
+      <a href="#other">other</a>
+      <a href="#patch-ahead">patch-ahead</a>
+      <a href="#patch-at">patch-at</a>
+      <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>
+      <a href="#patch-here">patch-here</a>
+      <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>
+      <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>
+      <a href="#pen-switch-status">pen-down</a>  (<a href="#pen-switch-status">pd</a>)
+      <a href="#pen-switch-status">pen-erase</a> (<a href="#pen-switch-status">pe</a>)
+      <a href="#pen-switch-status">pen-up</a>    (<a href="#pen-switch-status">pu</a>)
+      <a href="#random-cor">random-xcor</a>
+      <a href="#random-cor">random-ycor</a>
+      <a href="#right">right</a> (<a href="#right">rt</a>)
+      <a href="#self">self</a>
+      <a href="#set-default-shape">set-default-shape</a>
+      <a href="#set-line-thickness">__set-line-thickness</a>
+      <a href="#setxy">setxy</a>
+      <a href="#shapes">shapes</a>
+      <a href="#show-turtle">show-turtle</a> (<a href="#show-turtle">st</a>)
+      <a href="#sprout">sprout</a>
+      <a href="#sprout">sprout-<i>&lt;breeds&gt;</i></a>
+      <a href="#stamp">stamp</a>
+      <a href="#stamp-erase">stamp-erase</a>
+      <a href="#stop-inspecting">stop-inspecting</a>
+      <a href="#subject">subject</a>
+      <a href="#subtract-headings">subtract-headings</a>
+      <a href="#tie">tie</a>
+      <a href="#towards">towards</a>
+      <a href="#towardsxy">towardsxy</a>
+      <a href="#turtle">turtle</a>
+      <a href="#turtle-set">turtle-set</a>
+      <a href="#turtles">turtles</a>
+      <a href="#turtles-at">turtles-at</a>
+      <a href="#turtles-here">turtles-here</a>
+      <a href="#turtles-on">turtles-on</a>
+      <a href="#turtles-own">turtles-own</a>
+      <a href="#untie">untie</a>
+      <a href="#uphill">uphill</a>
+      <a href="#uphill">uphill4</a>
+    </p>
+    <!-- ======================================== -->
+    <h3 id="patchgroup">
+      Patch-related
+    </h3>
+    <p>
+      <a href="#clear-patches">clear-patches</a> (<a href="#clear-patches">cp</a>)
+      <a href="#diffuse">diffuse</a>
+      <a href="#diffuse4">diffuse4</a>
+      <a href="#distance">distance</a>
+      <a href="#distancexy">distancexy</a>
+      <a href="#import-pcolors">import-pcolors</a>
+      <a href="#import-pcolors-rgb">import-pcolors-rgb</a>
+      <a href="#inspect">inspect</a>
+      <a href="#is-of-type">is-patch?</a>
+      <a href="#myself">myself</a>
+      <a href="#neighbors">neighbors</a>
+      <a href="#neighbors">neighbors4</a>
+      <a href="#nobody">nobody</a>
+      <a href="#no-patches">no-patches</a>
+      <a href="#of">of</a>
+      <a href="#other">other</a>
+      <a href="#patch">patch</a>
+      <a href="#patch-at">patch-at</a>
+      <a href="#patch-ahead">patch-ahead</a>
+      <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>
+      <a href="#patch-here">patch-here</a>
+      <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>
+      <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>
+      <a href="#patch-set">patch-set</a>
+      <a href="#patches">patches</a>
+      <a href="#patches-own">patches-own</a>
+      <a href="#random-pcor">random-pxcor</a>
+      <a href="#random-pcor">random-pycor</a>
+      <a href="#self">self</a>
+      <a href="#sprout">sprout</a>
+      <a href="#sprout">sprout-<i>&lt;breeds&gt;</i></a>
+      <a href="#stop-inspecting">stop-inspecting</a>
+      <a href="#subject">subject</a>
+      <a href="#turtles-here">turtles-here</a>
+    </p>
+    <!-- ======================================== -->
+    <h3 id="linkgroup">
+      Link-related
+    </h3>
+    <p>
+      <a href="#both-ends">both-ends</a>
+      <a href="#clear-links">clear-links</a>
+      <a href="#create-link">create-&lt;breed&gt;-from</a>
+      <a href="#create-link">create-&lt;breeds&gt;-from</a>
+      <a href="#create-link">create-&lt;breed&gt;-to</a>
+      <a href="#create-link">create-&lt;breeds&gt;-to</a>
+      <a href="#create-link">create-&lt;breed&gt;-with</a>
+      <a href="#create-link">create-&lt;breeds&gt;-with</a>
+      <a href="#create-link">create-link-from</a>
+      <a href="#create-link">create-links-from</a>
+      <a href="#create-link">create-link-to</a>
+      <a href="#create-link">create-links-to</a>
+      <a href="#create-link">create-link-with</a>
+      <a href="#create-link">create-links-with</a>
+      <a href="#die">die</a>
+      <a href="#directed-link-breed">directed-link-breed</a>
+      <a href="#hide-link">hide-link</a>
+      <a href="#in-link-neighbor">in-&lt;breed&gt;-neighbor?</a>
+      <a href="#in-link-neighbors">in-&lt;breed&gt;-neighbors</a>
+      <a href="#in-link-from">in-&lt;breed&gt;-from</a>
+      <a href="#in-link-neighbor">in-link-neighbor?</a>
+      <a href="#in-link-neighbors">in-link-neighbors</a>
+      <a href="#in-link-from">in-link-from</a>
+      <a href="#is-of-type">is-directed-link?</a>
+      <a href="#is-of-type">is-link?</a>
+      <a href="#is-of-type">is-link-set?</a>
+      <a href="#is-of-type">is-<i>&lt;link-breed&gt;</i>?</a>
+      <a href="#is-of-type">is-undirected-link?</a>
+      <a href="#layout-radial">layout-radial</a>
+      <a href="#layout-spring">layout-spring</a>
+      <a href="#layout-tutte">layout-tutte</a>
+      <a href="#link-neighbor">&lt;breed&gt;-neighbor?</a>
+      <a href="#link-neighbors">&lt;breed&gt;-neighbors</a>
+      <a href="#link-with">&lt;breed&gt;-with</a>
+      <a href="#link-heading">link-heading</a>
+      <a href="#link-length">link-length</a>
+      <a href="#link-neighbor">link-neighbor?</a>
+      <a href="#link">link</a>
+      <a href="#links">links</a>
+      <a href="#links-own">links-own</a>
+      <a href="#links-own">&lt;link-breeds&gt;-own</a>
+      <a href="#link-neighbors">link-neighbors</a>
+      <a href="#link-with">link-with</a>
+      <a href="#my-links">my-&lt;breeds&gt;</a>
+      <a href="#my-in-links">my-in-&lt;breeds&gt;</a>
+      <a href="#my-in-links">my-in-links</a>
+      <a href="#my-links">my-links</a>
+      <a href="#my-out-links">my-out-&lt;breeds&gt;</a>
+      <a href="#my-out-links">my-out-links</a>
+      <a href="#no-links">no-links</a>
+      <a href="#other-end">other-end</a>
+      <a href="#out-link-neighbor">out-&lt;breed&gt;-neighbor?</a>
+      <a href="#out-link-neighbors">out-&lt;breed&gt;-neighbors</a>
+      <a href="#out-link-to">out-&lt;breed&gt;-to</a>
+      <a href="#out-link-neighbor">out-link-neighbor?</a>
+      <a href="#out-link-neighbors">out-link-neighbors</a>
+      <a href="#out-link-to">out-link-to</a>
+      <a href="#show-link">show-link</a>
+      <a href="#tie">tie</a>
+      <a href="#undirected-link-breed">undirected-link-breed</a>
+      <a href="#untie">untie</a>
+    </p>
+    <!-- ======================================== -->
+    <h3 id="agentsetgroup">
+      <a>Agentset</a>
+    </h3>
+    <p>
+      <a href="#all">all?</a>
+      <a href="#any">any?</a>
+      <a href="#ask">ask</a>
+      <a href="#ask-concurrent">ask-concurrent</a>
+      <a href="#at-points">at-points</a>
+      <a href="#turtles-at"><i>&lt;breeds&gt;</i>-at</a>
+      <a href="#turtles-here"><i>&lt;breeds&gt;</i>-here</a>
+      <a href="#turtles-on"><i>&lt;breeds&gt;</i>-on</a>
+      <a href="#count">count</a>
+      <a href="#in-cone">in-cone</a>
+      <a href="#in-radius">in-radius</a>
+      <a href="#is-of-type">is-agent?</a>
+      <a href="#is-of-type">is-agentset?</a>
+      <a href="#is-of-type">is-patch-set?</a>
+      <a href="#is-of-type">is-turtle-set?</a>
+      <a href="#link-set">link-set</a>
+      <a href="#max-n-of">max-n-of</a>
+      <a href="#max-one-of">max-one-of</a>
+      <a href="#member">member?</a>
+      <a href="#min-n-of">min-n-of</a>
+      <a href="#min-one-of">min-one-of</a>
+      <a href="#n-of">n-of</a>
+      <a href="#neighbors">neighbors</a>
+      <a href="#neighbors">neighbors4</a>
+      <a href="#no-links">no-links</a>
+      <a href="#no-patches">no-patches</a>
+      <a href="#no-turtles">no-turtles</a>
+      <a href="#of">of</a>
+      <a href="#one-of">one-of</a>
+      <a href="#other">other</a>
+      <a href="#patch-set">patch-set</a>
+      <a href="#patches">patches</a>
+      <a href="#sort">sort</a>
+      <a href="#sort-by">sort-by</a>
+      <a href="#sort-on">sort-on</a>
+      <a href="#turtle-set">turtle-set</a>
+      <a href="#turtles">turtles</a>
+      <a href="#turtles-at">turtles-at</a>
+      <a href="#turtles-here">turtles-here</a>
+      <a href="#turtles-on">turtles-on</a>
+      <a href="#up-to-n-of">up-to-n-of</a>
+      <a href="#with">with</a>
+      <a href="#with-max">with-max</a>
+      <a href="#with-min">with-min</a>
+    </p>
+    <!-- ======================================== -->
+    <h3 id="colorgroup">
+      Color
+    </h3>
+    <p>
+      <a href="#approximate-hsb">approximate-hsb</a>
+      <a href="#approximate-rgb">approximate-rgb</a>
+      <a href="#base-colors">base-colors</a>
+      <a href="#color">color</a>
+      <a href="#extract-hsb">extract-hsb</a>
+      <a href="#extract-rgb">extract-rgb</a>
+      <a href="#hsb">hsb</a>
+      <a href="#import-pcolors">import-pcolors</a>
+      <a href="#import-pcolors-rgb">import-pcolors-rgb</a>
+      <a href="#pcolor">pcolor</a>
+      <a href="#rgb">rgb</a>
+      <a href="#scale-color">scale-color</a>
+      <a href="#shade-of">shade-of?</a>
+      <a href="#wrap-color">wrap-color</a>
+    </p>
+    <!-- ======================================== -->
+    <h3 id="controlgroup">
+      Control flow and logic
+    </h3>
+    <p>
+      <a href="#and">and</a>
+      <a href="#ask">ask</a>
+      <a href="#ask-concurrent">ask-concurrent</a>
+      <a href="#carefully">carefully</a>
+      <a href="#end">end</a>
+      <a href="#error">error</a>
+      <a href="#error-message">error-message</a>
+      <a href="#every">every</a>
+      <a href="#if">if</a>
+      <a href="#ifelse">ifelse</a>
+      <a href="#ifelse-value">ifelse-value</a>
+      <a href="#let">let</a>
+      <a href="#loop">loop</a>
+      <a href="#not">not</a>
+      <a href="#or">or</a>
+      <a href="#repeat">repeat</a>
+      <a href="#report">report</a>
+      <a href="#run">run</a>
+      <a href="#run">runresult</a>
+      <a href="#semicolon">; (semicolon)</a>
+      <a href="#set">set</a>
+      <a href="#stop">stop</a>
+      <a href="#startup">startup</a>
+      <a href="#to">to</a>
+      <a href="#to-report">to-report</a>
+      <a href="#wait">wait</a>
+      <a href="#while">while</a>
+      <a href="#with-local-randomness">with-local-randomness</a>
+      <a href="#without-interruption">without-interruption</a>
+      <a href="#xor">xor</a>
+    </p>
+    <!-- ======================================== -->
+    <h3 id="anonproceduresgroup">
+      Anonymous Procedures
+    </h3>
+    <p>
+      <a href="#arrow">-&gt; (anonymous procedure)</a>
+      <a href="#filter">filter</a>
+      <a href="#foreach">foreach</a>
+      <a href="#is-of-type">is-anonymous-command?</a>
+      <a href="#is-of-type">is-anonymous-reporter?</a>
+      <a href="#map">map</a>
+      <a href="#n-values">n-values</a>
+      <a href="#reduce">reduce</a>
+      <a href="#run">run</a>
+      <a href="#run">runresult</a>
+      <a href="#sort-by">sort-by</a>
+    </p>
+    <!-- ======================================== -->
+    <h3 id="worldgroup">
+      World
+    </h3>
+    <p>
+      <a href="#clear-all">clear-all</a> (<a href="#clear-all">ca</a>)
+      <a href="#clear-drawing">clear-drawing</a> (<a href="#clear-drawing">cd</a>)
+      <a href="#clear-globals">clear-globals</a>
+      <a href="#clear-patches">clear-patches</a> (<a href="#clear-patches">cp</a>)
+      <a href="#clear-ticks">clear-ticks</a>
+      <a href="#clear-turtles">clear-turtles</a> (<a href="#clear-turtles">ct</a>)
+      <a href="#display">display</a>
+      <a href="#import-drawing">import-drawing</a>
+      <a href="#import-pcolors">import-pcolors</a>
+      <a href="#import-pcolors-rgb">import-pcolors-rgb</a>
+      <a href="#no-display">no-display</a>
+      <a href="#max-pcor">max-pxcor</a>
+      <a href="#max-pcor">max-pycor</a>
+      <a href="#min-pcor">min-pxcor</a>
+      <a href="#min-pcor">min-pycor</a>
+      <a href="#patch-size">patch-size</a>
+      <a href="#reset-ticks">reset-ticks</a>
+      <a href="#resize-world">resize-world</a>
+      <a href="#set-patch-size">set-patch-size</a>
+      <a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>
+      <a href="#tick">tick</a>
+      <a href="#tick-advance">tick-advance</a>
+      <a href="#ticks">ticks</a>
+      <a href="#world-dim">world-width</a>
+      <a href="#world-dim">world-height</a>
+    </p>
+    <!-- ======================================== -->
+    <h3 id="perspectivegroup">
+      Perspective
+    </h3>
+    <p>
+      <a href="#follow">follow</a>
+      <a href="#follow-me">follow-me</a>
+      <a href="#reset-perspective">reset-perspective</a> (<a href="#reset-perspective">rp</a>)
+      <a href="#ride">ride</a>
+      <a href="#ride-me">ride-me</a>
+      <a href="#subject">subject</a>
+      <a href="#watch">watch</a>
+      <a href="#watch-me">watch-me</a>
+    </p>
+    <!-- ======================================== -->
+    <h3 id="hubnetgroup">
+      <a>HubNet</a>
+    </h3>
+    <p>
+      <a href="#hubnet-broadcast">hubnet-broadcast</a>
+      <a href="#hubnet-broadcast-clear-output">hubnet-broadcast-clear-output</a>
+      <a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>
+      <a href="#hubnet-clear-override">hubnet-clear-override</a>
+      <a href="#hubnet-clear-override">hubnet-clear-overrides</a>
+      <a href="#hubnet-clients-list">hubnet-clients-list</a>
+      <a href="#hubnet-enter-message">hubnet-enter-message?</a>
+      <a href="#hubnet-exit-message">hubnet-exit-message?</a>
+      <a href="#hubnet-kick-all-clients">hubnet-kick-all-clients</a>
+      <a href="#hubnet-kick-client">hubnet-kick-client</a>
+      <a href="#hubnet-fetch-message">hubnet-fetch-message</a>
+      <a href="#hubnet-message">hubnet-message</a>
+      <a href="#hubnet-message-source">hubnet-message-source</a>
+      <a href="#hubnet-message-tag">hubnet-message-tag</a>
+      <a href="#hubnet-message-waiting">hubnet-message-waiting?</a>
+      <a href="#hubnet-reset">hubnet-reset</a>
+      <a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
+      <a href="#hubnet-send">hubnet-send</a>
+      <a href="#hubnet-send-clear-output">hubnet-send-clear-output</a>
+      <a href="#hubnet-send-follow">hubnet-send-follow</a>
+      <a href="#hubnet-send-message">hubnet-send-message</a>
+      <a href="#hubnet-send-override">hubnet-send-override</a>
+      <a href="#hubnet-send-watch">hubnet-send-watch</a>
+    </p>
+    <!-- ======================================== -->
+    <h3 id="iogroup">
+      Input/output
+    </h3>
+    <p>
+      <a href="#beep">beep</a>
+      <a href="#clear-output">clear-output</a>
+      <a href="#date-and-time">date-and-time</a>
+      <a href="#export-cmds">export-view</a>
+      <a href="#export-cmds">export-interface</a>
+      <a href="#export-cmds">export-output</a>
+      <a href="#export-cmds">export-plot</a>
+      <a href="#export-cmds">export-all-plots</a>
+      <a href="#export-cmds">export-world</a>
+      <a href="#import-drawing">import-drawing</a>
+      <a href="#import-pcolors">import-pcolors</a>
+      <a href="#import-pcolors-rgb">import-pcolors-rgb</a>
+      <a href="#import-world">import-world</a>
+      <a href="#mouse-down">mouse-down?</a>
+      <a href="#mouse-inside">mouse-inside?</a>
+      <a href="#mouse-cor">mouse-xcor</a>
+      <a href="#mouse-cor">mouse-ycor</a>
+      <a href="#output-cmds">output-print</a>
+      <a href="#output-cmds">output-show</a>
+      <a href="#output-cmds">output-type</a>
+      <a href="#output-cmds">output-write</a>
+      <a href="#print">print</a>
+      <a href="#read-from-string">read-from-string</a>
+      <a href="#reset-timer">reset-timer</a>
+      <a href="#set-current-directory">set-current-directory</a>
+      <a href="#show">show</a>
+      <a href="#timer">timer</a>
+      <a href="#type">type</a>
+      <a href="#user-directory">user-directory</a>
+      <a href="#user-file">user-file</a>
+      <a href="#user-new-file">user-new-file</a>
+      <a href="#user-input">user-input</a>
+      <a href="#user-message">user-message</a>
+      <a href="#user-one-of">user-one-of</a>
+      <a href="#user-yes-or-no">user-yes-or-no?</a>
+      <a href="#write">write</a>
+    </p>
+    <!-- ======================================== -->
+    <h3 id="fileiogroup">
+      File
+    </h3>
+    <p>
+      <a href="#file-at-end">file-at-end?</a>
+      <a href="#file-close">file-close</a>
+      <a href="#file-close-all">file-close-all</a>
+      <a href="#file-delete">file-delete</a>
+      <a href="#file-exists">file-exists?</a>
+      <a href="#file-flush">file-flush</a>
+      <a href="#file-open">file-open</a>
+      <a href="#file-print">file-print</a>
+      <a href="#file-read">file-read</a>
+      <a href="#file-read-characters">file-read-characters</a>
+      <a href="#file-read-line">file-read-line</a>
+      <a href="#file-show">file-show</a>
+      <a href="#file-type">file-type</a>
+      <a href="#file-write">file-write</a>
+      <a href="#user-directory">user-directory</a>
+      <a href="#user-file">user-file</a>
+      <a href="#user-new-file">user-new-file</a>
+    </p>
+    <!-- ======================================== -->
+    <h3 id="listsgroup">
+      List
+    </h3>
+    <p>
+      <a href="#but-first-and-last">but-first</a>
+      <a href="#but-first-and-last">but-last</a>
+      <a href="#empty">empty?</a>
+      <a href="#filter">filter</a>
+      <a href="#first">first</a>
+      <a href="#foreach">foreach</a>
+      <a href="#fput">fput</a>
+      <a href="#histogram">histogram</a>
+      <a href="#insert-item">insert-item</a>
+      <a href="#is-of-type">is-list?</a>
+      <a href="#item">item</a>
+      <a href="#last">last</a>
+      <a href="#length">length</a>
+      <a href="#list">list</a>
+      <a href="#lput">lput</a>
+      <a href="#map">map</a>
+      <a href="#max">max</a>
+      <a href="#member">member?</a>
+      <a href="#min">min</a>
+      <a href="#modes">modes</a>
+      <a href="#n-of">n-of</a>
+      <a href="#n-values">n-values</a>
+      <a href="#of">of</a>
+      <a href="#position">position</a>
+      <a href="#one-of">one-of</a>
+      <a href="#range">range</a>
+      <a href="#reduce">reduce</a>
+      <a href="#remove">remove</a>
+      <a href="#remove-duplicates">remove-duplicates</a>
+      <a href="#remove-item">remove-item</a>
+      <a href="#replace-item">replace-item</a>
+      <a href="#reverse">reverse</a>
+      <a href="#sentence">sentence</a>
+      <a href="#shuffle">shuffle</a>
+      <a href="#sort">sort</a>
+      <a href="#sort-by">sort-by</a>
+      <a href="#sort-on">sort-on</a>
+      <a href="#subliststring">sublist</a>
+      <a href="#up-to-n-of">up-to-n-of</a>
+    </p>
+    <!-- ======================================== -->
+    <h3 id="stringgroup">
+      String
+    </h3>
+    <p>
+      <a href="#Symbols">Operators (&lt;, &gt;, =, !=, &lt;=, &gt;=)</a>
+      <a href="#but-first-and-last">but-first</a>
+      <a href="#but-first-and-last">but-last</a>
+      <a href="#empty">empty?</a>
+      <a href="#first">first</a>
+      <a href="#insert-item">insert-item</a>
+      <a href="#is-of-type">is-string?</a>
+      <a href="#item">item</a>
+      <a href="#last">last</a>
+      <a href="#length">length</a>
+      <a href="#member">member?</a>
+      <a href="#position">position</a>
+      <a href="#remove">remove</a>
+      <a href="#remove-item">remove-item</a>
+      <a href="#read-from-string">read-from-string</a>
+      <a href="#replace-item">replace-item</a>
+      <a href="#reverse">reverse</a>
+      <a href="#subliststring">substring</a>
+      <a href="#word">word</a>
+    </p>
+    <!-- ======================================== -->
+    <h3 id="mathematicalgroup">
+      Mathematical
+    </h3>
+    <p>
+      <a href="#Symbols">Arithmetic Operators (+, *, -, /, ^, &lt;, &gt;, =, !=, &lt;=, &gt;=)</a>
+      <a href="#abs">abs</a>
+      <a href="#acos">acos</a>
+      <a href="#asin">asin</a>
+      <a href="#atan">atan</a>
+      <a href="#ceiling">ceiling</a>
+      <a href="#cos">cos</a>
+      <a href="#num-e">e</a>
+      <a href="#exp">exp</a>
+      <a href="#floor">floor</a>
+      <a href="#int">int</a>
+      <a href="#is-of-type">is-number?</a>
+      <a href="#ln">ln</a>
+      <a href="#log">log</a>
+      <a href="#max">max</a>
+      <a href="#mean">mean</a>
+      <a href="#median">median</a>
+      <a href="#min">min</a>
+      <a href="#mod">mod</a>
+      <a href="#modes">modes</a>
+      <a href="#new-seed">new-seed</a>
+      <a href="#pi">pi</a>
+      <a href="#precision">precision</a>
+      <a href="#random">random</a>
+      <a href="#random-reporters">random-exponential</a>
+      <a href="#random-float">random-float</a>
+      <a href="#random-reporters">random-gamma</a>
+      <a href="#random-reporters">random-normal</a>
+      <a href="#random-reporters">random-poisson</a>
+      <a href="#random-seed">random-seed</a>
+      <a href="#remainder">remainder</a>
+      <a href="#round">round</a>
+      <a href="#sin">sin</a>
+      <a href="#sqrt">sqrt</a>
+      <a href="#standard-deviation">standard-deviation</a>
+      <a href="#subtract-headings">subtract-headings</a>
+      <a href="#sum">sum</a>
+      <a href="#tan">tan</a>
+      <a href="#variance">variance</a>
+    </p>
+    <!-- ======================================== -->
+    <h3 id="plottinggroup">
+      Plotting
+    </h3>
+    <p>
+      <a href="#autoplot">autoplot?</a>
+      <a href="#auto-plot-status">auto-plot-off</a>
+      <a href="#auto-plot-status">auto-plot-on</a>
+      <a href="#clear-all-plots">clear-all-plots</a>
+      <a href="#clear-plot">clear-plot</a>
+      <a href="#create-temporary-plot-pen">create-temporary-plot-pen</a>
+      <a href="#export-cmds">export-plot</a>
+      <a href="#export-cmds">export-all-plots</a>
+      <a href="#histogram">histogram</a>
+      <a href="#plot">plot</a>
+      <a href="#plot-name">plot-name</a>
+      <a href="#plot-pen-exists">plot-pen-exists?</a>
+      <a href="#plot-pen-switch-status">plot-pen-down</a>
+      <a href="#plot-pen-reset">plot-pen-reset</a>
+      <a href="#plot-pen-switch-status">plot-pen-up</a>
+      <a href="#plot-cor-max-or-min">plot-x-max</a>
+      <a href="#plot-cor-max-or-min">plot-x-min</a>
+      <a href="#plot-cor-max-or-min">plot-y-max</a>
+      <a href="#plot-cor-max-or-min">plot-y-min</a>
+      <a href="#plotxy">plotxy</a>
+      <a href="#set-current-plot">set-current-plot</a>
+      <a href="#set-current-plot-pen">set-current-plot-pen</a>
+      <a href="#set-histogram-num-bars">set-histogram-num-bars</a>
+      <a href="#set-plot-background-color">set-plot-background-color</a>
+      <a href="#set-plot-pen-color">set-plot-pen-color</a>
+      <a href="#set-plot-pen-interval">set-plot-pen-interval</a>
+      <a href="#set-plot-pen-mode">set-plot-pen-mode</a>
+      <a href="#set-plot--range">set-plot-x-range</a>
+      <a href="#set-plot--range">set-plot-y-range</a>
+      <a href="#setup-plots">setup-plots</a>
+      <a href="#update-plots">update-plots</a>
+    </p>
+    <!-- ======================================== -->
+    <h3 id="behaviorspacegroup">
+      BehaviorSpace
+    </h3>
+    <p>
+      <a href="#behaviorspace-experiment-name">behaviorspace-experiment-name</a>
+      <a href="#behaviorspace-run-number">behaviorspace-run-number</a>
+    </p>
+    <!-- ======================================== -->
+    <h3 id="systemgroup">
+      System
+    </h3>
+    <p>
+      <a href="#netlogo-version">netlogo-version</a>
+      <a href="#netlogo-web">netlogo-web?</a>
+    </p>
+    <!-- ======================================== -->
+    <!-- ======================================== -->
+    <!-- ======================================== -->
+    <h2 id="builtinvariables">
+      <a>Built-In Variables</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <h3 id="turtle-variables">
+        <a>Turtles</a>
+      </h3>
+      <p>
+        <a href="#breedvar">breed</a>
+        <a href="#color">color</a>
+        <a href="#heading">heading</a>
+        <a href="#hidden">hidden?</a>
+        <a href="#label">label</a>
+        <a href="#label-color">label-color</a>
+        <a href="#pen-mode">pen-mode</a>
+        <a href="#pen-size">pen-size</a>
+        <a href="#shape">shape</a>
+        <a href="#size">size</a>
+        <a href="#who">who</a>
+        <a href="#xcor">xcor</a>
+        <a href="#ycor">ycor</a>
+      </p>
+      <!-- ======================================== -->
+      <h3 id="patch-variables">
+        <a>Patches</a>
+      </h3>
+      <p>
+        <a href="#pcolor">pcolor</a>
+        <a href="#plabel">plabel</a>
+        <a href="#plabel-color">plabel-color</a>
+        <a href="#pcor">pxcor</a>
+        <a href="#pcor">pycor</a>
+      </p>
+      <!-- ======================================== -->
+      <h3 id="link-variables">
+        <a>Links</a>
+      </h3>
+      <p>
+        <a href="#breed">breed</a>
+        <a href="#color">color</a>
+        <a href="#end1">end1</a>
+        <a href="#end2">end2</a>
+        <a href="#hidden">hidden?</a>
+        <a href="#label">label</a>
+        <a href="#label-color">label-color</a>
+        <a href="#shape">shape</a>
+        <a href="#thickness">thickness</a>
+        <a href="#tie-mode">tie-mode</a>
+      </p>
+      <!-- ======================================== -->
+      <h3 id="other-variables">
+        <a>Other</a>
+      </h3>
+      <p>
+        <a href="#arrow">-&gt;</a>
+      </p>
+      <!-- ======================================== -->
+      <!-- ======================================== -->
+      <!-- ======================================== -->
+    </div>
+    <h2 id="Keywords">
+      <a>Keywords</a>
+    </h2>
+    <p>
+      <a href="#breed">breed</a>
+      <a href="#directed-link-breed">directed-link-breed</a>
+      <a href="#end">end</a>
+      <a href="#extensions">extensions</a>
+      <a href="#globals">globals</a>
+      <a href="#includes">__includes</a>
+      <a href="#links-own">links-own</a>
+      <a href="#patches-own">patches-own</a>
+      <a href="#to">to</a>
+      <a href="#to-report">to-report</a>
+      <a href="#turtles-own">turtles-own</a>
+      <a href="#undirected-link-breed">undirected-link-breed</a>
+    </p>
+    <!-- ======================================== -->
+    <!-- ======================================== -->
+    <!-- ======================================== -->
+    <h2 id="Constants">
+      <a>Constants</a>
+    </h2><!-- ======================================== -->
+    <div class="dict_entry" id="mathconstants" data-constants="e pi">
+      <h3>
+        Mathematical Constants
+      </h3>
+      <p>
+        <b id="num-e"><a>e</a></b> = 2.718281828459045
+        <br/>
+        <b id="pi"><a>pi</a></b> = 3.141592653589793
+      </p>
+    </div><!-- ======================================== -->
+    <div class="dict_entry" id="boolconstants" data-constants="false true">
+      <h3>
+        <a>Boolean Constants</a>
+      </h3>
+      <p id="false_true">
+        <b><a>false</a></b>
+        <br/>
+        <b><a>true</a></b>
+      </p>
+    </div><!-- ======================================== -->
+    <div class="dict_entry" id="colorconstants" data-constants="black gray white red orange brown yellow green lime turquoise cyan sky blue violet magenta pink">
+      <h3>
+        <a>Color Constants</a>
+      </h3>
+      <p>
+        <b>black</b> = 0
+        <br/>
+        <b>gray</b> = 5
+        <br/>
+        <b>white</b> = 9.9
+        <br/>
+        <b>red</b> = 15
+        <br/>
+        <b>orange</b> = 25
+        <br/>
+        <b>brown</b> = 35
+        <br/>
+        <b>yellow</b> = 45
+        <br/>
+        <b>green</b> = 55
+        <br/>
+        <b>lime</b> = 65
+        <br/>
+        <b>turquoise</b> = 75
+        <br/>
+        <b>cyan</b> = 85
+        <br/>
+        <b>sky</b> = 95
+        <br/>
+        <b>blue</b> = 105
+        <br/>
+        <b>violet</b> = 115
+        <br/>
+        <b>magenta</b> = 125
+        <br/>
+        <b>pink</b> = 135
+      </p>
+      <p>
+        See the <a href="programming.html#colors">Colors</a> section of the
+        Programming Guide for more details.
+      </p>
+    </div><!-- ======================================== -->
+    <!-- ======================================== -->
+    <!-- ======================================== -->
+    <!-- ======================================== -->
+    <h2 id="A">
+      <a>A</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="abs">
+        <h3>
+          <a>abs<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">abs <i>number</i></span>
+        </h4>
+        <p>
+          Reports the absolute value of <i>number</i>.
+        </p>
+        <pre>
+          show abs -7
+          =&gt; 7
+          show abs 5
+          =&gt; 5
+        </pre>
+      </div>
+      <div class="dict_entry" id="acos">
+        <h3>
+          <a>acos<span class="since">1.3</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">acos <i>number</i></span>
+        </h4>
+        <p>
+          Reports the arc cosine (inverse cosine) of the given number. The
+          input must be in the range -1 to 1. The result is in degrees, and
+          lies in the range 0 to 180.
+        </p>
+      </div>
+      <div class="dict_entry" id="all">
+        <h3>
+          <a>all?<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">all? <i>agentset</i> [<i>reporter</i>]</span>
+        </h4>
+        <p>
+          Reports true if all of the agents in the agentset report true for
+          the given reporter. Otherwise reports false as soon as a
+          counterexample is found.
+        </p>
+        <p>
+          If the agentset is empty, reports true.
+        </p>
+        <p>
+          The reporter must report a boolean value for every agent (either
+          true or false), otherwise an error occurs.
+        </p>
+        <pre>
+          if all? turtles [color = red]
+          [ show &quot;every turtle is red!&quot; ]
+        </pre>
+        <p>
+          See also <a href="#any">any?</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="and">
+        <h3>
+          <a>and<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example"><i>condition1</i> and <i>condition2</i></span>
+        </h4>
+        <p>
+          Reports true if both <i>condition1</i> and <i>condition2</i> are
+          true.
+        </p>
+        <p>
+          Note that if <i>condition1</i> is false, then <i>condition2</i>
+          will not be run (since it can't affect the result).
+        </p>
+        <pre>
+          if (pxcor &gt; 0) and (pycor &gt; 0)
+          [ set pcolor blue ]  ;; the upper-right quadrant of
+          ;; patches turn blue
+        </pre>
+      </div>
+      <div class="dict_entry" id="any">
+        <h3>
+          <a>any?<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">any? <i>agentset</i></span>
+        </h4>
+        <p>
+          Reports true if the given agentset is non-empty, false otherwise.
+        </p>
+        <p>
+          Equivalent to &quot;count <i>agentset</i> &gt; 0&quot;, but more
+          efficient (and arguably more readable).
+        </p>
+        <pre>
+          if any? turtles with [color = red]
+          [ show &quot;at least one turtle is red!&quot; ]
+        </pre>
+        <p>
+          Note: nobody is not an agentset. You only get nobody back in
+          situations where you were expecting a single agent, not a whole
+          agentset. If any? gets nobody as input, an error results.
+        </p>
+        <p>
+          See also <a href="#all">all?</a>, <a href="#nobody">nobody</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="approximate-hsb">
+        <h3>
+          <a>approximate-hsb<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">approximate-hsb <i>hue saturation brightness</i></span>
+        </h4>
+        <p>
+          Reports a number in the range 0 to 140, not including 140 itself,
+          that represents the given color, specified in the HSB spectrum, in
+          NetLogo's color space.
+        </p>
+        <p>
+          The first value (hue) should be in the range of 0 to 360, the second
+          and third (saturation and brightness) in the range between 0 and 100.
+        </p>
+        <p>
+          The color reported may be only an approximation, since the NetLogo
+          color space does not include all possible colors.
+        </p>
+        <pre>
+          show approximate-hsb 0 0 0
+          =&gt; 0  ;; (black)
+          show approximate-hsb 180 57.143 76.863
+          =&gt; 85 ;; (cyan)
+        </pre>
+        <p>
+          See also <a href="#extract-hsb">extract-hsb</a>, <a href="#approximate-rgb">approximate-rgb</a>, <a href="#extract-rgb">extract-rgb</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="approximate-rgb">
+        <h3>
+          <a>approximate-rgb<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">approximate-rgb <i>red green blue</i></span>
+        </h4>
+        <p>
+          Reports a number in the range 0 to 140, not including 140 itself,
+          that represents the given color, specified in the RGB spectrum, in
+          NetLogo's color space.
+        </p>
+        <p>
+          All three inputs should be in the range 0 to 255.
+        </p>
+        <p>
+          The color reported may be only an approximation, since the NetLogo
+          color space does not include all possible colors. (See <a href="#approximate-hsb">approximate-hsb</a> for a description of what
+          parts of the HSB color space NetLogo colors cover; this is
+          difficult to characterize in RGB terms.)
+        </p>
+        <pre>
+          show approximate-rgb 0 0 0
+          =&gt; 0  ;; black
+          show approximate-rgb 0 255 255
+          =&gt; 85.2 ;; cyan
+        </pre>
+        <p>
+          See also <a href="#extract-rgb">extract-rgb</a>, <a href="#approximate-hsb">approximate-hsb</a>, and <a href="#extract-hsb">extract-hsb</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="Symbols">
+        <h3>
+          <a>Arithmetic Operators</a>
+          <a>+<span class="since">1.0</span></a>
+          <a>*<span class="since">1.0</span></a>
+          <a>-<span class="since">1.0</span></a>
+          <a>/<span class="since">1.0</span></a>
+          <a>^<span class="since">1.0</span></a>
+          <a>&lt;<span class="since">1.0</span></a>
+          <a>&gt;<span class="since">1.0</span></a>
+          <a>=<span class="since">1.0</span></a>
+          <a>!=<span class="since">1.0</span></a>
+          <a>&lt;=<span class="since">1.0</span></a>
+          <a>&gt;=<span class="since">1.0</span></a>
+        </h3>
+        <p>
+          All of these operators take two inputs, and all act as &quot;infix
+          operators&quot; (going between the two inputs, as in standard
+          mathematical use). NetLogo correctly supports order of operations
+          for infix operators.
+        </p>
+        <p>
+          The operators work as follows: + is addition, * is multiplication,
+          - is subtraction, / is division, ^ is exponentiation, &lt; is less
+          than, &gt; is greater than, = is equal to, != is not equal to,
+          &lt;= is less than or equal, &gt;= is greater than or equal.
+        </p>
+        <p>
+          Note that the subtraction operator (-) always takes two inputs
+          unless you put parentheses around it, in which case it can take one
+          input. For example, to take the negative of x, write (- x), with
+          the parentheses.
+        </p>
+        <p>
+          All of the comparison operators also work on strings.
+        </p>
+        <p>
+          All of the comparison operators work on agents. Turtles are
+          compared by who number. Patches are compared top to bottom left to
+          right, so patch 0 10 is less than patch 0 9 and patch 9 0 is less
+          than patch 10 0. Links are ordered by end points and in case of a
+          tie by breed. So link 0 9 is before link 1 10 as the end1 is
+          smaller, and link 0 8 is less than link 0 9. If there are multiple
+          breeds of links unbreeded links will come before breeded links of
+          the same end points and breeded links will be sorted in the order
+          they are declared in the Code tab.
+        </p>
+        <p>
+          Agentsets can be tested for equality or inequality. Two agentsets
+          are equal if they are the same type (turtle or patch) and contain
+          the same agents.
+        </p>
+        <p>
+          If you are not sure how NetLogo will interpret your code, you
+          should add parentheses.
+        </p>
+        <pre>
+          show 5 * 6 + 6 / 3
+          =&gt; 32
+          show 5 * (6 + 6) / 3
+          =&gt; 20
+        </pre>
+        <p>
+          Many extension objects may be tested for equality and inequality
+          using = and !=.
+          For instance, the array, matrix, and table objects returned by their
+          respective extensions may be compared for equality / inequality.
+          Extension objects may not be tested using &lt;, &gt;, &lt;=, or &gt;=.
+        </p>
+      </div>
+      <div class="dict_entry" id="asin">
+        <h3>
+          <a>asin<span class="since">1.3</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">asin <i>number</i></span>
+        </h4>
+        <p>
+          Reports the arc sine (inverse sine) of the given number. The input
+          must be in the range -1 to 1. The result is in degrees, and lies in
+          the range -90 to 90.
+        </p>
+      </div>
+      <div class="dict_entry" id="ask">
+        <h3>
+          <a>ask<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">ask <i>agentset</i> [<i>commands</i>]</span>
+          <span class="prim_example">ask <i>agent</i> [<i>commands</i>]</span>
+        </h4>
+        <p>
+          The specified agent or agentset runs the given commands.  Because
+          agentset members are always read in a random order, when ask is
+          used with an agentset each agent will take its turn in a random
+          order.  See <a href="programming.html#agentsets">Agentsets</a>
+          for more information.
+        </p>
+        <pre>
+          ask turtles [ fd 1 ]
+          ;; all turtles move forward one step
+          ask patches [ set pcolor red ]
+          ;; all patches turn red
+          ask turtle 4 [ rt 90 ]
+          ;; only the turtle with id 4 turns right
+        </pre>
+        <p>
+          Note: only the observer can ask all turtles or all patches. This
+          prevents you from inadvertently having all turtles ask all turtles
+          or all patches ask all patches, which is a common mistake to make
+          if you're not careful about which agents will run the code you
+          are writing.
+        </p>
+        <p>
+          Note: Only the agents that are in the agentset <i>at the time the
+            ask begins</i> run the commands.
+        </p>
+      </div>
+      <div class="dict_entry" id="ask-concurrent">
+        <h3>
+          <a>ask-concurrent<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">ask-concurrent <i>agentset</i> [<i>commands</i>]</span>
+        </h4>
+        <p>
+          This primitive exists only for backwards compatibility. We
+          don't recommend using it new models.
+        </p>
+        <p>
+          The agents in the given agentset run the given commands, using a
+          turn-taking mechanism to produce simulated concurrency. See the
+          <a href="programming.html#ask-concurrent">Ask-Concurrent</a>
+          section of the Programming Guide for details on how this works.
+        </p>
+        <p>
+          Note: Only the agents that are in the agentset <i>at the time the
+            ask begins</i> run the commands.
+        </p>
+        <p>
+          See also <a href="#without-interruption">without-interruption</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="at-points">
+        <h3>
+          <a>at-points<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example"><i>agentset</i> at-points [[<i>x1 y1</i>] [<i>x2 y2</i>] ...]</span>
+        </h4>
+        <p>
+          Reports a subset of the given agentset that includes only the
+          agents on the patches at the given coordinates (relative to this
+          agent). The coordinates are specified as a list of two-item lists,
+          where the two items are the x and y offsets.
+        </p>
+        <p>
+          If the caller is the observer, then the points are measured
+          relative to the origin, in other words, the points are taken as
+          absolute patch coordinates.
+        </p>
+        <p>
+          If the caller is a turtle, the points are measured relative to the
+          turtle's exact location, and not from the center of the patch
+          under the turtle.
+        </p>
+        <pre>
+          ask turtles at-points [[2 4] [1 2] [10 15]]
+          [ fd 1 ]  ;; only the turtles on the patches at the
+          ;; coordinates (2,4), (1,2) and (10,15),
+          ;; relative to the caller, move
+        </pre>
+      </div>
+      <div class="dict_entry" id="atan">
+        <h3>
+          <a>atan<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">atan <i>x y</i></span>
+        </h4>
+        <p>
+          Converts x and y offsets to a turtle heading in degrees (from 0 to
+          360).
+        </p>
+        <p>
+          Note that this version of atan is designed to conform to the
+          geometry of the NetLogo world, where a heading of 0 is straight up,
+          90 is to the right, and so on clockwise around the circle.
+          (Normally in geometry an angle of 0 is right, 90 is up, and so on,
+          counterclockwise around the circle, and atan would be defined
+          accordingly.)
+        </p>
+        <p>
+          When y is 0: if x is positive, it reports 90; if x is negative, it
+          reports 270; if x is zero, you get an error.
+        </p>
+        <pre>
+          show atan 1 -1
+          =&gt; 135
+          show atan -1 1
+          =&gt; 315
+          crt 1 [ set heading 30  fd 1  print atan xcor ycor ]
+          =&gt; 30
+        </pre>
+        <p>
+          In the final example, note that the result of <code>atan</code> equals
+          the turtle's heading.
+        </p>
+        <p>
+          If you ever need to convert a turtle heading (obtained with atan or
+          otherwise) to a normal mathematical angle, the following should be
+          helpful:
+        </p>
+        <pre>
+          to-report heading-to-angle [ h ]
+          report (90 - h) mod 360
+          end
+        </pre>
+      </div>
+      <div class="dict_entry" id="autoplot">
+        <h3>
+          <a>autoplot?<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">autoplot?</span>
+        </h4>
+        <p>
+          Reports true if auto-plotting is on for the current plot, false
+          otherwise.
+        </p>
+      </div>
+      <div class="dict_entry" id="auto-plot-status">
+        <h3>
+          <a>auto-plot-off<span class="since">1.0</span></a>
+          <a>auto-plot-on<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">auto-plot-off</span>
+          <span class="prim_example">auto-plot-on</span>
+        </h4>
+        <p>
+          This pair of commands is used to control the NetLogo feature of
+          auto-plotting in the current plot. Auto-plotting will automatically
+          update the x and y axes of the plot whenever the current pen
+          exceeds these boundaries. It is useful when wanting to show all
+          plotted values in the current plot, regardless of the current plot
+          ranges.
+        </p>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="B">
+      <a>B</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="back">
+        <h3>
+          <a>back<span class="since">1.0</span></a>
+          <a>bk<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">back <i>number</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          The turtle moves backward by <i>number</i> steps. (If <i>number</i>
+          is negative, the turtle moves forward.)
+        </p>
+        <p>
+          Turtles using this primitive can move a maximum of one unit per
+          time increment. So <code>bk 0.5</code> and <code>bk 1</code> both take one
+          unit of time, but <code>bk 3</code> takes three.
+        </p>
+        <p>
+          If the turtle cannot move backward <i>number</i> steps because it
+          is not permitted by the current topology the turtle will complete
+          as many steps of 1 as it can and stop.
+        </p>
+        <p>
+          See also <a href="#forward">forward</a>, <a href="#jump">jump</a>,
+          <a href="#can-move">can-move?</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="base-colors">
+        <h3>
+          <a>base-colors<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">base-colors</span>
+        </h4>
+        <p>
+          Reports a list of the 14 basic NetLogo hues.
+        </p>
+        <pre>
+          print base-colors
+          =&gt; [5 15 25 35 45 55 65 75 85 95 105 115 125 135]
+          ask turtles [ set color one-of base-colors ]
+          ;; each turtle turns a random base color
+          ask turtles [ set color one-of remove gray base-colors ]
+          ;; each turtle turns a random base color except for gray
+        </pre>
+      </div>
+      <div class="dict_entry" id="beep">
+        <h3>
+          <a>beep<span class="since">2.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">beep</span>
+        </h4>
+        <p>
+          Emits a beep. Note that the beep sounds immediately, so several
+          beep commands in close succession may produce only one audible
+          sound.
+        </p>
+        <p>
+          Example:
+        </p>
+        <pre>
+          beep                       ;; emits one beep
+          repeat 3 [ beep ]          ;; emits 3 beeps at once,
+          ;; so you only hear one sound
+          repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
+          ;; separated by 1/10th of a second
+        </pre>
+        <p>
+          When running headless, this command has no effect.
+        </p>
+      </div>
+      <div class="dict_entry" id="behaviorspace-experiment-name">
+        <h3>
+          <a>behaviorspace-experiment-name<span class="since">5.2</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">behaviorspace-experiment-name</span>
+        </h4>
+        <p>
+          Reports the current experiment name in the current experiment.
+        </p>
+        <p>
+          If no BehaviorSpace experiment is running, reports &quot;&quot;.
+        </p>
+      </div>
+      <div class="dict_entry" id="behaviorspace-run-number">
+        <h3>
+          <a>behaviorspace-run-number<span class="since">4.1.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">behaviorspace-run-number</span>
+        </h4>
+        <p>
+          Reports the current run number in the current BehaviorSpace
+          experiment, starting at 1.
+        </p>
+        <p>
+          If no BehaviorSpace experiment is running, reports 0.
+        </p>
+      </div>
+      <div class="dict_entry" id="both-ends">
+        <h3>
+          <a>both-ends<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">both-ends</span>
+          <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          Reports the agentset of the 2 nodes connected by this link.
+        </p>
+        <pre>
+          crt 2
+          ask turtle 0 [ create-link-with turtle 1 ]
+          ask link 0 1 [
+          ask both-ends [ set color red ] ;; turtles 0 and 1 both turn red
+          ]
+        </pre>
+      </div>
+      <div class="dict_entry" id="breedvar">
+        <h3>
+          <a>breed</a>
+        </h3>
+        <h4>
+          <span class="prim_example">breed</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          This is a built-in turtle and link variable. It holds the agentset
+          of all turtles or links of the same breed as this turtle or link.
+          (For turtles or links that do not have any particular breed, this
+          is the <a href="#turtles">turtles</a> agentset of all turtles or
+          the <a href="#links">links</a> agentset of all links respectively.)
+        </p>
+        <p>
+          You can set this variable to change a turtle or link's breed.
+          (When a turtle changes breeds, its shape is reset to the default
+          shape for that breed. See <a href="#set-default-shape">set-default-shape</a>.)
+        </p>
+        <p>
+          See also <a href="#breed">breed</a>, <a href="#directed-link-breed">directed-link-breed</a>, <a href="#undirected-link-breed">undirected-link-breed</a>
+        </p>
+        <p>
+          Example:
+        </p>
+        <pre>
+          breed [cats cat]
+          breed [dogs dog]
+          ;; turtle code:
+          if breed = cats [ show &quot;meow!&quot; ]
+          set breed dogs
+          show &quot;woof!&quot;
+        </pre>
+        <pre>
+          directed-link-breed [ roads road ]
+          ;; link code
+          if breed = roads [ set color gray ]
+        </pre>
+      </div>
+      <div class="dict_entry" id="breed">
+        <h3>
+          <a>breed</a>
+        </h3>
+        <h4>
+          <span class="prim_example">breed [<i>&lt;breeds&gt;</i> <i>&lt;breed&gt;</i>]</span>
+        </h4>
+        <p>
+          This keyword, like the globals, turtles-own, and patches-own
+          keywords, can only be used at the beginning of the Code tab, before
+          any procedure definitions. It defines a breed. The first input
+          defines the name of the agentset associated with the breed. The
+          second input defines the name of a single member of the breed.
+        </p>
+        <p>
+          Any turtle of the given breed:
+        </p>
+        <ul>
+          <li>is part of the agentset named by the breed name</li>
+          <li>has its breed built-in variable set to that agentset</li>
+        </ul>
+        <p>
+          Most often, the agentset is used in conjunction with ask to give
+          commands to only the turtles of a particular breed.
+        </p>
+        <pre>
+          breed [mice mouse]
+          breed [frogs frog]
+          to setup
+          clear-all
+          create-mice 50
+          ask mice [ set color white ]
+          create-frogs 50
+          ask frogs [ set color green ]
+          show [breed] of one-of mice    ;; prints mice
+          show [breed] of one-of frogs   ;; prints frogs
+          end
 
-					show mouse 1
-					;; prints (mouse 1)
-					show frog 51
-					;; prints (frog 51)
-					show turtle 51
-					;; prints (frog 51)
-				</pre>
-				<p>
-					See also <a href="#globals">globals</a>, <a href="#patches-own">patches-own</a>, <a href="#turtles-own">turtles-own</a>, <a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>, <a href="#create-turtles">create-<i>&lt;breeds&gt;</i></a>, <a href="#turtles-at"><i>&lt;breeds&gt;</i>-at</a>, <a href="#turtles-here"><i>&lt;breeds&gt;</i>-here</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="but-first-and-last">
-				<h3>
-					<a>but-first<span class="since">1.0</span></a>
-					<a>butfirst<span class="since">1.0</span></a>
-					<a>bf<span class="since">1.0</span></a>
-					<a>but-last<span class="since">1.0</span></a>
-					<a>butlast<span class="since">1.0</span></a>
-					<a>bl<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">but-first <i>list</i></span>
-					<span class="prim_example">but-first <i>string</i></span>
-					<span class="prim_example">but-last <i>list</i></span>
-					<span class="prim_example">but-last <i>string</i></span>
-				</h4>
-				<p>
-					When used on a list, but-first reports all of the list items of
-					<i>list</i> except the first, and but-last reports all of the list
-					items of <i>list</i> except the last.
-				</p>
-				<p>
-					On strings, but-first and but-last report a shorter string omitting
-					the first or last character of the original string.
-				</p>
-				<pre>
-					;; mylist is [2 4 6 5 8 12]
-					set mylist but-first mylist
-					;; mylist is now [4 6 5 8 12]
-					set mylist but-last mylist
-					;; mylist is now [4 6 5 8]
-					show but-first &quot;string&quot;
-					;; prints &quot;tring&quot;
-					show but-last &quot;string&quot;
-					;; prints &quot;strin&quot;
-				</pre><!-- ======================================== -->
-			</div>
-		</div>
-		<h2 id="C">
-			<a>C</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="can-move">
-				<h3>
-					<a>can-move?<span class="since">3.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">can-move? <i>distance</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Reports true if this turtle can move <i>distance</i> in the
-					direction it is facing without violating the topology; reports
-					false otherwise.
-				</p>
-				<p>
-					It is equivalent to:
-				</p>
-				<pre>
-					patch-ahead <i>distance</i> != nobody
-				</pre>
-			</div>
-			<div class="dict_entry" id="carefully">
-				<h3>
-					<a>carefully<span class="since">2.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">carefully [ <i>commands1</i> ] [ <i>commands2</i> ]</span>
-				</h4>
-				<p>
-					Runs <i>commands1</i>. If a runtime error occurs inside
-					<i>commands1</i>, NetLogo won't stop and alert the user that an
-					error occurred. It will suppress the error and run <i>commands2</i>
-					instead.
-				</p>
-				<p>
-					The error-message reporter can be used in <i>commands2</i> to find
-					out what error was suppressed in <i>commands1</i>. See <a href="#error-message">error-message</a>.
-				</p>
-				<pre>
-					carefully [ print one-of [1 2 3] ] [ print error-message ]
-					=&gt; 3
-					observer&gt; carefully [ print one-of [] ] [ print error-message ]
-					=&gt; ONE-OF got an empty list as input.
-				</pre>
-			</div>
-			<div class="dict_entry" id="ceiling">
-				<h3>
-					<a>ceiling<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">ceiling <i>number</i></span>
-				</h4>
-				<p>
-					Reports the smallest integer greater than or equal to
-					<i>number</i>.
-				</p>
-				<pre>
-					show ceiling 4.5
-					=&gt; 5
-					show ceiling -4.5
-					=&gt; -4
-				</pre>
-				<p>
-					See also <a href="#floor">floor</a>, <a href="#round">round</a>,
-					<a href="#precision">precision</a>.
-				</p>
-			</div>
-		</div>
-		<div class="dict_entry" id="clear-all">
-			<h3>
-				<a>clear-all<span class="since">1.0</span></a>
-				<a>ca<span class="since">1.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">clear-all</span>
-				<img alt="Observer Command" src="images/observer.gif"/>
-			</h4>
-			<p>
-				Combines the effects of clear-globals, clear-ticks,
-				clear-turtles, clear-patches, clear-drawing, clear-all-plots, and
-				clear-output.
-			</p>
-		</div>
-		<div class="dict_entry" id="clear-all-plots">
-			<h3>
-				<a>clear-all-plots<span class="since">1.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">clear-all-plots</span>
-				<img alt="Observer Command" src="images/observer.gif"/>
-			</h4>
-			<p>
-				Clears every plot in the model. See <a href="#clear-plot">clear-plot</a> for more information.
-			</p>
-		</div>
-		<div class="dict_entry" id="clear-drawing">
-			<h3>
-				<a>clear-drawing<span class="since">3.0</span></a>
-				<a>cd<span class="since">3.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">clear-drawing</span>
-				<img alt="Observer Command" src="images/observer.gif"/>
-			</h4>
-			<p>
-				Clears all lines and stamps drawn by turtles.
-			</p>
-		</div>
-		<div class="dict_entry" id="clear-globals">
-			<h3>
-				<a>clear-globals<span class="since">5.2</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">clear-globals</span>
-				<img alt="Observer Command" src="images/observer.gif"/>
-			</h4>
-			<p>
-				Sets all code-defined global variables (i.e., those defined inside of <code>globals [ ... ]</code>) to 0.  Global variables defined by widgets are not affected by this primitive.
-			</p>
-		</div>
-		<div class="dict_entry" id="clear-links">
-			<h3>
-				<a>clear-links<span class="since">4.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">clear-links</span>
-				<img alt="Observer Command" src="images/observer.gif"/>
-			</h4>
-			<p>
-				Kills all links.
-			</p>
-			<p>
-				See also <a href="#die">die</a>.
-			</p>
-		</div>
-		<div class="dict_entry" id="clear-output">
-			<h3>
-				<a>clear-output<span class="since">1.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">clear-output</span>
-				<img alt="Observer Command" src="images/observer.gif"/>
-			</h4>
-			<p>
-				Clears all text from the model's output area, if it has one.
-				Otherwise does nothing.
-			</p>
-		</div>
-		<div class="dict_entry" id="clear-patches">
-			<h3>
-				<a>clear-patches<span class="since">1.0</span></a>
-				<a>cp<span class="since">1.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">clear-patches</span>
-				<img alt="Observer Command" src="images/observer.gif"/>
-			</h4>
-			<p>
-				Clears the patches by resetting all patch variables to their
-				default initial values, including setting their color to black.
-			</p>
-		</div>
-		<div class="dict_entry" id="clear-plot">
-			<h3>
-				<a>clear-plot</a>
-			</h3>
-			<h4>
-				<span class="prim_example">clear-plot</span>
-			</h4>
-			<p>
-				In the current plot only, resets all plot pens, deletes all
-				temporary plot pens, resets the plot to its default values (for x
-				range, y range, etc.), and resets all permanent plot pens to their
-				default values. The default values for the plot and for the
-				permanent plot pens are set in the plot Edit dialog, which is
-				displayed when you edit the plot. If there are no plot pens after
-				deleting all temporary pens, that is to say if there are no
-				permanent plot pens, a default plot pen will be created with the
-				following initial settings:
-			</p>
-			<ul>
-				<li>Pen: down</li>
-				<li>Color: black</li>
-				<li>Mode: 0 (line mode)</li>
-				<li>Name: &quot;default&quot;</li>
-				<li>Interval: 1</li>
-			</ul>
-			<p>
-				See also <a href="#clear-all-plots">clear-all-plots</a>.
-			</p>
-		</div>
-		<div class="dict_entry" id="clear-ticks">
-			<h3>
-				<a>clear-ticks<span class="since">5.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">clear-ticks</span>
-				<img alt="Observer Command" src="images/observer.gif"/>
-			</h4>
-			<p>
-				Clears the tick counter.
-			</p>
-			<p>
-				Does not set the counter to zero. After this command runs, the tick
-				counter has no value. Attempting to access or update it is an error
-				until <a href="#reset-ticks">reset-ticks</a> is called. This is
-				useful if you want to set the model to a "pre-setup" state with some
-				forever buttons disabled.
-			</p>
-			<p>
-				See also <a href="#reset-ticks">reset-ticks</a>.
-			</p>
-		</div>
-		<div class="dict_entry" id="clear-turtles">
-			<h3>
-				<a>clear-turtles<span class="since">1.0</span></a>
-				<a>ct<span class="since">1.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">clear-turtles</span>
-				<img alt="Observer Command" src="images/observer.gif"/>
-			</h4>
-			<p>
-				Kills all turtles.
-			</p>
-			<p>
-				Also resets the who numbering, so the next turtle created will be
-				turtle 0.
-			</p>
-			<p>
-				See also <a href="#die">die</a>.
-			</p>
-		</div>
-		<div class="dict_entry" id="color">
-			<h3>
-				<a>color</a>
-			</h3>
-			<h4>
-				<span class="prim_example">color</span>
-				<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
-			</h4>
-			<p>
-				This is a built-in turtle or link variable. It holds the color of
-				the turtle or link. You can set this variable to make the turtle or
-				link change color. Color can be represented either as a NetLogo
-				color (a single number), or an RGB color (a list of 3 numbers). See
-				details in the <a href="programming.html#colors">Colors section</a>
-				of the Programming Guide.
-			</p>
-			<p>
-				See also <a href="#pcolor">pcolor</a>.
-			</p>
-		</div>
-		<div class="dict_entry" id="cos">
-			<h3>
-				<a>cos<span class="since">1.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">cos <i>number</i></span>
-			</h4>
-			<p>
-				Reports the cosine of the given angle. Assumes the angle is given
-				in degrees.
-			</p>
-			<pre>
-				show cos 180
-				=&gt; -1
-			</pre>
-		</div>
-		<div class="dict_entry" id="count">
-			<h3>
-				<a>count<span class="since">1.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">count <i>agentset</i></span>
-			</h4>
-			<p>
-				Reports the number of agents in the given agentset.
-			</p>
-			<pre>
-				show count turtles
-				;; prints the total number of turtles
-				show count patches with [pcolor = red]
-				;; prints the total number of red patches
-			</pre>
-		</div>
-		<div class="dict_entry" id="create-ordered-turtles">
-			<h3>
-				<a>create-ordered-turtles<span class="since">4.0</span></a>
-				<a>cro<span class="since">4.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">create-ordered-turtles <i>number</i></span>
-				<span class="prim_example">create-ordered-turtles <i>number</i> [ <i>commands</i> ]</span>
-				<span class="prim_example">create-ordered<i>&lt;breeds&gt;</i> <i>number</i></span>
-				<span class="prim_example">create-ordered<i>&lt;breeds&gt;</i> <i>number</i> [ <i>commands</i> ]</span>
-				<img alt="Observer Command" src="images/observer.gif"/>
-			</h4>
-			<p>
-				Creates <i>number</i> new turtles. New turtles start at position
-				(0, 0), are created with the 14 primary colors, and have headings
-				from 0 to 360, evenly spaced.
-			</p>
-			<p>
-				If the create-ordered-<i>&lt;breeds&gt;</i> form is used, the new
-				turtles are created as members of the given breed.
-			</p>
-			<p>
-				If <i>commands</i> are supplied, the new turtles immediately run
-				them. This is useful for giving the new turtles a different color,
-				heading, or whatever. (The new turtles are created all at once then
-				run one at a time, in random order.)
-			</p>
-			<pre>
-				cro 100 [ fd 10 ]  ;; makes an evenly spaced circle
-			</pre>
-		</div>
-		<div class="dict_entry" id="create-link">
-			<h3>
-				<a>create-&lt;breed&gt;-to</a>
-				<a>create-&lt;breeds&gt;-to</a>
-				<a>create-&lt;breed&gt;-from</a>
-				<a>create-&lt;breeds&gt;-from</a>
-				<a>create-&lt;breed&gt;-with</a>
-				<a>create-&lt;breeds&gt;-with</a>
-				<a>create-link-to<span class="since">4.0</span></a>
-				<a>create-links-to<span class="since">4.0</span></a>
-				<a>create-link-from<span class="since">4.0</span></a>
-				<a>create-links-from<span class="since">4.0</span></a>
-				<a>create-link-with<span class="since">4.0</span></a>
-				<a>create-links-with<span class="since">4.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">create-&lt;breed&gt;-to <i>turtle</i></span>
-				<span class="prim_example">create-&lt;breed&gt;-to <i>turtle</i> [ <i>commands</i> ]</span>
-				<span class="prim_example">create-&lt;breed&gt;-from <i>turtle</i></span>
-				<span class="prim_example">create-&lt;breed&gt;-from <i>turtle</i> [ <i>commands</i> ]</span>
-				<span class="prim_example">create-&lt;breed&gt;-with <i>turtle</i></span>
-				<span class="prim_example">create-&lt;breed&gt;-with <i>turtle</i> [ <i>commands</i> ]</span>
-				<span class="prim_example">create-&lt;breeds&gt;-to <i>turtleset</i></span>
-				<span class="prim_example">create-&lt;breeds&gt;-to <i>turtleset</i> [ <i>commands</i> ]</span>
-				<span class="prim_example">create-&lt;breeds&gt;-from <i>turtleset</i></span>
-				<span class="prim_example">create-&lt;breeds&gt;-from <i>turtleset</i> [ <i>commands</i> ]</span>
-				<span class="prim_example">create-&lt;breeds&gt;-with <i>turtleset</i></span>
-				<span class="prim_example">create-&lt;breeds&gt;-with <i>turtleset</i> [ <i>commands</i> ]</span>
-				<span class="prim_example">create-link-to <i>turtle</i></span>
-				<span class="prim_example">create-link-to <i>turtle</i> [ <i>commands</i> ]</span>
-				<span class="prim_example">create-link-from <i>turtle</i></span>
-				<span class="prim_example">create-link-from <i>turtle</i> [ <i>commands</i> ]</span>
-				<span class="prim_example">create-link-with <i>turtle</i></span>
-				<span class="prim_example">create-link-with <i>turtle</i> [ <i>commands</i> ]</span>
-				<span class="prim_example">create-links-to <i>turtleset</i></span>
-				<span class="prim_example">create-links-to <i>turtleset</i> [ <i>commands</i> ]</span>
-				<span class="prim_example">create-links-from <i>turtleset</i></span>
-				<span class="prim_example">create-links-from <i>turtleset</i> [ <i>commands</i> ]</span>
-				<span class="prim_example">create-links-with <i>turtleset</i></span>
-				<span class="prim_example">create-links-with <i>turtleset</i> [ <i>commands</i> ]</span>
-				<img alt="Turtle Command" src="images/turtle.gif"/>
-			</h4>
-			<p>
-				Used for creating breeded and unbreeded links between turtles.
-			</p>
-			<p>
-				<code>create-link-with</code> creates an undirected link between the caller and
-				<i>agent</i>. <code>create-link-to</code> creates a directed link from the
-				caller to <i>agent</i>. <code>create-link-from</code> creates a directed link
-				from <i>agent</i> to the caller.
-			</p>
-			<p>
-				When the plural form of the breed name is used, an <i>agentset</i>
-				is expected instead of an agent and links are created between the
-				caller and all agents in the agentset.
-			</p>
-			<p>
-				The optional command block is the set of commands each newly formed
-				link runs. (The links are created all at once then run one at a
-				time, in random order.)
-			</p>
-			<p>
-				A node cannot be linked to itself. Also, you cannot have more than
-				one undirected link of the same breed between the same two nodes,
-				nor can you have more than one directed link of the same breed
-				going in the same direction between two nodes.
-			</p>
-			<p>
-				If you try to create a link where one (of the same breed) already
-				exists, nothing happens. If you try to create a link from a turtle
-				to itself you get a runtime error.
-			</p>
-			<pre>
-				to setup
-				clear-all
-				create-turtles 5
-				;; turtle 1 creates links with all other turtles
-				;; the link between the turtle and itself is ignored
-				ask turtle 0 [ create-links-with other turtles ]
-				show count links ;; shows 4
-				;; this does nothing since the link already exists
-				ask turtle 0 [ create-link-with turtle 1 ]
-				show count links ;; shows 4 since the previous link already existed
-				ask turtle 2 [ create-link-with turtle 1 ]
-				show count links ;; shows 5
-				end
-			</pre>
-			<pre>
-				directed-link-breed [red-links red-link]
-				undirected-link-breed [blue-links blue-link]
+          show mouse 1
+          ;; prints (mouse 1)
+          show frog 51
+          ;; prints (frog 51)
+          show turtle 51
+          ;; prints (frog 51)
+        </pre>
+        <p>
+          See also <a href="#globals">globals</a>, <a href="#patches-own">patches-own</a>, <a href="#turtles-own">turtles-own</a>, <a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>, <a href="#create-turtles">create-<i>&lt;breeds&gt;</i></a>, <a href="#turtles-at"><i>&lt;breeds&gt;</i>-at</a>, <a href="#turtles-here"><i>&lt;breeds&gt;</i>-here</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="but-first-and-last">
+        <h3>
+          <a>but-first<span class="since">1.0</span></a>
+          <a>butfirst<span class="since">1.0</span></a>
+          <a>bf<span class="since">1.0</span></a>
+          <a>but-last<span class="since">1.0</span></a>
+          <a>butlast<span class="since">1.0</span></a>
+          <a>bl<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">but-first <i>list</i></span>
+          <span class="prim_example">but-first <i>string</i></span>
+          <span class="prim_example">but-last <i>list</i></span>
+          <span class="prim_example">but-last <i>string</i></span>
+        </h4>
+        <p>
+          When used on a list, but-first reports all of the list items of
+          <i>list</i> except the first, and but-last reports all of the list
+          items of <i>list</i> except the last.
+        </p>
+        <p>
+          On strings, but-first and but-last report a shorter string omitting
+          the first or last character of the original string.
+        </p>
+        <pre>
+          ;; mylist is [2 4 6 5 8 12]
+          set mylist but-first mylist
+          ;; mylist is now [4 6 5 8 12]
+          set mylist but-last mylist
+          ;; mylist is now [4 6 5 8]
+          show but-first &quot;string&quot;
+          ;; prints &quot;tring&quot;
+          show but-last &quot;string&quot;
+          ;; prints &quot;strin&quot;
+        </pre><!-- ======================================== -->
+      </div>
+    </div>
+    <h2 id="C">
+      <a>C</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="can-move">
+        <h3>
+          <a>can-move?<span class="since">3.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">can-move? <i>distance</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Reports true if this turtle can move <i>distance</i> in the
+          direction it is facing without violating the topology; reports
+          false otherwise.
+        </p>
+        <p>
+          It is equivalent to:
+        </p>
+        <pre>
+          patch-ahead <i>distance</i> != nobody
+        </pre>
+      </div>
+      <div class="dict_entry" id="carefully">
+        <h3>
+          <a>carefully<span class="since">2.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">carefully [ <i>commands1</i> ] [ <i>commands2</i> ]</span>
+        </h4>
+        <p>
+          Runs <i>commands1</i>. If a runtime error occurs inside
+          <i>commands1</i>, NetLogo won't stop and alert the user that an
+          error occurred. It will suppress the error and run <i>commands2</i>
+          instead.
+        </p>
+        <p>
+          The error-message reporter can be used in <i>commands2</i> to find
+          out what error was suppressed in <i>commands1</i>. See <a href="#error-message">error-message</a>.
+        </p>
+        <pre>
+          carefully [ print one-of [1 2 3] ] [ print error-message ]
+          =&gt; 3
+          observer&gt; carefully [ print one-of [] ] [ print error-message ]
+          =&gt; ONE-OF got an empty list as input.
+        </pre>
+      </div>
+      <div class="dict_entry" id="ceiling">
+        <h3>
+          <a>ceiling<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">ceiling <i>number</i></span>
+        </h4>
+        <p>
+          Reports the smallest integer greater than or equal to
+          <i>number</i>.
+        </p>
+        <pre>
+          show ceiling 4.5
+          =&gt; 5
+          show ceiling -4.5
+          =&gt; -4
+        </pre>
+        <p>
+          See also <a href="#floor">floor</a>, <a href="#round">round</a>,
+          <a href="#precision">precision</a>.
+        </p>
+      </div>
+    </div>
+    <div class="dict_entry" id="clear-all">
+      <h3>
+        <a>clear-all<span class="since">1.0</span></a>
+        <a>ca<span class="since">1.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">clear-all</span>
+        <img alt="Observer Command" src="images/observer.gif"/>
+      </h4>
+      <p>
+        Combines the effects of clear-globals, clear-ticks,
+        clear-turtles, clear-patches, clear-drawing, clear-all-plots, and
+        clear-output.
+      </p>
+    </div>
+    <div class="dict_entry" id="clear-all-plots">
+      <h3>
+        <a>clear-all-plots<span class="since">1.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">clear-all-plots</span>
+        <img alt="Observer Command" src="images/observer.gif"/>
+      </h4>
+      <p>
+        Clears every plot in the model. See <a href="#clear-plot">clear-plot</a> for more information.
+      </p>
+    </div>
+    <div class="dict_entry" id="clear-drawing">
+      <h3>
+        <a>clear-drawing<span class="since">3.0</span></a>
+        <a>cd<span class="since">3.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">clear-drawing</span>
+        <img alt="Observer Command" src="images/observer.gif"/>
+      </h4>
+      <p>
+        Clears all lines and stamps drawn by turtles.
+      </p>
+    </div>
+    <div class="dict_entry" id="clear-globals">
+      <h3>
+        <a>clear-globals<span class="since">5.2</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">clear-globals</span>
+        <img alt="Observer Command" src="images/observer.gif"/>
+      </h4>
+      <p>
+        Sets all code-defined global variables (i.e., those defined inside of <code>globals [ ... ]</code>) to 0.  Global variables defined by widgets are not affected by this primitive.
+      </p>
+    </div>
+    <div class="dict_entry" id="clear-links">
+      <h3>
+        <a>clear-links<span class="since">4.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">clear-links</span>
+        <img alt="Observer Command" src="images/observer.gif"/>
+      </h4>
+      <p>
+        Kills all links.
+      </p>
+      <p>
+        See also <a href="#die">die</a>.
+      </p>
+    </div>
+    <div class="dict_entry" id="clear-output">
+      <h3>
+        <a>clear-output<span class="since">1.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">clear-output</span>
+        <img alt="Observer Command" src="images/observer.gif"/>
+      </h4>
+      <p>
+        Clears all text from the model's output area, if it has one.
+        Otherwise does nothing.
+      </p>
+    </div>
+    <div class="dict_entry" id="clear-patches">
+      <h3>
+        <a>clear-patches<span class="since">1.0</span></a>
+        <a>cp<span class="since">1.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">clear-patches</span>
+        <img alt="Observer Command" src="images/observer.gif"/>
+      </h4>
+      <p>
+        Clears the patches by resetting all patch variables to their
+        default initial values, including setting their color to black.
+      </p>
+    </div>
+    <div class="dict_entry" id="clear-plot">
+      <h3>
+        <a>clear-plot</a>
+      </h3>
+      <h4>
+        <span class="prim_example">clear-plot</span>
+      </h4>
+      <p>
+        In the current plot only, resets all plot pens, deletes all
+        temporary plot pens, resets the plot to its default values (for x
+        range, y range, etc.), and resets all permanent plot pens to their
+        default values. The default values for the plot and for the
+        permanent plot pens are set in the plot Edit dialog, which is
+        displayed when you edit the plot. If there are no plot pens after
+        deleting all temporary pens, that is to say if there are no
+        permanent plot pens, a default plot pen will be created with the
+        following initial settings:
+      </p>
+      <ul>
+        <li>Pen: down</li>
+        <li>Color: black</li>
+        <li>Mode: 0 (line mode)</li>
+        <li>Name: &quot;default&quot;</li>
+        <li>Interval: 1</li>
+      </ul>
+      <p>
+        See also <a href="#clear-all-plots">clear-all-plots</a>.
+      </p>
+    </div>
+    <div class="dict_entry" id="clear-ticks">
+      <h3>
+        <a>clear-ticks<span class="since">5.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">clear-ticks</span>
+        <img alt="Observer Command" src="images/observer.gif"/>
+      </h4>
+      <p>
+        Clears the tick counter.
+      </p>
+      <p>
+        Does not set the counter to zero. After this command runs, the tick
+        counter has no value. Attempting to access or update it is an error
+        until <a href="#reset-ticks">reset-ticks</a> is called. This is
+        useful if you want to set the model to a "pre-setup" state with some
+        forever buttons disabled.
+      </p>
+      <p>
+        See also <a href="#reset-ticks">reset-ticks</a>.
+      </p>
+    </div>
+    <div class="dict_entry" id="clear-turtles">
+      <h3>
+        <a>clear-turtles<span class="since">1.0</span></a>
+        <a>ct<span class="since">1.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">clear-turtles</span>
+        <img alt="Observer Command" src="images/observer.gif"/>
+      </h4>
+      <p>
+        Kills all turtles.
+      </p>
+      <p>
+        Also resets the who numbering, so the next turtle created will be
+        turtle 0.
+      </p>
+      <p>
+        See also <a href="#die">die</a>.
+      </p>
+    </div>
+    <div class="dict_entry" id="color">
+      <h3>
+        <a>color</a>
+      </h3>
+      <h4>
+        <span class="prim_example">color</span>
+        <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+      </h4>
+      <p>
+        This is a built-in turtle or link variable. It holds the color of
+        the turtle or link. You can set this variable to make the turtle or
+        link change color. Color can be represented either as a NetLogo
+        color (a single number), or an RGB color (a list of 3 numbers). See
+        details in the <a href="programming.html#colors">Colors section</a>
+        of the Programming Guide.
+      </p>
+      <p>
+        See also <a href="#pcolor">pcolor</a>.
+      </p>
+    </div>
+    <div class="dict_entry" id="cos">
+      <h3>
+        <a>cos<span class="since">1.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">cos <i>number</i></span>
+      </h4>
+      <p>
+        Reports the cosine of the given angle. Assumes the angle is given
+        in degrees.
+      </p>
+      <pre>
+        show cos 180
+        =&gt; -1
+      </pre>
+    </div>
+    <div class="dict_entry" id="count">
+      <h3>
+        <a>count<span class="since">1.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">count <i>agentset</i></span>
+      </h4>
+      <p>
+        Reports the number of agents in the given agentset.
+      </p>
+      <pre>
+        show count turtles
+        ;; prints the total number of turtles
+        show count patches with [pcolor = red]
+        ;; prints the total number of red patches
+      </pre>
+    </div>
+    <div class="dict_entry" id="create-ordered-turtles">
+      <h3>
+        <a>create-ordered-turtles<span class="since">4.0</span></a>
+        <a>cro<span class="since">4.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">create-ordered-turtles <i>number</i></span>
+        <span class="prim_example">create-ordered-turtles <i>number</i> [ <i>commands</i> ]</span>
+        <span class="prim_example">create-ordered<i>&lt;breeds&gt;</i> <i>number</i></span>
+        <span class="prim_example">create-ordered<i>&lt;breeds&gt;</i> <i>number</i> [ <i>commands</i> ]</span>
+        <img alt="Observer Command" src="images/observer.gif"/>
+      </h4>
+      <p>
+        Creates <i>number</i> new turtles. New turtles start at position
+        (0, 0), are created with the 14 primary colors, and have headings
+        from 0 to 360, evenly spaced.
+      </p>
+      <p>
+        If the create-ordered-<i>&lt;breeds&gt;</i> form is used, the new
+        turtles are created as members of the given breed.
+      </p>
+      <p>
+        If <i>commands</i> are supplied, the new turtles immediately run
+        them. This is useful for giving the new turtles a different color,
+        heading, or whatever. (The new turtles are created all at once then
+        run one at a time, in random order.)
+      </p>
+      <pre>
+        cro 100 [ fd 10 ]  ;; makes an evenly spaced circle
+      </pre>
+    </div>
+    <div class="dict_entry" id="create-link">
+      <h3>
+        <a>create-&lt;breed&gt;-to</a>
+        <a>create-&lt;breeds&gt;-to</a>
+        <a>create-&lt;breed&gt;-from</a>
+        <a>create-&lt;breeds&gt;-from</a>
+        <a>create-&lt;breed&gt;-with</a>
+        <a>create-&lt;breeds&gt;-with</a>
+        <a>create-link-to<span class="since">4.0</span></a>
+        <a>create-links-to<span class="since">4.0</span></a>
+        <a>create-link-from<span class="since">4.0</span></a>
+        <a>create-links-from<span class="since">4.0</span></a>
+        <a>create-link-with<span class="since">4.0</span></a>
+        <a>create-links-with<span class="since">4.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">create-&lt;breed&gt;-to <i>turtle</i></span>
+        <span class="prim_example">create-&lt;breed&gt;-to <i>turtle</i> [ <i>commands</i> ]</span>
+        <span class="prim_example">create-&lt;breed&gt;-from <i>turtle</i></span>
+        <span class="prim_example">create-&lt;breed&gt;-from <i>turtle</i> [ <i>commands</i> ]</span>
+        <span class="prim_example">create-&lt;breed&gt;-with <i>turtle</i></span>
+        <span class="prim_example">create-&lt;breed&gt;-with <i>turtle</i> [ <i>commands</i> ]</span>
+        <span class="prim_example">create-&lt;breeds&gt;-to <i>turtleset</i></span>
+        <span class="prim_example">create-&lt;breeds&gt;-to <i>turtleset</i> [ <i>commands</i> ]</span>
+        <span class="prim_example">create-&lt;breeds&gt;-from <i>turtleset</i></span>
+        <span class="prim_example">create-&lt;breeds&gt;-from <i>turtleset</i> [ <i>commands</i> ]</span>
+        <span class="prim_example">create-&lt;breeds&gt;-with <i>turtleset</i></span>
+        <span class="prim_example">create-&lt;breeds&gt;-with <i>turtleset</i> [ <i>commands</i> ]</span>
+        <span class="prim_example">create-link-to <i>turtle</i></span>
+        <span class="prim_example">create-link-to <i>turtle</i> [ <i>commands</i> ]</span>
+        <span class="prim_example">create-link-from <i>turtle</i></span>
+        <span class="prim_example">create-link-from <i>turtle</i> [ <i>commands</i> ]</span>
+        <span class="prim_example">create-link-with <i>turtle</i></span>
+        <span class="prim_example">create-link-with <i>turtle</i> [ <i>commands</i> ]</span>
+        <span class="prim_example">create-links-to <i>turtleset</i></span>
+        <span class="prim_example">create-links-to <i>turtleset</i> [ <i>commands</i> ]</span>
+        <span class="prim_example">create-links-from <i>turtleset</i></span>
+        <span class="prim_example">create-links-from <i>turtleset</i> [ <i>commands</i> ]</span>
+        <span class="prim_example">create-links-with <i>turtleset</i></span>
+        <span class="prim_example">create-links-with <i>turtleset</i> [ <i>commands</i> ]</span>
+        <img alt="Turtle Command" src="images/turtle.gif"/>
+      </h4>
+      <p>
+        Used for creating breeded and unbreeded links between turtles.
+      </p>
+      <p>
+        <code>create-link-with</code> creates an undirected link between the caller and
+        <i>agent</i>. <code>create-link-to</code> creates a directed link from the
+        caller to <i>agent</i>. <code>create-link-from</code> creates a directed link
+        from <i>agent</i> to the caller.
+      </p>
+      <p>
+        When the plural form of the breed name is used, an <i>agentset</i>
+        is expected instead of an agent and links are created between the
+        caller and all agents in the agentset.
+      </p>
+      <p>
+        The optional command block is the set of commands each newly formed
+        link runs. (The links are created all at once then run one at a
+        time, in random order.)
+      </p>
+      <p>
+        A node cannot be linked to itself. Also, you cannot have more than
+        one undirected link of the same breed between the same two nodes,
+        nor can you have more than one directed link of the same breed
+        going in the same direction between two nodes.
+      </p>
+      <p>
+        If you try to create a link where one (of the same breed) already
+        exists, nothing happens. If you try to create a link from a turtle
+        to itself you get a runtime error.
+      </p>
+      <pre>
+        to setup
+        clear-all
+        create-turtles 5
+        ;; turtle 1 creates links with all other turtles
+        ;; the link between the turtle and itself is ignored
+        ask turtle 0 [ create-links-with other turtles ]
+        show count links ;; shows 4
+        ;; this does nothing since the link already exists
+        ask turtle 0 [ create-link-with turtle 1 ]
+        show count links ;; shows 4 since the previous link already existed
+        ask turtle 2 [ create-link-with turtle 1 ]
+        show count links ;; shows 5
+        end
+      </pre>
+      <pre>
+        directed-link-breed [red-links red-link]
+        undirected-link-breed [blue-links blue-link]
 
-				to setup
-				clear-all
-				create-turtles 5
-				;; create links in both directions between turtle 0
-				;; and all other turtles
-				ask turtle 0 [ create-red-links-to other turtles ]
-				ask turtle 0 [ create-red-links-from other turtles ]
-				show count links ;; shows 8
-				;; now create undirected links between turtle 0 and other turtles
-				ask turtle 0 [ create-blue-links-with other turtles ]
-				show count links ;; shows 12
-				end
-			</pre>
-		</div>
-		<div class="dict_entry" id="create-turtles">
-			<h3>
-				<a>create-turtles<span class="since">1.0</span></a>
-				<a>crt<span class="since">1.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">create-turtles <i>number</i></span>
-				<span class="prim_example">create-turtles <i>number</i> [ <i>commands</i> ]</span>
-				<span class="prim_example">create-<i>&lt;breeds&gt;</i> <i>number</i></span>
-				<span class="prim_example">create-<i>&lt;breeds&gt;</i> <i>number</i> [ <i>commands</i> ]</span>
-				<img alt="Observer Command" src="images/observer.gif"/>
-			</h4>
-			<p>
-				Creates <i>number</i> new turtles at the origin. New turtles have
-				random integer headings and the color is randomly selected from the
-				14 primary colors.
-			</p>
-			<p>
-				If the create-<i>&lt;breeds&gt;</i> form is used, the new turtles
-				are created as members of the given breed.
-			</p>
-			<p>
-				If <i>commands</i> are supplied, the new turtles immediately run
-				them. This is useful for giving the new turtles a different color,
-				heading, or whatever. (The new turtles are created all at once then
-				run one at a time, in random order.)
-			</p>
-			<pre>
-				crt 100 [ fd 10 ]     ;; makes a randomly spaced circle
-			</pre>
-			<pre>
-				breed [canaries canary]
-				breed [snakes snake]
-				to setup
-				clear-all
-				create-canaries 50 [ set color yellow ]
-				create-snakes 50 [ set color green ]
-				end
-			</pre>
-			<p>
-				See also <a href="#hatch">hatch</a>, <a href="#sprout">sprout</a>.
-			</p>
-		</div>
-		<div class="dict_entry" id="create-temporary-plot-pen">
-			<h3>
-				<a>create-temporary-plot-pen<span class="since">1.1</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">create-temporary-plot-pen <i>string</i></span>
-			</h4>
-			<p>
-				A new temporary plot pen with the given name is created in the
-				current plot and set to be the current pen.
-			</p>
-			<p>
-				Few models will want to use this primitive, because all temporary
-				pens disappear when clear-plot or clear-all-plots are called. The
-				normal way to make a pen is to make a permanent pen in the
-				plot's Edit dialog.
-			</p>
-			<p>
-				If a pen with that name already exists in the current plot, no
-				new pen is created, and the existing pen is set to the current
-				pen.
-			</p>
-			<p>
-				The new temporary plot pen has the following initial settings:
-			</p>
-			<ul>
-				<li>Pen: down</li>
-				<li>Color: black</li>
-				<li>Mode: 0 (line mode)</li>
-				<li>Interval: 1</li>
-			</ul>
-			<p>
-				See: <a href="#clear-plot">clear-plot</a>, <a href="#clear-all-plots">clear-all-plots</a>, and <a href="#set-current-plot-pen">set-current-plot-pen</a>.
-			</p>
-			<!-- ======================================== -->
-		</div>
-		<h2 id="D">
-			<a>D</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="date-and-time">
-				<h3>
-					<a>date-and-time<span class="since">3.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">date-and-time</span>
-				</h4>
-				<p>
-					Reports a string containing the current date and time. The format
-					is shown below. All fields are fixed width, so they are always at
-					the same locations in the string. The potential resolution of the
-					clock is milliseconds. (Whether you get resolution that high in
-					practice may vary from system to system, depending on the
-					capabilities of the underlying Java Virtual Machine.)
-				</p>
-				<pre>
-					show date-and-time
-					=&gt; &quot;01:19:36.685 PM 19-Sep-2002&quot;
-				</pre>
-			</div>
-			<div class="dict_entry" id="die">
-				<h3>
-					<a>die<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">die</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					The turtle or link dies.
-				</p>
-				<pre>
-					if xcor &gt; 20 [ die ]
-					;; all turtles with xcor greater than 20 die
-					ask links with [color = blue] [ die ]
-					;; all the blue links will die
-				</pre>
-				<p>
-					A dead agent ceases to exist. The effects of this include:
-				</p>
-				<ul>
-					<li>The agent will not execute any further code. So if you write
-						<code>ask turtles [ die print &quot;last words?&quot; ]</code>, no last
-						words will be printed, because the turtles are already dead before
-						they have a chance to print anything.
-					</li>
-					<li>The agent will disappear from any agentsets it was in, reducing
-						the size of those agentsets by one.
-					</li>
-					<li>Any variable that was storing the agent will now instead have
-						<code>nobody</code> in it. So for example <code>let x one-of turtles ask
-							x [ die ] print x</code> prints <code>nobody</code>.
-					</li>
-					<li>If the dead agent was a turtle, every link connected to it also
-						dies.
-					</li>
-					<li>If the observer was watching or following the agent, the
-						observer's perspective resets, as if <code>reset-perspective</code>
-						had been run.
-					</li>
-				</ul>
-				<p>
-					See also: <a href="#clear-turtles">clear-turtles</a> <a href="#clear-links">clear-links</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="diffuse">
-				<h3>
-					<a>diffuse<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">diffuse <i>patch-variable</i> <i>number</i></span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Tells each patch to give equal shares of (<i>number</i> * 100)
-					percent of the value of <i>patch-variable</i> to its eight
-					neighboring patches. <i>number</i> should be between 0 and 1.
-					Regardless of topology the sum of <i>patch-variable</i> will be
-					conserved across the world. (If a patch has fewer than eight
-					neighbors, each neighbor still gets an eighth share; the patch
-					keeps any leftover shares.)
-				</p>
-				<p>
-					Note that this is an observer command only, even though you might
-					expect it to be a patch command. (The reason is that it acts on all
-					the patches at once -- patch commands act on individual patches.)
-				</p>
-				<pre>
-					diffuse chemical 0.5
-					;; each patch diffuses 50% of its variable
-					;; chemical to its neighboring 8 patches. Thus,
-					;; each patch gets 1/8 of 50% of the chemical
-					;; from each neighboring patch.)
-				</pre>
-			</div>
-			<div class="dict_entry" id="diffuse4">
-				<h3>
-					<a>diffuse4<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">diffuse4 <i>patch-variable</i> <i>number</i></span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Like diffuse, but only diffuses to the four neighboring patches (to
-					the north, south, east, and west), not to the diagonal neighbors.
-				</p>
-				<pre>
-					diffuse4 chemical 0.5
-					;; each patch diffuses 50% of its variable
-					;; chemical to its neighboring 4 patches. Thus,
-					;; each patch gets 1/4 of 50% of the chemical
-					;; from each neighboring patch.)
-				</pre>
-			</div>
-			<div class="dict_entry" id="directed-link-breed">
-				<h3>
-					<a>directed-link-breed</a>
-				</h3>
-				<h4>
-					<span class="prim_example">directed-link-breed [<i>&lt;link-breeds&gt;</i> <i>&lt;link-breed&gt;</i>]</span>
-				</h4>
-				<p>
-					This keyword, like the globals and breeds keywords, can only be
-					used at the beginning of the Code tab, before any procedure
-					definitions. It defines a directed link breed. Links of a
-					particular breed are always all directed or all undirected The
-					first input defines the name of the agentset associated with the
-					link breed. The second input defines the name of a single member of
-					the breed. Directed links can be created using <a href="#create-link">create-link(s)-to</a>, and <a href="#create-link">create-link(s)-from</a>, but not
-					<code>create-link(s)-with</code>
-				</p>
-				<p>
-					Any link of the given link breed:
-				</p>
-				<ul>
-					<li>is part of the agentset named by the link breed name</li>
-					<li>has its built-in variable <code>breed</code> set to that agentset</li>
-					<li>is directed or undirected as declared by the keyword</li>
-				</ul>
-				<p>
-					Most often, the agentset is used in conjunction with ask to give
-					commands to only the links of a particular breed.
-				</p>
-				<pre>
-					directed-link-breed [streets street]
-					directed-link-breed [highways highway]
-					to setup
-					clear-all
-					crt 2
-					;; create a link from turtle 0 to turtle 1
-					ask turtle 0 [ create-street-to turtle 1 ]
-					;; create a link from turtle 1 to turtle 0
-					ask turtle 0 [ create-highway-from turtle 1 ]
-					end
+        to setup
+        clear-all
+        create-turtles 5
+        ;; create links in both directions between turtle 0
+        ;; and all other turtles
+        ask turtle 0 [ create-red-links-to other turtles ]
+        ask turtle 0 [ create-red-links-from other turtles ]
+        show count links ;; shows 8
+        ;; now create undirected links between turtle 0 and other turtles
+        ask turtle 0 [ create-blue-links-with other turtles ]
+        show count links ;; shows 12
+        end
+      </pre>
+    </div>
+    <div class="dict_entry" id="create-turtles">
+      <h3>
+        <a>create-turtles<span class="since">1.0</span></a>
+        <a>crt<span class="since">1.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">create-turtles <i>number</i></span>
+        <span class="prim_example">create-turtles <i>number</i> [ <i>commands</i> ]</span>
+        <span class="prim_example">create-<i>&lt;breeds&gt;</i> <i>number</i></span>
+        <span class="prim_example">create-<i>&lt;breeds&gt;</i> <i>number</i> [ <i>commands</i> ]</span>
+        <img alt="Observer Command" src="images/observer.gif"/>
+      </h4>
+      <p>
+        Creates <i>number</i> new turtles at the origin. New turtles have
+        random integer headings and the color is randomly selected from the
+        14 primary colors.
+      </p>
+      <p>
+        If the create-<i>&lt;breeds&gt;</i> form is used, the new turtles
+        are created as members of the given breed.
+      </p>
+      <p>
+        If <i>commands</i> are supplied, the new turtles immediately run
+        them. This is useful for giving the new turtles a different color,
+        heading, or whatever. (The new turtles are created all at once then
+        run one at a time, in random order.)
+      </p>
+      <pre>
+        crt 100 [ fd 10 ]     ;; makes a randomly spaced circle
+      </pre>
+      <pre>
+        breed [canaries canary]
+        breed [snakes snake]
+        to setup
+        clear-all
+        create-canaries 50 [ set color yellow ]
+        create-snakes 50 [ set color green ]
+        end
+      </pre>
+      <p>
+        See also <a href="#hatch">hatch</a>, <a href="#sprout">sprout</a>.
+      </p>
+    </div>
+    <div class="dict_entry" id="create-temporary-plot-pen">
+      <h3>
+        <a>create-temporary-plot-pen<span class="since">1.1</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">create-temporary-plot-pen <i>string</i></span>
+      </h4>
+      <p>
+        A new temporary plot pen with the given name is created in the
+        current plot and set to be the current pen.
+      </p>
+      <p>
+        Few models will want to use this primitive, because all temporary
+        pens disappear when clear-plot or clear-all-plots are called. The
+        normal way to make a pen is to make a permanent pen in the
+        plot's Edit dialog.
+      </p>
+      <p>
+        If a pen with that name already exists in the current plot, no
+        new pen is created, and the existing pen is set to the current
+        pen.
+      </p>
+      <p>
+        The new temporary plot pen has the following initial settings:
+      </p>
+      <ul>
+        <li>Pen: down</li>
+        <li>Color: black</li>
+        <li>Mode: 0 (line mode)</li>
+        <li>Interval: 1</li>
+      </ul>
+      <p>
+        See: <a href="#clear-plot">clear-plot</a>, <a href="#clear-all-plots">clear-all-plots</a>, and <a href="#set-current-plot-pen">set-current-plot-pen</a>.
+      </p>
+      <!-- ======================================== -->
+    </div>
+    <h2 id="D">
+      <a>D</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="date-and-time">
+        <h3>
+          <a>date-and-time<span class="since">3.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">date-and-time</span>
+        </h4>
+        <p>
+          Reports a string containing the current date and time. The format
+          is shown below. All fields are fixed width, so they are always at
+          the same locations in the string. The potential resolution of the
+          clock is milliseconds. (Whether you get resolution that high in
+          practice may vary from system to system, depending on the
+          capabilities of the underlying Java Virtual Machine.)
+        </p>
+        <pre>
+          show date-and-time
+          =&gt; &quot;01:19:36.685 PM 19-Sep-2002&quot;
+        </pre>
+      </div>
+      <div class="dict_entry" id="die">
+        <h3>
+          <a>die<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">die</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          The turtle or link dies.
+        </p>
+        <pre>
+          if xcor &gt; 20 [ die ]
+          ;; all turtles with xcor greater than 20 die
+          ask links with [color = blue] [ die ]
+          ;; all the blue links will die
+        </pre>
+        <p>
+          A dead agent ceases to exist. The effects of this include:
+        </p>
+        <ul>
+          <li>The agent will not execute any further code. So if you write
+            <code>ask turtles [ die print &quot;last words?&quot; ]</code>, no last
+            words will be printed, because the turtles are already dead before
+            they have a chance to print anything.
+          </li>
+          <li>The agent will disappear from any agentsets it was in, reducing
+            the size of those agentsets by one.
+          </li>
+          <li>Any variable that was storing the agent will now instead have
+            <code>nobody</code> in it. So for example <code>let x one-of turtles ask
+              x [ die ] print x</code> prints <code>nobody</code>.
+          </li>
+          <li>If the dead agent was a turtle, every link connected to it also
+            dies.
+          </li>
+          <li>If the observer was watching or following the agent, the
+            observer's perspective resets, as if <code>reset-perspective</code>
+            had been run.
+          </li>
+        </ul>
+        <p>
+          See also: <a href="#clear-turtles">clear-turtles</a> <a href="#clear-links">clear-links</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="diffuse">
+        <h3>
+          <a>diffuse<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">diffuse <i>patch-variable</i> <i>number</i></span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Tells each patch to give equal shares of (<i>number</i> * 100)
+          percent of the value of <i>patch-variable</i> to its eight
+          neighboring patches. <i>number</i> should be between 0 and 1.
+          Regardless of topology the sum of <i>patch-variable</i> will be
+          conserved across the world. (If a patch has fewer than eight
+          neighbors, each neighbor still gets an eighth share; the patch
+          keeps any leftover shares.)
+        </p>
+        <p>
+          Note that this is an observer command only, even though you might
+          expect it to be a patch command. (The reason is that it acts on all
+          the patches at once -- patch commands act on individual patches.)
+        </p>
+        <pre>
+          diffuse chemical 0.5
+          ;; each patch diffuses 50% of its variable
+          ;; chemical to its neighboring 8 patches. Thus,
+          ;; each patch gets 1/8 of 50% of the chemical
+          ;; from each neighboring patch.)
+        </pre>
+      </div>
+      <div class="dict_entry" id="diffuse4">
+        <h3>
+          <a>diffuse4<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">diffuse4 <i>patch-variable</i> <i>number</i></span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Like diffuse, but only diffuses to the four neighboring patches (to
+          the north, south, east, and west), not to the diagonal neighbors.
+        </p>
+        <pre>
+          diffuse4 chemical 0.5
+          ;; each patch diffuses 50% of its variable
+          ;; chemical to its neighboring 4 patches. Thus,
+          ;; each patch gets 1/4 of 50% of the chemical
+          ;; from each neighboring patch.)
+        </pre>
+      </div>
+      <div class="dict_entry" id="directed-link-breed">
+        <h3>
+          <a>directed-link-breed</a>
+        </h3>
+        <h4>
+          <span class="prim_example">directed-link-breed [<i>&lt;link-breeds&gt;</i> <i>&lt;link-breed&gt;</i>]</span>
+        </h4>
+        <p>
+          This keyword, like the globals and breeds keywords, can only be
+          used at the beginning of the Code tab, before any procedure
+          definitions. It defines a directed link breed. Links of a
+          particular breed are always all directed or all undirected The
+          first input defines the name of the agentset associated with the
+          link breed. The second input defines the name of a single member of
+          the breed. Directed links can be created using <a href="#create-link">create-link(s)-to</a>, and <a href="#create-link">create-link(s)-from</a>, but not
+          <code>create-link(s)-with</code>
+        </p>
+        <p>
+          Any link of the given link breed:
+        </p>
+        <ul>
+          <li>is part of the agentset named by the link breed name</li>
+          <li>has its built-in variable <code>breed</code> set to that agentset</li>
+          <li>is directed or undirected as declared by the keyword</li>
+        </ul>
+        <p>
+          Most often, the agentset is used in conjunction with ask to give
+          commands to only the links of a particular breed.
+        </p>
+        <pre>
+          directed-link-breed [streets street]
+          directed-link-breed [highways highway]
+          to setup
+          clear-all
+          crt 2
+          ;; create a link from turtle 0 to turtle 1
+          ask turtle 0 [ create-street-to turtle 1 ]
+          ;; create a link from turtle 1 to turtle 0
+          ask turtle 0 [ create-highway-from turtle 1 ]
+          end
 
-					ask turtle 0 [ show one-of my-in-links ]
-					;; prints (street 0 1)
-					ask turtle 0 [ show one-of my-out-links ]
-					;; prints (highway 1 0)
-				</pre>
-				<p>
-					See also <a href="#breed">breed</a>, <a href="#undirected-link-breed">undirected-link-breed</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="display">
-				<h3>
-					<a>display<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">display</span>
-				</h4>
-				<p>
-					Causes the view to be updated immediately. (Exception: if the user
-					is using the speed slider to fast-forward the model, then the
-					update may be skipped.)
-				</p>
-				<p>
-					Also undoes the effect of the no-display command, so that if view
-					updates were suspended by that command, they will resume.
-				</p>
-				<pre>
-					no-display
-					ask turtles [ jump 10 set color blue set size 5 ]
-					display
-					;; turtles move, change color, and grow, with none of
-					;; their intermediate states visible to the user, only
-					;; their final state
-				</pre>
-				<p>
-					Even if no-display was not used, &quot;display&quot; can still be
-					useful, because ordinarily NetLogo is free to skip some view
-					updates, so that fewer total updates take place, so that models run
-					faster. This command lets you force a view update, so whatever
-					changes have taken place in the world are visible to the user.
-				</p>
-				<pre>
-					ask turtles [ set color red ]
-					display
-					ask turtles [ set color blue]
-					;; turtles turn red, then blue; use of &quot;display&quot; forces
-					;; red turtles to appear briefly
-				</pre>
-				<p>
-					Note that display and no-display operate independently of the
-					switch in the view control strip that freezes the view.
-				</p>
-				<p>
-					See also <a href="#no-display">no-display</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="distance">
-				<h3>
-					<a>distance<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">distance <i>agent</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					Reports the distance from this agent to the given turtle or patch.
-				</p>
-				<p>
-					The distance to or a from a patch is measured from the center of
-					the patch. Turtles and patches use the wrapped distance (around the
-					edges of the world) if wrapping is allowed by the topology and the
-					wrapped distance is shorter.
-				</p>
-				<pre>
-					ask turtles [ show max-one-of turtles [distance myself] ]
-					;; each turtle prints the turtle farthest from itself
-				</pre>
-			</div>
-			<div class="dict_entry" id="distancexy">
-				<h3>
-					<a>distancexy<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">distancexy <i>x</i> <i>y</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					Reports the distance from this agent to the point (<i>x</i>,
-					<i>y</i>).
-				</p>
-				<p>
-					The distance from a patch is measured from the center of the patch.
-					Turtles and patches use the wrapped distance (around the edges of
-					the world) if wrapping is allowed by the topology and the wrapped
-					distance is shorter.
-				</p>
-				<pre>
-					if (distancexy 0 0) &gt; 10
-					[ set color green ]
-					;; all turtles more than 10 units from
-					;; the center of the world turn green.
-				</pre>
-			</div>
-			<div class="dict_entry" id="downhill">
-				<h3>
-					<a>downhill<span class="since">1.0</span></a>
-					<a>downhill4<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">downhill <i>patch-variable</i></span>
-					<span class="prim_example">downhill4 <i>patch-variable</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Moves the turtle to the neighboring patch with the lowest value for
-					<i>patch-variable</i>. If no neighboring patch has a smaller value
-					than the current patch, the turtle stays put. If there are multiple
-					patches with the same lowest value, the turtle picks one randomly.
-					Non-numeric values are ignored.
-				</p>
-				<p>
-					downhill considers the eight neighboring patches; downhill4 only
-					considers the four neighbors.
-				</p>
-				<p>
-					Equivalent to the following code (assumes variable values are
-					numeric):
-				</p>
-				<pre>
-					move-to patch-here  ;; go to patch center
-					let p min-one-of neighbors [<i>patch-variable</i>]  ;; or neighbors4
-					if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
-					face p
-					move-to p
-					]
-				</pre>
-				<p>
-					Note that the turtle always ends up on a patch center and has a
-					heading that is a multiple of 45 (downhill) or 90 (downhill4).
-				</p>
-				<p>
-					See also <a href="#uphill">uphill</a>, <a href="#uphill">uphill4</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="dxy">
-				<h3>
-					<a>dx<span class="since">1.0</span></a>
-					<a>dy<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">dx</span>
-					<span class="prim_example">dy</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Reports the x-increment or y-increment (the amount by which the
-					turtle's xcor or ycor would change) if the turtle were to take
-					one step forward in its current heading.
-				</p>
-				<p>
-					Note: dx is simply the sine of the turtle's heading, and dy is
-					simply the cosine. (If this is the reverse of what you expected,
-					it's because in NetLogo a heading of 0 is north and 90 is east,
-					which is the reverse of how angles are usually defined in
-					geometry.)
-				</p>
-				<p>
-					Note: In earlier versions of NetLogo, these primitives were used in
-					many situations where the new <code>patch-ahead</code> primitive is now
-					more appropriate.
-				</p> <!-- ======================================== -->
-			</div>
-		</div>
-		<h2 id="E">
-			<a>E</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="empty">
-				<h3>
-					<a>empty?<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">empty? <i>list</i></span>
-					<span class="prim_example">empty? <i>string</i></span>
-				</h4>
-				<p>
-					Reports true if the given list or string is empty, false otherwise.
-				</p>
-				<p>
-					Note: the empty list is written <code>[]</code>. The empty string is
-					written <code>&quot;&quot;</code>.
-				</p>
-			</div>
-			<div class="dict_entry" id="end">
-				<h3>
-					<a>end</a>
-				</h3>
-				<h4>
-					<span class="prim_example">end</span>
-				</h4>
-				<p>
-					Used to conclude a procedure. See <a href="#to">to</a> and <a href="#to-report">to-report</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="end1">
-				<h3>
-					<a>end1<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">end1</span>
-					<img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					This is a built-in link variable. It indicates the first endpoint
-					(turtle) of a link. For directed links this will always be the
-					source for undirected links it will always be the turtle with the
-					lower who number. You cannot set end1.
-				</p>
-				<pre>
-					crt 2
-					ask turtle 0
-					[ create-link-to turtle 1 ]
-					ask links
-					[ show end1 ] ;; shows turtle 0
-				</pre>
-			</div>
-			<div class="dict_entry" id="end2">
-				<h3>
-					<a>end2<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">end2</span>
-					<img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					This is a built-in link variable. It indicates the second endpoint
-					(turtle) of a link. For directed links this will always be the
-					destination for undirected links it will always be the turtle with
-					the higher who number. You cannot set end2.
-				</p>
-				<pre>
-					crt 2
-					ask turtle 1
-					[ create-link-with turtle 0 ]
-					ask links
-					[ show end2 ] ;; shows turtle 1
-				</pre>
-			</div>
-			<div class="dict_entry" id="error">
-				<h3>
-					<a>error<span class="since">5.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">error <i>value</i></span>
-				</h4>
-				<p>
-					Causes a runtime error to occur.
-				</p>
-				<p>
-					The given value is converted to a string (if it isn't one
-					already) and used as the error message.
-				</p>
-				<p>
-					See also <a href="#error-message">error-message</a>, <a href="#carefully">carefully</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="error-message">
-				<h3>
-					<a>error-message<span class="since">2.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">error-message</span>
-				</h4>
-				<p>
-					Reports a string describing the error that was suppressed by
-					carefully.
-				</p>
-				<p>
-					This reporter can only be used in the second block of a carefully
-					command.
-				</p>
-				<p>
-					See also <a href="#error">error</a>, <a href="#carefully">carefully</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="every">
-				<h3>
-					<a>every<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">every <i>number</i> [ <i>commands</i> ]</span>
-				</h4>
-				<p>
-					Runs the given commands only if it's been more than
-					<i>number</i> seconds since the last time this agent ran them in
-					this context. Otherwise, the commands are skipped.
-				</p>
-				<p>
-					By itself, every doesn't make commands run over and over again.
-					You need to use every inside a loop, or inside a forever button, if
-					you want the commands run over and over again. every only limits
-					how often the commands run.
-				</p>
-				<p>
-					Above, &quot;in this context&quot; means during the same ask (or
-					button press or command typed in the Command Center). So it
-					doesn't make sense to write <code>ask turtles [ every 0.5 [ ... ]
-						]</code>, because when the ask finishes the turtles will all discard
-					their timers for the &quot;every&quot;. The correct usage is shown
-					below.
-				</p>
-				<pre>
-					every 0.5 [ ask turtles [ fd 1 ] ]
-					;; twice a second the turtles will move forward 1
-					every 2 [ set index index + 1 ]
-					;; every 2 seconds index is incremented
-				</pre>
-				<p>
-					See also <a href="#wait">wait</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="exp">
-				<h3>
-					<a>exp<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">exp <i>number</i></span>
-				</h4>
-				<p>
-					Reports the value of e raised to the <i>number</i> power.
-				</p>
-				<p>
-					Note: This is the same as e ^ <i>number</i>.
-				</p>
-			</div>
-			<div class="dict_entry" id="export-cmds">
-				<h3>
-					<a>export-view<span class="since">3.0</span></a>
-					<a>export-interface<span class="since">2.0</span></a>
-					<a>export-output<span class="since">1.0</span></a>
-					<a>export-plot<span class="since">1.0</span></a>
-					<a>export-all-plots<span class="since">1.2.1</span></a>
-					<a>export-world<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">export-view <i>filename</i></span>
-					<span class="prim_example">export-interface <i>filename</i></span>
-					<span class="prim_example">export-output <i>filename</i></span>
-					<span class="prim_example">export-plot <i>plotname</i> <i>filename</i></span>
-					<span class="prim_example">export-all-plots <i>filename</i></span>
-					<span class="prim_example">export-world <i>filename</i></span>
-				</h4>
-				<p>
-					export-view writes the current contents of the current view to an
-					external file given by the string <i>filename</i>. The file is
-					saved in PNG (Portable Network Graphics) format, so it is
-					recommended to supply a filename ending in &quot;.png&quot;.
-				</p>
-				<p>
-					export-interface is similar, but for the whole interface tab.
-				</p>
-				<p>
-					Note that export-view still works when running NetLogo in headless
-					mode, but export-interface doesn't.
-				</p>
-				<p>
-					export-output writes the contents of the model's output area to
-					an external file given by the string <i>filename</i>. (If the model
-					does not have a separate output area, the output portion of the
-					Command Center is used.)
-				</p>
-				<p>
-					export-plot writes the x and y values of all points plotted by all
-					the plot pens in the plot given by the string <i>plotname</i> to an
-					external file given by the string <i>filename</i>. If a pen is in
-					bar mode (mode 0) and the y value of the point plotted is greater
-					than 0, the upper-left corner point of the bar will be exported. If
-					the y value is less than 0, then the lower-left corner point of the
-					bar will be exported.
-				</p>
-				<p>
-					export-all-plots writes every plot in the current model to an
-					external file given by the string <i>filename</i>. Each plot is
-					identical in format to the output of export-plot.
-				</p>
-				<p>
-					export-world writes the values of all variables, both built-in and
-					user-defined, including all observer, turtle, and patch variables,
-					the drawing, the contents of the output area if one exists, the
-					contents of any plots and the state of the random number generator,
-					to an external file given by the string <i>filename</i>. (The
-					result file can be read back into NetLogo with the <a href="#import-world">import-world</a> primitive.) export-world does not
-					save the state of open files.
-				</p>
-				<p>
-					export-plot, export-all-plots and export-world save files in in
-					plain-text, &quot;comma-separated values&quot; (<code>.csv</code>)
-					format. CSV files can be read by most popular spreadsheet and
-					database programs as well as any text editor.
-				</p>
-				<p>
-					If you wish to export to a file in a location other than the
-					model's location, you should include the full path to the file
-					you wish to export. (Use the forward-slash &quot;/&quot; as the
-					folder separator.)
-				</p>
-				<p>
-					Note that the functionality of these primitives is also available
-					directly from NetLogo's File menu.
-				</p>
-				<pre>
-					export-world &quot;fire.csv&quot;
-					;; exports the state of the model to the file fire.csv
-					;; located in the NetLogo folder
-					export-plot &quot;Temperature&quot; &quot;c:/My Documents/plot.csv&quot;
-					;; exports the plot named
-					;; &quot;Temperature&quot; to the file plot.csv located in
-					;; the C:\My Documents folder
-					export-all-plots &quot;c:/My Documents/plots.csv&quot;
-					;; exports all plots to the file plots.csv
-					;; located in the C:\My Documents folder
-				</pre>
-				<p>
-					If the file already exists, it is overwritten. To avoid this you
-					may wish to use some method of generating fresh names. Examples:
-				</p>
-				<pre>
-					export-world user-new-file
-					export-world (word &quot;results &quot; date-and-time &quot;.csv&quot;) ;; Colon characters in the time cause errors on Windows
-					export-world (word &quot;results &quot; random-float 1.0 &quot;.csv&quot;)
-				</pre>
-			</div>
-			<div class="dict_entry" id="extensions">
-				<h3>
-					<a>extensions</a>
-				</h3>
-				<h4>
-					<span class="prim_example">extensions [<i>name</i> ...]</span>
-				</h4>
-				<p>
-					Allows the model to use primitives from the extensions with the
-					given names. See the <a href="extensions.html">Extensions guide</a>
-					for more information.
-				</p>
-			</div>
-			<div class="dict_entry" id="extract-hsb">
-				<h3>
-					<a>extract-hsb<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">extract-hsb <i>color</i></span>
-				</h4>
-				<p>
-					Reports a list of three values, the first (hue) in the range of
-					0 to 360, the second and third (brightness and saturation) in
-					the range of 0 to 100.
-				</p>
-				<p>
-					The given <i>color</i> can either be a NetLogo color in the
-					range 0 to 140, not including 140 itself, or an RGB list of
-					three values in the range 0 to 255 representing the levels
-					of red, green, and blue.
-				</p>
-				<pre>
-					show extract-hsb cyan
-					=&gt; [180 57.143 76.863]
-					show extract-hsb red
-					=&gt; [3.103 80.93 84.314]
-					show extract-hsb [255 0 0]
-					=&gt; [0 100 100]
-				</pre>
-				<p>
-					See also <a href="#approximate-hsb">approximate-hsb</a>, <a href="#approximate-rgb">approximate-rgb</a>, <a href="#extract-rgb">extract-rgb</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="extract-rgb">
-				<h3>
-					<a>extract-rgb<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">extract-rgb <i>color</i></span>
-				</h4>
-				<p>
-					Reports a list of three values in the range 0 to 255 representing
-					the levels of red, green, and blue, respectively, of the given
-					NetLogo <i>color</i> in the range 0 to 140, not including 140
-					itself.
-				</p>
-				<pre>
-					show extract-rgb red
-					=&gt; [215 50 41]
-					show extract-rgb cyan
-					=&gt; [84 196 196]
-				</pre>
-				<p>
-					See also <a href="#approximate-rgb">approximate-rgb</a>, <a href="#approximate-hsb">approximate-hsb</a>, <a href="#extract-hsb">extract-hsb</a>.
-				</p>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="F">
-			<a>F</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="face">
-				<h3>
-					<a>face<span class="since">3.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">face <i>agent</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Set the caller's heading towards <i>agent</i>.
-				</p>
-				<p>
-					If wrapping is allowed by the topology and the wrapped distance
-					(around the edges of the world) is shorter, face will use the
-					wrapped path.
-				</p>
-				<p>
-					If the caller and the agent are at the exact same position, the
-					caller's heading won't change.
-				</p>
-			</div>
-			<div class="dict_entry" id="facexy">
-				<h3>
-					<a>facexy<span class="since">3.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">facexy <i>x</i> <i>y</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Set the caller's heading towards the point (x,y).
-				</p>
-				<p>
-					If wrapping is allowed by the topology and the wrapped distance
-					(around the edges of the world) is shorter and wrapping is allowed,
-					facexy will use the wrapped path.
-				</p>
-				<p>
-					If the caller is on the point (x,y), the caller's heading
-					won't change.
-				</p>
-			</div>
-			<div class="dict_entry" id="file-at-end">
-				<h3>
-					<a>file-at-end?<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">file-at-end?</span>
-				</h4>
-				<p>
-					Reports true when there are no more characters left to read in from
-					the current file (that was opened previously with <a href="#file-open">file-open</a>). Otherwise, reports false.
-				</p>
-				<pre>
-					file-open &quot;my-file.txt&quot;
-					print file-at-end?
-					=&gt; false ;; Can still read in more characters
-					print file-read-line
-					=&gt; This is the last line in file
-					print file-at-end?
-					=&gt; true ;; We reached the end of the file
-				</pre>
-				<p>
-					See also <a href="#file-open">file-open</a>, <a href="#file-close-all">file-close-all</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="file-close">
-				<h3>
-					<a>file-close<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">file-close</span>
-				</h4>
-				<p>
-					Closes a file that has been opened previously with <a href="#file-open">file-open</a>.
-				</p>
-				<p>
-					Note that this and file-close-all are the only ways to restart to
-					the beginning of an opened file or to switch between file modes.
-				</p>
-				<p>
-					If no file is open, does nothing.
-				</p>
-				<p>
-					See also <a href="#file-close-all">file-close-all</a>, <a href="#file-open">file-open</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="file-close-all">
-				<h3>
-					<a>file-close-all<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">file-close-all</span>
-				</h4>
-				<p>
-					Closes all files (if any) that have been opened previously with
-					<a href="#file-open">file-open</a>.
-				</p>
-				<p>
-					See also <a href="#file-close">file-close</a>, <a href="#file-open">file-open</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="file-delete">
-				<h3>
-					<a>file-delete<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">file-delete <i>string</i></span>
-				</h4>
-				<p>
-					Deletes the file specified as <i>string</i>
-				</p>
-				<p>
-					<i>string</i> must be an existing file with writable permission by
-					the user. Also, the file cannot be open. Use the command <a href="#file-close">file-close</a> to close an opened file before
-					deletion.
-				</p>
-				<p>
-					Note that the string can either be a file name or an absolute file
-					path. If it is a file name, it looks in whatever the current
-					directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It is defaulted
-					to the model's directory.
-				</p>
-			</div>
-			<div class="dict_entry" id="file-exists">
-				<h3>
-					<a>file-exists?<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">file-exists? <i>string</i></span>
-				</h4>
-				<p>
-					Reports true if <i>string</i> is the name of an existing file on
-					the system. Otherwise it reports false.
-				</p>
-				<p>
-					Note that the string can either be a file name or an absolute file
-					path. If it is a file name, it looks in whatever the current
-					directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It defaults to
-					to the model's directory.
-				</p>
-			</div>
-			<div class="dict_entry" id="file-flush">
-				<h3>
-					<a>file-flush<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">file-flush</span>
-				</h4>
-				<p>
-					Forces file updates to be written to disk. When you use file-write
-					or other output commands, the values may not be immediately written
-					to disk. This improves the performance of the file output commands.
-					Closing a file ensures that all output is written to disk.
-				</p>
-				<p>
-					Sometimes you need to ensure that data is written to disk without
-					closing the file. For example, you could be using a file to
-					communicate with another program on your machine and want the other
-					program to be able to see the output immediately.
-				</p>
-			</div>
-			<div class="dict_entry" id="file-open">
-				<h3>
-					<a>file-open<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">file-open <i>string</i></span>
-				</h4>
-				<p>
-					This command will interpret <i>string</i> as a path name to a file
-					and open the file. You may then use the reporters <a href="#file-read">file-read</a>, <a href="#file-read-line">file-read-line</a>, and <a href="#file-read-characters">file-read-characters</a> to read in from
-					the file, or <a href="#file-write">file-write</a>, <a href="#file-print">file-print</a>, <a href="#file-type">file-type</a>,
-					or <a href="#file-show">file-show</a> to write out to the file.
-				</p>
-				<p>
-					Note that you can only open a file for reading or writing but not
-					both. The next file i/o primitive you use after this command
-					dictates which mode the file is opened in. To switch modes, you
-					need to close the file using <a href="#file-close">file-close</a>.
-				</p>
-				<p>
-					Also, the file must already exist if opening a file in reading
-					mode.
-				</p>
-				<p>
-					When opening a file in writing mode, all new data will be appended
-					to the end of the original file. If there is no original file, a
-					new blank file will be created in its place. (You must have write
-					permission in the file's directory.) (If you don't want to
-					append, but want to replace the file's existing contents, use
-					<a href="#file-delete">file-delete</a> to delete it first, perhaps
-					inside a <a href="#carefully">carefully</a> if you're not sure
-					whether it already exists.)
-				</p>
-				<p>
-					Note that the string can either be a file name or an absolute file
-					path. If it is a file name, it looks in whatever the current
-					directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It is defaulted
-					to the model's directory.
-				</p>
-				<pre>
-					file-open &quot;my-file-in.txt&quot;
-					print file-read-line
-					=&gt; First line in file ;; File is in reading mode
-					file-open &quot;C:\\NetLogo\\my-file-out.txt&quot;
-					;; assuming Windows machine
-					file-print &quot;Hello World&quot; ;; File is in writing mode
-				</pre>
-				<p>
-					Opening a file does not close previously opened files. You can use
-					<code>file-open</code> to switch back and forth between multiple open
-					files.
-				</p>
-				<p>
-					See also <a href="#file-close">file-close</a> See also <a href="#file-close-all">file-close-all</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="file-print">
-				<h3>
-					<a>file-print<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">file-print <i>value</i></span>
-				</h4>
-				<p>
-					Prints <i>value</i> to an opened file, followed by a carriage
-					return.
-				</p>
-				<p>
-					This agent is <i>not</i> printed before the value, unlike <a href="#file-show">file-show</a>.
-				</p>
-				<p>
-					Note that this command is the file i/o equivalent of <a href="#print">print</a>, and <a href="#file-open">file-open</a> needs to
-					be called before this command can be used.
-				</p>
-				<p>
-					See also <a href="#file-show">file-show</a>, <a href="#file-type">file-type</a>,
-					<a href="#file-write">file-write</a>,
-					and <a href="programming.html#output">Output (programming guide)</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="file-read">
-				<h3>
-					<a>file-read<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">file-read</span>
-				</h4>
-				<p>
-					This reporter will read in the next constant from the opened file
-					and interpret it as if it had been typed in the Command Center. It
-					reports the resulting value. The result may be a number, list,
-					string, boolean, or the special value nobody.
-				</p>
-				<p>
-					Whitespace separates the constants. Each call to file-read will
-					skip past both leading and trailing whitespace.
-				</p>
-				<p>
-					Note that strings need to have quotes around them. Use the command
-					<a href="#file-write">file-write</a> to have quotes included.
-				</p>
-				<p>
-					Also note that the <a href="#file-open">file-open</a> command must
-					be called before this reporter can be used, and there must be data
-					remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
-					of the file.
-				</p>
-				<pre>
-					file-open &quot;my-file.data&quot;
-					print file-read + 5
-					;; Next value is the number 1
-					=&gt; 6
-					print length file-read
-					;; Next value is the list [1 2 3 4]
-					=&gt; 4
-				</pre>
-				<p>
-					See also <a href="#file-open">file-open</a> and <a href="#file-write">file-write</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="file-read-characters">
-				<h3>
-					<a>file-read-characters<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">file-read-characters <i>number</i></span>
-				</h4>
-				<p>
-					Reports the given <i>number</i> of characters from an opened file
-					as a string. If there are fewer than that many characters left, it
-					will report all of the remaining characters.
-				</p>
-				<p>
-					Note that it will return every character including newlines and
-					spaces.
-				</p>
-				<p>
-					Also note that the <a href="#file-open">file-open</a> command must
-					be called before this reporter can be used, and there must be data
-					remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
-					of the file.
-				</p>
-				<pre>
-					file-open &quot;my-file.txt&quot;
-					print file-read-characters 5
-					;; Current line in file is &quot;Hello World&quot;
-					=&gt; Hello
-				</pre>
-				<p>
-					See also <a href="#file-open">file-open</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="file-read-line">
-				<h3>
-					<a>file-read-line<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">file-read-line</span>
-				</h4>
-				<p>
-					Reads the next line in the file and reports it as a string. It
-					determines the end of the file by a carriage return, an end of file
-					character or both in a row. It does not return the line terminator
-					characters.
-				</p>
-				<p>
-					Also note that the <a href="#file-open">file-open</a> command must
-					be called before this reporter can be used, and there must be data
-					remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
-					of the file.
-				</p>
-				<pre>
-					file-open &quot;my-file.txt&quot;
-					print file-read-line
-					=&gt; Hello World
-				</pre>
-				<p>
-					See also <a href="#file-open">file-open</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="file-show">
-				<h3>
-					<a>file-show<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">file-show <i>value</i></span>
-				</h4>
-				<p>
-					Prints <i>value</i> to an opened file, preceded by this agent
-					agent, and followed by a carriage return. (This agent is included
-					to help you keep track of what agents are producing which lines of
-					output.) Also, all strings have their quotes included similar to
-					<a href="#file-write">file-write</a>.
-				</p>
-				<p>
-					Note that this command is the file i/o equivalent of <a href="#show">show</a>, and <a href="#file-open">file-open</a> needs to
-					be called before this command can be used.
-				</p>
-				<p>
-					See also <a href="#file-print">file-print</a>, <a href="#file-type">file-type</a>,
-					<a href="#file-write">file-write</a>,
-					and <a href="programming.html#output">Output (programming guide)</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="file-type">
-				<h3>
-					<a>file-type<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">file-type <i>value</i></span>
-				</h4>
-				<p>
-					Prints <i>value</i> to an opened file, <i>not</i> followed by a
-					carriage return (unlike <a href="#file-print">file-print</a> and
-					<a href="#file-show">file-show</a>). The lack of a carriage return
-					allows you to print several values on the same line.
-				</p>
-				<p>
-					This agent is <i>not</i> printed before the value. unlike <a href="#file-show">file-show</a>.
-				</p>
-				<p>
-					Note that this command is the file i/o equivalent of <a href="#type">type</a>, and <a href="#file-open">file-open</a> needs to
-					be called before this command can be used.
-				</p>
-				<p>
-					See also <a href="#file-print">file-print</a>, <a href="#file-show">file-show</a>, <a href="#file-write">file-write</a>, and
-					<a href="programming.html#output">Output (programming guide)</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="file-write">
-				<h3>
-					<a>file-write<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">file-write <i>value</i></span>
-				</h4>
-				<p>
-					This command will output <i>value</i>, which can be a number,
-					string, list, boolean, or nobody to an opened file, <i>not</i>
-					followed by a carriage return (unlike <a href="#file-print">file-print</a> and <a href="#file-show">file-show</a>).
-				</p>
-				<p>
-					This agent is <i>not</i> printed before the value, unlike <a href="#file-show">file-show</a>. Its output also includes quotes around
-					strings and is prepended with a space. It will output the value in
-					such a manner that <a href="#file-read">file-read</a> will be able
-					to interpret it.
-				</p>
-				<p>
-					Note that this command is the file i/o equivalent of <a href="#write">write</a>, and <a href="#file-open">file-open</a> needs to
-					be called before this command can be used.
-				</p>
-				<pre>
-					file-open &quot;locations.txt&quot;
-					ask turtles
-					[ file-write xcor file-write ycor ]
-				</pre>
-				<p>
-					See also <a href="#file-print">file-print</a>, <a href="#file-show">file-show</a>,
-					<a href="#file-type">file-type</a>,
-					and <a href="programming.html#output">Output (programming guide)</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="filter">
-				<h3>
-					<a>filter<span class="since">1.3</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">filter <i>reporter</i> <i>list</i></span>
-				</h4>
-				<p>
-					Reports a list containing only those items of <i>list</i> for which
-					the reporter reports true -- in other words, the items satisfying the
-					given condition. <i>reporter</i> may be an anonymous reporter or the
-					name of a reporter.
-				</p>
-				<pre>
-					show filter is-number? [1 &quot;2&quot; 3]
-					=&gt; [1 3]
-					show filter [ i -&gt; i &lt; 3 ] [1 3 2]
-					=&gt; [1 2]
-					show filter [ s -&gt; first s != &quot;t&quot; ] [&quot;hi&quot; &quot;there&quot; &quot;everyone&quot;]
-					=&gt; [&quot;hi&quot; &quot;everyone&quot;]
-				</pre>
-				<p>
-					See also <a href="#map">map</a>, <a href="#reduce">reduce</a>,
-					<a href="#arrow">-> (anonymous procedure)</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="first">
-				<h3>
-					<a>first<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">first <i>list</i></span>
-					<span class="prim_example">first <i>string</i></span>
-				</h4>
-				<p>
-					On a list, reports the first (0th) item in the list.
-				</p>
-				<p>
-					On a string, reports a one-character string containing only the
-					first character of the original string.
-				</p>
-			</div>
-			<div class="dict_entry" id="floor">
-				<h3>
-					<a>floor<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">floor <i>number</i></span>
-				</h4>
-				<p>
-					Reports the largest integer less than or equal to <i>number</i>.
-				</p>
-				<pre>
-					show floor 4.5
-					=&gt; 4
-					show floor -4.5
-					=&gt; -5
-				</pre>
-				<p>
-					See also <a href="#ceiling">ceiling</a>, <a href="#round">round</a>, <a href="#precision">precision</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="follow">
-				<h3>
-					<a>follow<span class="since">3.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">follow <i>turtle</i></span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Similar to ride, but, in the 3D view, the observer&apos;s vantage
-					point is behind and above <i>turtle</i>.
-				</p>
-				<p>
-					The observer may only watch or follow a single subject.
-					Calling <code>follow</code> will alter the highlight created by
-					prior calls to <code>watch</code> and <code>watch-me</code>, highlighting
-					the followed turtle instead.
-				</p>
-				<p>
-					See also <a href="#follow-me">follow-me</a>, <a href="#ride">ride</a>,
-					<a href="#reset-perspective">reset-perspective</a>, <a href="#watch">watch</a>, <a href="#subject">subject</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="follow-me">
-				<h3>
-					<a>follow-me<span class="since">3.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">follow-me</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Asks the observer to follow this turtle.
-				</p>
-				<p>
-					The observer may only watch or follow a single subject.
-					Calling <code>follow-me</code> will remove the highlight created by
-					prior calls to <code>watch</code> and <code>watch-me</code>, highlighting
-					this turtle instead.
-				</p>
-				<p>
-					See also <a href="#follow">follow</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="foreach">
-				<h3>
-					<a>foreach<span class="since">1.3</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">foreach <i>list</i> <i>command</i></span>
-					<span class="prim_example">(foreach <i>list1</i> ... <i>command</i>)</span>
-				</h4>
-				<p>
-					With a single list, runs the command for each item of <i>list</i>.
-					<i>command</i> may be the name of a command, or an anonymous command
-					created with <a href="#arrow">-&gt;</a>.
-				</p>
-				<pre>
-					foreach [1.1 2.2 2.6] show
-					=&gt; 1.1
-					=&gt; 2.2
-					=&gt; 2.6
-					foreach [1.1 2.2 2.6] [ x -&gt; show (word x &quot; -&gt; &quot; round x) ]
-					=&gt; 1.1 -&gt; 1
-					=&gt; 2.2 -&gt; 2
-					=&gt; 2.6 -&gt; 3
-				</pre>
-				<p>
-					With multiple lists, runs <i>command</i> for each group of items
-					from each list.
-					So, they are run once for the first items, once for
-					the second items, and so on. All the lists must be the same length.
-				</p>
-				<p>
-					Some examples make this clearer:
-				</p>
-				<pre>
-					(foreach [1 2 3] [2 4 6]
-					[ [a b] -&gt; show word &quot;the sum is: &quot; (a + b) ])
-					=&gt; &quot;the sum is: 3&quot;
-					=&gt; &quot;the sum is: 6&quot;
-					=&gt; &quot;the sum is: 9&quot;
-					(foreach list (turtle 1) (turtle 2) [3 4]
-					[ [the-turtle num-steps] -&gt; ask the-turtle [ fd num-steps ] ])
-					;; turtle 1 moves forward 3 patches
-					;; turtle 2 moves forward 4 patches
-				</pre>
-				<p>
-					See also <a href="#map">map</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="forward">
-				<h3>
-					<a>forward<span class="since">1.0</span></a>
-					<a>fd<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">forward <i>number</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					The turtle moves forward by <i>number</i> steps, one step at a
-					time. (If <i>number</i> is negative, the turtle moves backward.)
-				</p>
-				<p>
-					<code>fd 10</code> is equivalent to <code>repeat 10 [ jump 1 ]</code>.
-					<code>fd 10.5</code> is equivalent to <code>repeat 10 [ jump 1 ] jump
-						0.5</code>.
-				</p>
-				<p>
-					If the turtle cannot move forward <i>number</i> steps because it is
-					not permitted by the current topology the turtle will complete as
-					many steps of 1 as it can, then stop.
-				</p>
-				<p>
-					See also <a href="#jump">jump</a>, <a href="#can-move">can-move?</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="fput">
-				<h3>
-					<a>fput<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">fput <i>item list</i></span>
-				</h4>
-				<p>
-					Adds <i>item</i> to the beginning of a list and reports the new
-					list.
-				</p>
-				<pre>
-					;; suppose mylist is [5 7 10]
-					set mylist fput 2 mylist
-					;; mylist is now [2 5 7 10]
-				</pre>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="G">
-			<a>G</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="globals">
-				<h3>
-					<a>globals</a>
-				</h3>
-				<h4>
-					<span class="prim_example">globals [<i>var1</i> ...]</span>
-				</h4>
-				<p>
-					This keyword, like the breed, <i>&lt;breeds&gt;</i>-own,
-					patches-own, and turtles-own keywords, can only be used at the
-					beginning of a program, before any function definitions. It defines
-					new global variables. Global variables are &quot;global&quot;
-					because they are accessible by all agents and can be used anywhere
-					in a model.
-				</p>
-				<p>
-					Most often, globals is used to define variables or constants that
-					need to be used in many parts of the program.
-				</p>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="H">
-			<a>H</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="hatch">
-				<h3>
-					<a>hatch<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hatch <i>number</i> [ <i>commands</i> ]</span>
-					<span class="prim_example">hatch-<i>&lt;breeds&gt;</i> <i>number</i> [ <i>commands</i> ]</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					This turtle creates <i>number</i> new turtles. Each new turtle
-					inherits of all its variables, including its location, from its
-					parent. (Exceptions: each new turtle will have a new <code>who</code>
-					number, and it may be of a different breed than its parent if the
-					<code>hatch-<i>&lt;breeds&gt;</i></code> form is used.)
-				</p>
-				<p>
-					The new turtles then run <i>commands</i>. You can use the commands
-					to give the new turtles different colors, headings, locations, or
-					whatever. (The new turtles are created all at once, then run one at
-					a time, in random order.)
-				</p>
-				<p>
-					If the hatch-<i>&lt;breeds&gt;</i> form is used, the new turtles
-					are created as members of the given breed. Otherwise, the new
-					turtles are the same breed as their parent.
-				</p>
-				<pre>
-					hatch 1 [ lt 45 fd 1 ]
-					;; this turtle creates one new turtle,
-					;; and the child turns and moves away
-					hatch-sheep 1 [ set color black ]
-					;; this turtle creates a new turtle
-					;; of the sheep breed
-				</pre>
-				<p>
-					See also <a href="#create-turtles">create-turtles</a>, <a href="#sprout">sprout</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="heading">
-				<h3>
-					<a>heading</a>
-				</h3>
-				<h4>
-					<span class="prim_example">heading</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					This is a built-in turtle variable. It indicates the direction the
-					turtle is facing. This is a number greater than or equal to 0 and
-					less than 360. 0 is north, 90 is east, and so on. You can set this
-					variable to make a turtle turn.
-				</p>
-				<p>
-					See also <a href="#right">right</a>, <a href="#left">left</a>,
-					<a href="#dxy">dx</a>, <a href="#dxy">dy</a>.
-				</p>
-				<p>
-					Example:
-				</p>
-				<pre>
-					set heading 45      ;; turtle is now facing northeast
-					set heading heading + 10 ;; same effect as &quot;rt 10&quot;
-				</pre>
-			</div>
-			<div class="dict_entry" id="hidden">
-				<h3>
-					<a>hidden?</a>
-				</h3>
-				<h4>
-					<span class="prim_example">hidden?</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					This is a built-in turtle or link variable. It holds a boolean
-					(true or false) value indicating whether the turtle or link is
-					currently hidden (i.e., invisible). You can set this variable to
-					make a turtle or link disappear or reappear.
-				</p>
-				<p>
-					See also <a href="#hide-turtle">hide-turtle</a>, <a href="#show-turtle">show-turtle</a>, <a href="#hide-link">hide-link</a>,
-					<a href="#show-link">show-link</a>
-				</p>
-				<p>
-					Example:
-				</p>
-				<pre>
-					set hidden? not hidden?
-					;; if turtle was showing, it hides, and if it was hiding,
-					;; it reappears
-				</pre>
-			</div>
-			<div class="dict_entry" id="hide-link">
-				<h3>
-					<a>hide-link<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hide-link</span>
-					<img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					The link makes itself invisible.
-				</p>
-				<p>
-					Note: This command is equivalent to setting the link variable
-					&quot;hidden?&quot; to true.
-				</p>
-				<p>
-					See also <a href="#show-turtle">show-link</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="hide-turtle">
-				<h3>
-					<a>hide-turtle<span class="since">1.0</span></a>
-					<a>ht<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hide-turtle</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					The turtle makes itself invisible.
-				</p>
-				<p>
-					Note: This command is equivalent to setting the turtle variable
-					&quot;hidden?&quot; to true.
-				</p>
-				<p>
-					See also <a href="#show-turtle">show-turtle</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="histogram">
-				<h3>
-					<a>histogram<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">histogram <i>list</i></span>
-				</h4>
-				<p>
-					Histograms the values in the given list
-				</p>
-				<p>
-					Draws a histogram showing the frequency distribution of the values
-					in the list. The heights of the bars in the histogram represent the
-					numbers of values in each subrange.
-				</p>
-				<p>
-					Before the histogram is drawn, first any previous points drawn by
-					the current plot pen are removed.
-				</p>
-				<p>
-					Any non-numeric values in the list are ignored.
-				</p>
-				<p>
-					The histogram is drawn on the current plot using the current plot
-					pen and pen color. Auto scaling does not affect a histogram's
-					horizontal range, so set-plot-x-range should be used to control the
-					range, and the pen interval can then be set (either directly with
-					set-plot-pen-interval, or indirectly via set-histogram-num-bars) to
-					control how many bars that range is split up into.
-				</p>
-				<p>
-					Be sure that if you want the histogram drawn with bars that the
-					current pen is in bar mode (mode 1).
-				</p>
-				<p>
-					For histogramming purposes the plot's X range is not considered
-					to include the maximum X value. Values equal to the maximum X will
-					fall outside of the histogram's range.
-				</p>
-				<pre>
-					histogram [color] of turtles
-					;; draws a histogram showing how many turtles there are
-					;; of each color
-				</pre>
-			</div>
-			<div class="dict_entry" id="home">
-				<h3>
-					<a>home<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">home</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					This turtle moves to the origin (0,0). Equivalent to <code>setxy 0
-						0</code>.
-				</p>
-			</div>
-			<div class="dict_entry" id="hsb">
-				<h3>
-					<a>hsb<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hsb <i>hue saturation brightness</i></span>
-				</h4>
-				<p>
-					Reports a RGB list when given three numbers describing an HSB
-					color. Hue, saturation, and brightness are integers in the range
-					0-360, 0-100, 0-100 respectively. The RGB list contains three
-					integers in the range of 0-255.
-				</p>
-				<p>
-					See also <a href="#rgb">rgb</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-broadcast">
-				<h3>
-					<a>hubnet-broadcast<span class="since">1.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-broadcast <i>tag-name value</i></span>
-				</h4>
-				<p>
-					This broadcasts <i>value</i> from NetLogo to the interface element
-					with the name <i>tag-name</i> on the clients.
-				</p>
-				<p>
-					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-					for details and instructions.
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-broadcast-clear-output">
-				<h3>
-					<a>hubnet-broadcast-clear-output<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-broadcast-clear-output</span>
-				</h4>
-				<p>
-					This clears all messages printed to the text area on every client.
-				</p>
-				<p>
-					See also: <a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>, <a href="#hubnet-send-clear-output">hubnet-send-clear-output</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-broadcast-message">
-				<h3>
-					<a>hubnet-broadcast-message<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-broadcast-message <i>value</i></span>
-				</h4>
-				<p>
-					This prints the value in the text area on each client. This is the
-					same functionality as the &quot;Broadcast Message&quot; button in
-					the HubNet Control Center.
-				</p>
-				<p>
-					See also: <a href="#hubnet-send-message">hubnet-send-message</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-clear-override">
-				<h3>
-					<a>hubnet-clear-override<span class="since">4.1</span></a>
-					<a>hubnet-clear-overrides<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-clear-override <i>client</i> <i>agent-or-set</i> <i>variable-name</i></span>
-					<span class="prim_example">hubnet-clear-overrides <i>client</i></span>
-				</h4>
-				<p>
-					Remove overrides from the override list on <i>client</i>.
-					<code>hubnet-clear-override</code> removes only the override for the
-					specified variable for the specified agent or agentset.
-					<code>hubnet-clear-overrides</code> removes all overrides from the
-					specified client.
-				</p>
-				<p>
-					See also: <a href="#hubnet-send-override">hubnet-send-override</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-clients-list">
-				<h3>
-					<a>hubnet-clients-list<span class="since">5.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-clients-list</span>
-				</h4>
-				<p>
-					Reports a list containing the names of all the clients currently
-					connected to the HubNet server.
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-enter-message">
-				<h3>
-					<a>hubnet-enter-message?<span class="since">1.2.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-enter-message?</span>
-				</h4>
-				<p>
-					Reports true if a new client just entered the simulation. Reports
-					false otherwise. <a href="#hubnet-message-source">hubnet-message-source</a> will contain the
-					user name of the client that just logged on.
-				</p>
-				<p>
-					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-					for details and instructions.
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-exit-message">
-				<h3>
-					<a>hubnet-exit-message?<span class="since">1.2.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-exit-message?</span>
-				</h4>
-				<p>
-					Reports true if a client just exited the simulation. Reports false
-					otherwise. <a href="#hubnet-message-source">hubnet-message-source</a> will contain the
-					user name of the client that just logged off.
-				</p>
-				<p>
-					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-					for details and instructions.
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-fetch-message">
-				<h3>
-					<a>hubnet-fetch-message<span class="since">1.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-fetch-message</span>
-				</h4>
-				<p>
-					If there is any new data sent by the clients, this retrieves the
-					next piece of data, so that it can be accessed by <a href="#hubnet-message">hubnet-message</a>, <a href="#hubnet-message-source">hubnet-message-source</a>, and <a href="#hubnet-message-tag">hubnet-message-tag</a>. This will cause an
-					error if there is no new data from the clients.
-				</p>
-				<p>
-					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-					for details.
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-kick-client">
-				<h3>
-					<a>hubnet-kick-client<span class="since">5.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-kick-client <i>client-name</i></span>
-				</h4>
-				<p>
-					Kicks the client with the given client-name. This is equivalent to
-					clicking the client name in the HubNet Control Center and pressing
-					the Kick button.
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-kick-all-clients">
-				<h3>
-					<a>hubnet-kick-all-clients<span class="since">5.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-kick-all-clients</span>
-				</h4>
-				<p>
-					Kicks out all currently connected HubNet clients. This is
-					equivalent to selecting all clients in the HubNet Control Center
-					and pressing the Kick button.
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-message">
-				<h3>
-					<a>hubnet-message<span class="since">1.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-message</span>
-				</h4>
-				<p>
-					Reports the message retrieved by <a href="#hubnet-fetch-message">hubnet-fetch-message</a>.
-				</p>
-				<p>
-					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-					for details.
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-message-source">
-				<h3>
-					<a>hubnet-message-source<span class="since">1.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-message-source</span>
-				</h4>
-				<p>
-					Reports the name of the client that sent the message retrieved by
-					<a href="#hubnet-fetch-message">hubnet-fetch-message</a>.
-				</p>
-				<p>
-					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-					for details.
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-message-tag">
-				<h3>
-					<a>hubnet-message-tag<span class="since">1.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-message-tag</span>
-				</h4>
-				<p>
-					Reports the tag that is associated with the data that was retrieved
-					by <a href="#hubnet-fetch-message">hubnet-fetch-message</a>. The
-					tag will be one of the Display Names of the interface elements in
-					the client interface.
-				</p>
-				<p>
-					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-					for details.
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-message-waiting">
-				<h3>
-					<a>hubnet-message-waiting?<span class="since">1.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-message-waiting?</span>
-				</h4>
-				<p>
-					This looks for a new message sent by the clients. It reports true
-					if there is one, and false if there is not.
-				</p>
-				<p>
-					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-					for details.
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-reset">
-				<h3>
-					<a>hubnet-reset<span class="since">1.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-reset</span>
-				</h4>
-				<p>
-					Starts up the HubNet system. HubNet must be started to use any of
-					the other hubnet primitives.
-				</p>
-				<p>
-					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-					for details.
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-reset-perspective">
-				<h3>
-					<a>hubnet-reset-perspective<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-reset-perspective <i>tag-name</i></span>
-				</h4>
-				<p>
-					Clears watch or follow sent directly to the client. The view
-					perspective will revert to the server perspective.
-				</p>
-				<p>
-					See also: <a href="#hubnet-send-watch">hubnet-send-watch</a>
-					<a href="#hubnet-send-follow">hubnet-send-follow</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-send">
-				<h3>
-					<a>hubnet-send<span class="since">1.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-send <i>string tag-name value</i></span>
-				</h4>
-				<h4>
-					<span class="prim_example">hubnet-send <i>list-of-strings tag-name value</i></span>
-				</h4>
-				<p>
-					For a <i>string</i>, this sends <i>value</i> from NetLogo to the
-					tag <i>tag-name</i> on the client that has <i>string</i> for its
-					user name.
-				</p>
-				<p>
-					For a <i>list-of-strings</i>, this sends <i>value</i> from NetLogo
-					to the tag <i>tag-name</i> on all the clients that have a user name
-					that is in the <i>list-of-strings</i>.
-				</p>
-				<p>
-					Sending a message to a non-existent client, using
-					<code>hubnet-send</code>, generates a <code>hubnet-exit-message</code>.
-				</p>
-				<p>
-					See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
-					for details.
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-send-clear-output">
-				<h3>
-					<a>hubnet-send-clear-output<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-send-clear-output <i>string</i></span>
-				</h4>
-				<h4>
-					<span class="prim_example">hubnet-send-clear-output <i>list-of-strings</i></span>
-				</h4>
-				<p>
-					This clears all messages printed to the text area on the given
-					client or clients (specified in the <i>string</i> or
-					<i>list-of-strings</i>.
-				</p>
-				<p>
-					See also: <a href="#hubnet-send-message">hubnet-send-message</a>,
-					<a href="#hubnet-broadcast-clear-output">hubnet-broadcast-clear-output</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-send-follow">
-				<h3>
-					<a>hubnet-send-follow<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-send-follow <i>client-name agent radius</i></span>
-				</h4>
-				<p>
-					Tells the client associated with <i>client-name</i> to follow
-					<i>agent</i> showing a <i>radius</i> sized Moore neighborhood
-					around the agent.
-				</p>
-				<p>
-					A client may only watch or follow a single subject.
-					Calling <code>hubnet-send-follow</code> will alter the highlight created by
-					prior calls to <code>hubnet-send-watch</code>, highlighting
-					the followed agent instead.
-				</p>
-				<p>
-					See also: <a href="#hubnet-send-watch">hubnet-send-watch</a>,
-					<a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-send-message">
-				<h3>
-					<a>hubnet-send-message<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-send-message <i>string</i> <i>value</i></span>
-				</h4>
-				<p>
-					This prints <code>value</code> in the text area on the client specified
-					by <code>string</code>.
-				</p>
-				<p>
-					See also: <a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-send-override">
-				<h3>
-					<a>hubnet-send-override<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-send-override <i>client-name agent-or-set variable-name</i></span>
-					<span class="prim_example">[ <i>reporter</i> ]</span>
-				</h4>
-				<p>
-					Evaluates <i>reporter</i> for the agent or agentset indicated then
-					sends the values to the client to &quot;override&quot; the value of
-					<i>variable-name</i> only on <i>client-name</i>. This is used to
-					change the appearance of agents in the client view, hence, only
-					built-in variables that affect the appearance of the agent may be
-					selected. For example, you can override the color variable of a
-					turtle:
-				</p>
-				<pre>
-					ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
-				</pre>
-				<p>
-					In this example assume that there is a turtles-own variable
-					client-name which is associated with a logged in client, and all
-					the turtles are blue. This code makes the turtle associated with
-					each client appear red in his or her own view but not on anyone
-					else's or on the server.
-				</p>
-				<p>
-					See also: <a href="#hubnet-clear-override">hubnet-clear-overrides</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="hubnet-send-watch">
-				<h3>
-					<a>hubnet-send-watch<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">hubnet-send-watch <i>client-name agent</i></span>
-				</h4>
-				<p>
-					Tells the client associated with <i>client-name</i> to watch
-					<i>agent</i>.
-				</p>
-				<p>
-					A client may only watch or follow a single subject.
-					Calling <code>hubnet-send-watch</code> will undo perspective changes caused
-					by prior calls to <code>hubnet-send-follow</code>.
-				</p>
-				<p>
-					See also: <a href="#hubnet-send-follow">hubnet-send-follow</a>,
-					<a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
-				</p>
-			</div>
-		</div> <!-- ======================================== -->
-		<h2 id="I">
-			<a>I</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="if">
-				<h3>
-					<a>if<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">if <i>condition</i> [ <i>commands</i> ]</span>
-				</h4>
-				<p>
-					Reporter must report a boolean (true or false) value.
-				</p>
-				<p>
-					If <i>condition</i> reports true, runs <i>commands</i>.
-				</p>
-				<p>
-					The reporter may report a different value for different agents, so
-					some agents may run <i>commands</i> and others don't.
-				</p>
-				<pre>
-					if xcor &gt; 0[ set color blue ]
-					;; turtles in the right half of the world
-					;; turn blue
-				</pre>
-				<p>
-					See also <a href="#ifelse">ifelse</a>, <a href="#ifelse-value">ifelse-value</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="ifelse">
-				<h3>
-					<a>ifelse<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">ifelse <i>reporter1</i> [ <i>commands1</i> ] [ <i>elsecommands</i> ]</span>
-					<span class="prim_example">(ifelse <i>reporter1</i> [ <i>commands1</i> ] <i>reporter2</i> [ <i>commands2</i> ] ... [ <i>elsecommands</i> ])</span>
-				</h4>
-				<p>
-					The <i>reporter</i>s must report boolean (true or false) values.
-				</p>
-				<p>
-					For the first <i>reporter</i> that reports true, runs the <i>commands</i> that follow.
-				</p>
-				<p>
-					If no <i>reporter</i> reports true, runs <i>elsecommands</i> or does nothing if
-					<i>elsecommands</i> is not given.  When using only one <i>reporter</i>
-					you do not need to surround the entire <i>ifelse</i> primitive and its blocks in parentheses.
-				</p>
-				<pre>
-					ask patches
-					[ ifelse pxcor &gt; 0
-					[ set pcolor blue ]
-					[ set pcolor red ] ]
-					;; the left half of the world turns red and
-					;; the right half turns blue
-				</pre>
-				<p>
-					The reporters may report a different value for different agents, so
-					some agents may run different command blocks.  When using more than one <i>reporter</i> you
-					must surround the whole <i>ifelse</i> primitive and its blocks in parentheses.
-				</p>
-				<pre>
-					ask patches [
-					let choice random 4
-					(ifelse
-					choice = 0 [
-					set pcolor red
-					set plabel "r"
-					]
-					choice = 1 [
-					set pcolor blue
-					set plabel "b"
-					]
-					choice = 2 [
-					set pcolor green
-					set plabel "g"
-					]
-					; elsecommands
-					[
-					set pcolor yellow
-					set plabel "y"
-					])
-					]
-				</pre>
-				<p>
-					See also <a href="#if">if</a>, <a href="#ifelse-value">ifelse-value</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="ifelse-value">
-				<h3>
-					<a>ifelse-value<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">ifelse-value <i>tfreporter1</i> [ <i>reporter1</i> ] [ <i>elsereporter</i> ]</span>
-					<span class="prim_example">(ifelse-value <i>tfreporter1</i> [ <i>reporter1</i> ] <i>tfreporter2</i> [ <i>reporter2</i> ] ... [ <i>elsereporter</i> ])</span>
-				</h4>
-				<p>
-					The <i>tfreporter</i>s must report boolean (true or false) values.
-				</p>
-				<p>
-					For the first <i>tfreporter</i> that reports true, runs the
-					<i>reporter</i> that follows and reports that result.  When using only one <i>tfreporter1</i>
-					you do not need to surround the entire <i>ifelse-value</i> primitive and its blocks in parentheses.
-				</p>
-				<p>
-					If all <i>tfreporter</i>s report false, the result is the value of
-					<i>elsereporter</i>.  You may leave out the <i>elsereporter</i>, but
-					if all <i>tfreporter</i>s report false then a runtime error will occur.
-				</p>
-				<p>
-					This can be used when a conditional is needed in the context of a
-					reporter, where commands (such as <a href="#ifelse">ifelse</a>) are
-					not allowed.
-				</p>
-				<pre>
-					ask patches [
-					set pcolor ifelse-value (pxcor &gt; 0) [blue] [red]
-					]
-					;; the left half of the world turns red and
-					;; the right half turns blue
-					show n-values 10 [ifelse-value (? &lt; 5) [0] [1]]
-					=&gt; [0 0 0 0 0 1 1 1 1 1]
-					show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
-					[1 3 2 5 3 8 3 2 1]
-					=&gt; 8
-				</pre>
-				<p>
-					When using more than one <i>tfreporter</i> you
-					must surround the whole <i>ifelse-value</i> primitive and its blocks in parentheses.
-				</p>
-				<pre>
-					ask patches [
-					let choice random 4
-					set pcolor (ifelse-value
-					choice = 0 [ red ]
-					choice = 1 [ blue ]
-					choice = 2 [ green ]
-					[ yellow ])
-					]
-				</pre>
-				<p>
-					A runtime error can occur if there is no <i>elsereporter</i>.
-				</p>
-				<pre>
-					ask patches [
-					let x = 2
-					set pcolor (ifelse-value
-					x = 0 [ red ]
-					x = 1 [ blue ]
-					; no final else reporter is given, and x is 2 so there will be a runtime error
-					)
-				</pre>
-				<p>
-					See also <a href="#if">if</a>, <a href="#ifelse">ifelse</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="import-drawing">
-				<h3>
-					<a>import-drawing<span class="since">3.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">import-drawing <i>filename</i></span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Reads an image file into the drawing, scaling it to the size of the
-					world, while retaining the original aspect ratio of the image. The
-					image is centered in the drawing. The old drawing is not cleared
-					first.
-				</p>
-				<p>
-					Agents cannot sense the drawing, so they cannot interact with or
-					process images imported by import-drawing. If you need agents to
-					sense an image, use <a href="#import-pcolors">import-pcolors</a> or
-					<a href="#import-pcolors-rgb">import-pcolors-rgb</a>.
-				</p>
-				<p>
-					The following image file formats are supported: BMP, JPG, GIF, and
-					PNG. If the image format supports transparency (alpha), that
-					information will be imported as well.
-				</p>
-			</div>
-			<div class="dict_entry" id="import-pcolors">
-				<h3>
-					<a>import-pcolors<span class="since">3.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">import-pcolors <i>filename</i></span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Reads an image file, scales it to the same dimensions as the patch
-					grid while maintaining the original aspect ratio of the image, and
-					transfers the resulting pixel colors to the patches. The image is
-					centered in the patch grid. The resulting patch colors may be
-					distorted, since the NetLogo color space does not include all
-					possible colors. (See the Color section of the Programming Guide.)
-					import-pcolors may be slow for some images, particularly when you
-					have many patches and a large image with many different colors.
-				</p>
-				<p>
-					Since import-pcolors sets the pcolor of patches, agents can sense
-					the image. This is useful if agents need to analyze, process, or
-					otherwise interact with the image. If you want to simply display a
-					static backdrop, without color distortion, see <a href="#import-drawing">import-drawing</a>.
-				</p>
-				<p>
-					The following image file formats are supported: BMP, JPG, GIF, and
-					PNG. If the image format supports transparency (alpha), then all
-					fully transparent pixels will be ignored. (Partially transparent
-					pixels will be treated as opaque.)
-				</p>
-			</div>
-			<div class="dict_entry" id="import-pcolors-rgb">
-				<h3>
-					<a>import-pcolors-rgb<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">import-pcolors-rgb <i>filename</i></span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Reads an image file, scales it to the same dimensions as the patch
-					grid while maintaining the original aspect ratio of the image, and
-					transfers the resulting pixel colors to the patches. The image is
-					centered in the patch grid. Unlike <a href="#import-pcolors">import-pcolors</a> the exact colors in the
-					original image are retained. The pcolor variable of all the patches
-					will be an RGB list rather than an (approximated) NetLogo color.
-				</p>
-				<p>
-					The following image file formats are supported: BMP, JPG, GIF, and
-					PNG. If the image format supports transparency (alpha), then all
-					fully transparent pixels will be ignored. (Partially transparent
-					pixels will be treated as opaque.)
-				</p>
-			</div>
-			<div class="dict_entry" id="import-world">
-				<h3>
-					<a>import-world<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">import-world <i>filename</i></span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Reads the values of all variables for a model, both built-in and
-					user-defined, including all observer, turtle, and patch variables,
-					from an external file named by the given string. The file should be
-					in the format used by the <a href="#export-cmds">export-world</a>
-					primitive.
-				</p>
-				<p>
-					Note that the functionality of this primitive is also directly
-					available from NetLogo's File menu.
-				</p>
-				<p>
-					When using import-world, to avoid errors, perform these steps in
-					the following order:
-				</p>
-				<ol>
-					<li>Open the model from which you created the export file.</li>
-					<li>Press the Setup button, to get the model in a state from which
-						it can be run.</li>
-					<li>Import the file.</li>
-					<li>Re-open any files that the model had opened with the
-						<code>file-open</code> command.</li>
-					<li>If you want, press Go button to continue running the model from
-						the point where it left off.</li>
-				</ol>
-				<p>
-					If you wish to import a file from a location other than the
-					model's location, you may include the full path to the file you
-					wish to import. See <a href="#export-cmds">export-world</a> for an
-					example.
-				</p>
-			</div>
-			<div class="dict_entry" id="in-cone">
-				<h3>
-					<a>in-cone<span class="since">3.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example"><i>agentset</i> in-cone <i>distance</i> <i>angle</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					This reporter lets you give a turtle a &quot;cone of vision&quot;
-					in front of itself. The cone is defined by the two inputs, the
-					vision distance (radius) and the viewing angle. The viewing angle
-					may range from 0 to 360 and is centered around the turtle's
-					current heading. (If the angle is 360, then in-cone is equivalent
-					to in-radius.)
-				</p>
-				<p>
-					in-cone reports an agentset that includes only those agents from
-					the original agentset that fall in the cone. (This can include the
-					agent itself.)
-				</p>
-				<p>
-					The distance to a patch is measured from the center of the patch.
-				</p>
-				<pre>
-					ask turtles
-					[ ask patches in-cone 3 60
-					[ set pcolor red ] ]
-					;; each turtle makes a red &quot;splotch&quot; of patches in a 60 degree
-					;; cone of radius 3 ahead of itself
-				</pre>
-			</div>
-			<div class="dict_entry" id="in-link-neighbor">
-				<h3>
-					<a>in-&lt;breed&gt;-neighbor?</a>
-					<a>in-link-neighbor?<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">in-&lt;breed&gt;-neighbor? <i>agent</i></span>
-					<span class="prim_example">in-link-neighbor? <i>turtle</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Reports true if there is a directed link going from <i>turtle</i>
-					to the caller or an undirected link connecting <i>turtle</i> to the
-					caller. You can think of this as "is there a link I can use to get from
-					<i>turtle</i> to the caller?"
-				</p>
-				<pre>
-					crt 2
-					ask turtle 0 [
-					create-link-to turtle 1
-					show in-link-neighbor? turtle 1  ;; prints false
-					show out-link-neighbor? turtle 1 ;; prints true
-					]
-					ask turtle 1 [
-					show in-link-neighbor? turtle 0  ;; prints true
-					show out-link-neighbor? turtle 0 ;; prints false
-					]
-				</pre>
-			</div>
-			<div class="dict_entry" id="in-link-neighbors">
-				<h3>
-					<a>in-&lt;breed&gt;-neighbors</a>
-					<a>in-link-neighbors<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">in-&lt;breed&gt;-neighbors</span>
-					<span class="prim_example">in-link-neighbors</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Reports the agentset of all the turtles that have directed links coming
-					from them to the caller as well as all turtles that have an undirected
-					link connecting them with the caller. You can think of this as "all the
-					turtles that can get to the caller using a link."
-				</p>
-				<pre>
-					crt 4
-					ask turtle 0 [ create-links-to other turtles ]
-					ask turtle 1 [ ask in-link-neighbors [ set color blue ] ] ;; turtle 0 turns blue
-				</pre>
-			</div>
-			<div class="dict_entry" id="in-link-from">
-				<h3>
-					<a>in-&lt;breed&gt;-from</a>
-					<a>in-link-from<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">in-&lt;breed&gt;-from <i>turtle</i></span>
-					<span class="prim_example">in-link-from <i>turtle</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Reports a directed link from <i>turtle</i> to the caller or an
-					undirected link connecting the two. If no link exists then it
-					reports nobody. If more than one such link exists, reports a
-					random one. You can think of this as "give me a link that I can use
-					to travel from <i>turtle</i> to the caller."
-				</p>
-				<pre>
-					crt 2
-					ask turtle 0 [ create-link-to turtle 1 ]
-					ask turtle 1 [ show in-link-from turtle 0 ] ;; shows link 0 1
-					ask turtle 0 [ show in-link-from turtle 1 ] ;; shows nobody
-				</pre>
-				<p>
-					See also: <a href="#out-link-to">out-link-to</a> <a href="#link-with">link-with</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="includes">
-				<h3>
-					<a>__includes<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">__includes [ <i>filename</i> ... ]</span>
-				</h4>
-				<p>
-					Causes external NetLogo source files (with the <code>.nls</code>
-					suffix) to be included in this model. Included files may contain
-					breed, variable, and procedure definitions. <code>__includes</code> can
-					only be used once per file.
-				</p>
-				<p>
-					The file names must be strings, for example:
-				</p>
-				<pre>
-					__includes [ &quot;utils.nls&quot; ]
-				</pre>
-				<p>
-					Or, for multiple files:
-				</p>
-				<pre>
-					__includes [ &quot;utils1.nls&quot; &quot;utils2.nls&quot; ]
-				</pre>
-			</div>
-			<div class="dict_entry" id="in-radius">
-				<h3>
-					<a>in-radius<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example"><i>agentset</i> in-radius <i>number</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					Reports an agentset that includes only those agents from the
-					original agentset whose distance from the caller is less than or
-					equal to <i>number</i>. (This can include the agent itself.)
-				</p>
-				<p>
-					The distance to or a from a patch is measured from the center of
-					the patch.
-				</p>
-				<pre>
-					ask turtles
-					[ ask patches in-radius 3
-					[ set pcolor red ] ]
-					;; each turtle makes a red &quot;splotch&quot; around itself
-				</pre>
-			</div>
+          ask turtle 0 [ show one-of my-in-links ]
+          ;; prints (street 0 1)
+          ask turtle 0 [ show one-of my-out-links ]
+          ;; prints (highway 1 0)
+        </pre>
+        <p>
+          See also <a href="#breed">breed</a>, <a href="#undirected-link-breed">undirected-link-breed</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="display">
+        <h3>
+          <a>display<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">display</span>
+        </h4>
+        <p>
+          Causes the view to be updated immediately. (Exception: if the user
+          is using the speed slider to fast-forward the model, then the
+          update may be skipped.)
+        </p>
+        <p>
+          Also undoes the effect of the no-display command, so that if view
+          updates were suspended by that command, they will resume.
+        </p>
+        <pre>
+          no-display
+          ask turtles [ jump 10 set color blue set size 5 ]
+          display
+          ;; turtles move, change color, and grow, with none of
+          ;; their intermediate states visible to the user, only
+          ;; their final state
+        </pre>
+        <p>
+          Even if no-display was not used, &quot;display&quot; can still be
+          useful, because ordinarily NetLogo is free to skip some view
+          updates, so that fewer total updates take place, so that models run
+          faster. This command lets you force a view update, so whatever
+          changes have taken place in the world are visible to the user.
+        </p>
+        <pre>
+          ask turtles [ set color red ]
+          display
+          ask turtles [ set color blue]
+          ;; turtles turn red, then blue; use of &quot;display&quot; forces
+          ;; red turtles to appear briefly
+        </pre>
+        <p>
+          Note that display and no-display operate independently of the
+          switch in the view control strip that freezes the view.
+        </p>
+        <p>
+          See also <a href="#no-display">no-display</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="distance">
+        <h3>
+          <a>distance<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">distance <i>agent</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          Reports the distance from this agent to the given turtle or patch.
+        </p>
+        <p>
+          The distance to or a from a patch is measured from the center of
+          the patch. Turtles and patches use the wrapped distance (around the
+          edges of the world) if wrapping is allowed by the topology and the
+          wrapped distance is shorter.
+        </p>
+        <pre>
+          ask turtles [ show max-one-of turtles [distance myself] ]
+          ;; each turtle prints the turtle farthest from itself
+        </pre>
+      </div>
+      <div class="dict_entry" id="distancexy">
+        <h3>
+          <a>distancexy<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">distancexy <i>x</i> <i>y</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          Reports the distance from this agent to the point (<i>x</i>,
+          <i>y</i>).
+        </p>
+        <p>
+          The distance from a patch is measured from the center of the patch.
+          Turtles and patches use the wrapped distance (around the edges of
+          the world) if wrapping is allowed by the topology and the wrapped
+          distance is shorter.
+        </p>
+        <pre>
+          if (distancexy 0 0) &gt; 10
+          [ set color green ]
+          ;; all turtles more than 10 units from
+          ;; the center of the world turn green.
+        </pre>
+      </div>
+      <div class="dict_entry" id="downhill">
+        <h3>
+          <a>downhill<span class="since">1.0</span></a>
+          <a>downhill4<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">downhill <i>patch-variable</i></span>
+          <span class="prim_example">downhill4 <i>patch-variable</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Moves the turtle to the neighboring patch with the lowest value for
+          <i>patch-variable</i>. If no neighboring patch has a smaller value
+          than the current patch, the turtle stays put. If there are multiple
+          patches with the same lowest value, the turtle picks one randomly.
+          Non-numeric values are ignored.
+        </p>
+        <p>
+          downhill considers the eight neighboring patches; downhill4 only
+          considers the four neighbors.
+        </p>
+        <p>
+          Equivalent to the following code (assumes variable values are
+          numeric):
+        </p>
+        <pre>
+          move-to patch-here  ;; go to patch center
+          let p min-one-of neighbors [<i>patch-variable</i>]  ;; or neighbors4
+          if [<i>patch-variable</i>] of p &lt; <i>patch-variable</i> [
+          face p
+          move-to p
+          ]
+        </pre>
+        <p>
+          Note that the turtle always ends up on a patch center and has a
+          heading that is a multiple of 45 (downhill) or 90 (downhill4).
+        </p>
+        <p>
+          See also <a href="#uphill">uphill</a>, <a href="#uphill">uphill4</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="dxy">
+        <h3>
+          <a>dx<span class="since">1.0</span></a>
+          <a>dy<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">dx</span>
+          <span class="prim_example">dy</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Reports the x-increment or y-increment (the amount by which the
+          turtle's xcor or ycor would change) if the turtle were to take
+          one step forward in its current heading.
+        </p>
+        <p>
+          Note: dx is simply the sine of the turtle's heading, and dy is
+          simply the cosine. (If this is the reverse of what you expected,
+          it's because in NetLogo a heading of 0 is north and 90 is east,
+          which is the reverse of how angles are usually defined in
+          geometry.)
+        </p>
+        <p>
+          Note: In earlier versions of NetLogo, these primitives were used in
+          many situations where the new <code>patch-ahead</code> primitive is now
+          more appropriate.
+        </p> <!-- ======================================== -->
+      </div>
+    </div>
+    <h2 id="E">
+      <a>E</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="empty">
+        <h3>
+          <a>empty?<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">empty? <i>list</i></span>
+          <span class="prim_example">empty? <i>string</i></span>
+        </h4>
+        <p>
+          Reports true if the given list or string is empty, false otherwise.
+        </p>
+        <p>
+          Note: the empty list is written <code>[]</code>. The empty string is
+          written <code>&quot;&quot;</code>.
+        </p>
+      </div>
+      <div class="dict_entry" id="end">
+        <h3>
+          <a>end</a>
+        </h3>
+        <h4>
+          <span class="prim_example">end</span>
+        </h4>
+        <p>
+          Used to conclude a procedure. See <a href="#to">to</a> and <a href="#to-report">to-report</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="end1">
+        <h3>
+          <a>end1<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">end1</span>
+          <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          This is a built-in link variable. It indicates the first endpoint
+          (turtle) of a link. For directed links this will always be the
+          source for undirected links it will always be the turtle with the
+          lower who number. You cannot set end1.
+        </p>
+        <pre>
+          crt 2
+          ask turtle 0
+          [ create-link-to turtle 1 ]
+          ask links
+          [ show end1 ] ;; shows turtle 0
+        </pre>
+      </div>
+      <div class="dict_entry" id="end2">
+        <h3>
+          <a>end2<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">end2</span>
+          <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          This is a built-in link variable. It indicates the second endpoint
+          (turtle) of a link. For directed links this will always be the
+          destination for undirected links it will always be the turtle with
+          the higher who number. You cannot set end2.
+        </p>
+        <pre>
+          crt 2
+          ask turtle 1
+          [ create-link-with turtle 0 ]
+          ask links
+          [ show end2 ] ;; shows turtle 1
+        </pre>
+      </div>
+      <div class="dict_entry" id="error">
+        <h3>
+          <a>error<span class="since">5.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">error <i>value</i></span>
+        </h4>
+        <p>
+          Causes a runtime error to occur.
+        </p>
+        <p>
+          The given value is converted to a string (if it isn't one
+          already) and used as the error message.
+        </p>
+        <p>
+          See also <a href="#error-message">error-message</a>, <a href="#carefully">carefully</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="error-message">
+        <h3>
+          <a>error-message<span class="since">2.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">error-message</span>
+        </h4>
+        <p>
+          Reports a string describing the error that was suppressed by
+          carefully.
+        </p>
+        <p>
+          This reporter can only be used in the second block of a carefully
+          command.
+        </p>
+        <p>
+          See also <a href="#error">error</a>, <a href="#carefully">carefully</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="every">
+        <h3>
+          <a>every<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">every <i>number</i> [ <i>commands</i> ]</span>
+        </h4>
+        <p>
+          Runs the given commands only if it's been more than
+          <i>number</i> seconds since the last time this agent ran them in
+          this context. Otherwise, the commands are skipped.
+        </p>
+        <p>
+          By itself, every doesn't make commands run over and over again.
+          You need to use every inside a loop, or inside a forever button, if
+          you want the commands run over and over again. every only limits
+          how often the commands run.
+        </p>
+        <p>
+          Above, &quot;in this context&quot; means during the same ask (or
+          button press or command typed in the Command Center). So it
+          doesn't make sense to write <code>ask turtles [ every 0.5 [ ... ]
+            ]</code>, because when the ask finishes the turtles will all discard
+          their timers for the &quot;every&quot;. The correct usage is shown
+          below.
+        </p>
+        <pre>
+          every 0.5 [ ask turtles [ fd 1 ] ]
+          ;; twice a second the turtles will move forward 1
+          every 2 [ set index index + 1 ]
+          ;; every 2 seconds index is incremented
+        </pre>
+        <p>
+          See also <a href="#wait">wait</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="exp">
+        <h3>
+          <a>exp<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">exp <i>number</i></span>
+        </h4>
+        <p>
+          Reports the value of e raised to the <i>number</i> power.
+        </p>
+        <p>
+          Note: This is the same as e ^ <i>number</i>.
+        </p>
+      </div>
+      <div class="dict_entry" id="export-cmds">
+        <h3>
+          <a>export-view<span class="since">3.0</span></a>
+          <a>export-interface<span class="since">2.0</span></a>
+          <a>export-output<span class="since">1.0</span></a>
+          <a>export-plot<span class="since">1.0</span></a>
+          <a>export-all-plots<span class="since">1.2.1</span></a>
+          <a>export-world<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">export-view <i>filename</i></span>
+          <span class="prim_example">export-interface <i>filename</i></span>
+          <span class="prim_example">export-output <i>filename</i></span>
+          <span class="prim_example">export-plot <i>plotname</i> <i>filename</i></span>
+          <span class="prim_example">export-all-plots <i>filename</i></span>
+          <span class="prim_example">export-world <i>filename</i></span>
+        </h4>
+        <p>
+          export-view writes the current contents of the current view to an
+          external file given by the string <i>filename</i>. The file is
+          saved in PNG (Portable Network Graphics) format, so it is
+          recommended to supply a filename ending in &quot;.png&quot;.
+        </p>
+        <p>
+          export-interface is similar, but for the whole interface tab.
+        </p>
+        <p>
+          Note that export-view still works when running NetLogo in headless
+          mode, but export-interface doesn't.
+        </p>
+        <p>
+          export-output writes the contents of the model's output area to
+          an external file given by the string <i>filename</i>. (If the model
+          does not have a separate output area, the output portion of the
+          Command Center is used.)
+        </p>
+        <p>
+          export-plot writes the x and y values of all points plotted by all
+          the plot pens in the plot given by the string <i>plotname</i> to an
+          external file given by the string <i>filename</i>. If a pen is in
+          bar mode (mode 0) and the y value of the point plotted is greater
+          than 0, the upper-left corner point of the bar will be exported. If
+          the y value is less than 0, then the lower-left corner point of the
+          bar will be exported.
+        </p>
+        <p>
+          export-all-plots writes every plot in the current model to an
+          external file given by the string <i>filename</i>. Each plot is
+          identical in format to the output of export-plot.
+        </p>
+        <p>
+          export-world writes the values of all variables, both built-in and
+          user-defined, including all observer, turtle, and patch variables,
+          the drawing, the contents of the output area if one exists, the
+          contents of any plots and the state of the random number generator,
+          to an external file given by the string <i>filename</i>. (The
+          result file can be read back into NetLogo with the <a href="#import-world">import-world</a> primitive.) export-world does not
+          save the state of open files.
+        </p>
+        <p>
+          export-plot, export-all-plots and export-world save files in in
+          plain-text, &quot;comma-separated values&quot; (<code>.csv</code>)
+          format. CSV files can be read by most popular spreadsheet and
+          database programs as well as any text editor.
+        </p>
+        <p>
+          If you wish to export to a file in a location other than the
+          model's location, you should include the full path to the file
+          you wish to export. (Use the forward-slash &quot;/&quot; as the
+          folder separator.)
+        </p>
+        <p>
+          Note that the functionality of these primitives is also available
+          directly from NetLogo's File menu.
+        </p>
+        <pre>
+          export-world &quot;fire.csv&quot;
+          ;; exports the state of the model to the file fire.csv
+          ;; located in the NetLogo folder
+          export-plot &quot;Temperature&quot; &quot;c:/My Documents/plot.csv&quot;
+          ;; exports the plot named
+          ;; &quot;Temperature&quot; to the file plot.csv located in
+          ;; the C:\My Documents folder
+          export-all-plots &quot;c:/My Documents/plots.csv&quot;
+          ;; exports all plots to the file plots.csv
+          ;; located in the C:\My Documents folder
+        </pre>
+        <p>
+          If the file already exists, it is overwritten. To avoid this you
+          may wish to use some method of generating fresh names. Examples:
+        </p>
+        <pre>
+          export-world user-new-file
+          export-world (word &quot;results &quot; date-and-time &quot;.csv&quot;) ;; Colon characters in the time cause errors on Windows
+          export-world (word &quot;results &quot; random-float 1.0 &quot;.csv&quot;)
+        </pre>
+      </div>
+      <div class="dict_entry" id="extensions">
+        <h3>
+          <a>extensions</a>
+        </h3>
+        <h4>
+          <span class="prim_example">extensions [<i>name</i> ...]</span>
+        </h4>
+        <p>
+          Allows the model to use primitives from the extensions with the
+          given names. See the <a href="extensions.html">Extensions guide</a>
+          for more information.
+        </p>
+      </div>
+      <div class="dict_entry" id="extract-hsb">
+        <h3>
+          <a>extract-hsb<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">extract-hsb <i>color</i></span>
+        </h4>
+        <p>
+          Reports a list of three values, the first (hue) in the range of
+          0 to 360, the second and third (brightness and saturation) in
+          the range of 0 to 100.
+        </p>
+        <p>
+          The given <i>color</i> can either be a NetLogo color in the
+          range 0 to 140, not including 140 itself, or an RGB list of
+          three values in the range 0 to 255 representing the levels
+          of red, green, and blue.
+        </p>
+        <pre>
+          show extract-hsb cyan
+          =&gt; [180 57.143 76.863]
+          show extract-hsb red
+          =&gt; [3.103 80.93 84.314]
+          show extract-hsb [255 0 0]
+          =&gt; [0 100 100]
+        </pre>
+        <p>
+          See also <a href="#approximate-hsb">approximate-hsb</a>, <a href="#approximate-rgb">approximate-rgb</a>, <a href="#extract-rgb">extract-rgb</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="extract-rgb">
+        <h3>
+          <a>extract-rgb<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">extract-rgb <i>color</i></span>
+        </h4>
+        <p>
+          Reports a list of three values in the range 0 to 255 representing
+          the levels of red, green, and blue, respectively, of the given
+          NetLogo <i>color</i> in the range 0 to 140, not including 140
+          itself.
+        </p>
+        <pre>
+          show extract-rgb red
+          =&gt; [215 50 41]
+          show extract-rgb cyan
+          =&gt; [84 196 196]
+        </pre>
+        <p>
+          See also <a href="#approximate-rgb">approximate-rgb</a>, <a href="#approximate-hsb">approximate-hsb</a>, <a href="#extract-hsb">extract-hsb</a>.
+        </p>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="F">
+      <a>F</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="face">
+        <h3>
+          <a>face<span class="since">3.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">face <i>agent</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Set the caller's heading towards <i>agent</i>.
+        </p>
+        <p>
+          If wrapping is allowed by the topology and the wrapped distance
+          (around the edges of the world) is shorter, face will use the
+          wrapped path.
+        </p>
+        <p>
+          If the caller and the agent are at the exact same position, the
+          caller's heading won't change.
+        </p>
+      </div>
+      <div class="dict_entry" id="facexy">
+        <h3>
+          <a>facexy<span class="since">3.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">facexy <i>x</i> <i>y</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Set the caller's heading towards the point (x,y).
+        </p>
+        <p>
+          If wrapping is allowed by the topology and the wrapped distance
+          (around the edges of the world) is shorter and wrapping is allowed,
+          facexy will use the wrapped path.
+        </p>
+        <p>
+          If the caller is on the point (x,y), the caller's heading
+          won't change.
+        </p>
+      </div>
+      <div class="dict_entry" id="file-at-end">
+        <h3>
+          <a>file-at-end?<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">file-at-end?</span>
+        </h4>
+        <p>
+          Reports true when there are no more characters left to read in from
+          the current file (that was opened previously with <a href="#file-open">file-open</a>). Otherwise, reports false.
+        </p>
+        <pre>
+          file-open &quot;my-file.txt&quot;
+          print file-at-end?
+          =&gt; false ;; Can still read in more characters
+          print file-read-line
+          =&gt; This is the last line in file
+          print file-at-end?
+          =&gt; true ;; We reached the end of the file
+        </pre>
+        <p>
+          See also <a href="#file-open">file-open</a>, <a href="#file-close-all">file-close-all</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="file-close">
+        <h3>
+          <a>file-close<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">file-close</span>
+        </h4>
+        <p>
+          Closes a file that has been opened previously with <a href="#file-open">file-open</a>.
+        </p>
+        <p>
+          Note that this and file-close-all are the only ways to restart to
+          the beginning of an opened file or to switch between file modes.
+        </p>
+        <p>
+          If no file is open, does nothing.
+        </p>
+        <p>
+          See also <a href="#file-close-all">file-close-all</a>, <a href="#file-open">file-open</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="file-close-all">
+        <h3>
+          <a>file-close-all<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">file-close-all</span>
+        </h4>
+        <p>
+          Closes all files (if any) that have been opened previously with
+          <a href="#file-open">file-open</a>.
+        </p>
+        <p>
+          See also <a href="#file-close">file-close</a>, <a href="#file-open">file-open</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="file-delete">
+        <h3>
+          <a>file-delete<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">file-delete <i>string</i></span>
+        </h4>
+        <p>
+          Deletes the file specified as <i>string</i>
+        </p>
+        <p>
+          <i>string</i> must be an existing file with writable permission by
+          the user. Also, the file cannot be open. Use the command <a href="#file-close">file-close</a> to close an opened file before
+          deletion.
+        </p>
+        <p>
+          Note that the string can either be a file name or an absolute file
+          path. If it is a file name, it looks in whatever the current
+          directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It is defaulted
+          to the model's directory.
+        </p>
+      </div>
+      <div class="dict_entry" id="file-exists">
+        <h3>
+          <a>file-exists?<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">file-exists? <i>string</i></span>
+        </h4>
+        <p>
+          Reports true if <i>string</i> is the name of an existing file on
+          the system. Otherwise it reports false.
+        </p>
+        <p>
+          Note that the string can either be a file name or an absolute file
+          path. If it is a file name, it looks in whatever the current
+          directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It defaults to
+          to the model's directory.
+        </p>
+      </div>
+      <div class="dict_entry" id="file-flush">
+        <h3>
+          <a>file-flush<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">file-flush</span>
+        </h4>
+        <p>
+          Forces file updates to be written to disk. When you use file-write
+          or other output commands, the values may not be immediately written
+          to disk. This improves the performance of the file output commands.
+          Closing a file ensures that all output is written to disk.
+        </p>
+        <p>
+          Sometimes you need to ensure that data is written to disk without
+          closing the file. For example, you could be using a file to
+          communicate with another program on your machine and want the other
+          program to be able to see the output immediately.
+        </p>
+      </div>
+      <div class="dict_entry" id="file-open">
+        <h3>
+          <a>file-open<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">file-open <i>string</i></span>
+        </h4>
+        <p>
+          This command will interpret <i>string</i> as a path name to a file
+          and open the file. You may then use the reporters <a href="#file-read">file-read</a>, <a href="#file-read-line">file-read-line</a>, and <a href="#file-read-characters">file-read-characters</a> to read in from
+          the file, or <a href="#file-write">file-write</a>, <a href="#file-print">file-print</a>, <a href="#file-type">file-type</a>,
+          or <a href="#file-show">file-show</a> to write out to the file.
+        </p>
+        <p>
+          Note that you can only open a file for reading or writing but not
+          both. The next file i/o primitive you use after this command
+          dictates which mode the file is opened in. To switch modes, you
+          need to close the file using <a href="#file-close">file-close</a>.
+        </p>
+        <p>
+          Also, the file must already exist if opening a file in reading
+          mode.
+        </p>
+        <p>
+          When opening a file in writing mode, all new data will be appended
+          to the end of the original file. If there is no original file, a
+          new blank file will be created in its place. (You must have write
+          permission in the file's directory.) (If you don't want to
+          append, but want to replace the file's existing contents, use
+          <a href="#file-delete">file-delete</a> to delete it first, perhaps
+          inside a <a href="#carefully">carefully</a> if you're not sure
+          whether it already exists.)
+        </p>
+        <p>
+          Note that the string can either be a file name or an absolute file
+          path. If it is a file name, it looks in whatever the current
+          directory is. This can be changed using the command <a href="#set-current-directory">set-current-directory</a>. It is defaulted
+          to the model's directory.
+        </p>
+        <pre>
+          file-open &quot;my-file-in.txt&quot;
+          print file-read-line
+          =&gt; First line in file ;; File is in reading mode
+          file-open &quot;C:\\NetLogo\\my-file-out.txt&quot;
+          ;; assuming Windows machine
+          file-print &quot;Hello World&quot; ;; File is in writing mode
+        </pre>
+        <p>
+          Opening a file does not close previously opened files. You can use
+          <code>file-open</code> to switch back and forth between multiple open
+          files.
+        </p>
+        <p>
+          See also <a href="#file-close">file-close</a> See also <a href="#file-close-all">file-close-all</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="file-print">
+        <h3>
+          <a>file-print<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">file-print <i>value</i></span>
+        </h4>
+        <p>
+          Prints <i>value</i> to an opened file, followed by a carriage
+          return.
+        </p>
+        <p>
+          This agent is <i>not</i> printed before the value, unlike <a href="#file-show">file-show</a>.
+        </p>
+        <p>
+          Note that this command is the file i/o equivalent of <a href="#print">print</a>, and <a href="#file-open">file-open</a> needs to
+          be called before this command can be used.
+        </p>
+        <p>
+          See also <a href="#file-show">file-show</a>, <a href="#file-type">file-type</a>,
+          <a href="#file-write">file-write</a>,
+          and <a href="programming.html#output">Output (programming guide)</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="file-read">
+        <h3>
+          <a>file-read<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">file-read</span>
+        </h4>
+        <p>
+          This reporter will read in the next constant from the opened file
+          and interpret it as if it had been typed in the Command Center. It
+          reports the resulting value. The result may be a number, list,
+          string, boolean, or the special value nobody.
+        </p>
+        <p>
+          Whitespace separates the constants. Each call to file-read will
+          skip past both leading and trailing whitespace.
+        </p>
+        <p>
+          Note that strings need to have quotes around them. Use the command
+          <a href="#file-write">file-write</a> to have quotes included.
+        </p>
+        <p>
+          Also note that the <a href="#file-open">file-open</a> command must
+          be called before this reporter can be used, and there must be data
+          remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
+          of the file.
+        </p>
+        <pre>
+          file-open &quot;my-file.data&quot;
+          print file-read + 5
+          ;; Next value is the number 1
+          =&gt; 6
+          print length file-read
+          ;; Next value is the list [1 2 3 4]
+          =&gt; 4
+        </pre>
+        <p>
+          See also <a href="#file-open">file-open</a> and <a href="#file-write">file-write</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="file-read-characters">
+        <h3>
+          <a>file-read-characters<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">file-read-characters <i>number</i></span>
+        </h4>
+        <p>
+          Reports the given <i>number</i> of characters from an opened file
+          as a string. If there are fewer than that many characters left, it
+          will report all of the remaining characters.
+        </p>
+        <p>
+          Note that it will return every character including newlines and
+          spaces.
+        </p>
+        <p>
+          Also note that the <a href="#file-open">file-open</a> command must
+          be called before this reporter can be used, and there must be data
+          remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
+          of the file.
+        </p>
+        <pre>
+          file-open &quot;my-file.txt&quot;
+          print file-read-characters 5
+          ;; Current line in file is &quot;Hello World&quot;
+          =&gt; Hello
+        </pre>
+        <p>
+          See also <a href="#file-open">file-open</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="file-read-line">
+        <h3>
+          <a>file-read-line<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">file-read-line</span>
+        </h4>
+        <p>
+          Reads the next line in the file and reports it as a string. It
+          determines the end of the file by a carriage return, an end of file
+          character or both in a row. It does not return the line terminator
+          characters.
+        </p>
+        <p>
+          Also note that the <a href="#file-open">file-open</a> command must
+          be called before this reporter can be used, and there must be data
+          remaining in the file. Use the reporter <a href="#file-at-end">file-at-end?</a> to determine if you are at the end
+          of the file.
+        </p>
+        <pre>
+          file-open &quot;my-file.txt&quot;
+          print file-read-line
+          =&gt; Hello World
+        </pre>
+        <p>
+          See also <a href="#file-open">file-open</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="file-show">
+        <h3>
+          <a>file-show<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">file-show <i>value</i></span>
+        </h4>
+        <p>
+          Prints <i>value</i> to an opened file, preceded by this agent
+          agent, and followed by a carriage return. (This agent is included
+          to help you keep track of what agents are producing which lines of
+          output.) Also, all strings have their quotes included similar to
+          <a href="#file-write">file-write</a>.
+        </p>
+        <p>
+          Note that this command is the file i/o equivalent of <a href="#show">show</a>, and <a href="#file-open">file-open</a> needs to
+          be called before this command can be used.
+        </p>
+        <p>
+          See also <a href="#file-print">file-print</a>, <a href="#file-type">file-type</a>,
+          <a href="#file-write">file-write</a>,
+          and <a href="programming.html#output">Output (programming guide)</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="file-type">
+        <h3>
+          <a>file-type<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">file-type <i>value</i></span>
+        </h4>
+        <p>
+          Prints <i>value</i> to an opened file, <i>not</i> followed by a
+          carriage return (unlike <a href="#file-print">file-print</a> and
+          <a href="#file-show">file-show</a>). The lack of a carriage return
+          allows you to print several values on the same line.
+        </p>
+        <p>
+          This agent is <i>not</i> printed before the value. unlike <a href="#file-show">file-show</a>.
+        </p>
+        <p>
+          Note that this command is the file i/o equivalent of <a href="#type">type</a>, and <a href="#file-open">file-open</a> needs to
+          be called before this command can be used.
+        </p>
+        <p>
+          See also <a href="#file-print">file-print</a>, <a href="#file-show">file-show</a>, <a href="#file-write">file-write</a>, and
+          <a href="programming.html#output">Output (programming guide)</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="file-write">
+        <h3>
+          <a>file-write<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">file-write <i>value</i></span>
+        </h4>
+        <p>
+          This command will output <i>value</i>, which can be a number,
+          string, list, boolean, or nobody to an opened file, <i>not</i>
+          followed by a carriage return (unlike <a href="#file-print">file-print</a> and <a href="#file-show">file-show</a>).
+        </p>
+        <p>
+          This agent is <i>not</i> printed before the value, unlike <a href="#file-show">file-show</a>. Its output also includes quotes around
+          strings and is prepended with a space. It will output the value in
+          such a manner that <a href="#file-read">file-read</a> will be able
+          to interpret it.
+        </p>
+        <p>
+          Note that this command is the file i/o equivalent of <a href="#write">write</a>, and <a href="#file-open">file-open</a> needs to
+          be called before this command can be used.
+        </p>
+        <pre>
+          file-open &quot;locations.txt&quot;
+          ask turtles
+          [ file-write xcor file-write ycor ]
+        </pre>
+        <p>
+          See also <a href="#file-print">file-print</a>, <a href="#file-show">file-show</a>,
+          <a href="#file-type">file-type</a>,
+          and <a href="programming.html#output">Output (programming guide)</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="filter">
+        <h3>
+          <a>filter<span class="since">1.3</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">filter <i>reporter</i> <i>list</i></span>
+        </h4>
+        <p>
+          Reports a list containing only those items of <i>list</i> for which
+          the reporter reports true -- in other words, the items satisfying the
+          given condition. <i>reporter</i> may be an anonymous reporter or the
+          name of a reporter.
+        </p>
+        <pre>
+          show filter is-number? [1 &quot;2&quot; 3]
+          =&gt; [1 3]
+          show filter [ i -&gt; i &lt; 3 ] [1 3 2]
+          =&gt; [1 2]
+          show filter [ s -&gt; first s != &quot;t&quot; ] [&quot;hi&quot; &quot;there&quot; &quot;everyone&quot;]
+          =&gt; [&quot;hi&quot; &quot;everyone&quot;]
+        </pre>
+        <p>
+          See also <a href="#map">map</a>, <a href="#reduce">reduce</a>,
+          <a href="#arrow">-> (anonymous procedure)</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="first">
+        <h3>
+          <a>first<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">first <i>list</i></span>
+          <span class="prim_example">first <i>string</i></span>
+        </h4>
+        <p>
+          On a list, reports the first (0th) item in the list.
+        </p>
+        <p>
+          On a string, reports a one-character string containing only the
+          first character of the original string.
+        </p>
+      </div>
+      <div class="dict_entry" id="floor">
+        <h3>
+          <a>floor<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">floor <i>number</i></span>
+        </h4>
+        <p>
+          Reports the largest integer less than or equal to <i>number</i>.
+        </p>
+        <pre>
+          show floor 4.5
+          =&gt; 4
+          show floor -4.5
+          =&gt; -5
+        </pre>
+        <p>
+          See also <a href="#ceiling">ceiling</a>, <a href="#round">round</a>, <a href="#precision">precision</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="follow">
+        <h3>
+          <a>follow<span class="since">3.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">follow <i>turtle</i></span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Similar to ride, but, in the 3D view, the observer&apos;s vantage
+          point is behind and above <i>turtle</i>.
+        </p>
+        <p>
+          The observer may only watch or follow a single subject.
+          Calling <code>follow</code> will alter the highlight created by
+          prior calls to <code>watch</code> and <code>watch-me</code>, highlighting
+          the followed turtle instead.
+        </p>
+        <p>
+          See also <a href="#follow-me">follow-me</a>, <a href="#ride">ride</a>,
+          <a href="#reset-perspective">reset-perspective</a>, <a href="#watch">watch</a>, <a href="#subject">subject</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="follow-me">
+        <h3>
+          <a>follow-me<span class="since">3.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">follow-me</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Asks the observer to follow this turtle.
+        </p>
+        <p>
+          The observer may only watch or follow a single subject.
+          Calling <code>follow-me</code> will remove the highlight created by
+          prior calls to <code>watch</code> and <code>watch-me</code>, highlighting
+          this turtle instead.
+        </p>
+        <p>
+          See also <a href="#follow">follow</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="foreach">
+        <h3>
+          <a>foreach<span class="since">1.3</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">foreach <i>list</i> <i>command</i></span>
+          <span class="prim_example">(foreach <i>list1</i> ... <i>command</i>)</span>
+        </h4>
+        <p>
+          With a single list, runs the command for each item of <i>list</i>.
+          <i>command</i> may be the name of a command, or an anonymous command
+          created with <a href="#arrow">-&gt;</a>.
+        </p>
+        <pre>
+          foreach [1.1 2.2 2.6] show
+          =&gt; 1.1
+          =&gt; 2.2
+          =&gt; 2.6
+          foreach [1.1 2.2 2.6] [ x -&gt; show (word x &quot; -&gt; &quot; round x) ]
+          =&gt; 1.1 -&gt; 1
+          =&gt; 2.2 -&gt; 2
+          =&gt; 2.6 -&gt; 3
+        </pre>
+        <p>
+          With multiple lists, runs <i>command</i> for each group of items
+          from each list.
+          So, they are run once for the first items, once for
+          the second items, and so on. All the lists must be the same length.
+        </p>
+        <p>
+          Some examples make this clearer:
+        </p>
+        <pre>
+          (foreach [1 2 3] [2 4 6]
+          [ [a b] -&gt; show word &quot;the sum is: &quot; (a + b) ])
+          =&gt; &quot;the sum is: 3&quot;
+          =&gt; &quot;the sum is: 6&quot;
+          =&gt; &quot;the sum is: 9&quot;
+          (foreach list (turtle 1) (turtle 2) [3 4]
+          [ [the-turtle num-steps] -&gt; ask the-turtle [ fd num-steps ] ])
+          ;; turtle 1 moves forward 3 patches
+          ;; turtle 2 moves forward 4 patches
+        </pre>
+        <p>
+          See also <a href="#map">map</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="forward">
+        <h3>
+          <a>forward<span class="since">1.0</span></a>
+          <a>fd<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">forward <i>number</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          The turtle moves forward by <i>number</i> steps, one step at a
+          time. (If <i>number</i> is negative, the turtle moves backward.)
+        </p>
+        <p>
+          <code>fd 10</code> is equivalent to <code>repeat 10 [ jump 1 ]</code>.
+          <code>fd 10.5</code> is equivalent to <code>repeat 10 [ jump 1 ] jump
+            0.5</code>.
+        </p>
+        <p>
+          If the turtle cannot move forward <i>number</i> steps because it is
+          not permitted by the current topology the turtle will complete as
+          many steps of 1 as it can, then stop.
+        </p>
+        <p>
+          See also <a href="#jump">jump</a>, <a href="#can-move">can-move?</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="fput">
+        <h3>
+          <a>fput<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">fput <i>item list</i></span>
+        </h4>
+        <p>
+          Adds <i>item</i> to the beginning of a list and reports the new
+          list.
+        </p>
+        <pre>
+          ;; suppose mylist is [5 7 10]
+          set mylist fput 2 mylist
+          ;; mylist is now [2 5 7 10]
+        </pre>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="G">
+      <a>G</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="globals">
+        <h3>
+          <a>globals</a>
+        </h3>
+        <h4>
+          <span class="prim_example">globals [<i>var1</i> ...]</span>
+        </h4>
+        <p>
+          This keyword, like the breed, <i>&lt;breeds&gt;</i>-own,
+          patches-own, and turtles-own keywords, can only be used at the
+          beginning of a program, before any function definitions. It defines
+          new global variables. Global variables are &quot;global&quot;
+          because they are accessible by all agents and can be used anywhere
+          in a model.
+        </p>
+        <p>
+          Most often, globals is used to define variables or constants that
+          need to be used in many parts of the program.
+        </p>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="H">
+      <a>H</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="hatch">
+        <h3>
+          <a>hatch<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hatch <i>number</i> [ <i>commands</i> ]</span>
+          <span class="prim_example">hatch-<i>&lt;breeds&gt;</i> <i>number</i> [ <i>commands</i> ]</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          This turtle creates <i>number</i> new turtles. Each new turtle
+          inherits of all its variables, including its location, from its
+          parent. (Exceptions: each new turtle will have a new <code>who</code>
+          number, and it may be of a different breed than its parent if the
+          <code>hatch-<i>&lt;breeds&gt;</i></code> form is used.)
+        </p>
+        <p>
+          The new turtles then run <i>commands</i>. You can use the commands
+          to give the new turtles different colors, headings, locations, or
+          whatever. (The new turtles are created all at once, then run one at
+          a time, in random order.)
+        </p>
+        <p>
+          If the hatch-<i>&lt;breeds&gt;</i> form is used, the new turtles
+          are created as members of the given breed. Otherwise, the new
+          turtles are the same breed as their parent.
+        </p>
+        <pre>
+          hatch 1 [ lt 45 fd 1 ]
+          ;; this turtle creates one new turtle,
+          ;; and the child turns and moves away
+          hatch-sheep 1 [ set color black ]
+          ;; this turtle creates a new turtle
+          ;; of the sheep breed
+        </pre>
+        <p>
+          See also <a href="#create-turtles">create-turtles</a>, <a href="#sprout">sprout</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="heading">
+        <h3>
+          <a>heading</a>
+        </h3>
+        <h4>
+          <span class="prim_example">heading</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          This is a built-in turtle variable. It indicates the direction the
+          turtle is facing. This is a number greater than or equal to 0 and
+          less than 360. 0 is north, 90 is east, and so on. You can set this
+          variable to make a turtle turn.
+        </p>
+        <p>
+          See also <a href="#right">right</a>, <a href="#left">left</a>,
+          <a href="#dxy">dx</a>, <a href="#dxy">dy</a>.
+        </p>
+        <p>
+          Example:
+        </p>
+        <pre>
+          set heading 45      ;; turtle is now facing northeast
+          set heading heading + 10 ;; same effect as &quot;rt 10&quot;
+        </pre>
+      </div>
+      <div class="dict_entry" id="hidden">
+        <h3>
+          <a>hidden?</a>
+        </h3>
+        <h4>
+          <span class="prim_example">hidden?</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          This is a built-in turtle or link variable. It holds a boolean
+          (true or false) value indicating whether the turtle or link is
+          currently hidden (i.e., invisible). You can set this variable to
+          make a turtle or link disappear or reappear.
+        </p>
+        <p>
+          See also <a href="#hide-turtle">hide-turtle</a>, <a href="#show-turtle">show-turtle</a>, <a href="#hide-link">hide-link</a>,
+          <a href="#show-link">show-link</a>
+        </p>
+        <p>
+          Example:
+        </p>
+        <pre>
+          set hidden? not hidden?
+          ;; if turtle was showing, it hides, and if it was hiding,
+          ;; it reappears
+        </pre>
+      </div>
+      <div class="dict_entry" id="hide-link">
+        <h3>
+          <a>hide-link<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hide-link</span>
+          <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          The link makes itself invisible.
+        </p>
+        <p>
+          Note: This command is equivalent to setting the link variable
+          &quot;hidden?&quot; to true.
+        </p>
+        <p>
+          See also <a href="#show-turtle">show-link</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="hide-turtle">
+        <h3>
+          <a>hide-turtle<span class="since">1.0</span></a>
+          <a>ht<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hide-turtle</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          The turtle makes itself invisible.
+        </p>
+        <p>
+          Note: This command is equivalent to setting the turtle variable
+          &quot;hidden?&quot; to true.
+        </p>
+        <p>
+          See also <a href="#show-turtle">show-turtle</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="histogram">
+        <h3>
+          <a>histogram<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">histogram <i>list</i></span>
+        </h4>
+        <p>
+          Histograms the values in the given list
+        </p>
+        <p>
+          Draws a histogram showing the frequency distribution of the values
+          in the list. The heights of the bars in the histogram represent the
+          numbers of values in each subrange.
+        </p>
+        <p>
+          Before the histogram is drawn, first any previous points drawn by
+          the current plot pen are removed.
+        </p>
+        <p>
+          Any non-numeric values in the list are ignored.
+        </p>
+        <p>
+          The histogram is drawn on the current plot using the current plot
+          pen and pen color. Auto scaling does not affect a histogram's
+          horizontal range, so set-plot-x-range should be used to control the
+          range, and the pen interval can then be set (either directly with
+          set-plot-pen-interval, or indirectly via set-histogram-num-bars) to
+          control how many bars that range is split up into.
+        </p>
+        <p>
+          Be sure that if you want the histogram drawn with bars that the
+          current pen is in bar mode (mode 1).
+        </p>
+        <p>
+          For histogramming purposes the plot's X range is not considered
+          to include the maximum X value. Values equal to the maximum X will
+          fall outside of the histogram's range.
+        </p>
+        <pre>
+          histogram [color] of turtles
+          ;; draws a histogram showing how many turtles there are
+          ;; of each color
+        </pre>
+      </div>
+      <div class="dict_entry" id="home">
+        <h3>
+          <a>home<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">home</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          This turtle moves to the origin (0,0). Equivalent to <code>setxy 0
+            0</code>.
+        </p>
+      </div>
+      <div class="dict_entry" id="hsb">
+        <h3>
+          <a>hsb<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hsb <i>hue saturation brightness</i></span>
+        </h4>
+        <p>
+          Reports a RGB list when given three numbers describing an HSB
+          color. Hue, saturation, and brightness are integers in the range
+          0-360, 0-100, 0-100 respectively. The RGB list contains three
+          integers in the range of 0-255.
+        </p>
+        <p>
+          See also <a href="#rgb">rgb</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-broadcast">
+        <h3>
+          <a>hubnet-broadcast<span class="since">1.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-broadcast <i>tag-name value</i></span>
+        </h4>
+        <p>
+          This broadcasts <i>value</i> from NetLogo to the interface element
+          with the name <i>tag-name</i> on the clients.
+        </p>
+        <p>
+          See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+          for details and instructions.
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-broadcast-clear-output">
+        <h3>
+          <a>hubnet-broadcast-clear-output<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-broadcast-clear-output</span>
+        </h4>
+        <p>
+          This clears all messages printed to the text area on every client.
+        </p>
+        <p>
+          See also: <a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>, <a href="#hubnet-send-clear-output">hubnet-send-clear-output</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-broadcast-message">
+        <h3>
+          <a>hubnet-broadcast-message<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-broadcast-message <i>value</i></span>
+        </h4>
+        <p>
+          This prints the value in the text area on each client. This is the
+          same functionality as the &quot;Broadcast Message&quot; button in
+          the HubNet Control Center.
+        </p>
+        <p>
+          See also: <a href="#hubnet-send-message">hubnet-send-message</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-clear-override">
+        <h3>
+          <a>hubnet-clear-override<span class="since">4.1</span></a>
+          <a>hubnet-clear-overrides<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-clear-override <i>client</i> <i>agent-or-set</i> <i>variable-name</i></span>
+          <span class="prim_example">hubnet-clear-overrides <i>client</i></span>
+        </h4>
+        <p>
+          Remove overrides from the override list on <i>client</i>.
+          <code>hubnet-clear-override</code> removes only the override for the
+          specified variable for the specified agent or agentset.
+          <code>hubnet-clear-overrides</code> removes all overrides from the
+          specified client.
+        </p>
+        <p>
+          See also: <a href="#hubnet-send-override">hubnet-send-override</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-clients-list">
+        <h3>
+          <a>hubnet-clients-list<span class="since">5.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-clients-list</span>
+        </h4>
+        <p>
+          Reports a list containing the names of all the clients currently
+          connected to the HubNet server.
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-enter-message">
+        <h3>
+          <a>hubnet-enter-message?<span class="since">1.2.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-enter-message?</span>
+        </h4>
+        <p>
+          Reports true if a new client just entered the simulation. Reports
+          false otherwise. <a href="#hubnet-message-source">hubnet-message-source</a> will contain the
+          user name of the client that just logged on.
+        </p>
+        <p>
+          See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+          for details and instructions.
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-exit-message">
+        <h3>
+          <a>hubnet-exit-message?<span class="since">1.2.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-exit-message?</span>
+        </h4>
+        <p>
+          Reports true if a client just exited the simulation. Reports false
+          otherwise. <a href="#hubnet-message-source">hubnet-message-source</a> will contain the
+          user name of the client that just logged off.
+        </p>
+        <p>
+          See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+          for details and instructions.
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-fetch-message">
+        <h3>
+          <a>hubnet-fetch-message<span class="since">1.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-fetch-message</span>
+        </h4>
+        <p>
+          If there is any new data sent by the clients, this retrieves the
+          next piece of data, so that it can be accessed by <a href="#hubnet-message">hubnet-message</a>, <a href="#hubnet-message-source">hubnet-message-source</a>, and <a href="#hubnet-message-tag">hubnet-message-tag</a>. This will cause an
+          error if there is no new data from the clients.
+        </p>
+        <p>
+          See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+          for details.
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-kick-client">
+        <h3>
+          <a>hubnet-kick-client<span class="since">5.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-kick-client <i>client-name</i></span>
+        </h4>
+        <p>
+          Kicks the client with the given client-name. This is equivalent to
+          clicking the client name in the HubNet Control Center and pressing
+          the Kick button.
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-kick-all-clients">
+        <h3>
+          <a>hubnet-kick-all-clients<span class="since">5.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-kick-all-clients</span>
+        </h4>
+        <p>
+          Kicks out all currently connected HubNet clients. This is
+          equivalent to selecting all clients in the HubNet Control Center
+          and pressing the Kick button.
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-message">
+        <h3>
+          <a>hubnet-message<span class="since">1.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-message</span>
+        </h4>
+        <p>
+          Reports the message retrieved by <a href="#hubnet-fetch-message">hubnet-fetch-message</a>.
+        </p>
+        <p>
+          See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+          for details.
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-message-source">
+        <h3>
+          <a>hubnet-message-source<span class="since">1.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-message-source</span>
+        </h4>
+        <p>
+          Reports the name of the client that sent the message retrieved by
+          <a href="#hubnet-fetch-message">hubnet-fetch-message</a>.
+        </p>
+        <p>
+          See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+          for details.
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-message-tag">
+        <h3>
+          <a>hubnet-message-tag<span class="since">1.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-message-tag</span>
+        </h4>
+        <p>
+          Reports the tag that is associated with the data that was retrieved
+          by <a href="#hubnet-fetch-message">hubnet-fetch-message</a>. The
+          tag will be one of the Display Names of the interface elements in
+          the client interface.
+        </p>
+        <p>
+          See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+          for details.
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-message-waiting">
+        <h3>
+          <a>hubnet-message-waiting?<span class="since">1.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-message-waiting?</span>
+        </h4>
+        <p>
+          This looks for a new message sent by the clients. It reports true
+          if there is one, and false if there is not.
+        </p>
+        <p>
+          See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+          for details.
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-reset">
+        <h3>
+          <a>hubnet-reset<span class="since">1.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-reset</span>
+        </h4>
+        <p>
+          Starts up the HubNet system. HubNet must be started to use any of
+          the other hubnet primitives.
+        </p>
+        <p>
+          See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+          for details.
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-reset-perspective">
+        <h3>
+          <a>hubnet-reset-perspective<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-reset-perspective <i>tag-name</i></span>
+        </h4>
+        <p>
+          Clears watch or follow sent directly to the client. The view
+          perspective will revert to the server perspective.
+        </p>
+        <p>
+          See also: <a href="#hubnet-send-watch">hubnet-send-watch</a>
+          <a href="#hubnet-send-follow">hubnet-send-follow</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-send">
+        <h3>
+          <a>hubnet-send<span class="since">1.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-send <i>string tag-name value</i></span>
+        </h4>
+        <h4>
+          <span class="prim_example">hubnet-send <i>list-of-strings tag-name value</i></span>
+        </h4>
+        <p>
+          For a <i>string</i>, this sends <i>value</i> from NetLogo to the
+          tag <i>tag-name</i> on the client that has <i>string</i> for its
+          user name.
+        </p>
+        <p>
+          For a <i>list-of-strings</i>, this sends <i>value</i> from NetLogo
+          to the tag <i>tag-name</i> on all the clients that have a user name
+          that is in the <i>list-of-strings</i>.
+        </p>
+        <p>
+          Sending a message to a non-existent client, using
+          <code>hubnet-send</code>, generates a <code>hubnet-exit-message</code>.
+        </p>
+        <p>
+          See the <a href="hubnet-authoring.html">HubNet Authoring Guide</a>
+          for details.
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-send-clear-output">
+        <h3>
+          <a>hubnet-send-clear-output<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-send-clear-output <i>string</i></span>
+        </h4>
+        <h4>
+          <span class="prim_example">hubnet-send-clear-output <i>list-of-strings</i></span>
+        </h4>
+        <p>
+          This clears all messages printed to the text area on the given
+          client or clients (specified in the <i>string</i> or
+          <i>list-of-strings</i>.
+        </p>
+        <p>
+          See also: <a href="#hubnet-send-message">hubnet-send-message</a>,
+          <a href="#hubnet-broadcast-clear-output">hubnet-broadcast-clear-output</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-send-follow">
+        <h3>
+          <a>hubnet-send-follow<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-send-follow <i>client-name agent radius</i></span>
+        </h4>
+        <p>
+          Tells the client associated with <i>client-name</i> to follow
+          <i>agent</i> showing a <i>radius</i> sized Moore neighborhood
+          around the agent.
+        </p>
+        <p>
+          A client may only watch or follow a single subject.
+          Calling <code>hubnet-send-follow</code> will alter the highlight created by
+          prior calls to <code>hubnet-send-watch</code>, highlighting
+          the followed agent instead.
+        </p>
+        <p>
+          See also: <a href="#hubnet-send-watch">hubnet-send-watch</a>,
+          <a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-send-message">
+        <h3>
+          <a>hubnet-send-message<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-send-message <i>string</i> <i>value</i></span>
+        </h4>
+        <p>
+          This prints <code>value</code> in the text area on the client specified
+          by <code>string</code>.
+        </p>
+        <p>
+          See also: <a href="#hubnet-broadcast-message">hubnet-broadcast-message</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-send-override">
+        <h3>
+          <a>hubnet-send-override<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-send-override <i>client-name agent-or-set variable-name</i></span>
+          <span class="prim_example">[ <i>reporter</i> ]</span>
+        </h4>
+        <p>
+          Evaluates <i>reporter</i> for the agent or agentset indicated then
+          sends the values to the client to &quot;override&quot; the value of
+          <i>variable-name</i> only on <i>client-name</i>. This is used to
+          change the appearance of agents in the client view, hence, only
+          built-in variables that affect the appearance of the agent may be
+          selected. For example, you can override the color variable of a
+          turtle:
+        </p>
+        <pre>
+          ask turtles [ hubnet-send-override client-name self &quot;color&quot; [ red ] ]
+        </pre>
+        <p>
+          In this example assume that there is a turtles-own variable
+          client-name which is associated with a logged in client, and all
+          the turtles are blue. This code makes the turtle associated with
+          each client appear red in his or her own view but not on anyone
+          else's or on the server.
+        </p>
+        <p>
+          See also: <a href="#hubnet-clear-override">hubnet-clear-overrides</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="hubnet-send-watch">
+        <h3>
+          <a>hubnet-send-watch<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">hubnet-send-watch <i>client-name agent</i></span>
+        </h4>
+        <p>
+          Tells the client associated with <i>client-name</i> to watch
+          <i>agent</i>.
+        </p>
+        <p>
+          A client may only watch or follow a single subject.
+          Calling <code>hubnet-send-watch</code> will undo perspective changes caused
+          by prior calls to <code>hubnet-send-follow</code>.
+        </p>
+        <p>
+          See also: <a href="#hubnet-send-follow">hubnet-send-follow</a>,
+          <a href="#hubnet-reset-perspective">hubnet-reset-perspective</a>
+        </p>
+      </div>
+    </div> <!-- ======================================== -->
+    <h2 id="I">
+      <a>I</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="if">
+        <h3>
+          <a>if<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">if <i>condition</i> [ <i>commands</i> ]</span>
+        </h4>
+        <p>
+          Reporter must report a boolean (true or false) value.
+        </p>
+        <p>
+          If <i>condition</i> reports true, runs <i>commands</i>.
+        </p>
+        <p>
+          The reporter may report a different value for different agents, so
+          some agents may run <i>commands</i> and others don't.
+        </p>
+        <pre>
+          if xcor &gt; 0[ set color blue ]
+          ;; turtles in the right half of the world
+          ;; turn blue
+        </pre>
+        <p>
+          See also <a href="#ifelse">ifelse</a>, <a href="#ifelse-value">ifelse-value</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="ifelse">
+        <h3>
+          <a>ifelse<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">ifelse <i>reporter1</i> [ <i>commands1</i> ] [ <i>elsecommands</i> ]</span>
+          <span class="prim_example">(ifelse <i>reporter1</i> [ <i>commands1</i> ] <i>reporter2</i> [ <i>commands2</i> ] ... [ <i>elsecommands</i> ])</span>
+        </h4>
+        <p>
+          The <i>reporter</i>s must report boolean (true or false) values.
+        </p>
+        <p>
+          For the first <i>reporter</i> that reports true, runs the <i>commands</i> that follow.
+        </p>
+        <p>
+          If no <i>reporter</i> reports true, runs <i>elsecommands</i> or does nothing if
+          <i>elsecommands</i> is not given.  When using only one <i>reporter</i>
+          you do not need to surround the entire <i>ifelse</i> primitive and its blocks in parentheses.
+        </p>
+        <pre>
+          ask patches
+          [ ifelse pxcor &gt; 0
+          [ set pcolor blue ]
+          [ set pcolor red ] ]
+          ;; the left half of the world turns red and
+          ;; the right half turns blue
+        </pre>
+        <p>
+          The reporters may report a different value for different agents, so
+          some agents may run different command blocks.  When using more than one <i>reporter</i> you
+          must surround the whole <i>ifelse</i> primitive and its blocks in parentheses.
+        </p>
+        <pre>
+          ask patches [
+          let choice random 4
+          (ifelse
+          choice = 0 [
+          set pcolor red
+          set plabel "r"
+          ]
+          choice = 1 [
+          set pcolor blue
+          set plabel "b"
+          ]
+          choice = 2 [
+          set pcolor green
+          set plabel "g"
+          ]
+          ; elsecommands
+          [
+          set pcolor yellow
+          set plabel "y"
+          ])
+          ]
+        </pre>
+        <p>
+          See also <a href="#if">if</a>, <a href="#ifelse-value">ifelse-value</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="ifelse-value">
+        <h3>
+          <a>ifelse-value<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">ifelse-value <i>tfreporter1</i> [ <i>reporter1</i> ] [ <i>elsereporter</i> ]</span>
+          <span class="prim_example">(ifelse-value <i>tfreporter1</i> [ <i>reporter1</i> ] <i>tfreporter2</i> [ <i>reporter2</i> ] ... [ <i>elsereporter</i> ])</span>
+        </h4>
+        <p>
+          The <i>tfreporter</i>s must report boolean (true or false) values.
+        </p>
+        <p>
+          For the first <i>tfreporter</i> that reports true, runs the
+          <i>reporter</i> that follows and reports that result.  When using only one <i>tfreporter1</i>
+          you do not need to surround the entire <i>ifelse-value</i> primitive and its blocks in parentheses.
+        </p>
+        <p>
+          If all <i>tfreporter</i>s report false, the result is the value of
+          <i>elsereporter</i>.  You may leave out the <i>elsereporter</i>, but
+          if all <i>tfreporter</i>s report false then a runtime error will occur.
+        </p>
+        <p>
+          This can be used when a conditional is needed in the context of a
+          reporter, where commands (such as <a href="#ifelse">ifelse</a>) are
+          not allowed.
+        </p>
+        <pre>
+          ask patches [
+          set pcolor ifelse-value (pxcor &gt; 0) [blue] [red]
+          ]
+          ;; the left half of the world turns red and
+          ;; the right half turns blue
+          show n-values 10 [ifelse-value (? &lt; 5) [0] [1]]
+          =&gt; [0 0 0 0 0 1 1 1 1 1]
+          show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
+          [1 3 2 5 3 8 3 2 1]
+          =&gt; 8
+        </pre>
+        <p>
+          When using more than one <i>tfreporter</i> you
+          must surround the whole <i>ifelse-value</i> primitive and its blocks in parentheses.
+        </p>
+        <pre>
+          ask patches [
+          let choice random 4
+          set pcolor (ifelse-value
+          choice = 0 [ red ]
+          choice = 1 [ blue ]
+          choice = 2 [ green ]
+          [ yellow ])
+          ]
+        </pre>
+        <p>
+          A runtime error can occur if there is no <i>elsereporter</i>.
+        </p>
+        <pre>
+          ask patches [
+          let x = 2
+          set pcolor (ifelse-value
+          x = 0 [ red ]
+          x = 1 [ blue ]
+          ; no final else reporter is given, and x is 2 so there will be a runtime error
+          )
+        </pre>
+        <p>
+          See also <a href="#if">if</a>, <a href="#ifelse">ifelse</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="import-drawing">
+        <h3>
+          <a>import-drawing<span class="since">3.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">import-drawing <i>filename</i></span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Reads an image file into the drawing, scaling it to the size of the
+          world, while retaining the original aspect ratio of the image. The
+          image is centered in the drawing. The old drawing is not cleared
+          first.
+        </p>
+        <p>
+          Agents cannot sense the drawing, so they cannot interact with or
+          process images imported by import-drawing. If you need agents to
+          sense an image, use <a href="#import-pcolors">import-pcolors</a> or
+          <a href="#import-pcolors-rgb">import-pcolors-rgb</a>.
+        </p>
+        <p>
+          The following image file formats are supported: BMP, JPG, GIF, and
+          PNG. If the image format supports transparency (alpha), that
+          information will be imported as well.
+        </p>
+      </div>
+      <div class="dict_entry" id="import-pcolors">
+        <h3>
+          <a>import-pcolors<span class="since">3.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">import-pcolors <i>filename</i></span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Reads an image file, scales it to the same dimensions as the patch
+          grid while maintaining the original aspect ratio of the image, and
+          transfers the resulting pixel colors to the patches. The image is
+          centered in the patch grid. The resulting patch colors may be
+          distorted, since the NetLogo color space does not include all
+          possible colors. (See the Color section of the Programming Guide.)
+          import-pcolors may be slow for some images, particularly when you
+          have many patches and a large image with many different colors.
+        </p>
+        <p>
+          Since import-pcolors sets the pcolor of patches, agents can sense
+          the image. This is useful if agents need to analyze, process, or
+          otherwise interact with the image. If you want to simply display a
+          static backdrop, without color distortion, see <a href="#import-drawing">import-drawing</a>.
+        </p>
+        <p>
+          The following image file formats are supported: BMP, JPG, GIF, and
+          PNG. If the image format supports transparency (alpha), then all
+          fully transparent pixels will be ignored. (Partially transparent
+          pixels will be treated as opaque.)
+        </p>
+      </div>
+      <div class="dict_entry" id="import-pcolors-rgb">
+        <h3>
+          <a>import-pcolors-rgb<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">import-pcolors-rgb <i>filename</i></span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Reads an image file, scales it to the same dimensions as the patch
+          grid while maintaining the original aspect ratio of the image, and
+          transfers the resulting pixel colors to the patches. The image is
+          centered in the patch grid. Unlike <a href="#import-pcolors">import-pcolors</a> the exact colors in the
+          original image are retained. The pcolor variable of all the patches
+          will be an RGB list rather than an (approximated) NetLogo color.
+        </p>
+        <p>
+          The following image file formats are supported: BMP, JPG, GIF, and
+          PNG. If the image format supports transparency (alpha), then all
+          fully transparent pixels will be ignored. (Partially transparent
+          pixels will be treated as opaque.)
+        </p>
+      </div>
+      <div class="dict_entry" id="import-world">
+        <h3>
+          <a>import-world<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">import-world <i>filename</i></span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Reads the values of all variables for a model, both built-in and
+          user-defined, including all observer, turtle, and patch variables,
+          from an external file named by the given string. The file should be
+          in the format used by the <a href="#export-cmds">export-world</a>
+          primitive.
+        </p>
+        <p>
+          Note that the functionality of this primitive is also directly
+          available from NetLogo's File menu.
+        </p>
+        <p>
+          When using import-world, to avoid errors, perform these steps in
+          the following order:
+        </p>
+        <ol>
+          <li>Open the model from which you created the export file.</li>
+          <li>Press the Setup button, to get the model in a state from which
+            it can be run.</li>
+          <li>Import the file.</li>
+          <li>Re-open any files that the model had opened with the
+            <code>file-open</code> command.</li>
+          <li>If you want, press Go button to continue running the model from
+            the point where it left off.</li>
+        </ol>
+        <p>
+          If you wish to import a file from a location other than the
+          model's location, you may include the full path to the file you
+          wish to import. See <a href="#export-cmds">export-world</a> for an
+          example.
+        </p>
+      </div>
+      <div class="dict_entry" id="in-cone">
+        <h3>
+          <a>in-cone<span class="since">3.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example"><i>agentset</i> in-cone <i>distance</i> <i>angle</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          This reporter lets you give a turtle a &quot;cone of vision&quot;
+          in front of itself. The cone is defined by the two inputs, the
+          vision distance (radius) and the viewing angle. The viewing angle
+          may range from 0 to 360 and is centered around the turtle's
+          current heading. (If the angle is 360, then in-cone is equivalent
+          to in-radius.)
+        </p>
+        <p>
+          in-cone reports an agentset that includes only those agents from
+          the original agentset that fall in the cone. (This can include the
+          agent itself.)
+        </p>
+        <p>
+          The distance to a patch is measured from the center of the patch.
+        </p>
+        <pre>
+          ask turtles
+          [ ask patches in-cone 3 60
+          [ set pcolor red ] ]
+          ;; each turtle makes a red &quot;splotch&quot; of patches in a 60 degree
+          ;; cone of radius 3 ahead of itself
+        </pre>
+      </div>
+      <div class="dict_entry" id="in-link-neighbor">
+        <h3>
+          <a>in-&lt;breed&gt;-neighbor?</a>
+          <a>in-link-neighbor?<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">in-&lt;breed&gt;-neighbor? <i>agent</i></span>
+          <span class="prim_example">in-link-neighbor? <i>turtle</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Reports true if there is a directed link going from <i>turtle</i>
+          to the caller or an undirected link connecting <i>turtle</i> to the
+          caller. You can think of this as "is there a link I can use to get from
+          <i>turtle</i> to the caller?"
+        </p>
+        <pre>
+          crt 2
+          ask turtle 0 [
+          create-link-to turtle 1
+          show in-link-neighbor? turtle 1  ;; prints false
+          show out-link-neighbor? turtle 1 ;; prints true
+          ]
+          ask turtle 1 [
+          show in-link-neighbor? turtle 0  ;; prints true
+          show out-link-neighbor? turtle 0 ;; prints false
+          ]
+        </pre>
+      </div>
+      <div class="dict_entry" id="in-link-neighbors">
+        <h3>
+          <a>in-&lt;breed&gt;-neighbors</a>
+          <a>in-link-neighbors<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">in-&lt;breed&gt;-neighbors</span>
+          <span class="prim_example">in-link-neighbors</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Reports the agentset of all the turtles that have directed links coming
+          from them to the caller as well as all turtles that have an undirected
+          link connecting them with the caller. You can think of this as "all the
+          turtles that can get to the caller using a link."
+        </p>
+        <pre>
+          crt 4
+          ask turtle 0 [ create-links-to other turtles ]
+          ask turtle 1 [ ask in-link-neighbors [ set color blue ] ] ;; turtle 0 turns blue
+        </pre>
+      </div>
+      <div class="dict_entry" id="in-link-from">
+        <h3>
+          <a>in-&lt;breed&gt;-from</a>
+          <a>in-link-from<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">in-&lt;breed&gt;-from <i>turtle</i></span>
+          <span class="prim_example">in-link-from <i>turtle</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Reports a directed link from <i>turtle</i> to the caller or an
+          undirected link connecting the two. If no link exists then it
+          reports nobody. If more than one such link exists, reports a
+          random one. You can think of this as "give me a link that I can use
+          to travel from <i>turtle</i> to the caller."
+        </p>
+        <pre>
+          crt 2
+          ask turtle 0 [ create-link-to turtle 1 ]
+          ask turtle 1 [ show in-link-from turtle 0 ] ;; shows link 0 1
+          ask turtle 0 [ show in-link-from turtle 1 ] ;; shows nobody
+        </pre>
+        <p>
+          See also: <a href="#out-link-to">out-link-to</a> <a href="#link-with">link-with</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="includes">
+        <h3>
+          <a>__includes<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">__includes [ <i>filename</i> ... ]</span>
+        </h4>
+        <p>
+          Causes external NetLogo source files (with the <code>.nls</code>
+          suffix) to be included in this model. Included files may contain
+          breed, variable, and procedure definitions. <code>__includes</code> can
+          only be used once per file.
+        </p>
+        <p>
+          The file names must be strings, for example:
+        </p>
+        <pre>
+          __includes [ &quot;utils.nls&quot; ]
+        </pre>
+        <p>
+          Or, for multiple files:
+        </p>
+        <pre>
+          __includes [ &quot;utils1.nls&quot; &quot;utils2.nls&quot; ]
+        </pre>
+      </div>
+      <div class="dict_entry" id="in-radius">
+        <h3>
+          <a>in-radius<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example"><i>agentset</i> in-radius <i>number</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          Reports an agentset that includes only those agents from the
+          original agentset whose distance from the caller is less than or
+          equal to <i>number</i>. (This can include the agent itself.)
+        </p>
+        <p>
+          The distance to or a from a patch is measured from the center of
+          the patch.
+        </p>
+        <pre>
+          ask turtles
+          [ ask patches in-radius 3
+          [ set pcolor red ] ]
+          ;; each turtle makes a red &quot;splotch&quot; around itself
+        </pre>
+      </div>
 
-			<div class="dict_entry" id="insert-item">
-				<h3>
-					<a>insert-item<span class="since">6.0.2</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">insert-item <i>index list value</i></span>
-					<span class="prim_example">insert-item <i>index string1 string2</i></span>
-				</h4>
-				<p>
-					On a list, inserts an item in that list. <i>index</i> is the index
-					where the item will be inserted. The first item has an index of 0.
-					(The 6th item in a list would have an index of 5.)
-				</p>
-				<p>
-					Likewise for a string, but all characters in a multiple-character <i>string2</i>
-					are inserted at <i>index</i>.
-				</p>
-				<pre>
-					show insert-item 2 [2 7 4 5] 15
-					=&gt; [2 7 15 4 5]
-					show insert-item 2 &quot;cat&quot; &quot;re&quot;
-					=&gt; &quot;caret&quot;
-				</pre>
-			</div>
+      <div class="dict_entry" id="insert-item">
+        <h3>
+          <a>insert-item<span class="since">6.0.2</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">insert-item <i>index list value</i></span>
+          <span class="prim_example">insert-item <i>index string1 string2</i></span>
+        </h4>
+        <p>
+          On a list, inserts an item in that list. <i>index</i> is the index
+          where the item will be inserted. The first item has an index of 0.
+          (The 6th item in a list would have an index of 5.)
+        </p>
+        <p>
+          Likewise for a string, but all characters in a multiple-character <i>string2</i>
+          are inserted at <i>index</i>.
+        </p>
+        <pre>
+          show insert-item 2 [2 7 4 5] 15
+          =&gt; [2 7 15 4 5]
+          show insert-item 2 &quot;cat&quot; &quot;re&quot;
+          =&gt; &quot;caret&quot;
+        </pre>
+      </div>
 
 
-			<div class="dict_entry" id="inspect">
-				<h3>
-					<a>inspect<span class="since">1.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">inspect <i>agent</i></span>
-				</h4>
-				<p>
-					Opens an agent monitor for the given agent (turtle or patch).
-				</p>
-				<pre>
-					inspect patch 2 4
-					;; an agent monitor opens for that patch
-					inspect one-of sheep
-					;; an agent monitor opens for a random turtle from
-					;; the &quot;sheep&quot; breed
-				</pre>
-				<p>
-					See <a href="#stop-inspecting">stop-inspecting</a> and <a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="int">
-				<h3>
-					<a>int<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">int <i>number</i></span>
-				</h4>
-				<p>
-					Reports the integer part of number -- any fractional part is
-					discarded.
-				</p>
-				<pre>
-					show int 4.7
-					=&gt; 4
-					show int -3.5
-					=&gt; -3
-				</pre>
-			</div>
-			<div class="dict_entry" id="is-of-type">
-				<h3>
-					<a>is-agent?<span class="since">1.2.1</span></a>
-					<a>is-agentset?<span class="since">1.2.1</span></a>
-					<a>is-anonymous-command?<span class="since">6.0</span></a>
-					<a>is-anonymous-reporter?<span class="since">6.0</span></a>
-					<a>is-boolean?<span class="since">1.2.1</span></a>
-					<a>is-directed-link?<span class="since">4.0</span></a>
-					<a>is-link?<span class="since">4.0</span></a>
-					<a>is-link-set?<span class="since">4.0</span></a>
-					<a>is-list?<span class="since">1.0</span></a>
-					<a>is-number?<span class="since">1.2.1</span></a>
-					<a>is-patch?<span class="since">1.2.1</span></a>
-					<a>is-patch-set?<span class="since">4.0</span></a>
-					<a>is-string?<span class="since">1.0</span></a>
-					<a>is-turtle?<span class="since">1.2.1</span></a>
-					<a>is-turtle-set?<span class="since">4.0</span></a>
-					<a>is-undirected-link?<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">is-agent? <i>value</i></span>
-					<span class="prim_example">is-agentset? <i>value</i></span>
-					<span class="prim_example">is-anonymous-command? <i>value</i></span>
-					<span class="prim_example">is-anonymous-reporter? <i>value</i></span>
-					<span class="prim_example">is-boolean? <i>value</i></span>
-					<span class="prim_example">is-<i>&lt;breed&gt;</i>? <i>value</i></span>
-					<span class="prim_example">is-<i>&lt;link-breed&gt;</i>? <i>value</i></span>
-					<span class="prim_example">is-directed-link? <i>value</i></span>
-					<span class="prim_example">is-link? <i>value</i></span>
-					<span class="prim_example">is-link-set? <i>value</i></span>
-					<span class="prim_example">is-list? <i>value</i></span>
-					<span class="prim_example">is-number? <i>value</i></span>
-					<span class="prim_example">is-patch? <i>value</i></span>
-					<span class="prim_example">is-patch-set? <i>value</i></span>
-					<span class="prim_example">is-string? <i>value</i></span>
-					<span class="prim_example">is-turtle? <i>value</i></span>
-					<span class="prim_example">is-turtle-set? <i>value</i></span>
-					<span class="prim_example">is-undirected-link? <i>value</i></span>
-				</h4>
-				<p>
-					Reports true if <i>value</i> is of the given type, false otherwise.
-				</p>
-			</div>
-			<div class="dict_entry" id="item">
-				<h3>
-					<a>item<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">item <i>index list</i></span>
-					<span class="prim_example">item <i>index string</i></span>
-				</h4>
-				<p>
-					On lists, reports the value of the item in the given list with the
-					given index.
-				</p>
-				<p>
-					On strings, reports the character in the given string at the given
-					index.
-				</p>
-				<p>
-					Note that the indices begin from 0, not 1. (The first item is item
-					0, the second item is item 1, and so on.)
-				</p>
-				<pre>
-					;; suppose mylist is [2 4 6 8 10]
-					show item 2 mylist
-					=&gt; 6
-					show item 3 &quot;my-shoe&quot;
-					=&gt; &quot;s&quot;
-				</pre>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="J">
-			<a>J</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="jump">
-				<h3>
-					<a>jump<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">jump <i>number</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					The turtle moves forward by <i>number</i> units all at once (rather
-					than one step at a time as with the <code>forward</code> command).
-				</p>
-				<p>
-					If the turtle cannot jump <i>number</i> units because it is not
-					permitted by the current topology the turtle does not move at all.
-				</p>
-				<p>
-					See also <a href="#forward">forward</a>, <a href="#can-move">can-move?</a>.
-				</p>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="L">
-			<a>L</a>
-		</h2><!-- ======================================== -->
-		<div class="dict_entry" id="label">
-			<h3>
-				<a>label</a>
-			</h3>
-			<h4>
-				<span class="prim_example">label</span>
-				<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
-			</h4>
-			<p>
-				This is a built-in turtle or link variable. It may hold a value of
-				any type. The turtle or link appears in the view with the given
-				value &quot;attached&quot; to it as text. You can set this variable
-				to add, change, or remove a turtle or link's label.
-			</p>
-			<p>
-				See also <a href="#label-color">label-color</a>, <a href="#plabel">plabel</a>, <a href="#plabel-color">plabel-color</a>.
-			</p>
-			<p>
-				Example:
-			</p>
-			<pre>
-				ask turtles [ set label who ]
-				;; all the turtles now are labeled with their
-				;; who numbers
-				ask turtles [ set label &quot;&quot; ]
-				;; all turtles now are not labeled
-			</pre>
-		</div>
-		<div class="dict_entry" id="label-color">
-			<h3>
-				<a>label-color</a>
-			</h3>
-			<h4>
-				<span class="prim_example">label-color</span>
-				<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
-			</h4>
-			<p>
-				This is a built-in turtle or link variable. It holds a number
-				greater than or equal to 0 and less than 140. This number
-				determines what color the turtle or link's label appears in (if
-				it has a label). You can set this variable to change the color of a
-				turtle or link's label.
-			</p>
-			<p>
-				See also <a href="#label">label</a>, <a href="#plabel">plabel</a>,
-				<a href="#plabel-color">plabel-color</a>.
-			</p>
-			<p>
-				Example:
-			</p>
-			<pre>
-				ask turtles [ set label-color red ]
-				;; all the turtles now have red labels
-			</pre>
-		</div>
-		<div class="dict_entry" id="last">
-			<h3>
-				<a>last<span class="since">1.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">last <i>list</i></span>
-				<span class="prim_example">last <i>string</i></span>
-			</h4>
-			<p>
-				On a list, reports the last item in the list.
-			</p>
-			<p>
-				On a string, reports a one-character string containing only the
-				last character of the original string.
-			</p>
-		</div>
-		<div class="dict_entry" id="layout-circle">
-			<h3>
-				<a>layout-circle<span class="since">4.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">layout-circle <i>agentset</i> <i>radius</i></span>
-				<span class="prim_example">layout-circle <i>list-of-turtles</i> <i>radius</i></span>
-			</h4>
-			<p>
-				Arranges the given turtles in a circle centered on the patch at the
-				center of the world with the given radius. (If the world has an
-				even size the center of the circle is rounded down to the nearest
-				patch.) The turtles point outwards.
-			</p>
-			<p>
-				If the first input is an agentset, the turtles are arranged in
-				random order.
-			</p>
-			<p>
-				If the first input is a list, the turtles are arranged clockwise in
-				the given order, starting at the top of the circle. (Any
-				non-turtles in the list are ignored.)
-			</p>
-			<pre>
-				;; in random order
-				layout-circle turtles 10
-				;; in order by who number
-				layout-circle sort turtles 10
-				;; in order by size
-				layout-circle sort-by [ [a b] -&gt; [size] of a &lt; [size] of b ] turtles 10
-			</pre>
-		</div>
-		<div class="dict_entry" id="layout-radial">
-			<h3>
-				<a>layout-radial<span class="since">4.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">layout-radial <i>turtle-set</i> <i>link-set</i> <i>root-agent</i></span>
-			</h4>
-			<p>
-				Arranges the turtles in <i>turtle-set</i> connected by links in
-				<i>link-set</i>, in a radial tree layout, centered around the
-				<i>root-agent</i> which is moved to the center of the world view.
-			</p>
-			<p>
-				Only links in the <i>link-set</i> will be used to determine the
-				layout. If links connect turtles that are not in <i>turtle-set</i>
-				those turtles will remain stationary.
-			</p>
-			<p>
-				Even if the network does contain cycles, and is not a true tree
-				structure, this layout will still work, although the results will
-				not always be pretty.
-			</p>
-			<pre>
-				to make-a-tree
-				set-default-shape turtles &quot;circle&quot;
-				crt 6
-				ask turtle 0 [
-				create-link-with turtle 1
-				create-link-with turtle 2
-				create-link-with turtle 3
-				]
-				ask turtle 1 [
-				create-link-with turtle 4
-				create-link-with turtle 5
-				]
-				; do a radial tree layout, centered on turtle 0
-				layout-radial turtles links (turtle 0)
-				end
-			</pre>
-		</div>
-		<div class="dict_entry" id="layout-spring">
-			<h3>
-				<a>layout-spring<span class="since">4.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">layout-spring <i>turtle-set</i> <i>link-set</i>
-					<i>spring-constant</i> <i>spring-length</i> <i>repulsion-constant</i></span>
-			</h4>
-			<p>
-				Arranges the turtles in <i>turtle-set</i>, as if the links in
-				<i>link-set</i> are springs and the turtles are repelling each
-				other. Turtles that are connected by links in <i>link-set</i> but
-				not included in <i>turtle-set</i> are treated as anchors and are
-				not moved.
-			</p>
-			<p>
-				<i>spring-constant</i> is a measure of the &quot;tautness&quot; of
-				the spring. It is the &quot;resistance&quot; to change in their
-				length. spring-constant is the force the spring would exert if
-				it's length were changed by 1 unit.
-			</p>
-			<p>
-				spring-length is the &quot;zero-force&quot; length or the natural
-				length of the springs. This is the length which all springs try to
-				achieve either by pushing out their nodes or pulling them in.
-			</p>
-			<p>
-				repulsion-constant is a measure of repulsion between the nodes. It
-				is the force that 2 nodes at a distance of 1 unit will exert on
-				each other.
-			</p>
-			<p>
-				The repulsion effect tries to get the nodes as far as possible from
-				each other, in order to avoid crowding and the spring effect tries
-				to keep them at &quot;about&quot; a certain distance from the nodes
-				they are connected to. The result is the laying out of the whole
-				network in a way which highlights relationships among the nodes and
-				at the same time is crowded less and is visually pleasing.
-			</p>
-			<p>
-				The layout algorithm is based on the Fruchterman-Reingold layout
-				algorithm. More information about this algorithm can be obtained
-				<a href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.13.8444" target="_blank">here</a>.
-			</p>
-			<pre>
-				to make-a-triangle
-				set-default-shape turtles &quot;circle&quot;
-				crt 3
-				ask turtle 0
-				[
-				create-links-with other turtles
-				]
-				ask turtle 1
-				[
-				create-link-with turtle 2
-				]
-				repeat 30 [ layout-spring turtles links 0.2 5 1 ] ;; lays the nodes in a triangle
-				end
-			</pre>
-		</div>
-		<div class="dict_entry" id="layout-tutte">
-			<h3>
-				<a>layout-tutte<span class="since">4.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">layout-tutte <i>turtle-set</i> <i>link-set</i> <i>radius</i></span>
-			</h4>
-			<p>
-				The turtles that are connected by links in <i>link-set</i> but not
-				included in <i>turtle-set</i> are placed in a circle layout with
-				the given <i>radius</i>. There should be at least 3 agents in this
-				agentset.
-			</p>
-			<p>
-				The turtles in <i>turtle-set</i> are then laid out in the following
-				manner: Each turtle is placed at centroid (or barycenter) of the
-				polygon formed by its linked neighbors. (The centroid is like a
-				2-dimensional average of the coordinates of the neighbors.)
-			</p>
-			<p>
-				(The purpose of the circle of &quot;anchor agents&quot; is to
-				prevent all the turtles from collapsing down to one point.)
-			</p>
-			<p>
-				After a few iterations of this, the layout will stabilize.
-			</p>
-			<p>
-				This layout is named after the mathematician William Thomas Tutte,
-				who proposed it as a method for graph layout.
-			</p>
-			<pre>
-				to make-a-tree
-				set-default-shape turtles &quot;circle&quot;
-				crt 6
-				ask turtle 0 [
-				create-link-with turtle 1
-				create-link-with turtle 2
-				create-link-with turtle 3
-				]
-				ask turtle 1 [
-				create-link-with turtle 4
-				create-link-with turtle 5
-				]
-				; place all the turtles with just one
-				; neighbor on the perimeter of a circle
-				; and then place the remaining turtles inside
-				; this circle, spread between their neighbors.
-				repeat 10 [ layout-tutte (turtles with [link-neighbors = 1]) links 12 ]
-				end
-			</pre>
-		</div>
-		<div class="dict_entry" id="left">
-			<h3>
-				<a>left<span class="since">1.0</span></a>
-				<a>lt<span class="since">1.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">left <i>number</i></span>
-				<img alt="Turtle Command" src="images/turtle.gif"/>
-			</h4>
-			<p>
-				The turtle turns left by <i>number</i> degrees. (If <i>number</i>
-				is negative, it turns right.)
-			</p>
-		</div>
-		<div class="dict_entry" id="length">
-			<h3>
-				<a>length<span class="since">1.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">length <i>list</i></span>
-				<span class="prim_example">length <i>string</i></span>
-			</h4>
-			<p>
-				Reports the number of items in the given list, or the number of
-				characters in the given string.
-			</p>
-		</div>
-		<div class="dict_entry" id="let">
-			<h3>
-				<a>let<span class="since">2.1</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">let <i>variable</i> <i>value</i></span>
-			</h4>
-			<p>
-				Creates a new local variable and gives it the given value. A local
-				variable is one that exists only within the enclosing block of
-				commands.
-			</p>
-			<p>
-				If you want to change the value afterwards, use <a href="#set">set</a>.
-			</p>
-			<p>
-				Example:
-			</p>
-			<pre>
-				let prey one-of sheep-here
-				if prey != nobody
-				[ ask prey [ die ] ]
-			</pre>
-		</div>
-		<div class="dict_entry" id="link">
-			<h3>
-				<a>link<span class="since">4.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">link <i>end1</i> <i>end2</i></span>
-				<span class="prim_example">&lt;breed&gt; <i>end1</i> <i>end2</i></span>
-			</h4>
-			<p>
-				Given the who numbers of the endpoints, reports the link connecting
-				the turtles. If there is no such link reports <code>nobody</code>. To
-				refer to breeded links you must use the singular breed form with
-				the endpoints.
-			</p>
-			<pre>
-				ask link 0 1 [ set color green ]
-				;; unbreeded link connecting turtle 0 and turtle 1 will turn green
-				ask directed-link 0 1 [ set color red ]
-				;; directed link connecting turtle 0 and turtle 1 will turn red
-			</pre>
-			<p>
-				See also <a href="#patch-at">patch-at</a>.
-			</p>
-		</div>
-		<div class="dict_entry" id="link-heading">
-			<h3>
-				<a>link-heading<span class="since">4.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">link-heading</span>
-				<img alt="Link Command" src="images/link.gif"/>
-			</h4>
-			<p>
-				Reports the heading in degrees (at least 0, less than 360) from
-				<code>end1</code> to <code>end2</code> of the link. Throws a runtime error
-				if the endpoints are at the same location.
-			</p>
-			<pre>
-				ask link 0 1 [ print link-heading ]
-				;; prints [[towards other-end] of end1] of link 0 1
-			</pre>
-			<p>
-				See also <a href="#link-length">link-length</a>
-			</p>
-		</div>
-		<div class="dict_entry" id="link-length">
-			<h3>
-				<a>link-length<span class="since">4.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">link-length</span>
-				<img alt="Link Command" src="images/link.gif"/>
-			</h4>
-			<p>
-				Reports the distance between the endpoints of the link.
-			</p>
-			<pre>
-				ask link 0 1 [ print link-length ]
-				;; prints [[distance other-end] of end1] of link 0 1
-			</pre>
-			<p>
-				See also <a href="#link-heading">link-heading</a>
-			</p>
-		</div>
-		<div class="dict_entry" id="link-set">
-			<h3>
-				<a>link-set<span class="since">4.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">link-set <i>value</i></span>
-				<span class="prim_example">(link-set <i>value1</i> <i>value2</i> ...)</span>
-			</h4>
-			<p>
-				Reports an agentset containing all of the links anywhere in any of
-				the inputs. The inputs may be individual links, link agentsets,
-				nobody, or lists (or nested lists) containing any of the above.
-			</p>
-			<pre>
-				link-set self
-				link-set [my-links] of nodes with [color = red]
-			</pre>
-			<p>
-				See also <a href="#turtle-set">turtle-set</a>, <a href="#patch-set">patch-set</a>.
-			</p>
-		</div>
-		<div class="dict_entry" id="link-shapes">
-			<h3>
-				<a>link-shapes<span class="since">4.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">link-shapes</span>
-			</h4>
-			<p>
-				Reports a list of strings containing all of the link shapes in the
-				model.
-			</p>
-			<p>
-				New shapes can be created, or imported from other models, in the
-				<a href="shapes.html">Link Shapes Editor</a>.
-			</p>
-			<pre>
-				show link-shapes
-				=&gt; [&quot;default&quot;]
-			</pre>
-		</div>
-		<div class="dict_entry" id="links">
-			<h3>
-				<a>links<span class="since">4.0</span></a>
-			</h3>
-			<h4>
-				<span class="prim_example">links</span>
-			</h4>
-			<p>
-				Reports the agentset consisting of all links. This is a special agentset that can grow as links are added to the world, see <a href="programming.html#special-agentsets">the programming guide for more info</a>.
-			</p>
-			<pre>
-				show count links
-				;; prints the number of links
-			</pre>
-		</div>
-		<div class="dict_entry" id="links-own">
-			<h3>
-				<a>links-own</a>
-			</h3>
-			<h4>
-				<span class="prim_example">links-own [<i>var1</i> ...]</span>
-				<span class="prim_example"><i>&lt;link-breeds&gt;</i>-own [<i>var1</i> ...]</span>
-			</h4>
-			<p>
-				The links-own keyword, like the globals, breed,
-				<i>&lt;breeds&gt;</i>-own, turtles-own, and patches-own keywords,
-				can only be used at the beginning of a program, before any function
-				definitions. It defines the variables belonging to each link.
-			</p>
-			<p>
-				If you specify a breed instead of &quot;links&quot;, only links of
-				that breed have the listed variables. (More than one link breed may
-				list the same variable.)
-			</p>
-			<pre>
-				undirected-link-breed [sidewalks sidewalk]
-				directed-link-breed [streets street]
-				links-own [traffic]   ;; applies to all breeds
-				sidewalks-own [pedestrians]
-				streets-own [cars bikes]
-			</pre>
-			<div class="dict_entry" id="list">
-				<h3>
-					<a>list<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">list <i>value1</i> <i>value2</i></span>
-					<span class="prim_example">(list <i>value1</i> ...)</span>
-				</h4>
-				<p>
-					Reports a list containing the given items. The items can be of
-					any type, produced by any kind of reporter.
-				</p>
-				<pre>
-					show list (random 10) (random 10)
-					=&gt; [4 9]  ;; or similar list
-					show (list 5)
-					=&gt; [5]
-					show (list (random 10) 1 2 3 (random 10))
-					=&gt; [4 1 2 3 9]  ;; or similar list
-				</pre>
-			</div>
-			<div class="dict_entry" id="ln">
-				<h3>
-					<a>ln<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">ln <i>number</i></span>
-				</h4>
-				<p>
-					Reports the natural logarithm of <i>number</i>, that is, the
-					logarithm to the base e (2.71828...).
-				</p>
-				<p>
-					See also <a href="#num-e">e</a>, <a href="#log">log</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="log">
-				<h3>
-					<a>log<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">log <i>number</i> <i>base</i></span>
-				</h4>
-				<p>
-					Reports the logarithm of <i>number</i> in base <i>base</i>.
-				</p>
-				<pre>
-					show log 64 2
-					=&gt; 6
-				</pre>
-				<p>
-					See also <a href="#ln">ln</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="loop">
-				<h3>
-					<a>loop<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">loop [ <i>commands</i> ]</span>
-				</h4>
-				<p>
-					Repeats the commands forever, or until the enclosing procedure
-					exits through use of the <a href="#stop">stop</a> or
-					<a href="#report">report</a> commands.
-				</p>
-				<pre>to move-to-world-edge  ;; turtle procedure
-					loop [
-					if not can-move? 1 [ stop ]
-					fd 1
-					]
-					end</pre>
-				<p>In this example, <code>stop</code> exits not just the loop,
-					but the entire procedure.
-				</p>
-				<p>
-					Note: in many circumstances, it is more appropriate to use
-					a forever button to repeat something indefinitely.  See
-					<a href="programming.html#buttons">Buttons</a> in the
-					Programming Guide.
-				</p>
-			</div>
-			<div class="dict_entry" id="lput">
-				<h3>
-					<a>lput<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">lput <i>value list</i></span>
-				</h4>
-				<p>
-					Adds <i>value</i> to the end of a list and reports the new list.
-				</p>
-				<pre>
-					;; suppose mylist is [2 7 10 &quot;Bob&quot;]
-					set mylist lput 42 mylist
-					;; mylist now is [2 7 10 &quot;Bob&quot; 42]
-				</pre>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="M">
-			<a>M</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="map">
-				<h3>
-					<a>map<span class="since">1.3</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">map <i>reporter</i> <i>list</i></span>
-					<span class="prim_example">(map <i>reporter</i> <i>list1</i> ...)</span>
-				</h4>
-				<p>
-					With a single <i>list</i>, the given reporter is run for each item in
-					the list, and a list of the results is collected and reported.
-					<i>reporter</i> may be an anonymous reporter or the name of a reporter.
-				</p>
-				<pre>
-					show map round [1.1 2.2 2.7]
-					=&gt; [1 2 3]
-					show map [ i -&gt; i * i ] [1 2 3]
-					=&gt; [1 4 9]
-				</pre>
-				<p>
-					With multiple lists, the given reporter is run for each group of
-					items from each list. So, it is run once for the first items,
-					once for the second items, and so on. All the lists must be the
-					same length.
-				</p>
-				<p>
-					Some examples make this clearer:
-				</p>
-				<pre>
-					show (map + [1 2 3] [2 4 6])
-					=&gt; [3 6 9]
-					show (map [ [a b c] -&gt; a + b = c ] [1 2 3] [2 4 6] [3 5 9])
-					=&gt; [true false true]
-				</pre>
-				<p>
-					See also <a href="#foreach">foreach</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="max">
-				<h3>
-					<a>max<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">max <i>list</i></span>
-				</h4>
-				<p>
-					Reports the maximum number value in the list. It ignores other
-					types of items.
-				</p>
-				<pre>
-					show max [xcor] of turtles
-					;; prints the x coordinate of the turtle which is
-					;; farthest right in the world
-					show max list a b
-					;; prints the larger of the two variables a and b
-					show max (list a b c)
-					;; prints the largest of the three variables a, b, and c
-				</pre>
-			</div>
-			<div class="dict_entry" id="max-n-of">
-				<h3>
-					<a>max-n-of<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">max-n-of <i>number</i> <i>agentset</i> [<i>reporter</i>]</span>
-				</h4>
-				<p>
-					Reports an agentset containing <i>number</i> agents from
-					<i>agentset</i> with the highest values of <i>reporter</i>. The
-					agentset is built by finding all the agents with the highest
-					value of <i>reporter</i>, if there are not <i>number</i> agents
-					with that value then agents with the second highest value are
-					found, and so on. At the end, if there is a tie that would make
-					the resulting agentset too large, the tie is broken randomly.
-				</p>
-				<pre>
-					;; assume the world is 11 x 11
-					show max-n-of 5 patches [pxcor]
-					;; shows 5 patches with pxcor = max-pxcor
-					show max-n-of 5 patches with [pycor = 0] [pxcor]
-					;; shows an agentset containing:
-					;; (patch 1 0) (patch 2 0) (patch 3 0) (patch 4 0) (patch 5 0)
-				</pre>
-				<p>
-					See also <a href="#max-one-of">max-one-of</a>, <a href="#with-max">with-max</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="max-one-of">
-				<h3>
-					<a>max-one-of<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">max-one-of <i>agentset</i> [<i>reporter</i>]</span>
-				</h4>
-				<p>
-					Reports the agent in the agentset that has the highest value for
-					the given reporter. If there is a tie this command reports one
-					random agent with the highest value. If you want all such agents,
-					use with-max instead.
-				</p>
-				<pre>
-					show max-one-of patches [count turtles-here]
-					<br/>;; prints the first patch with the most turtles on it
-				</pre>
-				<p>
-					See also <a href="#max-n-of">max-n-of</a>, <a href="#with-max">with-max</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="max-pcor">
-				<h3>
-					<a>max-pxcor<span class="since">3.1</span></a>
-					<a>max-pycor<span class="since">3.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">max-pxcor</span>
-					<span class="prim_example">max-pycor</span>
-				</h4>
-				<p>
-					These reporters give the maximum x-coordinate and maximum
-					y-coordinate, (respectively) for patches, which determines the
-					size of the world.
-				</p>
-				<p>
-					Unlike in older versions of NetLogo the origin does not have to
-					be at the center of the world. However, the maximum x- and y-
-					coordinates must be greater than or equal to zero.
-				</p>
-				<p>
-					Note: You can set the size of the world only by editing the view
-					-- these are reporters which cannot be set.
-				</p>
-				<pre>
-					crt 100 [ setxy random-float max-pxcor
-					random-float max-pycor ]
-					;; distributes 100 turtles randomly in the
-					;; first quadrant
-				</pre>
-				<p>
-					See also <a href="#min-pcor">min-pxcor</a>, <a href="#min-pcor">min-pycor</a>, <a href="#world-dim">world-width</a>, and <a href="#world-dim">world-height</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="mean">
-				<h3>
-					<a>mean<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">mean <i>list</i></span>
-				</h4>
-				<p>
-					Reports the statistical mean of the numeric items in the given
-					list. Errors on non-numeric items. The mean is the average, i.e.,
-					the sum of the items divided by the total number of items.
-				</p>
-				<pre>
-					show mean [xcor] of turtles
-					;; prints the average of all the turtles' x coordinates
-				</pre>
-			</div>
-			<div class="dict_entry" id="median">
-				<h3>
-					<a>median<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">median <i>list</i></span>
-				</h4>
-				<p>
-					Reports the statistical median of the numeric items of the given
-					list. Ignores non-numeric items. The median is the item that
-					would be in the middle if all the items were arranged in order.
-					(If two items would be in the middle, the median is the average
-					of the two.)
-				</p>
-				<pre>
-					show median [xcor] of turtles
-					;; prints the median of all the turtles' x coordinates
-				</pre>
-			</div>
-			<div class="dict_entry" id="member">
-				<h3>
-					<a>member?<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">member? <i>value list</i></span>
-					<span class="prim_example">member? <i>string1 string2</i></span>
-					<span class="prim_example">member? <i>agent agentset</i></span>
-				</h4>
-				<p>
-					For a list, reports true if the given value appears in the given
-					list, otherwise reports false.
-				</p>
-				<p>
-					For a string, reports true or false depending on whether
-					<i>string1</i> appears anywhere inside <i>string2</i> as a
-					substring.
-				</p>
-				<p>
-					For an agentset, reports true if the given agent is appears in
-					the given agentset, otherwise reports false.
-				</p>
-				<pre>
-					show member? 2 [1 2 3]
-					=&gt; true
-					show member? 4 [1 2 3]
-					=&gt; false
-					show member? &quot;bat&quot; &quot;abate&quot;
-					=&gt; true
-					show member? turtle 0 turtles
-					=&gt; true
-					show member? turtle 0 patches
-					=&gt; false
-				</pre>
-				<p>
-					See also <a href="#position">position</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="min">
-				<h3>
-					<a>min<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">min <i>list</i></span>
-				</h4>
-				<p>
-					Reports the minimum number value in the list. It ignores other
-					types of items.
-				</p>
-				<pre>
-					show min [xcor] of turtles
-					;; prints the lowest x-coordinate of all the turtles
-					show min list a b
-					;; prints the smaller of the two variables a and b
-					show min (list a b c)
-					;; prints the smallest of the three variables a, b, and c
-				</pre>
-			</div>
-			<div class="dict_entry" id="min-n-of">
-				<h3>
-					<a>min-n-of<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">min-n-of <i>number</i> <i>agentset</i> [<i>reporter</i>]</span>
-				</h4>
-				<p>
-					Reports an agentset containing <i>number</i> agents from
-					<i>agentset</i> with the lowest values of <i>reporter</i>. The
-					agentset is built by finding all the agents with the lowest value
-					of <i>reporter</i>, if there are not <i>number</i> agents with
-					that value then the agents with the second lowest value are
-					found, and so on. At the end, if there is a tie that would make
-					the resulting agentset too large, the tie is broken randomly.
-				</p>
-				<pre>
-					;; assume the world is 11 x 11
-					show min-n-of 5 patches [pxcor]
-					;; shows 5 patches with pxcor = min-pxcor
-					show min-n-of 5 patches with [pycor = 0] [pxcor]
-					;; shows an agentset containing:
-					;; (patch -5 0) (patch -4 0) (patch -3 0) (patch -2 0) (patch -1 0)
-				</pre>
-				<p>
-					See also <a href="#min-one-of">min-one-of</a>, <a href="#with-min">with-min</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="min-one-of">
-				<h3>
-					<a>min-one-of<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">min-one-of <i>agentset</i> [<i>reporter</i>]</span>
-				</h4>
-				<p>
-					Reports a random agent in the agentset that reports the lowest
-					value for the given reporter. If there is a tie, this command
-					reports one random agent that meets the condition. If you want
-					all such agents use with-min instead.
-				</p>
-				<pre>
-					show min-one-of turtles [xcor + ycor]
-					;; reports the first turtle with the smallest sum of
-					;; coordinates
-				</pre>
-				<p>
-					See also <a href="#with-min">with-min</a>, <a href="#min-n-of">min-n-of</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="min-pcor">
-				<h3>
-					<a>min-pxcor<span class="since">3.1</span></a>
-					<a>min-pycor<span class="since">3.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">min-pxcor</span>
-					<span class="prim_example">min-pycor</span>
-				</h4>
-				<p>
-					These reporters give the minimum x-coordinate and minimum
-					y-coordinate, (respectively) for patches, which determines the
-					size of the world.
-				</p>
-				<p>
-					Unlike in older versions of NetLogo the origin does not have to
-					be at the center of the world. However, the minimum x- and y-
-					coordinates must be less than or equal to zero.
-				</p>
-				<p>
-					Note: You can set the size of the world only by editing the view
-					-- these are reporters which cannot be set.
-				</p>
-				<pre>
-					crt 100 [ setxy random-float min-pxcor
-					random-float min-pycor ]
-					;; distributes 100 turtles randomly in the
-					;; third quadrant
-				</pre>
-				<p>
-					See also <a href="#max-pcor">max-pxcor</a>, <a href="#max-pcor">max-pycor</a>, <a href="#world-dim">world-width</a>, and <a href="#world-dim">world-height</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="mod">
-				<h3>
-					<a>mod<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example"><i>number1</i> mod <i>number2</i></span>
-				</h4>
-				<p>
-					Reports <i>number1</i> modulo <i>number2</i>: that is, the
-					residue of <i>number1</i> (mod <i>number2</i>). mod is is
-					equivalent to the following NetLogo code:
-				</p>
-				<pre>
-					<i>number1</i> - (floor (<i>number1</i> / <i>number2</i>)) * <i>number2</i>
-				</pre>
-				<p>
-					Note that mod is &quot;infix&quot;, that is, it comes between its
-					two inputs.
-				</p>
-				<pre>
-					show 62 mod 5
-					=&gt; 2
-					show -8 mod 3
-					=&gt; 1
-				</pre>
-				<p>
-					See also <a href="#remainder">remainder</a>. mod and remainder
-					behave the same for positive numbers, but differently for
-					negative numbers.
-				</p>
-			</div>
-			<div class="dict_entry" id="modes">
-				<h3>
-					<a>modes<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">modes <i>list</i></span>
-				</h4>
-				<p>
-					Reports a list of the most common item or items in <i>list</i>.
-				</p>
-				<p>
-					The input list may contain any NetLogo values.
-				</p>
-				<p>
-					If the input is an empty list, reports an empty list.
-				</p>
-				<pre>
-					show modes [1 2 2 3 4]
-					=&gt; [2]
-					show modes [1 2 2 3 3 4]
-					=&gt; [2 3]
-					show modes [ [1 2 [3]] [1 2 [3]] [2 3 4] ]
-					=&gt; [[1 2 [3]]]
-					show modes [pxcor] of turtles
-					;; shows which columns of patches have the most
-					;; turtles on them
-				</pre>
-			</div>
-			<div class="dict_entry" id="mouse-down">
-				<h3>
-					<a>mouse-down?<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">mouse-down?</span>
-				</h4>
-				<p>
-					Reports true if the mouse button is down, false otherwise.
-				</p>
-				<p>
-					Note: If the mouse pointer is outside of the current view ,
-					mouse-down? will always report false.
-				</p>
-			</div>
-			<div class="dict_entry" id="mouse-inside">
-				<h3>
-					<a>mouse-inside?<span class="since">3.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">mouse-inside?</span>
-				</h4>
-				<p>
-					Reports true if the mouse pointer is inside the current view,
-					false otherwise.
-				</p>
-			</div>
-			<div class="dict_entry" id="mouse-cor">
-				<h3>
-					<a>mouse-xcor<span class="since">1.0</span></a>
-					<a>mouse-ycor<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">mouse-xcor</span>
-					<span class="prim_example">mouse-ycor</span>
-				</h4>
-				<p>
-					Reports the x or y coordinate of the mouse in the 2D view. The
-					value is in terms of turtle coordinates, so it might not be an
-					integer. If you want patch coordinates, use <code>round
-						mouse-xcor</code> and <code>round mouse-ycor</code>.
-				</p>
-				<p>
-					Note: If the mouse is outside of the 2D view, reports the value
-					from the last time it was inside.
-				</p>
-				<pre>
-					;; to make the mouse &quot;draw&quot; in red:
-					if mouse-down?
-					[ ask patch mouse-xcor mouse-ycor [ set pcolor red ] ]
-				</pre>
-			</div>
-			<div class="dict_entry" id="move-to">
-				<h3>
-					<a>move-to<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">move-to <i>agent</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					The turtle sets its x and y coordinates to be the same as the
-					given agent's.
-				</p>
-				<p>
-					(If that agent is a patch, the effect is to move the turtle to
-					the center of that patch.)
-				</p>
-				<pre>
-					move-to turtle 5
-					;; turtle moves to same point as turtle 5
-					move-to one-of patches
-					;; turtle moves to the center of a random patch
-					move-to max-one-of turtles [size]
-					;; turtle moves to same point as biggest turtle
-				</pre>
-				<p>
-					Note that the turtle's heading is unaltered. You may want to
-					use the <a href="#face">face</a> command first to orient the
-					turtle in the direction of motion.
-				</p>
-				<p>
-					See also <a href="#setxy">setxy</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="my-links">
-				<h3>
-					<a>my-&lt;breeds&gt;</a>
-					<a>my-links<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">my-&lt;breeds&gt;</span>
-					<span class="prim_example">my-links</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Reports an agentset of all links connected to the caller of
-					the corresponding breed, regardless of directedness.
-					Generally, you might consider using
-					<a href="#my-out-links"><code>my-out-links</code></a> instead
-					of this primitive, as it works well for either directed or
-					undirected networks (since it excludes directed, incoming
-					links).
-				</p>
-				<pre>
-					crt 5
-					ask turtle 0
-					[
-					create-links-with other turtles
-					show my-links ;; prints the agentset containing all links
-					;; (since all the links we created were with turtle 0 )
-					]
-					ask turtle 1
-					[
-					show my-links ;; shows an agentset containing the link 0 1
-					]
-					end
-				</pre>
-				If you only want the undirected links connected to a node, you
-				can do <code>my-links with [ not is-directed-link? self ]</code>.
-			</div>
-			<div class="dict_entry" id="my-in-links">
-				<h3>
-					<a>my-in-&lt;breeds&gt;</a>
-					<a>my-in-links<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">my-in-&lt;breeds&gt;</span>
-					<span class="prim_example">my-in-links</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Reports an agentset of all the directed links coming in from
-					other nodes to the caller as well as all undirected links
-					connected to the caller. You can think of this as "all links
-					that you can use to travel <i>to</i> this node".
-				</p>
-				<pre>
-					crt 5
-					ask turtle 0
-					[
-					create-links-to other turtles
-					show my-in-links ;; shows an empty agentset
-					]
-					ask turtle 1
-					[
-					show my-in-links ;; shows an agentset containing the link 0 1
-					]
-				</pre>
-			</div>
-			<div class="dict_entry" id="my-out-links">
-				<h3>
-					<a>my-out-&lt;breeds&gt;</a>
-					<a>my-out-links<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">my-out-&lt;breeds&gt;</span>
-					<span class="prim_example">my-out-links</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Reports an agentset of all the directed links going out from the
-					caller to other nodes as well as undirected links connected to the
-					caller. You can think of this as "all links you can use to travel
-					<i>from</i> this node".
-				</p>
-				<pre>
-					crt 5
-					ask turtle 0
-					[
-					create-links-to other turtles
-					show my-out-links ;; shows agentset containing all the links
-					]
-					ask turtle 1
-					[
-					show my-out-links ;; shows an empty agentset
-					]
-				</pre>
-			</div>
-			<div class="dict_entry" id="myself">
-				<h3>
-					<a>myself<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">myself</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/> <img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					&quot;self&quot; and &quot;myself&quot; are very different.
-					&quot;self&quot; is simple; it means &quot;me&quot;.
-					&quot;myself&quot; means &quot;the turtle, patch or link who asked me
-					to do what I'm doing right now.&quot;
-				</p>
-				<p>
-					When an agent has been asked to run some code, using myself in
-					that code reports the agent (turtle, patch or link) that did the
-					asking.
-				</p>
-				<p>
-					myself is most often used in conjunction with <code>of</code> to read
-					or set variables in the asking agent.
-				</p>
-				<p>
-					myself can be used within blocks of code not just in the ask
-					command, but also hatch, sprout, of, with, all?, with-min,
-					with-max, min-one-of, max-one-of, min-n-of, max-n-of.
-				</p>
-				<pre>
-					ask turtles
-					[ ask patches in-radius 3
-					[ set pcolor [color] of myself ] ]
-					;; each turtle makes a colored &quot;splotch&quot; around itself
-				</pre>
-				<p>
-					See the &quot;Myself Example&quot; code example for more
-					examples.
-				</p>
-				<p>
-					See also <a href="#self">self</a>.
-				</p>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="N">
-			<a>N</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="n-of">
-				<h3>
-					<a>n-of<span class="since">3.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">n-of <i>size</i> <i>agentset</i></span>
-					<span class="prim_example">n-of <i>size</i> <i>list</i></span>
-				</h4>
-				<p>
-					From an agentset, reports an agentset of size <i>size</i>
-					randomly chosen from the input set, with no repeats.
-				</p>
-				<p>
-					From a list, reports a list of size <i>size</i> randomly chosen
-					from the input set, with no repeats. The items in the result
-					appear in the same order that they appeared in the input list.
-					(If you want them in random order, use shuffle on the result.)
-				</p>
-				<p>
-					It is an error for <i>size</i> to be greater than the size of the
-					input.
-				</p>
-				<pre>
-					ask n-of 50 patches [ set pcolor green ]
-					;; 50 randomly chosen patches turn green
-				</pre>
-				<p>
-					See also <a href="#one-of">one-of</a> and <a href="#up-to-n-of">up-to-n-of</a>,
-					a version that does not error with a <i>size</i> greater than
-					the size of the input.
-				</p>
-			</div>
-			<div class="dict_entry" id="n-values">
-				<h3>
-					<a>n-values<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">n-values <i>size</i> <i>reporter</i></span>
-				</h4>
-				<p>
-					Reports a list of length <i>size</i> containing values computed
-					by repeatedly running the reporter. <i>reporter</i> may be an anonymous
-					reporter or the name of a reporter.
-				</p>
-				<p>
-					If the reporter accepts inputs, the input will be the number of the
-					item currently being computed, starting from zero.
-				</p>
-				<pre>
-					show n-values 5 [1]
-					=&gt; [1 1 1 1 1]
-					show n-values 5 [ i -&gt; i ]
-					=&gt; [0 1 2 3 4]
-					show n-values 3 turtle
-					=&gt; [(turtle 0) (turtle 1) (turtle 2)]
-					show n-values 5 [ x -&gt; x * x ]
-					=&gt; [0 1 4 9 16]
-				</pre>
-				<p>
-					See also <a href="#reduce">reduce</a>, <a href="#filter">filter</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>, <a href="#range">range</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="neighbors">
-				<h3>
-					<a>neighbors<span class="since">1.1</span></a>
-					<a>neighbors4<span class="since">1.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">neighbors</span>
-					<span class="prim_example">neighbors4</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					Reports an agentset containing the 8 surrounding patches
-					(neighbors) or 4 surrounding patches (neighbors4).
-				</p>
-				<pre>
-					show sum [count turtles-here] of neighbors
-					;; prints the total number of turtles on the eight
-					;; patches around this turtle or patch
-					show count turtles-on neighbors
-					;; a shorter way to say the same thing
-					ask neighbors4 [ set pcolor red ]
-					;; turns the four neighboring patches red
-				</pre>
-			</div>
-			<div class="dict_entry" id="link-neighbors">
-				<h3>
-					<a>&lt;breed&gt;-neighbors</a>
-					<a>link-neighbors<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">&lt;breed&gt;-neighbors</span>
-					<span class="prim_example">link-neighbors</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Reports the agentset of all turtles found at the other end of
-					any links (undirected or directed, incoming or outgoing)
-					connected to this turtle.
-				</p>
-				<pre>
-					crt 3
-					ask turtle 0
-					[
-					create-links-with other turtles
-					ask link-neighbors [ set color red ] ;; turtles 1 and 2 turn red
-					]
-					ask turtle 1
-					[
-					ask link-neighbors [ set color blue ] ;; turtle 0 turns blue
-					]
-					end
-				</pre>
-			</div>
-			<div class="dict_entry" id="link-neighbor">
-				<h3>
-					<a>&lt;breed&gt;-neighbor?</a>
-					<a>link-neighbor?<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">&lt;breed&gt;-neighbor? <i>turtle</i></span>
-					<span class="prim_example">link-neighbor? <i>turtle</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Reports true if there is a link (either directed or undirected,
-					incoming or outgoing) between <i>turtle</i> and the caller.
-				</p>
-				<pre>
-					crt 2
-					ask turtle 0
-					[
-					create-link-with turtle 1
-					show link-neighbor? turtle 1  ;; prints true
-					]
-					ask turtle 1
-					[
-					show link-neighbor? turtle 0     ;; prints true
-					]
-				</pre>
-			</div>
-			<div class="dict_entry" id="netlogo-version">
-				<h3>
-					<a>netlogo-version<span class="since">3.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">netlogo-version</span>
-				</h4>
-				<p>
-					Reports a string containing the version number of the NetLogo you
-					are running.
-				</p>
-				<pre>
-					show netlogo-version
-					=&gt; &quot;{{version}}&quot;
-				</pre>
-			</div>
-			<div class="dict_entry" id="netlogo-web">
-				<h3>
-					<a>netlogo-web?<span class="since">5.2</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">netlogo-web?</span>
-				</h4>
-				<p>
-					Reports true if the model is running in NetLogo Web.
-				</p>
-			</div>
-			<div class="dict_entry" id="new-seed">
-				<h3>
-					<a>new-seed<span class="since">3.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">new-seed</span>
-				</h4>
-				<p>
-					Reports a number suitable for seeding the random number generator.
-				</p>
-				<p>
-					The numbers reported by new-seed are based on the current date and
-					time in milliseconds and lie in the generator's usable range of
-					seeds, -2147483648 to 2147483647.
-				</p>
-				<p>
-					new-seed never reports the same number twice in succession, even
-					across parallel BehaviorSpace runs. (This
-					is accomplished by waiting a millisecond if the seed for the
-					current millisecond was already used.)
-				</p>
-				<p>
-					See also <a href="#random-seed">random-seed</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="no-display">
-				<h3>
-					<a>no-display<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">no-display</span>
-				</h4>
-				<p>
-					Turns off all updates to the current view until the display command
-					is issued. This has two major uses.
-				</p>
-				<p>
-					One, you can control when the user sees view updates. You might
-					want to change lots of things on the view behind the user's
-					back, so to speak, then make them visible to the user all at once.
-				</p>
-				<p>
-					Two, your model will run faster when view updating is off, so if
-					you're in a hurry, this command will let you get results
-					faster. (Note that normally you don't need to use no-display
-					for this, since you can also use the on/off switch in view control
-					strip to freeze the view.)
-				</p>
-				<p>
-					Note that display and no-display operate independently of the
-					switch in the view control strip that freezes the view.
-				</p>
-				<p>
-					See also <a href="#display">display</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="nobody">
-				<h3>
-					<a>nobody</a>
-				</h3>
-				<h4>
-					<span class="prim_example">nobody</span>
-				</h4>
-				<p>
-					This is a special value which some primitives such as turtle,
-					one-of, max-one-of, etc. report to indicate that no agent was
-					found. Also, when a turtle dies, it becomes equal to nobody.
-				</p>
-				<p>
-					Note: Empty agentsets are not equal to nobody. If you want to test
-					for an empty agentset, use <a href="#any">any?</a>. You only get
-					nobody back in situations where you were expecting a single agent,
-					not a whole agentset.
-				</p>
-				<pre>
-					set target one-of other turtles-here
-					if target != nobody
-					[ ask target [ set color red ] ]
-				</pre>
-			</div>
-			<div class="dict_entry" id="no-links">
-				<h3>
-					<a>no-links<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">no-links</span>
-				</h4>
-				<p>
-					Reports an empty link agentset.
-				</p>
-			</div>
-			<div class="dict_entry" id="no-patches">
-				<h3>
-					<a>no-patches<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">no-patches</span>
-				</h4>
-				<p>
-					Reports an empty patch agentset.
-				</p>
-			</div>
-			<div class="dict_entry" id="not">
-				<h3>
-					<a>not<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">not <i>boolean</i></span>
-				</h4>
-				<p>
-					Reports true if <i>boolean</i> is false, otherwise reports false.
-				</p>
-				<pre>
-					if not any? turtles [ crt 10 ]
-				</pre>
-			</div>
-			<div class="dict_entry" id="no-turtles">
-				<h3>
-					<a>no-turtles<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">no-turtles</span>
-				</h4>
-				<p>
-					Reports an empty turtle agentset.
-				</p>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="O">
-			<a>O</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="of">
-				<h3>
-					<a>of<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">[<i>reporter</i>] of <i>agent</i></span>
-					<span class="prim_example">[<i>reporter</i>] of <i>agentset</i></span>
-				</h4>
-				<p>
-					For an agent, reports the value of the reporter for that agent
-					(turtle or patch).
-				</p>
-				<pre>
-					show [pxcor] of patch 3 5
-					;; prints 3
-					show [pxcor] of one-of patches
-					;; prints the value of a random patch's pxcor variable
-					show [who * who] of turtle 5
-					=&gt; 25
-					show [count turtles in-radius 3] of patch 0 0
-					;; prints the number of turtles located within a
-					;; three-patch radius of the origin
-				</pre>
-				<p>
-					For an agentset, reports a list that contains the value of the
-					reporter for each agent in the agentset (in random order).
-				</p>
-				<pre>
-					crt 4
-					show sort [who] of turtles
-					=&gt; [0 1 2 3]
-					show sort [who * who] of turtles
-					=&gt; [0 1 4 9]
-				</pre>
-			</div>
-			<div class="dict_entry" id="one-of">
-				<h3>
-					<a>one-of<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">one-of <i>agentset</i></span>
-					<span class="prim_example">one-of <i>list</i></span>
-				</h4>
-				<p>
-					From an agentset, reports a random agent. If the agentset is empty,
-					reports <a href="#nobody">nobody</a>.
-				</p>
-				<p>
-					From a list, reports a random list item. It is an error for the
-					list to be empty.
-				</p>
-				<pre>
-					ask one-of patches [ set pcolor green ]
-					;; a random patch turns green
-					ask patches with [any? turtles-here]
-					[ show one-of turtles-here ]
-					;; for each patch containing turtles, prints one of
-					;; those turtles
+      <div class="dict_entry" id="inspect">
+        <h3>
+          <a>inspect<span class="since">1.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">inspect <i>agent</i></span>
+        </h4>
+        <p>
+          Opens an agent monitor for the given agent (turtle or patch).
+        </p>
+        <pre>
+          inspect patch 2 4
+          ;; an agent monitor opens for that patch
+          inspect one-of sheep
+          ;; an agent monitor opens for a random turtle from
+          ;; the &quot;sheep&quot; breed
+        </pre>
+        <p>
+          See <a href="#stop-inspecting">stop-inspecting</a> and <a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="int">
+        <h3>
+          <a>int<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">int <i>number</i></span>
+        </h4>
+        <p>
+          Reports the integer part of number -- any fractional part is
+          discarded.
+        </p>
+        <pre>
+          show int 4.7
+          =&gt; 4
+          show int -3.5
+          =&gt; -3
+        </pre>
+      </div>
+      <div class="dict_entry" id="is-of-type">
+        <h3>
+          <a>is-agent?<span class="since">1.2.1</span></a>
+          <a>is-agentset?<span class="since">1.2.1</span></a>
+          <a>is-anonymous-command?<span class="since">6.0</span></a>
+          <a>is-anonymous-reporter?<span class="since">6.0</span></a>
+          <a>is-boolean?<span class="since">1.2.1</span></a>
+          <a>is-directed-link?<span class="since">4.0</span></a>
+          <a>is-link?<span class="since">4.0</span></a>
+          <a>is-link-set?<span class="since">4.0</span></a>
+          <a>is-list?<span class="since">1.0</span></a>
+          <a>is-number?<span class="since">1.2.1</span></a>
+          <a>is-patch?<span class="since">1.2.1</span></a>
+          <a>is-patch-set?<span class="since">4.0</span></a>
+          <a>is-string?<span class="since">1.0</span></a>
+          <a>is-turtle?<span class="since">1.2.1</span></a>
+          <a>is-turtle-set?<span class="since">4.0</span></a>
+          <a>is-undirected-link?<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">is-agent? <i>value</i></span>
+          <span class="prim_example">is-agentset? <i>value</i></span>
+          <span class="prim_example">is-anonymous-command? <i>value</i></span>
+          <span class="prim_example">is-anonymous-reporter? <i>value</i></span>
+          <span class="prim_example">is-boolean? <i>value</i></span>
+          <span class="prim_example">is-<i>&lt;breed&gt;</i>? <i>value</i></span>
+          <span class="prim_example">is-<i>&lt;link-breed&gt;</i>? <i>value</i></span>
+          <span class="prim_example">is-directed-link? <i>value</i></span>
+          <span class="prim_example">is-link? <i>value</i></span>
+          <span class="prim_example">is-link-set? <i>value</i></span>
+          <span class="prim_example">is-list? <i>value</i></span>
+          <span class="prim_example">is-number? <i>value</i></span>
+          <span class="prim_example">is-patch? <i>value</i></span>
+          <span class="prim_example">is-patch-set? <i>value</i></span>
+          <span class="prim_example">is-string? <i>value</i></span>
+          <span class="prim_example">is-turtle? <i>value</i></span>
+          <span class="prim_example">is-turtle-set? <i>value</i></span>
+          <span class="prim_example">is-undirected-link? <i>value</i></span>
+        </h4>
+        <p>
+          Reports true if <i>value</i> is of the given type, false otherwise.
+        </p>
+      </div>
+      <div class="dict_entry" id="item">
+        <h3>
+          <a>item<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">item <i>index list</i></span>
+          <span class="prim_example">item <i>index string</i></span>
+        </h4>
+        <p>
+          On lists, reports the value of the item in the given list with the
+          given index.
+        </p>
+        <p>
+          On strings, reports the character in the given string at the given
+          index.
+        </p>
+        <p>
+          Note that the indices begin from 0, not 1. (The first item is item
+          0, the second item is item 1, and so on.)
+        </p>
+        <pre>
+          ;; suppose mylist is [2 4 6 8 10]
+          show item 2 mylist
+          =&gt; 6
+          show item 3 &quot;my-shoe&quot;
+          =&gt; &quot;s&quot;
+        </pre>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="J">
+      <a>J</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="jump">
+        <h3>
+          <a>jump<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">jump <i>number</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          The turtle moves forward by <i>number</i> units all at once (rather
+          than one step at a time as with the <code>forward</code> command).
+        </p>
+        <p>
+          If the turtle cannot jump <i>number</i> units because it is not
+          permitted by the current topology the turtle does not move at all.
+        </p>
+        <p>
+          See also <a href="#forward">forward</a>, <a href="#can-move">can-move?</a>.
+        </p>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="L">
+      <a>L</a>
+    </h2><!-- ======================================== -->
+    <div class="dict_entry" id="label">
+      <h3>
+        <a>label</a>
+      </h3>
+      <h4>
+        <span class="prim_example">label</span>
+        <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+      </h4>
+      <p>
+        This is a built-in turtle or link variable. It may hold a value of
+        any type. The turtle or link appears in the view with the given
+        value &quot;attached&quot; to it as text. You can set this variable
+        to add, change, or remove a turtle or link's label.
+      </p>
+      <p>
+        See also <a href="#label-color">label-color</a>, <a href="#plabel">plabel</a>, <a href="#plabel-color">plabel-color</a>.
+      </p>
+      <p>
+        Example:
+      </p>
+      <pre>
+        ask turtles [ set label who ]
+        ;; all the turtles now are labeled with their
+        ;; who numbers
+        ask turtles [ set label &quot;&quot; ]
+        ;; all turtles now are not labeled
+      </pre>
+    </div>
+    <div class="dict_entry" id="label-color">
+      <h3>
+        <a>label-color</a>
+      </h3>
+      <h4>
+        <span class="prim_example">label-color</span>
+        <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+      </h4>
+      <p>
+        This is a built-in turtle or link variable. It holds a number
+        greater than or equal to 0 and less than 140. This number
+        determines what color the turtle or link's label appears in (if
+        it has a label). You can set this variable to change the color of a
+        turtle or link's label.
+      </p>
+      <p>
+        See also <a href="#label">label</a>, <a href="#plabel">plabel</a>,
+        <a href="#plabel-color">plabel-color</a>.
+      </p>
+      <p>
+        Example:
+      </p>
+      <pre>
+        ask turtles [ set label-color red ]
+        ;; all the turtles now have red labels
+      </pre>
+    </div>
+    <div class="dict_entry" id="last">
+      <h3>
+        <a>last<span class="since">1.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">last <i>list</i></span>
+        <span class="prim_example">last <i>string</i></span>
+      </h4>
+      <p>
+        On a list, reports the last item in the list.
+      </p>
+      <p>
+        On a string, reports a one-character string containing only the
+        last character of the original string.
+      </p>
+    </div>
+    <div class="dict_entry" id="layout-circle">
+      <h3>
+        <a>layout-circle<span class="since">4.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">layout-circle <i>agentset</i> <i>radius</i></span>
+        <span class="prim_example">layout-circle <i>list-of-turtles</i> <i>radius</i></span>
+      </h4>
+      <p>
+        Arranges the given turtles in a circle centered on the patch at the
+        center of the world with the given radius. (If the world has an
+        even size the center of the circle is rounded down to the nearest
+        patch.) The turtles point outwards.
+      </p>
+      <p>
+        If the first input is an agentset, the turtles are arranged in
+        random order.
+      </p>
+      <p>
+        If the first input is a list, the turtles are arranged clockwise in
+        the given order, starting at the top of the circle. (Any
+        non-turtles in the list are ignored.)
+      </p>
+      <pre>
+        ;; in random order
+        layout-circle turtles 10
+        ;; in order by who number
+        layout-circle sort turtles 10
+        ;; in order by size
+        layout-circle sort-by [ [a b] -&gt; [size] of a &lt; [size] of b ] turtles 10
+      </pre>
+    </div>
+    <div class="dict_entry" id="layout-radial">
+      <h3>
+        <a>layout-radial<span class="since">4.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">layout-radial <i>turtle-set</i> <i>link-set</i> <i>root-agent</i></span>
+      </h4>
+      <p>
+        Arranges the turtles in <i>turtle-set</i> connected by links in
+        <i>link-set</i>, in a radial tree layout, centered around the
+        <i>root-agent</i> which is moved to the center of the world view.
+      </p>
+      <p>
+        Only links in the <i>link-set</i> will be used to determine the
+        layout. If links connect turtles that are not in <i>turtle-set</i>
+        those turtles will remain stationary.
+      </p>
+      <p>
+        Even if the network does contain cycles, and is not a true tree
+        structure, this layout will still work, although the results will
+        not always be pretty.
+      </p>
+      <pre>
+        to make-a-tree
+        set-default-shape turtles &quot;circle&quot;
+        crt 6
+        ask turtle 0 [
+        create-link-with turtle 1
+        create-link-with turtle 2
+        create-link-with turtle 3
+        ]
+        ask turtle 1 [
+        create-link-with turtle 4
+        create-link-with turtle 5
+        ]
+        ; do a radial tree layout, centered on turtle 0
+        layout-radial turtles links (turtle 0)
+        end
+      </pre>
+    </div>
+    <div class="dict_entry" id="layout-spring">
+      <h3>
+        <a>layout-spring<span class="since">4.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">layout-spring <i>turtle-set</i> <i>link-set</i>
+          <i>spring-constant</i> <i>spring-length</i> <i>repulsion-constant</i></span>
+      </h4>
+      <p>
+        Arranges the turtles in <i>turtle-set</i>, as if the links in
+        <i>link-set</i> are springs and the turtles are repelling each
+        other. Turtles that are connected by links in <i>link-set</i> but
+        not included in <i>turtle-set</i> are treated as anchors and are
+        not moved.
+      </p>
+      <p>
+        <i>spring-constant</i> is a measure of the &quot;tautness&quot; of
+        the spring. It is the &quot;resistance&quot; to change in their
+        length. spring-constant is the force the spring would exert if
+        it's length were changed by 1 unit.
+      </p>
+      <p>
+        spring-length is the &quot;zero-force&quot; length or the natural
+        length of the springs. This is the length which all springs try to
+        achieve either by pushing out their nodes or pulling them in.
+      </p>
+      <p>
+        repulsion-constant is a measure of repulsion between the nodes. It
+        is the force that 2 nodes at a distance of 1 unit will exert on
+        each other.
+      </p>
+      <p>
+        The repulsion effect tries to get the nodes as far as possible from
+        each other, in order to avoid crowding and the spring effect tries
+        to keep them at &quot;about&quot; a certain distance from the nodes
+        they are connected to. The result is the laying out of the whole
+        network in a way which highlights relationships among the nodes and
+        at the same time is crowded less and is visually pleasing.
+      </p>
+      <p>
+        The layout algorithm is based on the Fruchterman-Reingold layout
+        algorithm. More information about this algorithm can be obtained
+        <a href="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.13.8444" target="_blank">here</a>.
+      </p>
+      <pre>
+        to make-a-triangle
+        set-default-shape turtles &quot;circle&quot;
+        crt 3
+        ask turtle 0
+        [
+        create-links-with other turtles
+        ]
+        ask turtle 1
+        [
+        create-link-with turtle 2
+        ]
+        repeat 30 [ layout-spring turtles links 0.2 5 1 ] ;; lays the nodes in a triangle
+        end
+      </pre>
+    </div>
+    <div class="dict_entry" id="layout-tutte">
+      <h3>
+        <a>layout-tutte<span class="since">4.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">layout-tutte <i>turtle-set</i> <i>link-set</i> <i>radius</i></span>
+      </h4>
+      <p>
+        The turtles that are connected by links in <i>link-set</i> but not
+        included in <i>turtle-set</i> are placed in a circle layout with
+        the given <i>radius</i>. There should be at least 3 agents in this
+        agentset.
+      </p>
+      <p>
+        The turtles in <i>turtle-set</i> are then laid out in the following
+        manner: Each turtle is placed at centroid (or barycenter) of the
+        polygon formed by its linked neighbors. (The centroid is like a
+        2-dimensional average of the coordinates of the neighbors.)
+      </p>
+      <p>
+        (The purpose of the circle of &quot;anchor agents&quot; is to
+        prevent all the turtles from collapsing down to one point.)
+      </p>
+      <p>
+        After a few iterations of this, the layout will stabilize.
+      </p>
+      <p>
+        This layout is named after the mathematician William Thomas Tutte,
+        who proposed it as a method for graph layout.
+      </p>
+      <pre>
+        to make-a-tree
+        set-default-shape turtles &quot;circle&quot;
+        crt 6
+        ask turtle 0 [
+        create-link-with turtle 1
+        create-link-with turtle 2
+        create-link-with turtle 3
+        ]
+        ask turtle 1 [
+        create-link-with turtle 4
+        create-link-with turtle 5
+        ]
+        ; place all the turtles with just one
+        ; neighbor on the perimeter of a circle
+        ; and then place the remaining turtles inside
+        ; this circle, spread between their neighbors.
+        repeat 10 [ layout-tutte (turtles with [link-neighbors = 1]) links 12 ]
+        end
+      </pre>
+    </div>
+    <div class="dict_entry" id="left">
+      <h3>
+        <a>left<span class="since">1.0</span></a>
+        <a>lt<span class="since">1.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">left <i>number</i></span>
+        <img alt="Turtle Command" src="images/turtle.gif"/>
+      </h4>
+      <p>
+        The turtle turns left by <i>number</i> degrees. (If <i>number</i>
+        is negative, it turns right.)
+      </p>
+    </div>
+    <div class="dict_entry" id="length">
+      <h3>
+        <a>length<span class="since">1.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">length <i>list</i></span>
+        <span class="prim_example">length <i>string</i></span>
+      </h4>
+      <p>
+        Reports the number of items in the given list, or the number of
+        characters in the given string.
+      </p>
+    </div>
+    <div class="dict_entry" id="let">
+      <h3>
+        <a>let<span class="since">2.1</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">let <i>variable</i> <i>value</i></span>
+      </h4>
+      <p>
+        Creates a new local variable and gives it the given value. A local
+        variable is one that exists only within the enclosing block of
+        commands.
+      </p>
+      <p>
+        If you want to change the value afterwards, use <a href="#set">set</a>.
+      </p>
+      <p>
+        Example:
+      </p>
+      <pre>
+        let prey one-of sheep-here
+        if prey != nobody
+        [ ask prey [ die ] ]
+      </pre>
+    </div>
+    <div class="dict_entry" id="link">
+      <h3>
+        <a>link<span class="since">4.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">link <i>end1</i> <i>end2</i></span>
+        <span class="prim_example">&lt;breed&gt; <i>end1</i> <i>end2</i></span>
+      </h4>
+      <p>
+        Given the who numbers of the endpoints, reports the link connecting
+        the turtles. If there is no such link reports <code>nobody</code>. To
+        refer to breeded links you must use the singular breed form with
+        the endpoints.
+      </p>
+      <pre>
+        ask link 0 1 [ set color green ]
+        ;; unbreeded link connecting turtle 0 and turtle 1 will turn green
+        ask directed-link 0 1 [ set color red ]
+        ;; directed link connecting turtle 0 and turtle 1 will turn red
+      </pre>
+      <p>
+        See also <a href="#patch-at">patch-at</a>.
+      </p>
+    </div>
+    <div class="dict_entry" id="link-heading">
+      <h3>
+        <a>link-heading<span class="since">4.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">link-heading</span>
+        <img alt="Link Command" src="images/link.gif"/>
+      </h4>
+      <p>
+        Reports the heading in degrees (at least 0, less than 360) from
+        <code>end1</code> to <code>end2</code> of the link. Throws a runtime error
+        if the endpoints are at the same location.
+      </p>
+      <pre>
+        ask link 0 1 [ print link-heading ]
+        ;; prints [[towards other-end] of end1] of link 0 1
+      </pre>
+      <p>
+        See also <a href="#link-length">link-length</a>
+      </p>
+    </div>
+    <div class="dict_entry" id="link-length">
+      <h3>
+        <a>link-length<span class="since">4.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">link-length</span>
+        <img alt="Link Command" src="images/link.gif"/>
+      </h4>
+      <p>
+        Reports the distance between the endpoints of the link.
+      </p>
+      <pre>
+        ask link 0 1 [ print link-length ]
+        ;; prints [[distance other-end] of end1] of link 0 1
+      </pre>
+      <p>
+        See also <a href="#link-heading">link-heading</a>
+      </p>
+    </div>
+    <div class="dict_entry" id="link-set">
+      <h3>
+        <a>link-set<span class="since">4.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">link-set <i>value</i></span>
+        <span class="prim_example">(link-set <i>value1</i> <i>value2</i> ...)</span>
+      </h4>
+      <p>
+        Reports an agentset containing all of the links anywhere in any of
+        the inputs. The inputs may be individual links, link agentsets,
+        nobody, or lists (or nested lists) containing any of the above.
+      </p>
+      <pre>
+        link-set self
+        link-set [my-links] of nodes with [color = red]
+      </pre>
+      <p>
+        See also <a href="#turtle-set">turtle-set</a>, <a href="#patch-set">patch-set</a>.
+      </p>
+    </div>
+    <div class="dict_entry" id="link-shapes">
+      <h3>
+        <a>link-shapes<span class="since">4.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">link-shapes</span>
+      </h4>
+      <p>
+        Reports a list of strings containing all of the link shapes in the
+        model.
+      </p>
+      <p>
+        New shapes can be created, or imported from other models, in the
+        <a href="shapes.html">Link Shapes Editor</a>.
+      </p>
+      <pre>
+        show link-shapes
+        =&gt; [&quot;default&quot;]
+      </pre>
+    </div>
+    <div class="dict_entry" id="links">
+      <h3>
+        <a>links<span class="since">4.0</span></a>
+      </h3>
+      <h4>
+        <span class="prim_example">links</span>
+      </h4>
+      <p>
+        Reports the agentset consisting of all links. This is a special agentset that can grow as links are added to the world, see <a href="programming.html#special-agentsets">the programming guide for more info</a>.
+      </p>
+      <pre>
+        show count links
+        ;; prints the number of links
+      </pre>
+    </div>
+    <div class="dict_entry" id="links-own">
+      <h3>
+        <a>links-own</a>
+      </h3>
+      <h4>
+        <span class="prim_example">links-own [<i>var1</i> ...]</span>
+        <span class="prim_example"><i>&lt;link-breeds&gt;</i>-own [<i>var1</i> ...]</span>
+      </h4>
+      <p>
+        The links-own keyword, like the globals, breed,
+        <i>&lt;breeds&gt;</i>-own, turtles-own, and patches-own keywords,
+        can only be used at the beginning of a program, before any function
+        definitions. It defines the variables belonging to each link.
+      </p>
+      <p>
+        If you specify a breed instead of &quot;links&quot;, only links of
+        that breed have the listed variables. (More than one link breed may
+        list the same variable.)
+      </p>
+      <pre>
+        undirected-link-breed [sidewalks sidewalk]
+        directed-link-breed [streets street]
+        links-own [traffic]   ;; applies to all breeds
+        sidewalks-own [pedestrians]
+        streets-own [cars bikes]
+      </pre>
+      <div class="dict_entry" id="list">
+        <h3>
+          <a>list<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">list <i>value1</i> <i>value2</i></span>
+          <span class="prim_example">(list <i>value1</i> ...)</span>
+        </h4>
+        <p>
+          Reports a list containing the given items. The items can be of
+          any type, produced by any kind of reporter.
+        </p>
+        <pre>
+          show list (random 10) (random 10)
+          =&gt; [4 9]  ;; or similar list
+          show (list 5)
+          =&gt; [5]
+          show (list (random 10) 1 2 3 (random 10))
+          =&gt; [4 1 2 3 9]  ;; or similar list
+        </pre>
+      </div>
+      <div class="dict_entry" id="ln">
+        <h3>
+          <a>ln<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">ln <i>number</i></span>
+        </h4>
+        <p>
+          Reports the natural logarithm of <i>number</i>, that is, the
+          logarithm to the base e (2.71828...).
+        </p>
+        <p>
+          See also <a href="#num-e">e</a>, <a href="#log">log</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="log">
+        <h3>
+          <a>log<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">log <i>number</i> <i>base</i></span>
+        </h4>
+        <p>
+          Reports the logarithm of <i>number</i> in base <i>base</i>.
+        </p>
+        <pre>
+          show log 64 2
+          =&gt; 6
+        </pre>
+        <p>
+          See also <a href="#ln">ln</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="loop">
+        <h3>
+          <a>loop<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">loop [ <i>commands</i> ]</span>
+        </h4>
+        <p>
+          Repeats the commands forever, or until the enclosing procedure
+          exits through use of the <a href="#stop">stop</a> or
+          <a href="#report">report</a> commands.
+        </p>
+        <pre>to move-to-world-edge  ;; turtle procedure
+          loop [
+          if not can-move? 1 [ stop ]
+          fd 1
+          ]
+          end</pre>
+        <p>In this example, <code>stop</code> exits not just the loop,
+          but the entire procedure.
+        </p>
+        <p>
+          Note: in many circumstances, it is more appropriate to use
+          a forever button to repeat something indefinitely.  See
+          <a href="programming.html#buttons">Buttons</a> in the
+          Programming Guide.
+        </p>
+      </div>
+      <div class="dict_entry" id="lput">
+        <h3>
+          <a>lput<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">lput <i>value list</i></span>
+        </h4>
+        <p>
+          Adds <i>value</i> to the end of a list and reports the new list.
+        </p>
+        <pre>
+          ;; suppose mylist is [2 7 10 &quot;Bob&quot;]
+          set mylist lput 42 mylist
+          ;; mylist now is [2 7 10 &quot;Bob&quot; 42]
+        </pre>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="M">
+      <a>M</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="map">
+        <h3>
+          <a>map<span class="since">1.3</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">map <i>reporter</i> <i>list</i></span>
+          <span class="prim_example">(map <i>reporter</i> <i>list1</i> ...)</span>
+        </h4>
+        <p>
+          With a single <i>list</i>, the given reporter is run for each item in
+          the list, and a list of the results is collected and reported.
+          <i>reporter</i> may be an anonymous reporter or the name of a reporter.
+        </p>
+        <pre>
+          show map round [1.1 2.2 2.7]
+          =&gt; [1 2 3]
+          show map [ i -&gt; i * i ] [1 2 3]
+          =&gt; [1 4 9]
+        </pre>
+        <p>
+          With multiple lists, the given reporter is run for each group of
+          items from each list. So, it is run once for the first items,
+          once for the second items, and so on. All the lists must be the
+          same length.
+        </p>
+        <p>
+          Some examples make this clearer:
+        </p>
+        <pre>
+          show (map + [1 2 3] [2 4 6])
+          =&gt; [3 6 9]
+          show (map [ [a b c] -&gt; a + b = c ] [1 2 3] [2 4 6] [3 5 9])
+          =&gt; [true false true]
+        </pre>
+        <p>
+          See also <a href="#foreach">foreach</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="max">
+        <h3>
+          <a>max<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">max <i>list</i></span>
+        </h4>
+        <p>
+          Reports the maximum number value in the list. It ignores other
+          types of items.
+        </p>
+        <pre>
+          show max [xcor] of turtles
+          ;; prints the x coordinate of the turtle which is
+          ;; farthest right in the world
+          show max list a b
+          ;; prints the larger of the two variables a and b
+          show max (list a b c)
+          ;; prints the largest of the three variables a, b, and c
+        </pre>
+      </div>
+      <div class="dict_entry" id="max-n-of">
+        <h3>
+          <a>max-n-of<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">max-n-of <i>number</i> <i>agentset</i> [<i>reporter</i>]</span>
+        </h4>
+        <p>
+          Reports an agentset containing <i>number</i> agents from
+          <i>agentset</i> with the highest values of <i>reporter</i>. The
+          agentset is built by finding all the agents with the highest
+          value of <i>reporter</i>, if there are not <i>number</i> agents
+          with that value then agents with the second highest value are
+          found, and so on. At the end, if there is a tie that would make
+          the resulting agentset too large, the tie is broken randomly.
+        </p>
+        <pre>
+          ;; assume the world is 11 x 11
+          show max-n-of 5 patches [pxcor]
+          ;; shows 5 patches with pxcor = max-pxcor
+          show max-n-of 5 patches with [pycor = 0] [pxcor]
+          ;; shows an agentset containing:
+          ;; (patch 1 0) (patch 2 0) (patch 3 0) (patch 4 0) (patch 5 0)
+        </pre>
+        <p>
+          See also <a href="#max-one-of">max-one-of</a>, <a href="#with-max">with-max</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="max-one-of">
+        <h3>
+          <a>max-one-of<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">max-one-of <i>agentset</i> [<i>reporter</i>]</span>
+        </h4>
+        <p>
+          Reports the agent in the agentset that has the highest value for
+          the given reporter. If there is a tie this command reports one
+          random agent with the highest value. If you want all such agents,
+          use with-max instead.
+        </p>
+        <pre>
+          show max-one-of patches [count turtles-here]
+          <br/>;; prints the first patch with the most turtles on it
+        </pre>
+        <p>
+          See also <a href="#max-n-of">max-n-of</a>, <a href="#with-max">with-max</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="max-pcor">
+        <h3>
+          <a>max-pxcor<span class="since">3.1</span></a>
+          <a>max-pycor<span class="since">3.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">max-pxcor</span>
+          <span class="prim_example">max-pycor</span>
+        </h4>
+        <p>
+          These reporters give the maximum x-coordinate and maximum
+          y-coordinate, (respectively) for patches, which determines the
+          size of the world.
+        </p>
+        <p>
+          Unlike in older versions of NetLogo the origin does not have to
+          be at the center of the world. However, the maximum x- and y-
+          coordinates must be greater than or equal to zero.
+        </p>
+        <p>
+          Note: You can set the size of the world only by editing the view
+          -- these are reporters which cannot be set.
+        </p>
+        <pre>
+          crt 100 [ setxy random-float max-pxcor
+          random-float max-pycor ]
+          ;; distributes 100 turtles randomly in the
+          ;; first quadrant
+        </pre>
+        <p>
+          See also <a href="#min-pcor">min-pxcor</a>, <a href="#min-pcor">min-pycor</a>, <a href="#world-dim">world-width</a>, and <a href="#world-dim">world-height</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="mean">
+        <h3>
+          <a>mean<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">mean <i>list</i></span>
+        </h4>
+        <p>
+          Reports the statistical mean of the numeric items in the given
+          list. Errors on non-numeric items. The mean is the average, i.e.,
+          the sum of the items divided by the total number of items.
+        </p>
+        <pre>
+          show mean [xcor] of turtles
+          ;; prints the average of all the turtles' x coordinates
+        </pre>
+      </div>
+      <div class="dict_entry" id="median">
+        <h3>
+          <a>median<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">median <i>list</i></span>
+        </h4>
+        <p>
+          Reports the statistical median of the numeric items of the given
+          list. Ignores non-numeric items. The median is the item that
+          would be in the middle if all the items were arranged in order.
+          (If two items would be in the middle, the median is the average
+          of the two.)
+        </p>
+        <pre>
+          show median [xcor] of turtles
+          ;; prints the median of all the turtles' x coordinates
+        </pre>
+      </div>
+      <div class="dict_entry" id="member">
+        <h3>
+          <a>member?<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">member? <i>value list</i></span>
+          <span class="prim_example">member? <i>string1 string2</i></span>
+          <span class="prim_example">member? <i>agent agentset</i></span>
+        </h4>
+        <p>
+          For a list, reports true if the given value appears in the given
+          list, otherwise reports false.
+        </p>
+        <p>
+          For a string, reports true or false depending on whether
+          <i>string1</i> appears anywhere inside <i>string2</i> as a
+          substring.
+        </p>
+        <p>
+          For an agentset, reports true if the given agent is appears in
+          the given agentset, otherwise reports false.
+        </p>
+        <pre>
+          show member? 2 [1 2 3]
+          =&gt; true
+          show member? 4 [1 2 3]
+          =&gt; false
+          show member? &quot;bat&quot; &quot;abate&quot;
+          =&gt; true
+          show member? turtle 0 turtles
+          =&gt; true
+          show member? turtle 0 patches
+          =&gt; false
+        </pre>
+        <p>
+          See also <a href="#position">position</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="min">
+        <h3>
+          <a>min<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">min <i>list</i></span>
+        </h4>
+        <p>
+          Reports the minimum number value in the list. It ignores other
+          types of items.
+        </p>
+        <pre>
+          show min [xcor] of turtles
+          ;; prints the lowest x-coordinate of all the turtles
+          show min list a b
+          ;; prints the smaller of the two variables a and b
+          show min (list a b c)
+          ;; prints the smallest of the three variables a, b, and c
+        </pre>
+      </div>
+      <div class="dict_entry" id="min-n-of">
+        <h3>
+          <a>min-n-of<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">min-n-of <i>number</i> <i>agentset</i> [<i>reporter</i>]</span>
+        </h4>
+        <p>
+          Reports an agentset containing <i>number</i> agents from
+          <i>agentset</i> with the lowest values of <i>reporter</i>. The
+          agentset is built by finding all the agents with the lowest value
+          of <i>reporter</i>, if there are not <i>number</i> agents with
+          that value then the agents with the second lowest value are
+          found, and so on. At the end, if there is a tie that would make
+          the resulting agentset too large, the tie is broken randomly.
+        </p>
+        <pre>
+          ;; assume the world is 11 x 11
+          show min-n-of 5 patches [pxcor]
+          ;; shows 5 patches with pxcor = min-pxcor
+          show min-n-of 5 patches with [pycor = 0] [pxcor]
+          ;; shows an agentset containing:
+          ;; (patch -5 0) (patch -4 0) (patch -3 0) (patch -2 0) (patch -1 0)
+        </pre>
+        <p>
+          See also <a href="#min-one-of">min-one-of</a>, <a href="#with-min">with-min</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="min-one-of">
+        <h3>
+          <a>min-one-of<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">min-one-of <i>agentset</i> [<i>reporter</i>]</span>
+        </h4>
+        <p>
+          Reports a random agent in the agentset that reports the lowest
+          value for the given reporter. If there is a tie, this command
+          reports one random agent that meets the condition. If you want
+          all such agents use with-min instead.
+        </p>
+        <pre>
+          show min-one-of turtles [xcor + ycor]
+          ;; reports the first turtle with the smallest sum of
+          ;; coordinates
+        </pre>
+        <p>
+          See also <a href="#with-min">with-min</a>, <a href="#min-n-of">min-n-of</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="min-pcor">
+        <h3>
+          <a>min-pxcor<span class="since">3.1</span></a>
+          <a>min-pycor<span class="since">3.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">min-pxcor</span>
+          <span class="prim_example">min-pycor</span>
+        </h4>
+        <p>
+          These reporters give the minimum x-coordinate and minimum
+          y-coordinate, (respectively) for patches, which determines the
+          size of the world.
+        </p>
+        <p>
+          Unlike in older versions of NetLogo the origin does not have to
+          be at the center of the world. However, the minimum x- and y-
+          coordinates must be less than or equal to zero.
+        </p>
+        <p>
+          Note: You can set the size of the world only by editing the view
+          -- these are reporters which cannot be set.
+        </p>
+        <pre>
+          crt 100 [ setxy random-float min-pxcor
+          random-float min-pycor ]
+          ;; distributes 100 turtles randomly in the
+          ;; third quadrant
+        </pre>
+        <p>
+          See also <a href="#max-pcor">max-pxcor</a>, <a href="#max-pcor">max-pycor</a>, <a href="#world-dim">world-width</a>, and <a href="#world-dim">world-height</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="mod">
+        <h3>
+          <a>mod<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example"><i>number1</i> mod <i>number2</i></span>
+        </h4>
+        <p>
+          Reports <i>number1</i> modulo <i>number2</i>: that is, the
+          residue of <i>number1</i> (mod <i>number2</i>). mod is is
+          equivalent to the following NetLogo code:
+        </p>
+        <pre>
+          <i>number1</i> - (floor (<i>number1</i> / <i>number2</i>)) * <i>number2</i>
+        </pre>
+        <p>
+          Note that mod is &quot;infix&quot;, that is, it comes between its
+          two inputs.
+        </p>
+        <pre>
+          show 62 mod 5
+          =&gt; 2
+          show -8 mod 3
+          =&gt; 1
+        </pre>
+        <p>
+          See also <a href="#remainder">remainder</a>. mod and remainder
+          behave the same for positive numbers, but differently for
+          negative numbers.
+        </p>
+      </div>
+      <div class="dict_entry" id="modes">
+        <h3>
+          <a>modes<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">modes <i>list</i></span>
+        </h4>
+        <p>
+          Reports a list of the most common item or items in <i>list</i>.
+        </p>
+        <p>
+          The input list may contain any NetLogo values.
+        </p>
+        <p>
+          If the input is an empty list, reports an empty list.
+        </p>
+        <pre>
+          show modes [1 2 2 3 4]
+          =&gt; [2]
+          show modes [1 2 2 3 3 4]
+          =&gt; [2 3]
+          show modes [ [1 2 [3]] [1 2 [3]] [2 3 4] ]
+          =&gt; [[1 2 [3]]]
+          show modes [pxcor] of turtles
+          ;; shows which columns of patches have the most
+          ;; turtles on them
+        </pre>
+      </div>
+      <div class="dict_entry" id="mouse-down">
+        <h3>
+          <a>mouse-down?<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">mouse-down?</span>
+        </h4>
+        <p>
+          Reports true if the mouse button is down, false otherwise.
+        </p>
+        <p>
+          Note: If the mouse pointer is outside of the current view ,
+          mouse-down? will always report false.
+        </p>
+      </div>
+      <div class="dict_entry" id="mouse-inside">
+        <h3>
+          <a>mouse-inside?<span class="since">3.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">mouse-inside?</span>
+        </h4>
+        <p>
+          Reports true if the mouse pointer is inside the current view,
+          false otherwise.
+        </p>
+      </div>
+      <div class="dict_entry" id="mouse-cor">
+        <h3>
+          <a>mouse-xcor<span class="since">1.0</span></a>
+          <a>mouse-ycor<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">mouse-xcor</span>
+          <span class="prim_example">mouse-ycor</span>
+        </h4>
+        <p>
+          Reports the x or y coordinate of the mouse in the 2D view. The
+          value is in terms of turtle coordinates, so it might not be an
+          integer. If you want patch coordinates, use <code>round
+            mouse-xcor</code> and <code>round mouse-ycor</code>.
+        </p>
+        <p>
+          Note: If the mouse is outside of the 2D view, reports the value
+          from the last time it was inside.
+        </p>
+        <pre>
+          ;; to make the mouse &quot;draw&quot; in red:
+          if mouse-down?
+          [ ask patch mouse-xcor mouse-ycor [ set pcolor red ] ]
+        </pre>
+      </div>
+      <div class="dict_entry" id="move-to">
+        <h3>
+          <a>move-to<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">move-to <i>agent</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          The turtle sets its x and y coordinates to be the same as the
+          given agent's.
+        </p>
+        <p>
+          (If that agent is a patch, the effect is to move the turtle to
+          the center of that patch.)
+        </p>
+        <pre>
+          move-to turtle 5
+          ;; turtle moves to same point as turtle 5
+          move-to one-of patches
+          ;; turtle moves to the center of a random patch
+          move-to max-one-of turtles [size]
+          ;; turtle moves to same point as biggest turtle
+        </pre>
+        <p>
+          Note that the turtle's heading is unaltered. You may want to
+          use the <a href="#face">face</a> command first to orient the
+          turtle in the direction of motion.
+        </p>
+        <p>
+          See also <a href="#setxy">setxy</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="my-links">
+        <h3>
+          <a>my-&lt;breeds&gt;</a>
+          <a>my-links<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">my-&lt;breeds&gt;</span>
+          <span class="prim_example">my-links</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Reports an agentset of all links connected to the caller of
+          the corresponding breed, regardless of directedness.
+          Generally, you might consider using
+          <a href="#my-out-links"><code>my-out-links</code></a> instead
+          of this primitive, as it works well for either directed or
+          undirected networks (since it excludes directed, incoming
+          links).
+        </p>
+        <pre>
+          crt 5
+          ask turtle 0
+          [
+          create-links-with other turtles
+          show my-links ;; prints the agentset containing all links
+          ;; (since all the links we created were with turtle 0 )
+          ]
+          ask turtle 1
+          [
+          show my-links ;; shows an agentset containing the link 0 1
+          ]
+          end
+        </pre>
+        If you only want the undirected links connected to a node, you
+        can do <code>my-links with [ not is-directed-link? self ]</code>.
+      </div>
+      <div class="dict_entry" id="my-in-links">
+        <h3>
+          <a>my-in-&lt;breeds&gt;</a>
+          <a>my-in-links<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">my-in-&lt;breeds&gt;</span>
+          <span class="prim_example">my-in-links</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Reports an agentset of all the directed links coming in from
+          other nodes to the caller as well as all undirected links
+          connected to the caller. You can think of this as "all links
+          that you can use to travel <i>to</i> this node".
+        </p>
+        <pre>
+          crt 5
+          ask turtle 0
+          [
+          create-links-to other turtles
+          show my-in-links ;; shows an empty agentset
+          ]
+          ask turtle 1
+          [
+          show my-in-links ;; shows an agentset containing the link 0 1
+          ]
+        </pre>
+      </div>
+      <div class="dict_entry" id="my-out-links">
+        <h3>
+          <a>my-out-&lt;breeds&gt;</a>
+          <a>my-out-links<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">my-out-&lt;breeds&gt;</span>
+          <span class="prim_example">my-out-links</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Reports an agentset of all the directed links going out from the
+          caller to other nodes as well as undirected links connected to the
+          caller. You can think of this as "all links you can use to travel
+          <i>from</i> this node".
+        </p>
+        <pre>
+          crt 5
+          ask turtle 0
+          [
+          create-links-to other turtles
+          show my-out-links ;; shows agentset containing all the links
+          ]
+          ask turtle 1
+          [
+          show my-out-links ;; shows an empty agentset
+          ]
+        </pre>
+      </div>
+      <div class="dict_entry" id="myself">
+        <h3>
+          <a>myself<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">myself</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/> <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          &quot;self&quot; and &quot;myself&quot; are very different.
+          &quot;self&quot; is simple; it means &quot;me&quot;.
+          &quot;myself&quot; means &quot;the turtle, patch or link who asked me
+          to do what I'm doing right now.&quot;
+        </p>
+        <p>
+          When an agent has been asked to run some code, using myself in
+          that code reports the agent (turtle, patch or link) that did the
+          asking.
+        </p>
+        <p>
+          myself is most often used in conjunction with <code>of</code> to read
+          or set variables in the asking agent.
+        </p>
+        <p>
+          myself can be used within blocks of code not just in the ask
+          command, but also hatch, sprout, of, with, all?, with-min,
+          with-max, min-one-of, max-one-of, min-n-of, max-n-of.
+        </p>
+        <pre>
+          ask turtles
+          [ ask patches in-radius 3
+          [ set pcolor [color] of myself ] ]
+          ;; each turtle makes a colored &quot;splotch&quot; around itself
+        </pre>
+        <p>
+          See the &quot;Myself Example&quot; code example for more
+          examples.
+        </p>
+        <p>
+          See also <a href="#self">self</a>.
+        </p>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="N">
+      <a>N</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="n-of">
+        <h3>
+          <a>n-of<span class="since">3.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">n-of <i>size</i> <i>agentset</i></span>
+          <span class="prim_example">n-of <i>size</i> <i>list</i></span>
+        </h4>
+        <p>
+          From an agentset, reports an agentset of size <i>size</i>
+          randomly chosen from the input set, with no repeats.
+        </p>
+        <p>
+          From a list, reports a list of size <i>size</i> randomly chosen
+          from the input set, with no repeats. The items in the result
+          appear in the same order that they appeared in the input list.
+          (If you want them in random order, use shuffle on the result.)
+        </p>
+        <p>
+          It is an error for <i>size</i> to be greater than the size of the
+          input.
+        </p>
+        <pre>
+          ask n-of 50 patches [ set pcolor green ]
+          ;; 50 randomly chosen patches turn green
+        </pre>
+        <p>
+          See also <a href="#one-of">one-of</a> and <a href="#up-to-n-of">up-to-n-of</a>,
+          a version that does not error with a <i>size</i> greater than
+          the size of the input.
+        </p>
+      </div>
+      <div class="dict_entry" id="n-values">
+        <h3>
+          <a>n-values<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">n-values <i>size</i> <i>reporter</i></span>
+        </h4>
+        <p>
+          Reports a list of length <i>size</i> containing values computed
+          by repeatedly running the reporter. <i>reporter</i> may be an anonymous
+          reporter or the name of a reporter.
+        </p>
+        <p>
+          If the reporter accepts inputs, the input will be the number of the
+          item currently being computed, starting from zero.
+        </p>
+        <pre>
+          show n-values 5 [1]
+          =&gt; [1 1 1 1 1]
+          show n-values 5 [ i -&gt; i ]
+          =&gt; [0 1 2 3 4]
+          show n-values 3 turtle
+          =&gt; [(turtle 0) (turtle 1) (turtle 2)]
+          show n-values 5 [ x -&gt; x * x ]
+          =&gt; [0 1 4 9 16]
+        </pre>
+        <p>
+          See also <a href="#reduce">reduce</a>, <a href="#filter">filter</a>, <a href="#arrow">-&gt; (anonymous procedure)</a>, <a href="#range">range</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="neighbors">
+        <h3>
+          <a>neighbors<span class="since">1.1</span></a>
+          <a>neighbors4<span class="since">1.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">neighbors</span>
+          <span class="prim_example">neighbors4</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          Reports an agentset containing the 8 surrounding patches
+          (neighbors) or 4 surrounding patches (neighbors4).
+        </p>
+        <pre>
+          show sum [count turtles-here] of neighbors
+          ;; prints the total number of turtles on the eight
+          ;; patches around this turtle or patch
+          show count turtles-on neighbors
+          ;; a shorter way to say the same thing
+          ask neighbors4 [ set pcolor red ]
+          ;; turns the four neighboring patches red
+        </pre>
+      </div>
+      <div class="dict_entry" id="link-neighbors">
+        <h3>
+          <a>&lt;breed&gt;-neighbors</a>
+          <a>link-neighbors<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">&lt;breed&gt;-neighbors</span>
+          <span class="prim_example">link-neighbors</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Reports the agentset of all turtles found at the other end of
+          any links (undirected or directed, incoming or outgoing)
+          connected to this turtle.
+        </p>
+        <pre>
+          crt 3
+          ask turtle 0
+          [
+          create-links-with other turtles
+          ask link-neighbors [ set color red ] ;; turtles 1 and 2 turn red
+          ]
+          ask turtle 1
+          [
+          ask link-neighbors [ set color blue ] ;; turtle 0 turns blue
+          ]
+          end
+        </pre>
+      </div>
+      <div class="dict_entry" id="link-neighbor">
+        <h3>
+          <a>&lt;breed&gt;-neighbor?</a>
+          <a>link-neighbor?<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">&lt;breed&gt;-neighbor? <i>turtle</i></span>
+          <span class="prim_example">link-neighbor? <i>turtle</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Reports true if there is a link (either directed or undirected,
+          incoming or outgoing) between <i>turtle</i> and the caller.
+        </p>
+        <pre>
+          crt 2
+          ask turtle 0
+          [
+          create-link-with turtle 1
+          show link-neighbor? turtle 1  ;; prints true
+          ]
+          ask turtle 1
+          [
+          show link-neighbor? turtle 0     ;; prints true
+          ]
+        </pre>
+      </div>
+      <div class="dict_entry" id="netlogo-version">
+        <h3>
+          <a>netlogo-version<span class="since">3.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">netlogo-version</span>
+        </h4>
+        <p>
+          Reports a string containing the version number of the NetLogo you
+          are running.
+        </p>
+        <pre>
+          show netlogo-version
+          =&gt; &quot;{{version}}&quot;
+        </pre>
+      </div>
+      <div class="dict_entry" id="netlogo-web">
+        <h3>
+          <a>netlogo-web?<span class="since">5.2</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">netlogo-web?</span>
+        </h4>
+        <p>
+          Reports true if the model is running in NetLogo Web.
+        </p>
+      </div>
+      <div class="dict_entry" id="new-seed">
+        <h3>
+          <a>new-seed<span class="since">3.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">new-seed</span>
+        </h4>
+        <p>
+          Reports a number suitable for seeding the random number generator.
+        </p>
+        <p>
+          The numbers reported by new-seed are based on the current date and
+          time in milliseconds and lie in the generator's usable range of
+          seeds, -2147483648 to 2147483647.
+        </p>
+        <p>
+          new-seed never reports the same number twice in succession, even
+          across parallel BehaviorSpace runs. (This
+          is accomplished by waiting a millisecond if the seed for the
+          current millisecond was already used.)
+        </p>
+        <p>
+          See also <a href="#random-seed">random-seed</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="no-display">
+        <h3>
+          <a>no-display<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">no-display</span>
+        </h4>
+        <p>
+          Turns off all updates to the current view until the display command
+          is issued. This has two major uses.
+        </p>
+        <p>
+          One, you can control when the user sees view updates. You might
+          want to change lots of things on the view behind the user's
+          back, so to speak, then make them visible to the user all at once.
+        </p>
+        <p>
+          Two, your model will run faster when view updating is off, so if
+          you're in a hurry, this command will let you get results
+          faster. (Note that normally you don't need to use no-display
+          for this, since you can also use the on/off switch in view control
+          strip to freeze the view.)
+        </p>
+        <p>
+          Note that display and no-display operate independently of the
+          switch in the view control strip that freezes the view.
+        </p>
+        <p>
+          See also <a href="#display">display</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="nobody">
+        <h3>
+          <a>nobody</a>
+        </h3>
+        <h4>
+          <span class="prim_example">nobody</span>
+        </h4>
+        <p>
+          This is a special value which some primitives such as turtle,
+          one-of, max-one-of, etc. report to indicate that no agent was
+          found. Also, when a turtle dies, it becomes equal to nobody.
+        </p>
+        <p>
+          Note: Empty agentsets are not equal to nobody. If you want to test
+          for an empty agentset, use <a href="#any">any?</a>. You only get
+          nobody back in situations where you were expecting a single agent,
+          not a whole agentset.
+        </p>
+        <pre>
+          set target one-of other turtles-here
+          if target != nobody
+          [ ask target [ set color red ] ]
+        </pre>
+      </div>
+      <div class="dict_entry" id="no-links">
+        <h3>
+          <a>no-links<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">no-links</span>
+        </h4>
+        <p>
+          Reports an empty link agentset.
+        </p>
+      </div>
+      <div class="dict_entry" id="no-patches">
+        <h3>
+          <a>no-patches<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">no-patches</span>
+        </h4>
+        <p>
+          Reports an empty patch agentset.
+        </p>
+      </div>
+      <div class="dict_entry" id="not">
+        <h3>
+          <a>not<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">not <i>boolean</i></span>
+        </h4>
+        <p>
+          Reports true if <i>boolean</i> is false, otherwise reports false.
+        </p>
+        <pre>
+          if not any? turtles [ crt 10 ]
+        </pre>
+      </div>
+      <div class="dict_entry" id="no-turtles">
+        <h3>
+          <a>no-turtles<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">no-turtles</span>
+        </h4>
+        <p>
+          Reports an empty turtle agentset.
+        </p>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="O">
+      <a>O</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="of">
+        <h3>
+          <a>of<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">[<i>reporter</i>] of <i>agent</i></span>
+          <span class="prim_example">[<i>reporter</i>] of <i>agentset</i></span>
+        </h4>
+        <p>
+          For an agent, reports the value of the reporter for that agent
+          (turtle or patch).
+        </p>
+        <pre>
+          show [pxcor] of patch 3 5
+          ;; prints 3
+          show [pxcor] of one-of patches
+          ;; prints the value of a random patch's pxcor variable
+          show [who * who] of turtle 5
+          =&gt; 25
+          show [count turtles in-radius 3] of patch 0 0
+          ;; prints the number of turtles located within a
+          ;; three-patch radius of the origin
+        </pre>
+        <p>
+          For an agentset, reports a list that contains the value of the
+          reporter for each agent in the agentset (in random order).
+        </p>
+        <pre>
+          crt 4
+          show sort [who] of turtles
+          =&gt; [0 1 2 3]
+          show sort [who * who] of turtles
+          =&gt; [0 1 4 9]
+        </pre>
+      </div>
+      <div class="dict_entry" id="one-of">
+        <h3>
+          <a>one-of<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">one-of <i>agentset</i></span>
+          <span class="prim_example">one-of <i>list</i></span>
+        </h4>
+        <p>
+          From an agentset, reports a random agent. If the agentset is empty,
+          reports <a href="#nobody">nobody</a>.
+        </p>
+        <p>
+          From a list, reports a random list item. It is an error for the
+          list to be empty.
+        </p>
+        <pre>
+          ask one-of patches [ set pcolor green ]
+          ;; a random patch turns green
+          ask patches with [any? turtles-here]
+          [ show one-of turtles-here ]
+          ;; for each patch containing turtles, prints one of
+          ;; those turtles
 
-					;; suppose mylist is [1 2 3 4 5 6]
-					show one-of mylist
-					;; prints a value randomly chosen from the list
-				</pre>
-				<p>
-					See also <a href="#n-of">n-of</a>, <a href="#up-to-n-of">up-to-n-of</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="or">
-				<h3>
-					<a>or<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example"><i>boolean1</i> or <i>boolean2</i></span>
-				</h4>
-				<p>
-					Reports true if either <i>boolean1</i> or <i>boolean2</i>, or both,
-					is true.
-				</p>
-				<p>
-					Note that if <i>condition1</i> is true, then <i>condition2</i> will
-					not be run (since it can't affect the result).
-				</p>
-				<pre>
-					if (pxcor &gt; 0) or (pycor &gt; 0) [ set pcolor red ]
-					;; patches turn red except in lower-left quadrant
-				</pre>
-			</div>
-			<div class="dict_entry" id="other">
-				<h3>
-					<a>other<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">other <i>agentset</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					Reports an agentset which is the same as the input agentset but
-					omits this agent.
-				</p>
-				<pre>
-					show count turtles-here
-					=&gt; 10
-					show count other turtles-here
-					=&gt; 9
-				</pre>
-			</div>
-			<div class="dict_entry" id="other-end">
-				<h3>
-					<a>other-end<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">other-end</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					If run by a turtle, reports the turtle at the other end of the
-					asking link.
-				</p>
-				<p>
-					If run by a link, reports the turtle at the end of the link that
-					isn't the asking turtle.
-				</p>
-				<p>
-					These definitions are difficult to understand in the abstract, but
-					the following examples should help:
-				</p>
-				<pre>
-					ask turtle 0 [ create-link-with turtle 1 ]
-					ask turtle 0 [ ask link 0 1 [ show other-end ] ] ;; prints turtle 1
-					ask turtle 1 [ ask link 0 1 [ show other-end ] ] ;; prints turtle 0
-					ask link 0 1 [ ask turtle 0 [ show other-end ] ] ;; prints turtle 1
-				</pre>
-				<p>
-					As these examples hopefully make plain, the &quot;other&quot; end
-					is the end that is neither asking nor being asked.
-				</p>
-			</div>
-			<div class="dict_entry" id="out-link-neighbor">
-				<h3>
-					<a>out-&lt;breed&gt;-neighbor?</a>
-					<a>out-link-neighbor?<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">out-&lt;breed&gt;-neighbor? <i>turtle</i></span>
-					<span class="prim_example">out-link-neighbor? <i>turtle</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Reports true if there is a directed link going from the caller to
-					<i>turtle</i> or if there is an undirected link connecting the caller
-					with <i>turtle</i>. You can think of this as "can I get from the caller
-					to <i>turtle</i> using a link?"
-				</p>
-				<pre>
-					crt 2
-					ask turtle 0 [
-					create-link-to turtle 1
-					show in-link-neighbor? turtle 1  ;; prints false
-					show out-link-neighbor? turtle 1 ;; prints true
-					]
-					ask turtle 1 [
-					show in-link-neighbor? turtle 0  ;; prints true
-					show out-link-neighbor? turtle 0 ;; prints false
-					]
-				</pre>
-			</div>
-			<div class="dict_entry" id="out-link-neighbors">
-				<h3>
-					<a>out-&lt;breed&gt;-neighbors</a>
-					<a>out-link-neighbors<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">out-&lt;breed&gt;-neighbors</span>
-					<span class="prim_example">out-link-neighbors</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Reports the agentset of all the turtles that have directed links
-					from the caller, or undirected links with the caller. You can think
-					of this as "who can I get to from the caller using a link?"
-				</p>
-				<pre>
-					crt 4
-					ask turtle 0
-					[
-					create-links-to other turtles
-					ask out-link-neighbors [ set color pink ] ;; turtles 1-3 turn pink
-					]
-					ask turtle 1
-					[
-					ask out-link-neighbors [ set color orange ]  ;; no turtles change colors
-					;; since turtle 1 only has in-links
-					]
-					end
-				</pre>
-			</div>
-			<div class="dict_entry" id="out-link-to">
-				<h3>
-					<a>out-&lt;breed&gt;-to</a>
-					<a>out-link-to<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">out-&lt;breed&gt;-to <i>turtle</i></span>
-					<span class="prim_example">out-link-to <i>turtle</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Reports a directed link from the caller to <i>turtle</i> or an
-					undirected link connecting the two. If no link exists then it
-					reports nobody. If more than one such link exists, reports a
-					random one. You can think of this as "give me a link that I can use
-					to travel from the caller to <i>turtle</i>."
-				</p>
-				<pre>
-					crt 2
-					ask turtle 0 [
-					create-link-to turtle 1
-					show out-link-to turtle 1 ;; shows link 0 1
-					]
-					ask turtle 1
-					[
-					show out-link-to turtle 0 ;; shows nobody
-					]
-				</pre>
-				<p>
-					See also: <a href="#in-link-from">in-link-from</a> <a href="#link-with">link-with</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="output-cmds">
-				<h3>
-					<a>output-print<span class="since">2.1</span></a>
-					<a>output-show<span class="since">2.1</span></a>
-					<a>output-type<span class="since">2.1</span></a>
-					<a>output-write<span class="since">2.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">output-print <i>value</i></span>
-					<span class="prim_example">output-show <i>value</i></span>
-					<span class="prim_example">output-type <i>value</i></span>
-					<span class="prim_example">output-write <i>value</i></span>
-				</h4>
-				<p>
-					These commands are the same as the <a href="#print">print</a>,
-					<a href="#show">show</a>, <a href="#type">type</a>, and <a href="#write">write</a> commands except that <i>value</i> is printed in
-					the model's output area, instead of in the Command Center. (If
-					the model does not have a separate output area, then the Command
-					Center is used.) See also <a href="programming.html#output">Output (programming guide)</a>.
-				</p>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="P">
-			<a>P</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="patch">
-				<h3>
-					<a>patch<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">patch <i>xcor</i> <i>ycor</i></span>
-				</h4>
-				<p>
-					Given the x and y coordinates of a point, reports the patch
-					containing that point. (The coordinates are absolute coordinates;
-					they are not computed relative to this agent, as with patch-at.)
-				</p>
-				<p>
-					If x and y are integers, the point is the center of a patch. If x
-					or y is not an integer, rounding to the nearest integer is used to
-					determine which patch contains the point.
-				</p>
-				<p>
-					If wrapping is allowed by the topology, the given coordinates will
-					be wrapped to be within the world. If wrapping is not allowed and
-					the given coordinates are outside the world, reports nobody.
-				</p>
-				<pre>
-					ask patch 3 -4 [ set pcolor green ]
-					;; patch with pxcor of 3 and pycor of -4 turns green
-					show patch 1.2 3.7
-					;; prints (patch 1 4); note rounding
-					show patch 18 19
-					;; supposing min-pxcor and min-pycor are -17
-					;; and max-pxcor and max-pycor are 17,
-					;; in a wrapping topology, prints (patch -17 -16);
-					;; in a non-wrapping topology, prints nobody
-				</pre>
-				<p>
-					See also <a href="#patch-at">patch-at</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="patch-ahead">
-				<h3>
-					<a>patch-ahead<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">patch-ahead <i>distance</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Reports the single patch that is the given distance
-					&quot;ahead&quot; of this turtle, that is, along the turtle's
-					current heading. Reports nobody if the patch does not exist because
-					it is outside the world.
-				</p>
-				<pre>
-					ask patch-ahead 1 [ set pcolor green ]
-					;; turns the patch 1 in front of this turtle
-					;;   green; note that this might be the same patch
-					;;   the turtle is standing on
-				</pre>
-				<p>
-					See also <a href="#patch-at">patch-at</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="patch-at">
-				<h3>
-					<a>patch-at<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">patch-at <i>dx</i> <i>dy</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					Reports the patch at (dx, dy) from the caller, that is, the patch
-					containing the point dx east and dy patches north of this agent.
-				</p>
-				<p>
-					Reports nobody if there is no such patch because that point is
-					beyond a non-wrapping world boundary.
-				</p>
-				<pre>
-					ask patch-at 1 -1 [ set pcolor green ]
-					;; if caller is a turtle or patch, turns the
-					;;   patch just southeast of the caller green
-				</pre>
-				<p>
-					See also <a href="#patch">patch</a>, <a href="#patch-ahead">patch-ahead</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="patch-at-heading-and-distance">
-				<h3>
-					<a>patch-at-heading-and-distance<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">patch-at-heading-and-distance <i>heading</i> <i>distance</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					patch-at-heading-and-distance reports the single patch that is the
-					given distance from this turtle or patch, along the given absolute
-					heading. (In contrast to patch-left-and-ahead and
-					patch-right-and-ahead, this turtle's current heading is not
-					taken into account.) Reports nobody if the patch does not exist
-					because it is outside the world.
-				</p>
-				<pre>
-					ask patch-at-heading-and-distance -90 1 [ set pcolor green ]
-					;; turns the patch 1 to the west of this patch green
-				</pre>
-				<p>
-					See also <a href="#patch">patch</a>, <a href="#patch-at">patch-at</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="patch-here">
-				<h3>
-					<a>patch-here<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">patch-here</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					patch-here reports the patch under the turtle.
-				</p>
-				<p>
-					Note that this reporter isn't available to a patch because a
-					patch can just say &quot;self&quot;.
-				</p>
-			</div>
-			<div class="dict_entry" id="patch-lr-and-ahead">
-				<h3>
-					<a>patch-left-and-ahead<span class="since">2.0</span></a>
-					<a>patch-right-and-ahead<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">patch-left-and-ahead <i>angle</i> <i>distance</i></span>
-					<span class="prim_example">patch-right-and-ahead <i>angle</i> <i>distance</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Reports the single patch that is the given distance from this
-					turtle, in the direction turned left or right the given angle (in
-					degrees) from the turtle's current heading. Reports nobody if
-					the patch does not exist because it is outside the world.
-				</p>
-				<p>
-					(If you want to find a patch in a given absolute heading, rather
-					than one relative to the current turtle's heading, use
-					patch-at-heading-and-distance instead.)
-				</p>
-				<pre>
-					ask patch-right-and-ahead 30 1 [ set pcolor green ]
-					;; this turtle &quot;looks&quot; 30 degrees right of its
-					;;   current heading at the patch 1 unit away, and turns
-					;;   that patch green; note that this might be the same
-					;;   patch the turtle is standing on
-				</pre>
-				<p>
-					See also <a href="#patch">patch</a>, <a href="#patch-at">patch-at</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="patch-set">
-				<h3>
-					<a>patch-set<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">patch-set <i>value1</i></span>
-					<span class="prim_example">(patch-set <i>value1</i> <i>value2</i> ...)</span>
-				</h4>
-				<p>
-					Reports an agentset containing all of the patches anywhere in any
-					of the inputs. The inputs may be individual patches, patch
-					agentsets, nobody, or lists (or nested lists) containing any of the
-					above.
-				</p>
-				<pre>
-					patch-set self
-					patch-set patch-here
-					(patch-set self neighbors)
-					(patch-set patch-here neighbors)
-					(patch-set patch 0 0 patch 1 3 patch 4 -2)
-					(patch-set patch-at -1 1 patch-at 0 1 patch-at 1 1)
-					patch-set [patch-here] of turtles
-					patch-set [neighbors] of turtles
-				</pre>
-				<p>
-					See also <a href="#turtle-set">turtle-set</a>, <a href="#link-set">link-set</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="patch-size">
-				<h3>
-					<a>patch-size<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">patch-size</span>
-				</h4>
-				<p>
-					Reports the size of the patches in the view in pixels. The size is
-					typically an integer, but may also be a floating point number.
-				</p>
-				<p>
-					See also <a href="#set-patch-size">set-patch-size</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="patches">
-				<h3>
-					<a>patches<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">patches</span>
-				</h4>
-				<p>
-					Reports the agentset consisting of all patches.
-				</p>
-			</div>
-			<div class="dict_entry" id="patches-own">
-				<h3>
-					<a>patches-own</a>
-				</h3>
-				<h4>
-					<span class="prim_example">patches-own [<i>var1</i> ...]</span>
-				</h4>
-				<p>
-					This keyword, like the globals, breed, <i>&lt;breed&gt;</i>-own,
-					and turtles-own keywords, can only be used at the beginning of a
-					program, before any function definitions. It defines the variables
-					that all patches can use.
-				</p>
-				<p>
-					All patches will then have the given variables and be able to use
-					them.
-				</p>
-				<p>
-					All patch variables can also be directly accessed by any turtle
-					standing on the patch.
-				</p>
-				<p>
-					See also <a href="#globals">globals</a>, <a href="#turtles-own">turtles-own</a>, <a href="#breed">breed</a>,
-					<a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="pcolor">
-				<h3>
-					<a>pcolor</a>
-				</h3>
-				<h4>
-					<span class="prim_example">pcolor</span>
-					<img alt="Patch Command" src="images/patch.gif"/> <img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					This is a built-in patch variable. It holds the color of the patch.
-					You can set this variable to make the patch change color.
-				</p>
-				<p>
-					All patch variables can be directly accessed by any turtle standing
-					on the patch. Color can be represented either as a NetLogo color (a
-					single number) or an RGB color (a list of 3 numbers). See details
-					in the <a href="programming.html#colors">Colors section</a> of the
-					Programming Guide.
-				</p>
-				<p>
-					See also <a href="#color">color</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="pen-switch-status">
-				<h3>
-					<a>pen-down<span class="since">1.0</span></a>
-					<a>pd<span class="since">1.0</span></a>
-					<a>pen-erase<span class="since">3.0</span></a>
-					<a>pe<span class="since">3.0</span></a>
-					<a>pen-up<span class="since">1.0</span></a>
-					<a>pu<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">pen-down</span>
-					<span class="prim_example">pen-erase</span>
-					<span class="prim_example">pen-up</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					The turtle changes modes between drawing lines, removing lines or
-					neither. The lines will always be displayed on top of the patches
-					and below the turtles. To change the color of the pen set the color
-					of the turtle using <code>set color</code>.
-				</p>
-				<p>
-					Note: When a turtle's pen is down, all movement commands cause
-					lines to be drawn, including jump, setxy, and move-to.
-				</p>
-				<p>
-					Note: These commands are equivalent to setting the turtle variable
-					&quot;pen-mode&quot; to &quot;down&quot; , &quot;up&quot;, and
-					&quot;erase&quot;.
-				</p>
-				<p>
-					Note: On Windows drawing and erasing a line might not erase every
-					pixel.
-				</p>
-			</div>
-			<div class="dict_entry" id="pen-mode">
-				<h3>
-					<a>pen-mode</a>
-				</h3>
-				<h4>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					This is a built-in turtle variable. It holds the state of the
-					turtle's pen. You set the variable to draw lines, erase lines
-					or stop either of these actions. Possible values are
-					&quot;up&quot;, &quot;down&quot;, and &quot;erase&quot;.
-				</p>
-			</div>
-			<div class="dict_entry" id="pen-size">
-				<h3>
-					<a>pen-size</a>
-				</h3>
-				<h4>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					This is a built-in turtle variable. It holds the width of the line,
-					in pixels, that the turtle will draw (or erase) when the pen is
-					down (or erasing).
-				</p>
-			</div>
-			<div class="dict_entry" id="plabel">
-				<h3>
-					<a>plabel</a>
-				</h3>
-				<h4>
-					<span class="prim_example">plabel</span>
-					<img alt="Patch Command" src="images/patch.gif"/> <img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					This is a built-in patch variable. It may hold a value of any type.
-					The patch appears in the view with the given value
-					&quot;attached&quot; to it as text. You can set this variable to
-					add, change, or remove a patch's label.
-				</p>
-				<p>
-					All patch variables can be directly accessed by any turtle standing
-					on the patch.
-				</p>
-				<p>
-					See also <a href="#plabel-color">plabel-color</a>, <a href="#label">label</a>, <a href="#label-color">label-color</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="plabel-color">
-				<h3>
-					<a>plabel-color</a>
-				</h3>
-				<h4>
-					<span class="prim_example">plabel-color</span>
-					<img alt="Patch Command" src="images/patch.gif"/> <img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					This is a built-in patch variable. It holds a number greater than
-					or equal to 0 and less than 140. This number determines what color
-					the patch's label appears in (if it has a label). You can set
-					this variable to change the color of a patch's label.
-				</p>
-				<p>
-					All patch variables can be directly accessed by any turtle standing
-					on the patch.
-				</p>
-				<p>
-					See also <a href="#plabel">plabel</a>, <a href="#label">label</a>,
-					<a href="#label-color">label-color</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="plot">
-				<h3>
-					<a>plot<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">plot <i>number</i></span>
-				</h4>
-				<p>
-					Increments the x-value of the plot pen by plot-pen-interval, then
-					plots a point at the updated x-value and a y-value of
-					<i>number</i>. (The first time the command is used on a plot, the
-					point plotted has an x-value of 0.)
-				</p>
-			</div>
-			<div class="dict_entry" id="plot-name">
-				<h3>
-					<a>plot-name<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">plot-name</span>
-				</h4>
-				<p>
-					Reports the name of the current plot (a string)
-				</p>
-			</div>
-			<div class="dict_entry" id="plot-pen-exists">
-				<h3>
-					<a>plot-pen-exists?<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">plot-pen-exists? <i>string</i></span>
-				</h4>
-				<p>
-					Reports true if a plot pen with the given name is defined in the
-					current plot. Otherwise reports false.
-				</p>
-			</div>
-			<div class="dict_entry" id="plot-pen-switch-status">
-				<h3>
-					<a>plot-pen-down<span class="since">1.0</span></a>
-					<a>plot-pen-up<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">plot-pen-down</span>
-					<span class="prim_example">plot-pen-up</span>
-				</h4>
-				<p>
-					Puts down (or up) the current plot-pen, so that it draws (or
-					doesn't). (By default, all pens are down initially.)
-				</p>
-			</div>
-			<div class="dict_entry" id="plot-pen-reset">
-				<h3>
-					<a>plot-pen-reset<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">plot-pen-reset</span>
-				</h4>
-				<p>
-					Clears everything the current plot pen has drawn, moves it to
-					(0,0), and puts it down. If the pen is a permanent pen, the color,
-					mode, and interval are reset to the default values from the plot
-					Edit dialog.
-				</p>
-			</div>
-			<div class="dict_entry" id="plotxy">
-				<h3>
-					<a>plotxy<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">plotxy <i>number1 number2</i></span>
-				</h4>
-				<p>
-					Moves the current plot pen to the point with coordinates
-					(<i>number1</i>, <i>number2</i>). If the pen is down, a line, bar,
-					or point will be drawn (depending on the pen's mode).
-				</p>
-			</div>
-			<div class="dict_entry" id="plot-cor-max-or-min">
-				<h3>
-					<a>plot-x-min<span class="since">1.0</span></a>
-					<a>plot-x-max<span class="since">1.0</span></a>
-					<a>plot-y-min<span class="since">1.0</span></a>
-					<a>plot-y-max<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">plot-x-min</span>
-					<span class="prim_example">plot-x-max</span>
-					<span class="prim_example">plot-y-min</span>
-					<span class="prim_example">plot-y-max</span>
-				</h4>
-				<p>
-					Reports the minimum or maximum value on the x or y axis of the
-					current plot.
-				</p>
-				<p>
-					These values can be set with the commands set-plot-x-range and
-					set-plot-y-range. (Their default values are set from the plot Edit
-					dialog.)
-				</p>
-			</div>
-			<div class="dict_entry" id="position">
-				<h3>
-					<a>position<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">position <i>item</i> <i>list</i></span>
-					<span class="prim_example">position <i>string1</i> <i>string2</i></span>
-				</h4>
-				<p>
-					On a list, reports the first position of <i>item</i> in
-					<i>list</i>, or false if it does not appear.
-				</p>
-				<p>
-					On strings, reports the position of the first appearance
-					<i>string1</i> as a substring of <i>string2</i>, or false if it
-					does not appear.
-				</p>
-				<p>
-					Note: The positions are numbered beginning with 0, not with 1.
-				</p>
-				<pre>
-					;; suppose mylist is [2 7 4 7 &quot;Bob&quot;]
-					show position 7 mylist
-					=&gt; 1
-					show position 10 mylist
-					=&gt; false
-					show position &quot;in&quot; &quot;string&quot;
-					=&gt; 3
-				</pre>
-				<p>
-					See also <a href="#member">member?</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="precision">
-				<h3>
-					<a>precision<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">precision <i>number places</i></span>
-				</h4>
-				<p>
-					Reports <i>number</i> rounded to <i>places</i> decimal places.
-				</p>
-				<p>
-					If <i>places</i> is negative, the rounding takes place to the left
-					of the decimal point.
-				</p>
-				<pre>
-					show precision 1.23456789 3
-					=&gt; 1.235
-					show precision 3834 -3
-					=&gt; 4000
-				</pre>
-				<p>
-					See also <a href="#round">round</a>, <a href="#ceiling">ceiling</a>, <a href="#floor">floor</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="print">
-				<h3>
-					<a>print<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">print <i>value</i></span>
-				</h4>
-				<p>
-					Prints <i>value</i> in the Command Center, followed by a carriage
-					return.
-				</p>
-				<p>
-					This agent is <i>not</i> printed before the value, unlike <a href="#show">show</a>.
-				</p>
-				<p>
-					See also <a href="#show">show</a>, <a href="#type">type</a>,
-					<a href="#write">write</a>, <a href="#output-cmds">output-print</a>, and
-					<a href="programming.html#output">Output (programming guide)</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="pcor">
-				<h3>
-					<a>pxcor</a>
-					<a>pycor</a>
-				</h3>
-				<h4>
-					<span class="prim_example">pxcor</span>
-					<span class="prim_example">pycor</span>
-					<img alt="Patch Command" src="images/patch.gif"/> <img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					These are built-in patch variables. They hold the x and y
-					coordinate of the patch. They are always integers. You cannot set
-					these variables, because patches don't move.
-				</p>
-				<p>
-					pxcor is greater than or equal to min-pxcor and less than or equal
-					to max-pxcor; similarly for pycor and min-pycor and max-pycor.
-				</p>
-				<p>
-					All patch variables can be directly accessed by any turtle standing
-					on the patch.
-				</p>
-				<p>
-					See also <a href="#xcor">xcor</a>, <a href="#ycor">ycor</a>.
-				</p>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="R">
-			<a>R</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="random">
-				<h3>
-					<a>random<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">random <i>number</i></span>
-				</h4>
-				<p>
-					If <i>number</i> is positive, reports a random integer greater than
-					or equal to 0, but strictly less than <i>number</i>.
-				</p>
-				<p>
-					If <i>number</i> is negative, reports a random integer less than or
-					equal to 0, but strictly greater than <i>number</i>.
-				</p>
-				<p>
-					If <i>number</i> is zero, the result is always 0 as well.
-				</p>
-				<p>
-					Note: In versions of NetLogo prior to version 2.0, this primitive
-					reported a floating point number if given a non-integer input. This
-					is no longer the case. If you want a floating point answer, you
-					must now use <a href="#random-float">random-float</a> instead.
-				</p>
-				<pre>
-					show random 3
-					;; prints 0, 1,  or 2
-					show random -3
-					;; prints 0, -1, or -2
-					show random 3.5
-					;; prints 0, 1, 2, or 3
-				</pre>
-				<p>
-					See also <a href="#random-float">random-float</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="random-float">
-				<h3>
-					<a>random-float<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">random-float <i>number</i></span>
-				</h4>
-				<p>
-					If <i>number</i> is positive, reports a random floating point
-					number greater than or equal to 0 but strictly less than
-					<i>number</i>.
-				</p>
-				<p>
-					If <i>number</i> is negative, reports a random floating point
-					number less than or equal to 0, but strictly greater than
-					<i>number</i>.
-				</p>
-				<p>
-					If <i>number</i> is zero, the result is always 0.
-				</p>
-				<pre>
-					show random-float 3
-					;; prints a number at least 0 but less than 3,
-					;; for example 2.589444906014774
-					show random-float 2.5
-					;; prints a number at least 0 but less than 2.5,
-					;; for example 1.0897423196760796
-				</pre>
-			</div>
-			<div class="dict_entry" id="random-reporters">
-				<h3>
-					<a>random-exponential<span class="since">1.2.1</span></a>
-					<a>random-gamma<span class="since">2.0</span></a>
-					<a>random-normal<span class="since">1.2.1</span></a>
-					<a>random-poisson<span class="since">1.2.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">random-exponential <i>mean</i></span>
-					<span class="prim_example">random-gamma <i>alpha lambda</i></span>
-					<span class="prim_example">random-normal <i>mean standard-deviation</i></span>
-					<span class="prim_example">random-poisson <i>mean</i></span>
-				</h4>
-				<p>
-					Reports an accordingly distributed random number with the
-					<i>mean</i> and, in the case of the normal distribution, the
-					<i>standard-deviation</i>. (The standard deviation may not be
-					negative.)
-				</p>
-				<p>
-					random-exponential reports an exponentially distributed random
-					floating point number. It is equivalent to <code>(- <i>mean</i>) * ln
-						random-float 1.0</code>.
-				</p>
-				<p>
-					random-gamma reports a gamma-distributed random floating point
-					number as controlled by the floating point alpha and lambda
-					parameters. Both inputs must be greater than zero. (Note: for
-					results with a given mean and variance, use inputs as follows:
-					alpha = mean * mean / variance; lambda = 1 / (variance / mean).)
-				</p>
-				<p>
-					random-normal reports a normally distributed random floating point
-					number.
-				</p>
-				<p>
-					random-poisson reports a Poisson-distributed random integer.
-				</p>
-				<pre>
-					show random-exponential 2
-					;; prints an exponentially distributed random floating
-					;; point number with a mean of 2
-					show random-normal 10.1 5.2
-					;; prints a normally distributed random floating point
-					;; number with a mean of 10.1 and a standard deviation
-					;; of 5.2
-					show random-poisson 3.4
-					;; prints a Poisson-distributed random integer with a
-					;; mean of 3.4
-				</pre>
-			</div>
-			<div class="dict_entry" id="random-pcor">
-				<h3>
-					<a>random-pxcor<span class="since">3.1</span></a>
-					<a>random-pycor<span class="since">3.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">random-pxcor</span>
-					<span class="prim_example">random-pycor</span>
-				</h4>
-				<p>
-					Reports a random integer ranging from min-pxcor (or -y) to
-					max-pxcor (or -y) inclusive.
-				</p>
-				<pre>
-					ask turtles [
-					;; move each turtle to the center of a random patch
-					setxy random-pxcor random-pycor
-					]
-				</pre>
-				<p>
-					See also <a href="#random-cor">random-xcor</a>, <a href="#random-cor">random-ycor</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="random-seed">
-				<h3>
-					<a>random-seed<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">random-seed <i>number</i></span>
-				</h4>
-				<p>
-					Sets the seed of the pseudo-random number generator to the integer
-					part of <i>number</i>. The seed must be in the range -2147483648 to
-					2147483647; note that this is smaller than the full range of
-					integers supported by NetLogo (-9007199254740992 to
-					9007199254740992).
-				</p>
-				<p>
-					See the <a href="programming.html#random-numbers">Random Numbers</a>
-					section of the Programming Guide for more details.
-				</p>
-				<pre>
-					random-seed 47822
-					show random 100
-					=&gt; 50
-					show random 100
-					=&gt; 35
-					random-seed 47822
-					show random 100
-					=&gt; 50
-					show random 100
-					=&gt; 35
-				</pre>
-			</div>
-			<div class="dict_entry" id="random-cor">
-				<h3>
-					<a>random-xcor<span class="since">3.1</span></a>
-					<a>random-ycor<span class="since">3.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">random-xcor</span>
-					<span class="prim_example">random-ycor</span>
-				</h4>
-				<p>
-					Reports a random floating point number from the allowable range of
-					turtle coordinates along the given axis, x or y.
-				</p>
-				<p>
-					Turtle coordinates range from min-pxcor - 0.5 (inclusive) to
-					max-pxcor + 0.5 (exclusive) horizontally; vertically, substitute -y
-					for -x.
-				</p>
-				<pre>
-					ask turtles [
-					;; move each turtle to a random point
-					setxy random-xcor random-ycor
-					]
-				</pre>
-				<p>
-					See also <a href="#random-pcor">random-pxcor</a>, <a href="#random-pcor">random-pycor</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="range">
-				<h3>
-					<a>range<span class="since">6.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">range <i>stop</i></span>
-					<span class="prim_example">(range <i>start</i> <i>stop</i>)</span>
-					<span class="prim_example">(range <i>start</i> <i>stop</i> <i>step</i>)</span>
-				</h4>
-				<p>
-					Generates a list of numbers, starting at <i>start</i>, ending before
-					<i>stop</i>, counting by <i>step</i>. <i>start</i> defaults to 0 and
-					<i>step</i> defaults to 1.
-				</p>
-				<pre>
-					show range 5
-					=&gt; [0 1 2 3 4]
-					show (range 2 5)
-					=&gt; [2 3 4]
-					show (range 2 5 0.5)
-					=&gt; [2 2.5 3 3.5 4 4.5]
-					show (range 10 0 -1)
-					=&gt; [10 9 8 7 6 5 4 3 2 1]
-				</pre>
-				<p>
-					See also <a href="#n-values">n-values</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="read-from-string">
-				<h3>
-					<a>read-from-string<span class="since">1.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">read-from-string <i>string</i></span>
-				</h4>
-				<p>
-					Interprets the given string as if it had been typed in the Command
-					Center, and reports the resulting value. The result may be a
-					number, list, string, or boolean value, or the special value
-					&quot;nobody&quot;.
-				</p>
-				<p>
-					Useful in conjunction with the <a href="#user-input">user-input</a>
-					primitive for converting the user's input into usable form.
-				</p>
-				<pre>
-					show read-from-string &quot;3&quot; + read-from-string &quot;5&quot;
-					=&gt; 8
-					show length read-from-string &quot;[1 2 3]&quot;
-					=&gt; 3
-					crt read-from-string user-input &quot;Make how many turtles?&quot;
-					;; the number of turtles input by the user
-					;; are created
-				</pre>
-			</div>
-			<div class="dict_entry" id="reduce">
-				<h3>
-					<a>reduce<span class="since">1.3</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">reduce <i>reporter</i> <i>list</i></span>
-				</h4>
-				<p>
-					Reduces a list from left to right using the given reporter, resulting
-					in a single value. This means, for example, that <code>reduce
-						[ [a b] -&gt; a + b] [1 2 3 4]</code>
-					is equivalent to <i>(((1 + 2) + 3) + 4)</i>. If
-					<i>list</i> has a single item, that item is reported. It is an
-					error to reduce an empty list. <i>reporter</i> may be an anonymous
-					reporter or the name of a reporter.
-				</p>
-				<p>
-					The first input passed to the reporter is the result so far, and the
-					second input is the next item in the list.
-				</p>
-				<p>
-					Since it can be difficult to develop an intuition about what
-					<code>reduce</code> does, here are some simple examples which, while
-					not useful in themselves, may give you a better understanding of
-					this primitive:
-				</p>
-				<pre>
-					show reduce + [1 2 3]
-					=&gt; 6
-					show reduce - [1 2 3]
-					=&gt; -4
-					show reduce [ [result-so-far next-item] -&gt; next-item - result-so-far ] [1 2 3]
-					=&gt; 2
-					show reduce [ [result-so-far ignored-item] -&gt; result-so-far ] [1 2 3]
-					=&gt; 1
-					show reduce [ [ignored next-item] -&gt; next-item ] [1 2 3]
-					=&gt; 3
-					show reduce sentence [[1 2] [3 [4]] 5]
-					=&gt; [1 2 3 [4] 5]
-					show reduce [ [result-so-far next-item] -&gt; fput next-item result-so-far ] (fput [] [1 2 3 4 5])
-					=&gt; [5 4 3 2 1]
-				</pre>
-				<p>
-					Here are some more useful examples:
-				</p>
-				<pre>
-					;; find the longest string in a list
-					to-report longest-string [strings]
-					report reduce
-					[ [longest-so-far next-string] -&gt; ifelse-value (length longest-so-far &gt;= length next-string) [longest-so-far] [next-string] ]
-					strings
-					end
+          ;; suppose mylist is [1 2 3 4 5 6]
+          show one-of mylist
+          ;; prints a value randomly chosen from the list
+        </pre>
+        <p>
+          See also <a href="#n-of">n-of</a>, <a href="#up-to-n-of">up-to-n-of</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="or">
+        <h3>
+          <a>or<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example"><i>boolean1</i> or <i>boolean2</i></span>
+        </h4>
+        <p>
+          Reports true if either <i>boolean1</i> or <i>boolean2</i>, or both,
+          is true.
+        </p>
+        <p>
+          Note that if <i>condition1</i> is true, then <i>condition2</i> will
+          not be run (since it can't affect the result).
+        </p>
+        <pre>
+          if (pxcor &gt; 0) or (pycor &gt; 0) [ set pcolor red ]
+          ;; patches turn red except in lower-left quadrant
+        </pre>
+      </div>
+      <div class="dict_entry" id="other">
+        <h3>
+          <a>other<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">other <i>agentset</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          Reports an agentset which is the same as the input agentset but
+          omits this agent.
+        </p>
+        <pre>
+          show count turtles-here
+          =&gt; 10
+          show count other turtles-here
+          =&gt; 9
+        </pre>
+      </div>
+      <div class="dict_entry" id="other-end">
+        <h3>
+          <a>other-end<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">other-end</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          If run by a turtle, reports the turtle at the other end of the
+          asking link.
+        </p>
+        <p>
+          If run by a link, reports the turtle at the end of the link that
+          isn't the asking turtle.
+        </p>
+        <p>
+          These definitions are difficult to understand in the abstract, but
+          the following examples should help:
+        </p>
+        <pre>
+          ask turtle 0 [ create-link-with turtle 1 ]
+          ask turtle 0 [ ask link 0 1 [ show other-end ] ] ;; prints turtle 1
+          ask turtle 1 [ ask link 0 1 [ show other-end ] ] ;; prints turtle 0
+          ask link 0 1 [ ask turtle 0 [ show other-end ] ] ;; prints turtle 1
+        </pre>
+        <p>
+          As these examples hopefully make plain, the &quot;other&quot; end
+          is the end that is neither asking nor being asked.
+        </p>
+      </div>
+      <div class="dict_entry" id="out-link-neighbor">
+        <h3>
+          <a>out-&lt;breed&gt;-neighbor?</a>
+          <a>out-link-neighbor?<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">out-&lt;breed&gt;-neighbor? <i>turtle</i></span>
+          <span class="prim_example">out-link-neighbor? <i>turtle</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Reports true if there is a directed link going from the caller to
+          <i>turtle</i> or if there is an undirected link connecting the caller
+          with <i>turtle</i>. You can think of this as "can I get from the caller
+          to <i>turtle</i> using a link?"
+        </p>
+        <pre>
+          crt 2
+          ask turtle 0 [
+          create-link-to turtle 1
+          show in-link-neighbor? turtle 1  ;; prints false
+          show out-link-neighbor? turtle 1 ;; prints true
+          ]
+          ask turtle 1 [
+          show in-link-neighbor? turtle 0  ;; prints true
+          show out-link-neighbor? turtle 0 ;; prints false
+          ]
+        </pre>
+      </div>
+      <div class="dict_entry" id="out-link-neighbors">
+        <h3>
+          <a>out-&lt;breed&gt;-neighbors</a>
+          <a>out-link-neighbors<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">out-&lt;breed&gt;-neighbors</span>
+          <span class="prim_example">out-link-neighbors</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Reports the agentset of all the turtles that have directed links
+          from the caller, or undirected links with the caller. You can think
+          of this as "who can I get to from the caller using a link?"
+        </p>
+        <pre>
+          crt 4
+          ask turtle 0
+          [
+          create-links-to other turtles
+          ask out-link-neighbors [ set color pink ] ;; turtles 1-3 turn pink
+          ]
+          ask turtle 1
+          [
+          ask out-link-neighbors [ set color orange ]  ;; no turtles change colors
+          ;; since turtle 1 only has in-links
+          ]
+          end
+        </pre>
+      </div>
+      <div class="dict_entry" id="out-link-to">
+        <h3>
+          <a>out-&lt;breed&gt;-to</a>
+          <a>out-link-to<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">out-&lt;breed&gt;-to <i>turtle</i></span>
+          <span class="prim_example">out-link-to <i>turtle</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Reports a directed link from the caller to <i>turtle</i> or an
+          undirected link connecting the two. If no link exists then it
+          reports nobody. If more than one such link exists, reports a
+          random one. You can think of this as "give me a link that I can use
+          to travel from the caller to <i>turtle</i>."
+        </p>
+        <pre>
+          crt 2
+          ask turtle 0 [
+          create-link-to turtle 1
+          show out-link-to turtle 1 ;; shows link 0 1
+          ]
+          ask turtle 1
+          [
+          show out-link-to turtle 0 ;; shows nobody
+          ]
+        </pre>
+        <p>
+          See also: <a href="#in-link-from">in-link-from</a> <a href="#link-with">link-with</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="output-cmds">
+        <h3>
+          <a>output-print<span class="since">2.1</span></a>
+          <a>output-show<span class="since">2.1</span></a>
+          <a>output-type<span class="since">2.1</span></a>
+          <a>output-write<span class="since">2.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">output-print <i>value</i></span>
+          <span class="prim_example">output-show <i>value</i></span>
+          <span class="prim_example">output-type <i>value</i></span>
+          <span class="prim_example">output-write <i>value</i></span>
+        </h4>
+        <p>
+          These commands are the same as the <a href="#print">print</a>,
+          <a href="#show">show</a>, <a href="#type">type</a>, and <a href="#write">write</a> commands except that <i>value</i> is printed in
+          the model's output area, instead of in the Command Center. (If
+          the model does not have a separate output area, then the Command
+          Center is used.) See also <a href="programming.html#output">Output (programming guide)</a>.
+        </p>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="P">
+      <a>P</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="patch">
+        <h3>
+          <a>patch<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">patch <i>xcor</i> <i>ycor</i></span>
+        </h4>
+        <p>
+          Given the x and y coordinates of a point, reports the patch
+          containing that point. (The coordinates are absolute coordinates;
+          they are not computed relative to this agent, as with patch-at.)
+        </p>
+        <p>
+          If x and y are integers, the point is the center of a patch. If x
+          or y is not an integer, rounding to the nearest integer is used to
+          determine which patch contains the point.
+        </p>
+        <p>
+          If wrapping is allowed by the topology, the given coordinates will
+          be wrapped to be within the world. If wrapping is not allowed and
+          the given coordinates are outside the world, reports nobody.
+        </p>
+        <pre>
+          ask patch 3 -4 [ set pcolor green ]
+          ;; patch with pxcor of 3 and pycor of -4 turns green
+          show patch 1.2 3.7
+          ;; prints (patch 1 4); note rounding
+          show patch 18 19
+          ;; supposing min-pxcor and min-pycor are -17
+          ;; and max-pxcor and max-pycor are 17,
+          ;; in a wrapping topology, prints (patch -17 -16);
+          ;; in a non-wrapping topology, prints nobody
+        </pre>
+        <p>
+          See also <a href="#patch-at">patch-at</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="patch-ahead">
+        <h3>
+          <a>patch-ahead<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">patch-ahead <i>distance</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Reports the single patch that is the given distance
+          &quot;ahead&quot; of this turtle, that is, along the turtle's
+          current heading. Reports nobody if the patch does not exist because
+          it is outside the world.
+        </p>
+        <pre>
+          ask patch-ahead 1 [ set pcolor green ]
+          ;; turns the patch 1 in front of this turtle
+          ;;   green; note that this might be the same patch
+          ;;   the turtle is standing on
+        </pre>
+        <p>
+          See also <a href="#patch-at">patch-at</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="patch-at">
+        <h3>
+          <a>patch-at<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">patch-at <i>dx</i> <i>dy</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          Reports the patch at (dx, dy) from the caller, that is, the patch
+          containing the point dx east and dy patches north of this agent.
+        </p>
+        <p>
+          Reports nobody if there is no such patch because that point is
+          beyond a non-wrapping world boundary.
+        </p>
+        <pre>
+          ask patch-at 1 -1 [ set pcolor green ]
+          ;; if caller is a turtle or patch, turns the
+          ;;   patch just southeast of the caller green
+        </pre>
+        <p>
+          See also <a href="#patch">patch</a>, <a href="#patch-ahead">patch-ahead</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="patch-at-heading-and-distance">
+        <h3>
+          <a>patch-at-heading-and-distance<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">patch-at-heading-and-distance <i>heading</i> <i>distance</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          patch-at-heading-and-distance reports the single patch that is the
+          given distance from this turtle or patch, along the given absolute
+          heading. (In contrast to patch-left-and-ahead and
+          patch-right-and-ahead, this turtle's current heading is not
+          taken into account.) Reports nobody if the patch does not exist
+          because it is outside the world.
+        </p>
+        <pre>
+          ask patch-at-heading-and-distance -90 1 [ set pcolor green ]
+          ;; turns the patch 1 to the west of this patch green
+        </pre>
+        <p>
+          See also <a href="#patch">patch</a>, <a href="#patch-at">patch-at</a>, <a href="#patch-lr-and-ahead">patch-left-and-ahead</a>, <a href="#patch-lr-and-ahead">patch-right-and-ahead</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="patch-here">
+        <h3>
+          <a>patch-here<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">patch-here</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          patch-here reports the patch under the turtle.
+        </p>
+        <p>
+          Note that this reporter isn't available to a patch because a
+          patch can just say &quot;self&quot;.
+        </p>
+      </div>
+      <div class="dict_entry" id="patch-lr-and-ahead">
+        <h3>
+          <a>patch-left-and-ahead<span class="since">2.0</span></a>
+          <a>patch-right-and-ahead<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">patch-left-and-ahead <i>angle</i> <i>distance</i></span>
+          <span class="prim_example">patch-right-and-ahead <i>angle</i> <i>distance</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Reports the single patch that is the given distance from this
+          turtle, in the direction turned left or right the given angle (in
+          degrees) from the turtle's current heading. Reports nobody if
+          the patch does not exist because it is outside the world.
+        </p>
+        <p>
+          (If you want to find a patch in a given absolute heading, rather
+          than one relative to the current turtle's heading, use
+          patch-at-heading-and-distance instead.)
+        </p>
+        <pre>
+          ask patch-right-and-ahead 30 1 [ set pcolor green ]
+          ;; this turtle &quot;looks&quot; 30 degrees right of its
+          ;;   current heading at the patch 1 unit away, and turns
+          ;;   that patch green; note that this might be the same
+          ;;   patch the turtle is standing on
+        </pre>
+        <p>
+          See also <a href="#patch">patch</a>, <a href="#patch-at">patch-at</a>, <a href="#patch-at-heading-and-distance">patch-at-heading-and-distance</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="patch-set">
+        <h3>
+          <a>patch-set<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">patch-set <i>value1</i></span>
+          <span class="prim_example">(patch-set <i>value1</i> <i>value2</i> ...)</span>
+        </h4>
+        <p>
+          Reports an agentset containing all of the patches anywhere in any
+          of the inputs. The inputs may be individual patches, patch
+          agentsets, nobody, or lists (or nested lists) containing any of the
+          above.
+        </p>
+        <pre>
+          patch-set self
+          patch-set patch-here
+          (patch-set self neighbors)
+          (patch-set patch-here neighbors)
+          (patch-set patch 0 0 patch 1 3 patch 4 -2)
+          (patch-set patch-at -1 1 patch-at 0 1 patch-at 1 1)
+          patch-set [patch-here] of turtles
+          patch-set [neighbors] of turtles
+        </pre>
+        <p>
+          See also <a href="#turtle-set">turtle-set</a>, <a href="#link-set">link-set</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="patch-size">
+        <h3>
+          <a>patch-size<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">patch-size</span>
+        </h4>
+        <p>
+          Reports the size of the patches in the view in pixels. The size is
+          typically an integer, but may also be a floating point number.
+        </p>
+        <p>
+          See also <a href="#set-patch-size">set-patch-size</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="patches">
+        <h3>
+          <a>patches<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">patches</span>
+        </h4>
+        <p>
+          Reports the agentset consisting of all patches.
+        </p>
+      </div>
+      <div class="dict_entry" id="patches-own">
+        <h3>
+          <a>patches-own</a>
+        </h3>
+        <h4>
+          <span class="prim_example">patches-own [<i>var1</i> ...]</span>
+        </h4>
+        <p>
+          This keyword, like the globals, breed, <i>&lt;breed&gt;</i>-own,
+          and turtles-own keywords, can only be used at the beginning of a
+          program, before any function definitions. It defines the variables
+          that all patches can use.
+        </p>
+        <p>
+          All patches will then have the given variables and be able to use
+          them.
+        </p>
+        <p>
+          All patch variables can also be directly accessed by any turtle
+          standing on the patch.
+        </p>
+        <p>
+          See also <a href="#globals">globals</a>, <a href="#turtles-own">turtles-own</a>, <a href="#breed">breed</a>,
+          <a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="pcolor">
+        <h3>
+          <a>pcolor</a>
+        </h3>
+        <h4>
+          <span class="prim_example">pcolor</span>
+          <img alt="Patch Command" src="images/patch.gif"/> <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          This is a built-in patch variable. It holds the color of the patch.
+          You can set this variable to make the patch change color.
+        </p>
+        <p>
+          All patch variables can be directly accessed by any turtle standing
+          on the patch. Color can be represented either as a NetLogo color (a
+          single number) or an RGB color (a list of 3 numbers). See details
+          in the <a href="programming.html#colors">Colors section</a> of the
+          Programming Guide.
+        </p>
+        <p>
+          See also <a href="#color">color</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="pen-switch-status">
+        <h3>
+          <a>pen-down<span class="since">1.0</span></a>
+          <a>pd<span class="since">1.0</span></a>
+          <a>pen-erase<span class="since">3.0</span></a>
+          <a>pe<span class="since">3.0</span></a>
+          <a>pen-up<span class="since">1.0</span></a>
+          <a>pu<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">pen-down</span>
+          <span class="prim_example">pen-erase</span>
+          <span class="prim_example">pen-up</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          The turtle changes modes between drawing lines, removing lines or
+          neither. The lines will always be displayed on top of the patches
+          and below the turtles. To change the color of the pen set the color
+          of the turtle using <code>set color</code>.
+        </p>
+        <p>
+          Note: When a turtle's pen is down, all movement commands cause
+          lines to be drawn, including jump, setxy, and move-to.
+        </p>
+        <p>
+          Note: These commands are equivalent to setting the turtle variable
+          &quot;pen-mode&quot; to &quot;down&quot; , &quot;up&quot;, and
+          &quot;erase&quot;.
+        </p>
+        <p>
+          Note: On Windows drawing and erasing a line might not erase every
+          pixel.
+        </p>
+      </div>
+      <div class="dict_entry" id="pen-mode">
+        <h3>
+          <a>pen-mode</a>
+        </h3>
+        <h4>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          This is a built-in turtle variable. It holds the state of the
+          turtle's pen. You set the variable to draw lines, erase lines
+          or stop either of these actions. Possible values are
+          &quot;up&quot;, &quot;down&quot;, and &quot;erase&quot;.
+        </p>
+      </div>
+      <div class="dict_entry" id="pen-size">
+        <h3>
+          <a>pen-size</a>
+        </h3>
+        <h4>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          This is a built-in turtle variable. It holds the width of the line,
+          in pixels, that the turtle will draw (or erase) when the pen is
+          down (or erasing).
+        </p>
+      </div>
+      <div class="dict_entry" id="plabel">
+        <h3>
+          <a>plabel</a>
+        </h3>
+        <h4>
+          <span class="prim_example">plabel</span>
+          <img alt="Patch Command" src="images/patch.gif"/> <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          This is a built-in patch variable. It may hold a value of any type.
+          The patch appears in the view with the given value
+          &quot;attached&quot; to it as text. You can set this variable to
+          add, change, or remove a patch's label.
+        </p>
+        <p>
+          All patch variables can be directly accessed by any turtle standing
+          on the patch.
+        </p>
+        <p>
+          See also <a href="#plabel-color">plabel-color</a>, <a href="#label">label</a>, <a href="#label-color">label-color</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="plabel-color">
+        <h3>
+          <a>plabel-color</a>
+        </h3>
+        <h4>
+          <span class="prim_example">plabel-color</span>
+          <img alt="Patch Command" src="images/patch.gif"/> <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          This is a built-in patch variable. It holds a number greater than
+          or equal to 0 and less than 140. This number determines what color
+          the patch's label appears in (if it has a label). You can set
+          this variable to change the color of a patch's label.
+        </p>
+        <p>
+          All patch variables can be directly accessed by any turtle standing
+          on the patch.
+        </p>
+        <p>
+          See also <a href="#plabel">plabel</a>, <a href="#label">label</a>,
+          <a href="#label-color">label-color</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="plot">
+        <h3>
+          <a>plot<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">plot <i>number</i></span>
+        </h4>
+        <p>
+          Increments the x-value of the plot pen by plot-pen-interval, then
+          plots a point at the updated x-value and a y-value of
+          <i>number</i>. (The first time the command is used on a plot, the
+          point plotted has an x-value of 0.)
+        </p>
+      </div>
+      <div class="dict_entry" id="plot-name">
+        <h3>
+          <a>plot-name<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">plot-name</span>
+        </h4>
+        <p>
+          Reports the name of the current plot (a string)
+        </p>
+      </div>
+      <div class="dict_entry" id="plot-pen-exists">
+        <h3>
+          <a>plot-pen-exists?<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">plot-pen-exists? <i>string</i></span>
+        </h4>
+        <p>
+          Reports true if a plot pen with the given name is defined in the
+          current plot. Otherwise reports false.
+        </p>
+      </div>
+      <div class="dict_entry" id="plot-pen-switch-status">
+        <h3>
+          <a>plot-pen-down<span class="since">1.0</span></a>
+          <a>plot-pen-up<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">plot-pen-down</span>
+          <span class="prim_example">plot-pen-up</span>
+        </h4>
+        <p>
+          Puts down (or up) the current plot-pen, so that it draws (or
+          doesn't). (By default, all pens are down initially.)
+        </p>
+      </div>
+      <div class="dict_entry" id="plot-pen-reset">
+        <h3>
+          <a>plot-pen-reset<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">plot-pen-reset</span>
+        </h4>
+        <p>
+          Clears everything the current plot pen has drawn, moves it to
+          (0,0), and puts it down. If the pen is a permanent pen, the color,
+          mode, and interval are reset to the default values from the plot
+          Edit dialog.
+        </p>
+      </div>
+      <div class="dict_entry" id="plotxy">
+        <h3>
+          <a>plotxy<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">plotxy <i>number1 number2</i></span>
+        </h4>
+        <p>
+          Moves the current plot pen to the point with coordinates
+          (<i>number1</i>, <i>number2</i>). If the pen is down, a line, bar,
+          or point will be drawn (depending on the pen's mode).
+        </p>
+      </div>
+      <div class="dict_entry" id="plot-cor-max-or-min">
+        <h3>
+          <a>plot-x-min<span class="since">1.0</span></a>
+          <a>plot-x-max<span class="since">1.0</span></a>
+          <a>plot-y-min<span class="since">1.0</span></a>
+          <a>plot-y-max<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">plot-x-min</span>
+          <span class="prim_example">plot-x-max</span>
+          <span class="prim_example">plot-y-min</span>
+          <span class="prim_example">plot-y-max</span>
+        </h4>
+        <p>
+          Reports the minimum or maximum value on the x or y axis of the
+          current plot.
+        </p>
+        <p>
+          These values can be set with the commands set-plot-x-range and
+          set-plot-y-range. (Their default values are set from the plot Edit
+          dialog.)
+        </p>
+      </div>
+      <div class="dict_entry" id="position">
+        <h3>
+          <a>position<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">position <i>item</i> <i>list</i></span>
+          <span class="prim_example">position <i>string1</i> <i>string2</i></span>
+        </h4>
+        <p>
+          On a list, reports the first position of <i>item</i> in
+          <i>list</i>, or false if it does not appear.
+        </p>
+        <p>
+          On strings, reports the position of the first appearance
+          <i>string1</i> as a substring of <i>string2</i>, or false if it
+          does not appear.
+        </p>
+        <p>
+          Note: The positions are numbered beginning with 0, not with 1.
+        </p>
+        <pre>
+          ;; suppose mylist is [2 7 4 7 &quot;Bob&quot;]
+          show position 7 mylist
+          =&gt; 1
+          show position 10 mylist
+          =&gt; false
+          show position &quot;in&quot; &quot;string&quot;
+          =&gt; 3
+        </pre>
+        <p>
+          See also <a href="#member">member?</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="precision">
+        <h3>
+          <a>precision<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">precision <i>number places</i></span>
+        </h4>
+        <p>
+          Reports <i>number</i> rounded to <i>places</i> decimal places.
+        </p>
+        <p>
+          If <i>places</i> is negative, the rounding takes place to the left
+          of the decimal point.
+        </p>
+        <pre>
+          show precision 1.23456789 3
+          =&gt; 1.235
+          show precision 3834 -3
+          =&gt; 4000
+        </pre>
+        <p>
+          See also <a href="#round">round</a>, <a href="#ceiling">ceiling</a>, <a href="#floor">floor</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="print">
+        <h3>
+          <a>print<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">print <i>value</i></span>
+        </h4>
+        <p>
+          Prints <i>value</i> in the Command Center, followed by a carriage
+          return.
+        </p>
+        <p>
+          This agent is <i>not</i> printed before the value, unlike <a href="#show">show</a>.
+        </p>
+        <p>
+          See also <a href="#show">show</a>, <a href="#type">type</a>,
+          <a href="#write">write</a>, <a href="#output-cmds">output-print</a>, and
+          <a href="programming.html#output">Output (programming guide)</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="pcor">
+        <h3>
+          <a>pxcor</a>
+          <a>pycor</a>
+        </h3>
+        <h4>
+          <span class="prim_example">pxcor</span>
+          <span class="prim_example">pycor</span>
+          <img alt="Patch Command" src="images/patch.gif"/> <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          These are built-in patch variables. They hold the x and y
+          coordinate of the patch. They are always integers. You cannot set
+          these variables, because patches don't move.
+        </p>
+        <p>
+          pxcor is greater than or equal to min-pxcor and less than or equal
+          to max-pxcor; similarly for pycor and min-pycor and max-pycor.
+        </p>
+        <p>
+          All patch variables can be directly accessed by any turtle standing
+          on the patch.
+        </p>
+        <p>
+          See also <a href="#xcor">xcor</a>, <a href="#ycor">ycor</a>.
+        </p>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="R">
+      <a>R</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="random">
+        <h3>
+          <a>random<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">random <i>number</i></span>
+        </h4>
+        <p>
+          If <i>number</i> is positive, reports a random integer greater than
+          or equal to 0, but strictly less than <i>number</i>.
+        </p>
+        <p>
+          If <i>number</i> is negative, reports a random integer less than or
+          equal to 0, but strictly greater than <i>number</i>.
+        </p>
+        <p>
+          If <i>number</i> is zero, the result is always 0 as well.
+        </p>
+        <p>
+          Note: In versions of NetLogo prior to version 2.0, this primitive
+          reported a floating point number if given a non-integer input. This
+          is no longer the case. If you want a floating point answer, you
+          must now use <a href="#random-float">random-float</a> instead.
+        </p>
+        <pre>
+          show random 3
+          ;; prints 0, 1,  or 2
+          show random -3
+          ;; prints 0, -1, or -2
+          show random 3.5
+          ;; prints 0, 1, 2, or 3
+        </pre>
+        <p>
+          See also <a href="#random-float">random-float</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="random-float">
+        <h3>
+          <a>random-float<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">random-float <i>number</i></span>
+        </h4>
+        <p>
+          If <i>number</i> is positive, reports a random floating point
+          number greater than or equal to 0 but strictly less than
+          <i>number</i>.
+        </p>
+        <p>
+          If <i>number</i> is negative, reports a random floating point
+          number less than or equal to 0, but strictly greater than
+          <i>number</i>.
+        </p>
+        <p>
+          If <i>number</i> is zero, the result is always 0.
+        </p>
+        <pre>
+          show random-float 3
+          ;; prints a number at least 0 but less than 3,
+          ;; for example 2.589444906014774
+          show random-float 2.5
+          ;; prints a number at least 0 but less than 2.5,
+          ;; for example 1.0897423196760796
+        </pre>
+      </div>
+      <div class="dict_entry" id="random-reporters">
+        <h3>
+          <a>random-exponential<span class="since">1.2.1</span></a>
+          <a>random-gamma<span class="since">2.0</span></a>
+          <a>random-normal<span class="since">1.2.1</span></a>
+          <a>random-poisson<span class="since">1.2.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">random-exponential <i>mean</i></span>
+          <span class="prim_example">random-gamma <i>alpha lambda</i></span>
+          <span class="prim_example">random-normal <i>mean standard-deviation</i></span>
+          <span class="prim_example">random-poisson <i>mean</i></span>
+        </h4>
+        <p>
+          Reports an accordingly distributed random number with the
+          <i>mean</i> and, in the case of the normal distribution, the
+          <i>standard-deviation</i>. (The standard deviation may not be
+          negative.)
+        </p>
+        <p>
+          random-exponential reports an exponentially distributed random
+          floating point number. It is equivalent to <code>(- <i>mean</i>) * ln
+            random-float 1.0</code>.
+        </p>
+        <p>
+          random-gamma reports a gamma-distributed random floating point
+          number as controlled by the floating point alpha and lambda
+          parameters. Both inputs must be greater than zero. (Note: for
+          results with a given mean and variance, use inputs as follows:
+          alpha = mean * mean / variance; lambda = 1 / (variance / mean).)
+        </p>
+        <p>
+          random-normal reports a normally distributed random floating point
+          number.
+        </p>
+        <p>
+          random-poisson reports a Poisson-distributed random integer.
+        </p>
+        <pre>
+          show random-exponential 2
+          ;; prints an exponentially distributed random floating
+          ;; point number with a mean of 2
+          show random-normal 10.1 5.2
+          ;; prints a normally distributed random floating point
+          ;; number with a mean of 10.1 and a standard deviation
+          ;; of 5.2
+          show random-poisson 3.4
+          ;; prints a Poisson-distributed random integer with a
+          ;; mean of 3.4
+        </pre>
+      </div>
+      <div class="dict_entry" id="random-pcor">
+        <h3>
+          <a>random-pxcor<span class="since">3.1</span></a>
+          <a>random-pycor<span class="since">3.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">random-pxcor</span>
+          <span class="prim_example">random-pycor</span>
+        </h4>
+        <p>
+          Reports a random integer ranging from min-pxcor (or -y) to
+          max-pxcor (or -y) inclusive.
+        </p>
+        <pre>
+          ask turtles [
+          ;; move each turtle to the center of a random patch
+          setxy random-pxcor random-pycor
+          ]
+        </pre>
+        <p>
+          See also <a href="#random-cor">random-xcor</a>, <a href="#random-cor">random-ycor</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="random-seed">
+        <h3>
+          <a>random-seed<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">random-seed <i>number</i></span>
+        </h4>
+        <p>
+          Sets the seed of the pseudo-random number generator to the integer
+          part of <i>number</i>. The seed must be in the range -2147483648 to
+          2147483647; note that this is smaller than the full range of
+          integers supported by NetLogo (-9007199254740992 to
+          9007199254740992).
+        </p>
+        <p>
+          See the <a href="programming.html#random-numbers">Random Numbers</a>
+          section of the Programming Guide for more details.
+        </p>
+        <pre>
+          random-seed 47822
+          show random 100
+          =&gt; 50
+          show random 100
+          =&gt; 35
+          random-seed 47822
+          show random 100
+          =&gt; 50
+          show random 100
+          =&gt; 35
+        </pre>
+      </div>
+      <div class="dict_entry" id="random-cor">
+        <h3>
+          <a>random-xcor<span class="since">3.1</span></a>
+          <a>random-ycor<span class="since">3.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">random-xcor</span>
+          <span class="prim_example">random-ycor</span>
+        </h4>
+        <p>
+          Reports a random floating point number from the allowable range of
+          turtle coordinates along the given axis, x or y.
+        </p>
+        <p>
+          Turtle coordinates range from min-pxcor - 0.5 (inclusive) to
+          max-pxcor + 0.5 (exclusive) horizontally; vertically, substitute -y
+          for -x.
+        </p>
+        <pre>
+          ask turtles [
+          ;; move each turtle to a random point
+          setxy random-xcor random-ycor
+          ]
+        </pre>
+        <p>
+          See also <a href="#random-pcor">random-pxcor</a>, <a href="#random-pcor">random-pycor</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="range">
+        <h3>
+          <a>range<span class="since">6.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">range <i>stop</i></span>
+          <span class="prim_example">(range <i>start</i> <i>stop</i>)</span>
+          <span class="prim_example">(range <i>start</i> <i>stop</i> <i>step</i>)</span>
+        </h4>
+        <p>
+          Generates a list of numbers, starting at <i>start</i>, ending before
+          <i>stop</i>, counting by <i>step</i>. <i>start</i> defaults to 0 and
+          <i>step</i> defaults to 1.
+        </p>
+        <pre>
+          show range 5
+          =&gt; [0 1 2 3 4]
+          show (range 2 5)
+          =&gt; [2 3 4]
+          show (range 2 5 0.5)
+          =&gt; [2 2.5 3 3.5 4 4.5]
+          show (range 10 0 -1)
+          =&gt; [10 9 8 7 6 5 4 3 2 1]
+        </pre>
+        <p>
+          See also <a href="#n-values">n-values</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="read-from-string">
+        <h3>
+          <a>read-from-string<span class="since">1.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">read-from-string <i>string</i></span>
+        </h4>
+        <p>
+          Interprets the given string as if it had been typed in the Command
+          Center, and reports the resulting value. The result may be a
+          number, list, string, or boolean value, or the special value
+          &quot;nobody&quot;.
+        </p>
+        <p>
+          Useful in conjunction with the <a href="#user-input">user-input</a>
+          primitive for converting the user's input into usable form.
+        </p>
+        <pre>
+          show read-from-string &quot;3&quot; + read-from-string &quot;5&quot;
+          =&gt; 8
+          show length read-from-string &quot;[1 2 3]&quot;
+          =&gt; 3
+          crt read-from-string user-input &quot;Make how many turtles?&quot;
+          ;; the number of turtles input by the user
+          ;; are created
+        </pre>
+      </div>
+      <div class="dict_entry" id="reduce">
+        <h3>
+          <a>reduce<span class="since">1.3</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">reduce <i>reporter</i> <i>list</i></span>
+        </h4>
+        <p>
+          Reduces a list from left to right using the given reporter, resulting
+          in a single value. This means, for example, that <code>reduce
+            [ [a b] -&gt; a + b] [1 2 3 4]</code>
+          is equivalent to <i>(((1 + 2) + 3) + 4)</i>. If
+          <i>list</i> has a single item, that item is reported. It is an
+          error to reduce an empty list. <i>reporter</i> may be an anonymous
+          reporter or the name of a reporter.
+        </p>
+        <p>
+          The first input passed to the reporter is the result so far, and the
+          second input is the next item in the list.
+        </p>
+        <p>
+          Since it can be difficult to develop an intuition about what
+          <code>reduce</code> does, here are some simple examples which, while
+          not useful in themselves, may give you a better understanding of
+          this primitive:
+        </p>
+        <pre>
+          show reduce + [1 2 3]
+          =&gt; 6
+          show reduce - [1 2 3]
+          =&gt; -4
+          show reduce [ [result-so-far next-item] -&gt; next-item - result-so-far ] [1 2 3]
+          =&gt; 2
+          show reduce [ [result-so-far ignored-item] -&gt; result-so-far ] [1 2 3]
+          =&gt; 1
+          show reduce [ [ignored next-item] -&gt; next-item ] [1 2 3]
+          =&gt; 3
+          show reduce sentence [[1 2] [3 [4]] 5]
+          =&gt; [1 2 3 [4] 5]
+          show reduce [ [result-so-far next-item] -&gt; fput next-item result-so-far ] (fput [] [1 2 3 4 5])
+          =&gt; [5 4 3 2 1]
+        </pre>
+        <p>
+          Here are some more useful examples:
+        </p>
+        <pre>
+          ;; find the longest string in a list
+          to-report longest-string [strings]
+          report reduce
+          [ [longest-so-far next-string] -&gt; ifelse-value (length longest-so-far &gt;= length next-string) [longest-so-far] [next-string] ]
+          strings
+          end
 
-					show longest-string [&quot;hi&quot; &quot;there&quot; &quot;!&quot;]
-					=&gt; &quot;there&quot;
+          show longest-string [&quot;hi&quot; &quot;there&quot; &quot;!&quot;]
+          =&gt; &quot;there&quot;
 
-					;; count the number of occurrences of an item in a list
-					to-report occurrences [x the-list]
-					report reduce
-					[ [occurrence-count next-item] -&gt; ifelse-value (next-item = x) [occurrence-count + 1] [occurrence-count] ] (fput 0 the-list)
-					end
+          ;; count the number of occurrences of an item in a list
+          to-report occurrences [x the-list]
+          report reduce
+          [ [occurrence-count next-item] -&gt; ifelse-value (next-item = x) [occurrence-count + 1] [occurrence-count] ] (fput 0 the-list)
+          end
 
-					show occurrences 1 [1 2 1 3 1 2 3 1 1 4 5 1]
-					=&gt; 6
+          show occurrences 1 [1 2 1 3 1 2 3 1 1 4 5 1]
+          =&gt; 6
 
-					;; evaluate the polynomial, with given coefficients, at x
-					to-report evaluate-polynomial [coefficients x]
-					report reduce [ [value coefficient] -&gt; (x * value) + coefficient ] coefficients
-					end
+          ;; evaluate the polynomial, with given coefficients, at x
+          to-report evaluate-polynomial [coefficients x]
+          report reduce [ [value coefficient] -&gt; (x * value) + coefficient ] coefficients
+          end
 
-					;; evaluate 3x^2 + 2x + 1 at x = 4
-					show evaluate-polynomial [3 2 1] 4
-					=&gt; 57
-				</pre>
-				<p>
-					See also <a href="#filter">filter</a>, <a href="#arrow">-&gt; (anonymous procedure</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="remainder">
-				<h3>
-					<a>remainder<span class="since">1.2.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">remainder <i>number1</i> <i>number2</i></span>
-				</h4>
-				<p>
-					Reports the remainder when <i>number1</i> is divided by
-					<i>number2</i>. This is equivalent to the following NetLogo code:
-				</p>
-				<pre>
-					<i>number1</i> - (int (<i>number1</i> / <i>number2</i>)) * <i>number2</i>
-				</pre>
-				<pre>
-					show remainder 62 5
-					=&gt; 2
-					show remainder -8 3
-					=&gt; -2
-				</pre>
-				<p>
-					See also <a href="#mod">mod</a>. mod and remainder behave the same
-					for positive numbers, but differently for negative numbers.
-				</p>
-			</div>
-			<div class="dict_entry" id="remove">
-				<h3>
-					<a>remove<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">remove <i>item</i> <i>list</i></span>
-					<span class="prim_example">remove <i>string1</i> <i>string2</i></span>
-				</h4>
-				<p>
-					For a list, reports a copy of <i>list</i> with all instances of
-					<i>item</i> removed.
-				</p>
-				<p>
-					For strings, reports a copy of <i>string2</i> with all the
-					appearances of <i>string1</i> as a substring removed.
-				</p>
-				<pre>
-					set mylist [2 7 4 7 &quot;Bob&quot;]
-					set mylist remove 7 mylist
-					;; mylist is now [2 4 &quot;Bob&quot;]
-					show remove &quot;to&quot; &quot;phototonic&quot;
-					=&gt; &quot;phonic&quot;
-				</pre>
-			</div>
-			<div class="dict_entry" id="remove-duplicates">
-				<h3>
-					<a>remove-duplicates<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">remove-duplicates <i>list</i></span>
-				</h4>
-				<p>
-					Reports a copy of <i>list</i> with all duplicate items removed. The
-					first of each item remains in place.
-				</p>
-				<pre>
-					set mylist [2 7 4 7 &quot;Bob&quot; 7]
-					set mylist remove-duplicates mylist
-					;; mylist is now [2 7 4 &quot;Bob&quot;]
-				</pre>
-			</div>
-			<div class="dict_entry" id="remove-item">
-				<h3>
-					<a>remove-item<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">remove-item <i>index</i> <i>list</i></span>
-					<span class="prim_example">remove-item <i>index</i> <i>string</i></span>
-				</h4>
-				<p>
-					For a list, reports a copy of <i>list</i> with the item at the
-					given index removed.
-				</p>
-				<p>
-					For strings, reports a copy of <i>string</i> with the character at
-					the given index removed.
-				</p>
-				<p>
-					Note that the indices begin from 0, not 1. (The first item is item
-					0, the second item is item 1, and so on.)
-				</p>
-				<pre>
-					set mylist [2 7 4 7 &quot;Bob&quot;]
-					set mylist remove-item 2 mylist
-					;; mylist is now [2 7 7 &quot;Bob&quot;]
-					show remove-item 2 &quot;string&quot;
-					=&gt; &quot;sting&quot;
-				</pre>
-			</div>
-			<div class="dict_entry" id="repeat">
-				<h3>
-					<a>repeat<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">repeat <i>number</i> [ <i>commands</i> ]</span>
-				</h4>
-				<p>
-					Runs <i>commands</i> <i>number</i> times.
-				</p>
-				<pre>
+          ;; evaluate 3x^2 + 2x + 1 at x = 4
+          show evaluate-polynomial [3 2 1] 4
+          =&gt; 57
+        </pre>
+        <p>
+          See also <a href="#filter">filter</a>, <a href="#arrow">-&gt; (anonymous procedure</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="remainder">
+        <h3>
+          <a>remainder<span class="since">1.2.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">remainder <i>number1</i> <i>number2</i></span>
+        </h4>
+        <p>
+          Reports the remainder when <i>number1</i> is divided by
+          <i>number2</i>. This is equivalent to the following NetLogo code:
+        </p>
+        <pre>
+          <i>number1</i> - (int (<i>number1</i> / <i>number2</i>)) * <i>number2</i>
+        </pre>
+        <pre>
+          show remainder 62 5
+          =&gt; 2
+          show remainder -8 3
+          =&gt; -2
+        </pre>
+        <p>
+          See also <a href="#mod">mod</a>. mod and remainder behave the same
+          for positive numbers, but differently for negative numbers.
+        </p>
+      </div>
+      <div class="dict_entry" id="remove">
+        <h3>
+          <a>remove<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">remove <i>item</i> <i>list</i></span>
+          <span class="prim_example">remove <i>string1</i> <i>string2</i></span>
+        </h4>
+        <p>
+          For a list, reports a copy of <i>list</i> with all instances of
+          <i>item</i> removed.
+        </p>
+        <p>
+          For strings, reports a copy of <i>string2</i> with all the
+          appearances of <i>string1</i> as a substring removed.
+        </p>
+        <pre>
+          set mylist [2 7 4 7 &quot;Bob&quot;]
+          set mylist remove 7 mylist
+          ;; mylist is now [2 4 &quot;Bob&quot;]
+          show remove &quot;to&quot; &quot;phototonic&quot;
+          =&gt; &quot;phonic&quot;
+        </pre>
+      </div>
+      <div class="dict_entry" id="remove-duplicates">
+        <h3>
+          <a>remove-duplicates<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">remove-duplicates <i>list</i></span>
+        </h4>
+        <p>
+          Reports a copy of <i>list</i> with all duplicate items removed. The
+          first of each item remains in place.
+        </p>
+        <pre>
+          set mylist [2 7 4 7 &quot;Bob&quot; 7]
+          set mylist remove-duplicates mylist
+          ;; mylist is now [2 7 4 &quot;Bob&quot;]
+        </pre>
+      </div>
+      <div class="dict_entry" id="remove-item">
+        <h3>
+          <a>remove-item<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">remove-item <i>index</i> <i>list</i></span>
+          <span class="prim_example">remove-item <i>index</i> <i>string</i></span>
+        </h4>
+        <p>
+          For a list, reports a copy of <i>list</i> with the item at the
+          given index removed.
+        </p>
+        <p>
+          For strings, reports a copy of <i>string</i> with the character at
+          the given index removed.
+        </p>
+        <p>
+          Note that the indices begin from 0, not 1. (The first item is item
+          0, the second item is item 1, and so on.)
+        </p>
+        <pre>
+          set mylist [2 7 4 7 &quot;Bob&quot;]
+          set mylist remove-item 2 mylist
+          ;; mylist is now [2 7 7 &quot;Bob&quot;]
+          show remove-item 2 &quot;string&quot;
+          =&gt; &quot;sting&quot;
+        </pre>
+      </div>
+      <div class="dict_entry" id="repeat">
+        <h3>
+          <a>repeat<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">repeat <i>number</i> [ <i>commands</i> ]</span>
+        </h4>
+        <p>
+          Runs <i>commands</i> <i>number</i> times.
+        </p>
+        <pre>
 
-					pd repeat 36 [ fd 1 rt 10 ]
-					;; the turtle draws a circle
+          pd repeat 36 [ fd 1 rt 10 ]
+          ;; the turtle draws a circle
 
-				</pre>
-			</div>
-			<div class="dict_entry" id="replace-item">
-				<h3>
-					<a>replace-item<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">replace-item <i>index list value</i></span>
-					<span class="prim_example">replace-item <i>index string1 string2</i></span>
-				</h4>
-				<p>
-					On a list, replaces an item in that list. <i>index</i> is the index
-					of the item to be replaced, starting with 0. (The 6th item in a
-					list would have an index of 5.) Note that &quot;replace-item&quot;
-					is used in conjunction with &quot;set&quot; to change a list.
-				</p>
-				<p>
-					Likewise for a string, but the given character of <i>string1</i>
-					removed and the contents of <i>string2</i> spliced in instead.
-				</p>
-				<pre>
-					show replace-item 2 [2 7 4 5] 15
-					=&gt; [2 7 15 5]
-					show replace-item 1 &quot;cat&quot; &quot;are&quot;
-					=&gt; &quot;caret&quot;
-				</pre>
-			</div>
-			<div class="dict_entry" id="report">
-				<h3>
-					<a>report<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">report <i>value</i></span>
-				</h4>
-				<p>
-					Immediately exits from the current to-report procedure and reports
-					<i>value</i> as the result of that procedure. report and to-report
-					are always used in conjunction with each other. See <a href="#to-report">to-report</a> for a discussion of how to use them.
-				</p>
-			</div>
-			<div class="dict_entry" id="reset-perspective">
-				<h3>
-					<a>reset-perspective<span class="since">3.0</span></a>
-					<a>rp<span class="since">3.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">reset-perspective</span>
-				</h4>
-				<p>
-					The observer stops watching, following, or riding any turtles (or
-					patches). (If it wasn't watching, following, or riding anybody,
-					nothing happens.) In the 3D view, the observer also returns to its
-					default position (above the origin, looking straight down).
-				</p>
-				<p>
-					See also <a href="#follow">follow</a>, <a href="#ride">ride</a>,
-					<a href="#watch">watch</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="reset-ticks">
-				<h3>
-					<a>reset-ticks<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">reset-ticks</span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Resets the tick counter to zero, sets up all plots, then updates
-					all plots (so that the initial state of the world is plotted).
-				</p>
-				<p>
-					Normally <code>reset-ticks</code> goes at the end of a setup procedure.
-				</p>
-				<p>
-					See also <a href="#clear-ticks">clear-ticks</a>, <a href="#tick">tick</a>, <a href="#ticks">ticks</a>, <a href="#tick-advance">tick-advance</a>, <a href="#setup-plots">setup-plots</a>, <a href="#update-plots">update-plots</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="reset-timer">
-				<h3>
-					<a>reset-timer<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">reset-timer</span>
-				</h4>
-				<p>
-					Resets the timer to zero seconds. See also <a href="#timer">timer</a>.
-				</p>
-				<p>
-					Note that the timer is different from the tick counter. The timer
-					measures elapsed real time in seconds; the tick counter measures
-					elapsed model time in ticks.
-				</p>
-			</div>
-			<div class="dict_entry" id="resize-world">
-				<h3>
-					<a>resize-world<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">resize-world <i>min-pxcor</i> <i>max-pxcor</i> <i>min-pycor</i> <i>max-pycor</i></span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Changes the size of the patch grid.
-				</p>
-				<p>
-					If the given patch grid coordinates are different than the ones
-					in use, all turtles and links die, and the existing patch grid is
-					discarded and new patches created. Otherwise, existing turtles
-					and links will live if the grid coordinates are unchanged.
-				</p>
-				<p>
-					Retaining references to old patches or patch sets is inadvisable
-					and may subsequently cause runtime errors or other unexpected
-					behavior.
-				</p>
-				<p>
-					See also <a href="#set-patch-size">set-patch-size</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="reverse">
-				<h3>
-					<a>reverse<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">reverse <i>list</i></span>
-					<span class="prim_example">reverse <i>string</i></span>
-				</h4>
-				<p>
-					Reports a reversed copy of the given list or string.
-				</p>
-				<pre>
-					show mylist
-					;; mylist is [2 7 4 &quot;Bob&quot;]
-					set mylist reverse mylist
-					;; mylist now is [&quot;Bob&quot; 4 7 2]
-					show reverse &quot;live&quot;
-					=&gt; &quot;evil&quot;
-				</pre>
-			</div>
-			<div class="dict_entry" id="rgb">
-				<h3>
-					<a>rgb<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">rgb <i>red green blue</i></span>
-				</h4>
-				<p>
-					Reports a RGB list when given three numbers describing an RGB
-					color. The numbers are range checked to be between 0 and 255.
-				</p>
-				<p>
-					See also <a href="#hsb">hsb</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="ride">
-				<h3>
-					<a>ride<span class="since">3.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">ride <i>turtle</i></span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Set the perspective to <i>turtle</i>.
-				</p>
-				<p>
-					Every time <i>turtle</i> moves the observer also moves. Thus, in
-					the 2D View the turtle will stay at the center of the view. In the
-					3D view it is as if looking through the eyes of the turtle. If the
-					turtle dies, the perspective resets to the default.
-				</p>
-				<p>
-					The observer may only watch or follow a single subject.
-					Calling <code>ride</code> will remove the highlight created by
-					prior calls to <code>watch</code> and <code>watch-me</code>,
-					highlighting the ridden turtle instead.
-				</p>
-				<p>
-					See also <a href="#reset-perspective">reset-perspective</a>,
-					<a href="#watch">watch</a>, <a href="#follow">follow</a>, <a href="#subject">subject</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="ride-me">
-				<h3>
-					<a>ride-me<span class="since">3.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">ride-me</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Asks the observer to ride this turtle.
-				</p>
-				<p>
-					The observer may only watch or follow a single subject.
-					Calling <code>ride-me</code> will remove the highlight created by
-					prior calls to <code>watch</code> and <code>watch-me</code>,
-					highlighting this turtle instead.
-				</p>
-				<p>
-					See also <a href="#ride">ride</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="right">
-				<h3>
-					<a>right<span class="since">1.0</span></a>
-					<a>rt<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">right <i>number</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					The turtle turns right by <i>number</i> degrees. (If <i>number</i>
-					is negative, it turns left.)
-				</p>
-			</div>
-			<div class="dict_entry" id="round">
-				<h3>
-					<a>round<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">round <i>number</i></span>
-				</h4>
-				<p>
-					Reports the integer nearest to <i>number</i>.
-				</p>
-				<p>
-					If the decimal portion of <i>number</i> is exactly .5, the number
-					is rounded in the <b>positive</b> direction.
-				</p>
-				<p>
-					Note that rounding in the positive direction is not always how
-					rounding is done in other software programs. (In particular, it
-					does not match the behavior of StarLogoT, which always rounded
-					numbers ending in 0.5 to the nearest even integer.) The rationale
-					for this behavior is that it matches how turtle coordinates relate
-					to patch coordinates in NetLogo. For example, if a turtle's
-					xcor is -4.5, then it is on the boundary between a patch whose
-					pxcor is -4 and a patch whose pxcor is -5, but the turtle must be
-					considered to be in one patch or the other, so the turtle is
-					considered to be in the patch whose pxcor is -4, because we round
-					towards the positive numbers.
-				</p>
-				<pre>
-					show round 4.2
-					=&gt; 4
-					show round 4.5
-					=&gt; 5
-					show round -4.5
-					=&gt; -4
-				</pre>
-				<p>
-					See also <a href="#precision">precision</a>, <a href="#ceiling">ceiling</a>, <a href="#floor">floor</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="run">
-				<h3>
-					<a>run<span class="since">1.3</span></a>
-					<a>runresult<span class="since">1.3</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">run <i>command</i></span>
-					<span class="prim_example">(run <i>command</i> <i>input1</i> ...)</span>
-					<span class="prim_example">run <i>string</i></span>
-					<span class="prim_example">runresult <i>reporter</i></span>
-					<span class="prim_example">(runresult <i>reporter</i> <i>input1</i> ...)</span>
-					<span class="prim_example">runresult <i>string</i></span>
-				</h4>
-				<p>
-					The <code>run</code> form expects the name of a command, an anonymous command,
-					or a string containing commands. This agent then runs them.
-				</p>
-				<p>
-					The <code>runresult</code> form expects the name of a reporter, an anonymous reporter,
-					or a string containing a reporter. This agent runs it and reports the result.
-				</p>
-				<p>
-					Note that you can't use <code>run</code> to define or redefine
-					procedures. If you care about performance, note that the code must
-					be compiled first which takes time. However, compiled bits of code
-					are cached by NetLogo and thus using <code>run</code> on the same
-					string over and over is much faster than running different strings.
-					The first run, though, will be many times slower than
-					running the same code directly, or in an anonymous command.
-				</p>
-				<p>
-					Anonymous procedures are recommended over strings whenever possible.
-					(An example of when you must use strings is if you accept pieces
-					of code from the user of your model.)
-				</p>
-				<p>
-					Anonymous procedures may freely read and/or set local variables
-					and procedure inputs. Trying to do the same with strings may
-					or may not work and should not be relied on.
-				</p>
-				<p>
-					When using anonymous procedures, you can provide them with inputs,
-					if you surround the entire call with parentheses. For example:
-				</p>
-				<pre>
-					(run [ [turtle-count step-count] -&gt; crt turtle-count [ fd step-count ] ] 10 5)
-					;; creates 10 turtles and move them forward 5 steps
-					show (runresult [ [a b] -&gt; a + b ] 10 5)
-					=&gt; 15
-					;; adds 10 and 5
-				</pre>
-				<p>
-					See also <a href="#foreach">foreach</a>, <a href="#arrow">-> (anonymous procedure)</a>.
-				</p>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="S">
-			<a>S</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="scale-color">
-				<h3>
-					<a>scale-color<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">scale-color <i>color number range1 range2</i></span>
-				</h4>
-				<p>
-					Reports a shade of <i>color</i> proportional to the value of
-					<i>number</i>.
-				</p>
-				<p>
-					If <i>range1</i> is less than <i>range2</i>, then the larger the
-					number, the lighter the shade of <i>color</i>. But if <i>range2</i>
-					is less than <i>range1</i>, the color scaling is inverted.
-				</p>
-				<p>
-					If <i>number</i> is less than <i>range1</i>, then the darkest shade
-					of <i>color</i> is chosen.
-				</p>
-				<p>
-					If <i>number</i> is greater than <i>range2</i>, then the lightest
-					shade of <i>color</i> is chosen.
-				</p>
-				<p>
-					Note: for <i>color</i> shade is irrelevant, e.g. green and green +
-					2 are equivalent, and the same spectrum of colors will be used.
-				</p>
-				<pre>
-					ask turtles [ set color scale-color red age 0 50 ]
-					;; colors each turtle a shade of red proportional
-					;; to its value for the age variable
-				</pre>
-			</div>
-			<div class="dict_entry" id="self">
-				<h3>
-					<a>self<span class="since">1.3</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">self</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/> <img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					Reports this turtle, patch, or link.
-				</p>
-				<p>
-					&quot;self&quot; and &quot;myself&quot; are very different.
-					&quot;self&quot; is simple; it means &quot;me&quot;.
-					&quot;myself&quot; means &quot;the agent who asked me to do what
-					I'm doing right now.&quot;
-				</p>
-				<p>
-					Note that it is always redundant to write <code>[foo] of self</code>.
-					This is always equivalent to simply writing <code>foo</code>.
-				</p>
-				<p>
-					See also <a href="#myself">myself</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="semicolon">
-				<h3>
-					<a>; (semicolon)</a>
-				</h3>
-				<h4>
-					<span class="prim_example">; <i>comments</i></span>
-				</h4>
-				<p>
-					After a semicolon, the rest of the line is ignored. This is useful
-					for adding &quot;comments&quot; to your code -- text that explains
-					the code to human readers. Extra semicolons can be added for visual
-					effect.
-				</p>
-				<p>
-					NetLogo's Edit menu has items that let you comment or uncomment
-					whole sections of code.
-				</p>
-			</div>
-			<div class="dict_entry" id="sentence">
-				<h3>
-					<a>sentence<span class="since">1.0</span></a>
-					<a>se<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">sentence <i>value1</i> <i>value2</i></span>
-					<span class="prim_example">(sentence <i>value1</i> ...)</span>
-				</h4>
-				<p>
-					Makes a list out of the values. If any value is a list, its items
-					are included in the result directly, rather than being included as
-					a sublist. Examples make this clearer:
-				</p>
-				<pre>
-					show sentence 1 2
-					=&gt; [1 2]
-					show sentence [1 2] 3
-					=&gt; [1 2 3]
-					show sentence 1 [2 3]
-					=&gt; [1 2 3]
-					show sentence [1 2] [3 4]
-					=&gt; [1 2 3 4]
-					show sentence [[1 2]] [[3 4]]
-					=&gt; [[1 2] [3 4]]
-					show (sentence [1 2] 3 [4 5] (3 + 3) 7)
-					=&gt; [1 2 3 4 5 6 7]
-				</pre>
-			</div>
-			<div class="dict_entry" id="set">
-				<h3>
-					<a>set<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">set <i>variable</i> <i>value</i></span>
-				</h4>
-				<p>
-					Sets <i>variable</i> to the given value.
-				</p>
-				<p>
-					Variable can be any of the following:
-				</p>
-				<ul>
-					<li>A global variable declared using &quot;globals&quot;</li>
-					<li>The global variable associated with a slider, switch, chooser,
-						or input box.</li>
-					<li>A variable belonging to this agent</li>
-					<li>If this agent is a turtle, a variable belonging to the patch
-						under the turtle.</li>
-					<li>A local variable created by the <a href="#let">let</a> command.</li>
-					<li>An input to the current procedure.</li>
-				</ul>
-			</div>
-			<div class="dict_entry" id="set-current-directory">
-				<h3>
-					<a>set-current-directory<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">set-current-directory <i>string</i></span>
-				</h4>
-				<p>
-					Sets the current directory that is used by the primitives <a href="#file-delete">file-delete</a>, <a href="#file-exists">file-exists?</a>, and <a href="#file-open">file-open</a>.
-				</p>
-				<p>
-					The current directory is not used if the above commands are given
-					an absolute file path. This is defaulted to the user's home
-					directory for new models, and is changed to the model's
-					directory when a model is opened.
-				</p>
-				<p>
-					Note that in Windows file paths the backslash needs to be escaped
-					within a string by using another backslash &quot;C:\\&quot;
-				</p>
-				<p>
-					The change is temporary and is not saved with the model.
-				</p>
-				<pre>
-					set-current-directory &quot;C:\\NetLogo&quot;
-					;; Assume it is a Windows Machine
-					file-open &quot;my-file.txt&quot;
-					;; Opens file &quot;C:\\NetLogo\\my-file.txt&quot;
-				</pre>
-			</div>
-			<div class="dict_entry" id="set-current-plot">
-				<h3>
-					<a>set-current-plot<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">set-current-plot <i>plotname</i></span>
-				</h4>
-				<p>
-					Sets the current plot to the plot with the given name (a string).
-					Subsequent plotting commands will affect the current plot.
-				</p>
-			</div>
-			<div class="dict_entry" id="set-current-plot-pen">
-				<h3>
-					<a>set-current-plot-pen<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">set-current-plot-pen <i>penname</i></span>
-				</h4>
-				<p>
-					The current plot's current pen is set to the pen named
-					<i>penname</i> (a string). If no such pen exists in the current
-					plot, a runtime error occurs.
-				</p>
-			</div>
-			<div class="dict_entry" id="set-default-shape">
-				<h3>
-					<a>set-default-shape<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">set-default-shape turtles <i>string</i></span>
-					<span class="prim_example">set-default-shape links <i>string</i></span>
-					<span class="prim_example">set-default-shape <i>breed</i> <i>string</i></span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Specifies a default initial shape for all turtles or links, or for
-					a particular breed of turtles or links. When a turtle or link is
-					created, or it changes breeds, it shape is set to the given shape.
-				</p>
-				<p>
-					This command doesn't affect existing agents, only agents you
-					create afterwards.
-				</p>
-				<p>
-					The given breed must be either turtles, links, or the name of a
-					breed. The given string must be the name of a currently defined
-					shape.
-				</p>
-				<p>
-					In new models, the default shape for all turtles is
-					&quot;default&quot;.
-				</p>
-				<p>
-					Note that specifying a default shape does not prevent you from
-					changing an agent's shape later. Agents don't have to be
-					stuck with their breed's default shape.
-				</p>
-				<pre>
-					create-turtles 1 ;; new turtle's shape is &quot;default&quot;
-					create-cats 1    ;; new turtle's shape is &quot;default&quot;
+        </pre>
+      </div>
+      <div class="dict_entry" id="replace-item">
+        <h3>
+          <a>replace-item<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">replace-item <i>index list value</i></span>
+          <span class="prim_example">replace-item <i>index string1 string2</i></span>
+        </h4>
+        <p>
+          On a list, replaces an item in that list. <i>index</i> is the index
+          of the item to be replaced, starting with 0. (The 6th item in a
+          list would have an index of 5.) Note that &quot;replace-item&quot;
+          is used in conjunction with &quot;set&quot; to change a list.
+        </p>
+        <p>
+          Likewise for a string, but the given character of <i>string1</i>
+          removed and the contents of <i>string2</i> spliced in instead.
+        </p>
+        <pre>
+          show replace-item 2 [2 7 4 5] 15
+          =&gt; [2 7 15 5]
+          show replace-item 1 &quot;cat&quot; &quot;are&quot;
+          =&gt; &quot;caret&quot;
+        </pre>
+      </div>
+      <div class="dict_entry" id="report">
+        <h3>
+          <a>report<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">report <i>value</i></span>
+        </h4>
+        <p>
+          Immediately exits from the current to-report procedure and reports
+          <i>value</i> as the result of that procedure. report and to-report
+          are always used in conjunction with each other. See <a href="#to-report">to-report</a> for a discussion of how to use them.
+        </p>
+      </div>
+      <div class="dict_entry" id="reset-perspective">
+        <h3>
+          <a>reset-perspective<span class="since">3.0</span></a>
+          <a>rp<span class="since">3.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">reset-perspective</span>
+        </h4>
+        <p>
+          The observer stops watching, following, or riding any turtles (or
+          patches). (If it wasn't watching, following, or riding anybody,
+          nothing happens.) In the 3D view, the observer also returns to its
+          default position (above the origin, looking straight down).
+        </p>
+        <p>
+          See also <a href="#follow">follow</a>, <a href="#ride">ride</a>,
+          <a href="#watch">watch</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="reset-ticks">
+        <h3>
+          <a>reset-ticks<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">reset-ticks</span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Resets the tick counter to zero, sets up all plots, then updates
+          all plots (so that the initial state of the world is plotted).
+        </p>
+        <p>
+          Normally <code>reset-ticks</code> goes at the end of a setup procedure.
+        </p>
+        <p>
+          See also <a href="#clear-ticks">clear-ticks</a>, <a href="#tick">tick</a>, <a href="#ticks">ticks</a>, <a href="#tick-advance">tick-advance</a>, <a href="#setup-plots">setup-plots</a>, <a href="#update-plots">update-plots</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="reset-timer">
+        <h3>
+          <a>reset-timer<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">reset-timer</span>
+        </h4>
+        <p>
+          Resets the timer to zero seconds. See also <a href="#timer">timer</a>.
+        </p>
+        <p>
+          Note that the timer is different from the tick counter. The timer
+          measures elapsed real time in seconds; the tick counter measures
+          elapsed model time in ticks.
+        </p>
+      </div>
+      <div class="dict_entry" id="resize-world">
+        <h3>
+          <a>resize-world<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">resize-world <i>min-pxcor</i> <i>max-pxcor</i> <i>min-pycor</i> <i>max-pycor</i></span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Changes the size of the patch grid.
+        </p>
+        <p>
+          If the given patch grid coordinates are different than the ones
+          in use, all turtles and links die, and the existing patch grid is
+          discarded and new patches created. Otherwise, existing turtles
+          and links will live if the grid coordinates are unchanged.
+        </p>
+        <p>
+          Retaining references to old patches or patch sets is inadvisable
+          and may subsequently cause runtime errors or other unexpected
+          behavior.
+        </p>
+        <p>
+          See also <a href="#set-patch-size">set-patch-size</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="reverse">
+        <h3>
+          <a>reverse<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">reverse <i>list</i></span>
+          <span class="prim_example">reverse <i>string</i></span>
+        </h4>
+        <p>
+          Reports a reversed copy of the given list or string.
+        </p>
+        <pre>
+          show mylist
+          ;; mylist is [2 7 4 &quot;Bob&quot;]
+          set mylist reverse mylist
+          ;; mylist now is [&quot;Bob&quot; 4 7 2]
+          show reverse &quot;live&quot;
+          =&gt; &quot;evil&quot;
+        </pre>
+      </div>
+      <div class="dict_entry" id="rgb">
+        <h3>
+          <a>rgb<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">rgb <i>red green blue</i></span>
+        </h4>
+        <p>
+          Reports a RGB list when given three numbers describing an RGB
+          color. The numbers are range checked to be between 0 and 255.
+        </p>
+        <p>
+          See also <a href="#hsb">hsb</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="ride">
+        <h3>
+          <a>ride<span class="since">3.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">ride <i>turtle</i></span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Set the perspective to <i>turtle</i>.
+        </p>
+        <p>
+          Every time <i>turtle</i> moves the observer also moves. Thus, in
+          the 2D View the turtle will stay at the center of the view. In the
+          3D view it is as if looking through the eyes of the turtle. If the
+          turtle dies, the perspective resets to the default.
+        </p>
+        <p>
+          The observer may only watch or follow a single subject.
+          Calling <code>ride</code> will remove the highlight created by
+          prior calls to <code>watch</code> and <code>watch-me</code>,
+          highlighting the ridden turtle instead.
+        </p>
+        <p>
+          See also <a href="#reset-perspective">reset-perspective</a>,
+          <a href="#watch">watch</a>, <a href="#follow">follow</a>, <a href="#subject">subject</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="ride-me">
+        <h3>
+          <a>ride-me<span class="since">3.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">ride-me</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Asks the observer to ride this turtle.
+        </p>
+        <p>
+          The observer may only watch or follow a single subject.
+          Calling <code>ride-me</code> will remove the highlight created by
+          prior calls to <code>watch</code> and <code>watch-me</code>,
+          highlighting this turtle instead.
+        </p>
+        <p>
+          See also <a href="#ride">ride</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="right">
+        <h3>
+          <a>right<span class="since">1.0</span></a>
+          <a>rt<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">right <i>number</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          The turtle turns right by <i>number</i> degrees. (If <i>number</i>
+          is negative, it turns left.)
+        </p>
+      </div>
+      <div class="dict_entry" id="round">
+        <h3>
+          <a>round<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">round <i>number</i></span>
+        </h4>
+        <p>
+          Reports the integer nearest to <i>number</i>.
+        </p>
+        <p>
+          If the decimal portion of <i>number</i> is exactly .5, the number
+          is rounded in the <b>positive</b> direction.
+        </p>
+        <p>
+          Note that rounding in the positive direction is not always how
+          rounding is done in other software programs. (In particular, it
+          does not match the behavior of StarLogoT, which always rounded
+          numbers ending in 0.5 to the nearest even integer.) The rationale
+          for this behavior is that it matches how turtle coordinates relate
+          to patch coordinates in NetLogo. For example, if a turtle's
+          xcor is -4.5, then it is on the boundary between a patch whose
+          pxcor is -4 and a patch whose pxcor is -5, but the turtle must be
+          considered to be in one patch or the other, so the turtle is
+          considered to be in the patch whose pxcor is -4, because we round
+          towards the positive numbers.
+        </p>
+        <pre>
+          show round 4.2
+          =&gt; 4
+          show round 4.5
+          =&gt; 5
+          show round -4.5
+          =&gt; -4
+        </pre>
+        <p>
+          See also <a href="#precision">precision</a>, <a href="#ceiling">ceiling</a>, <a href="#floor">floor</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="run">
+        <h3>
+          <a>run<span class="since">1.3</span></a>
+          <a>runresult<span class="since">1.3</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">run <i>command</i></span>
+          <span class="prim_example">(run <i>command</i> <i>input1</i> ...)</span>
+          <span class="prim_example">run <i>string</i></span>
+          <span class="prim_example">runresult <i>reporter</i></span>
+          <span class="prim_example">(runresult <i>reporter</i> <i>input1</i> ...)</span>
+          <span class="prim_example">runresult <i>string</i></span>
+        </h4>
+        <p>
+          The <code>run</code> form expects the name of a command, an anonymous command,
+          or a string containing commands. This agent then runs them.
+        </p>
+        <p>
+          The <code>runresult</code> form expects the name of a reporter, an anonymous reporter,
+          or a string containing a reporter. This agent runs it and reports the result.
+        </p>
+        <p>
+          Note that you can't use <code>run</code> to define or redefine
+          procedures. If you care about performance, note that the code must
+          be compiled first which takes time. However, compiled bits of code
+          are cached by NetLogo and thus using <code>run</code> on the same
+          string over and over is much faster than running different strings.
+          The first run, though, will be many times slower than
+          running the same code directly, or in an anonymous command.
+        </p>
+        <p>
+          Anonymous procedures are recommended over strings whenever possible.
+          (An example of when you must use strings is if you accept pieces
+          of code from the user of your model.)
+        </p>
+        <p>
+          Anonymous procedures may freely read and/or set local variables
+          and procedure inputs. Trying to do the same with strings may
+          or may not work and should not be relied on.
+        </p>
+        <p>
+          When using anonymous procedures, you can provide them with inputs,
+          if you surround the entire call with parentheses. For example:
+        </p>
+        <pre>
+          (run [ [turtle-count step-count] -&gt; crt turtle-count [ fd step-count ] ] 10 5)
+          ;; creates 10 turtles and move them forward 5 steps
+          show (runresult [ [a b] -&gt; a + b ] 10 5)
+          =&gt; 15
+          ;; adds 10 and 5
+        </pre>
+        <p>
+          See also <a href="#foreach">foreach</a>, <a href="#arrow">-> (anonymous procedure)</a>.
+        </p>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="S">
+      <a>S</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="scale-color">
+        <h3>
+          <a>scale-color<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">scale-color <i>color number range1 range2</i></span>
+        </h4>
+        <p>
+          Reports a shade of <i>color</i> proportional to the value of
+          <i>number</i>.
+        </p>
+        <p>
+          If <i>range1</i> is less than <i>range2</i>, then the larger the
+          number, the lighter the shade of <i>color</i>. But if <i>range2</i>
+          is less than <i>range1</i>, the color scaling is inverted.
+        </p>
+        <p>
+          If <i>number</i> is less than <i>range1</i>, then the darkest shade
+          of <i>color</i> is chosen.
+        </p>
+        <p>
+          If <i>number</i> is greater than <i>range2</i>, then the lightest
+          shade of <i>color</i> is chosen.
+        </p>
+        <p>
+          Note: for <i>color</i> shade is irrelevant, e.g. green and green +
+          2 are equivalent, and the same spectrum of colors will be used.
+        </p>
+        <pre>
+          ask turtles [ set color scale-color red age 0 50 ]
+          ;; colors each turtle a shade of red proportional
+          ;; to its value for the age variable
+        </pre>
+      </div>
+      <div class="dict_entry" id="self">
+        <h3>
+          <a>self<span class="since">1.3</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">self</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/> <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          Reports this turtle, patch, or link.
+        </p>
+        <p>
+          &quot;self&quot; and &quot;myself&quot; are very different.
+          &quot;self&quot; is simple; it means &quot;me&quot;.
+          &quot;myself&quot; means &quot;the agent who asked me to do what
+          I'm doing right now.&quot;
+        </p>
+        <p>
+          Note that it is always redundant to write <code>[foo] of self</code>.
+          This is always equivalent to simply writing <code>foo</code>.
+        </p>
+        <p>
+          See also <a href="#myself">myself</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="semicolon">
+        <h3>
+          <a>; (semicolon)</a>
+        </h3>
+        <h4>
+          <span class="prim_example">; <i>comments</i></span>
+        </h4>
+        <p>
+          After a semicolon, the rest of the line is ignored. This is useful
+          for adding &quot;comments&quot; to your code -- text that explains
+          the code to human readers. Extra semicolons can be added for visual
+          effect.
+        </p>
+        <p>
+          NetLogo's Edit menu has items that let you comment or uncomment
+          whole sections of code.
+        </p>
+      </div>
+      <div class="dict_entry" id="sentence">
+        <h3>
+          <a>sentence<span class="since">1.0</span></a>
+          <a>se<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">sentence <i>value1</i> <i>value2</i></span>
+          <span class="prim_example">(sentence <i>value1</i> ...)</span>
+        </h4>
+        <p>
+          Makes a list out of the values. If any value is a list, its items
+          are included in the result directly, rather than being included as
+          a sublist. Examples make this clearer:
+        </p>
+        <pre>
+          show sentence 1 2
+          =&gt; [1 2]
+          show sentence [1 2] 3
+          =&gt; [1 2 3]
+          show sentence 1 [2 3]
+          =&gt; [1 2 3]
+          show sentence [1 2] [3 4]
+          =&gt; [1 2 3 4]
+          show sentence [[1 2]] [[3 4]]
+          =&gt; [[1 2] [3 4]]
+          show (sentence [1 2] 3 [4 5] (3 + 3) 7)
+          =&gt; [1 2 3 4 5 6 7]
+        </pre>
+      </div>
+      <div class="dict_entry" id="set">
+        <h3>
+          <a>set<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">set <i>variable</i> <i>value</i></span>
+        </h4>
+        <p>
+          Sets <i>variable</i> to the given value.
+        </p>
+        <p>
+          Variable can be any of the following:
+        </p>
+        <ul>
+          <li>A global variable declared using &quot;globals&quot;</li>
+          <li>The global variable associated with a slider, switch, chooser,
+            or input box.</li>
+          <li>A variable belonging to this agent</li>
+          <li>If this agent is a turtle, a variable belonging to the patch
+            under the turtle.</li>
+          <li>A local variable created by the <a href="#let">let</a> command.</li>
+          <li>An input to the current procedure.</li>
+        </ul>
+      </div>
+      <div class="dict_entry" id="set-current-directory">
+        <h3>
+          <a>set-current-directory<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">set-current-directory <i>string</i></span>
+        </h4>
+        <p>
+          Sets the current directory that is used by the primitives <a href="#file-delete">file-delete</a>, <a href="#file-exists">file-exists?</a>, and <a href="#file-open">file-open</a>.
+        </p>
+        <p>
+          The current directory is not used if the above commands are given
+          an absolute file path. This is defaulted to the user's home
+          directory for new models, and is changed to the model's
+          directory when a model is opened.
+        </p>
+        <p>
+          Note that in Windows file paths the backslash needs to be escaped
+          within a string by using another backslash &quot;C:\\&quot;
+        </p>
+        <p>
+          The change is temporary and is not saved with the model.
+        </p>
+        <pre>
+          set-current-directory &quot;C:\\NetLogo&quot;
+          ;; Assume it is a Windows Machine
+          file-open &quot;my-file.txt&quot;
+          ;; Opens file &quot;C:\\NetLogo\\my-file.txt&quot;
+        </pre>
+      </div>
+      <div class="dict_entry" id="set-current-plot">
+        <h3>
+          <a>set-current-plot<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">set-current-plot <i>plotname</i></span>
+        </h4>
+        <p>
+          Sets the current plot to the plot with the given name (a string).
+          Subsequent plotting commands will affect the current plot.
+        </p>
+      </div>
+      <div class="dict_entry" id="set-current-plot-pen">
+        <h3>
+          <a>set-current-plot-pen<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">set-current-plot-pen <i>penname</i></span>
+        </h4>
+        <p>
+          The current plot's current pen is set to the pen named
+          <i>penname</i> (a string). If no such pen exists in the current
+          plot, a runtime error occurs.
+        </p>
+      </div>
+      <div class="dict_entry" id="set-default-shape">
+        <h3>
+          <a>set-default-shape<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">set-default-shape turtles <i>string</i></span>
+          <span class="prim_example">set-default-shape links <i>string</i></span>
+          <span class="prim_example">set-default-shape <i>breed</i> <i>string</i></span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Specifies a default initial shape for all turtles or links, or for
+          a particular breed of turtles or links. When a turtle or link is
+          created, or it changes breeds, it shape is set to the given shape.
+        </p>
+        <p>
+          This command doesn't affect existing agents, only agents you
+          create afterwards.
+        </p>
+        <p>
+          The given breed must be either turtles, links, or the name of a
+          breed. The given string must be the name of a currently defined
+          shape.
+        </p>
+        <p>
+          In new models, the default shape for all turtles is
+          &quot;default&quot;.
+        </p>
+        <p>
+          Note that specifying a default shape does not prevent you from
+          changing an agent's shape later. Agents don't have to be
+          stuck with their breed's default shape.
+        </p>
+        <pre>
+          create-turtles 1 ;; new turtle's shape is &quot;default&quot;
+          create-cats 1    ;; new turtle's shape is &quot;default&quot;
 
-					set-default-shape turtles &quot;circle&quot;
-					create-turtles 1 ;; new turtle's shape is &quot;circle&quot;
-					create-cats 1    ;; new turtle's shape is &quot;circle&quot;
+          set-default-shape turtles &quot;circle&quot;
+          create-turtles 1 ;; new turtle's shape is &quot;circle&quot;
+          create-cats 1    ;; new turtle's shape is &quot;circle&quot;
 
-					set-default-shape cats &quot;cat&quot;
-					set-default-shape dogs &quot;dog&quot;
-					create-cats 1   ;; new turtle's shape is &quot;cat&quot;
-					ask cats [ set breed dogs ]
-					;; all cats become dogs, and automatically
-					;; change their shape to &quot;dog&quot;
-				</pre>
-				<p>
-					See also <a href="#shape">shape</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="set-histogram-num-bars">
-				<h3>
-					<a>set-histogram-num-bars<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">set-histogram-num-bars <i>number</i></span>
-				</h4>
-				<p>
-					Set the current plot pen's plot interval so that, given the
-					current x range for the plot, there would be <i>number</i> number
-					of bars drawn if the histogram command is called.
-				</p>
-				<p>
-					See also <a href="#histogram">histogram</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="set-line-thickness">
-				<h3>
-					<a>__set-line-thickness</a>
-				</h3>
-				<h4>
-					<span class="prim_example">__set-line-thickness <i>number</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Specifies the thickness of lines and outlined elements in the
-					turtle's shape.
-				</p>
-				<p>
-					The default value is 0. This always produces lines one pixel thick.
-				</p>
-				<p>
-					Non-zero values are interpreted as thickness in patches. A
-					thickness of 1, for example, produces lines which appear one patch
-					thick. (It's common to use a smaller value such as 0.5 or 0.2.)
-				</p>
-				<p>
-					Lines are always at least one pixel thick.
-				</p>
-				<p>
-					This command is experimental and may change in later releases.
-				</p>
-			</div>
-			<div class="dict_entry" id="set-patch-size">
-				<h3>
-					<a>set-patch-size<span class="since">4.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">set-patch-size <i>size</i></span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Sets the size of the patches of the view in pixels. The size is
-					typically an integer, but may also be a floating point number.
-				</p>
-				<p>
-					See also <a href="#patch-size">patch-size</a>, <a href="#resize-world">resize-world</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="set-plot-background-color">
-				<h3>
-					<a>set-plot-background-color<span class="since">6.0.2</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">set-plot-background-color <i>color</i></span>
-				</h4>
-				<p>
-					Sets the background color of the current plot.
-					The color may be specified as a number or a list.
-					See the <a href="programming.html#colors">Colors</a> section of the programming guide for more details.
-					This change is temporary and is not saved with the model. When the
-					plot is cleared, the background color will revert to white.
-				</p>
-				<p>
-					<b>Note:</b> Plot backgrounds do not support transparency.
-					If a list is used to set the color, the alpha component will be ignored.
-				</p>
-			</div>
-			<div class="dict_entry" id="set-plot-pen-color">
-				<h3>
-					<a>set-plot-pen-color<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">set-plot-pen-color <i>color</i></span>
-				</h4>
-				<p>
-					Sets the color of the current plot pen to <i>color</i>.
-				</p>
-			</div>
-			<div class="dict_entry" id="set-plot-pen-interval">
-				<h3>
-					<a>set-plot-pen-interval<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">set-plot-pen-interval <i>number</i></span>
-				</h4>
-				<p>
-					Tells the current plot pen to move a distance of <i>number</i> in
-					the x direction during each use of the plot command. (The plot pen
-					interval also affects the behavior of the histogram command.)
-				</p>
-			</div>
-			<div class="dict_entry" id="set-plot-pen-mode">
-				<h3>
-					<a>set-plot-pen-mode<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">set-plot-pen-mode <i>number</i></span>
-				</h4>
-				<p>
-					Sets the mode the current plot pen draws in to <i>number</i>. The
-					allowed plot pen modes are:
-				</p>
-				<ul>
-					<li>0 (line mode) the plot pen draws a line connecting two points
-						together.
-					</li>
-					<li>1 (bar mode): the plot pen draws a bar of width
-						plot-pen-interval with the point plotted as the upper (or lower, if
-						you are plotting a negative number) left corner of the bar.
-					</li>
-					<li>2 (point mode): the plot pen draws a point at the point
-						plotted. Points are not connected.
-					</li>
-				</ul>
-				<p>
-					The default mode for new pens is 0 (line mode).
-				</p>
-			</div>
-			<div class="dict_entry" id="setup-plots">
-				<h3>
-					<a>setup-plots<span class="since">5.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">setup-plots</span>
-				</h4>
-				<p>
-					For each plot, runs that plot's setup commands, including the
-					setup code for any pens in the plot.
-				</p>
-				<p>
-					<a href="#reset-ticks">reset-ticks</a> has the same effect, so in
-					models that use the tick counter, this primitive is not normally
-					used.
-				</p>
-				<p>
-					See the <a href="programming.html#plotting">Plotting section</a> of
-					the Programming Guide for more details.
-				</p>
-				<p>
-					See also <a href="#update-plots">update-plots</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="set-plot--range">
-				<h3>
-					<a>set-plot-x-range<span class="since">1.0</span></a>
-					<a>set-plot-y-range<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">set-plot-x-range <i>min max</i></span>
-					<span class="prim_example">set-plot-y-range <i>min max</i></span>
-				</h4>
-				<p>
-					Sets the minimum and maximum values of the x or y axis of the
-					current plot.
-				</p>
-				<p>
-					The change is temporary and is not saved with the model. When the
-					plot is cleared, the ranges will revert to their default values as
-					set in the plot's Edit dialog.
-				</p>
-			</div>
-			<div class="dict_entry" id="setxy">
-				<h3>
-					<a>setxy<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">setxy <i>x y</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					The turtle sets its x-coordinate to <i>x</i> and its y-coordinate
-					to <i>y</i>.
-				</p>
-				<p>
-					Equivalent to <code>set xcor x set ycor y</code>, except it happens in
-					one time step instead of two.
-				</p>
-				<p>
-					If <i>x</i> or <i>y</i> is outside the world, NetLogo will throw a
-					runtime error, unless wrapping is turned on in the relevant
-					dimensions. For example, with wrapping turned on in both dimensions
-					and the default world size where <code>min-pxcor = -16</code>,
-					<code>max-pxcor = 16</code>, <code>min-pycor = -16</code> and <code>max-pycor
-						= 16</code>, asking a turtle to <code>setxy 17 17</code> will move it to
-					the center of patch (-16, -16).
-				</p>
-				<pre>
-					setxy 0 0
-					;; turtle moves to the middle of the center patch
-					setxy random-xcor random-ycor
-					;; turtle moves to a random point
-					setxy random-pxcor random-pycor
-					;; turtle moves to the center of a random patch
-				</pre>
-				<p>
-					See also <a href="#move-to">move-to</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="shade-of">
-				<h3>
-					<a>shade-of?<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">shade-of? <i>color1</i> <i>color2</i></span>
-				</h4>
-				<p>
-					Reports true if both colors are shades of one another, false
-					otherwise.
-				</p>
-				<pre>
-					show shade-of? blue red
-					=&gt; false
-					show shade-of? blue (blue + 1)
-					=&gt; true
-					show shade-of? gray white
-					=&gt; true
-				</pre>
-			</div>
-			<div class="dict_entry" id="shape">
-				<h3>
-					<a>shape</a>
-				</h3>
-				<h4>
-					<span class="prim_example">shape</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-					<img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					This is a built-in turtle and link variable. It holds a string that
-					is the name of the turtle or link's current shape. You can set
-					this variable to change the shape. New turtles and links have the
-					shape &quot;default&quot; unless the a different shape has been
-					specified using <a href="#set-default-shape">set-default-shape</a>.
-				</p>
-				<p>
-					Example:
-				</p>
-				<pre>
-					ask turtles [ set shape &quot;wolf&quot; ]
-					;; assumes you have made a &quot;wolf&quot;
-					;; shape in NetLogo's <a href="shapes.html">Turtle Shapes Editor</a>
-					ask links [ set shape &quot;link 1&quot; ]
-					;; assumes you have made a &quot;link 1&quot; shape in
-					;; the Link Shapes Editor
-				</pre>
-				<p>
-					See also <a href="#set-default-shape">set-default-shape</a>,
-					<a href="#shapes">shapes</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="shapes">
-				<h3>
-					<a>shapes<span class="since">2.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">shapes</span>
-				</h4>
-				<p>
-					Reports a list of strings containing all of the turtle shapes in
-					the model.
-				</p>
-				<p>
-					New shapes can be created, or imported from the shapes library or
-					from other models, in the <a href="shapes.html">Shapes Editor</a>.
-				</p>
-				<pre>
-					show shapes
-					=&gt; [&quot;default&quot; &quot;airplane&quot; &quot;arrow&quot; &quot;box&quot; &quot;bug&quot; ...
-					ask turtles [ set shape one-of shapes ]
-				</pre>
-			</div>
-			<div class="dict_entry" id="show">
-				<h3>
-					<a>show<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">show <i>value</i></span>
-				</h4>
-				<p>
-					Prints <i>value</i> in the Command Center, preceded by this agent,
-					and followed by a carriage return. (This agent is included to help
-					you keep track of what agents are producing which lines of output.)
-					Also, all strings have their quotes included similar to <a href="#write">write</a>.
-				</p>
-				<p>
-					See also <a href="#print">print</a>, <a href="#type">type</a>,
-					<a href="#write">write</a>, <a href="#output-cmds">output-show</a>,
-					and <a href="programming.html#output">Output (programming guide)</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="show-turtle">
-				<h3>
-					<a>show-turtle<span class="since">1.0</span></a>
-					<a>st<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">show-turtle</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					The turtle becomes visible again.
-				</p>
-				<p>
-					Note: This command is equivalent to setting the turtle variable
-					&quot;hidden?&quot; to false.
-				</p>
-				<p>
-					See also <a href="#hide-turtle">hide-turtle</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="show-link">
-				<h3>
-					<a>show-link<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">show-link</span>
-					<img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					The link becomes visible again.
-				</p>
-				<p>
-					Note: This command is equivalent to setting the link variable
-					&quot;hidden?&quot; to false.
-				</p>
-				<p>
-					See also <a href="#hide-link">hide-link</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="shuffle">
-				<h3>
-					<a>shuffle<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">shuffle <i>list</i></span>
-				</h4>
-				<p>
-					Reports a new list containing the same items as the input list, but
-					in randomized order.
-				</p>
-				<pre>
-					show shuffle [1 2 3 4 5]
-					=&gt; [5 2 4 1 3]
-					show shuffle [1 2 3 4 5]
-					=&gt; [1 3 5 2 4]
-				</pre>
-			</div>
-			<div class="dict_entry" id="sin">
-				<h3>
-					<a>sin<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">sin <i>number</i></span>
-				</h4>
-				<p>
-					Reports the sine of the given angle. Assumes angle is given in
-					degrees.
-				</p>
-				<pre>
-					show sin 270
-					=&gt; -1
-				</pre>
-			</div>
-			<div class="dict_entry" id="size">
-				<h3>
-					<a>size</a>
-				</h3>
-				<h4>
-					<span class="prim_example">size</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					This is a built-in turtle variable. It holds a number that is the
-					turtle's apparent size. The default size is 1, which means that
-					the turtle is the same size as a patch. You can set this variable
-					to change a turtle's size.
-				</p>
-			</div>
-			<div class="dict_entry" id="sort">
-				<h3>
-					<a>sort<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">sort <i>list</i></span>
-					<span class="prim_example">sort <i>agentset</i></span>
-				</h4>
-				<p>
-					Reports a sorted list of numbers, strings, or agents.
-				</p>
-				<p>
-					If the input contains no numbers, strings, or agents, the result is
-					the empty list.
-				</p>
-				<p>
-					If the input contains at least one number, the numbers in the list
-					are sorted in ascending order and a new list reported; non-numbers
-					are ignored.
-				</p>
-				<p>
-					Or, if the input contains at least one string, the strings in the
-					list are sorted in ascending order and a new list reported;
-					non-strings are ignored.
-				</p>
-				<p>
-					Or, if the input is an agentset or a list containing at least one
-					agent, a sorted list of agents (never an agentset) is reported;
-					non-agents are ignored. Agents are sorted in the same order the
-					&lt; operator uses. (Patches are sorted with the top left-most patch first
-					and the bottom right-most patch last, turtles are sorted by <code>who</code>
-					number).
-				</p>
-				<pre>
-					show sort [3 1 4 2]
-					=&gt; [1 2 3 4]
-					show sort [2 1 "a"]
-					=&gt; [1 2]
-					show sort (list "a" "c" "b" (patch 0 0))
-					=&gt; ["a" "b" "c"]
-					show sort (list (patch 0 0) (patch 0 1) (patch 1 0))
-					=&gt; [(patch 0 1) (patch 0 0) (patch 1 0)]
+          set-default-shape cats &quot;cat&quot;
+          set-default-shape dogs &quot;dog&quot;
+          create-cats 1   ;; new turtle's shape is &quot;cat&quot;
+          ask cats [ set breed dogs ]
+          ;; all cats become dogs, and automatically
+          ;; change their shape to &quot;dog&quot;
+        </pre>
+        <p>
+          See also <a href="#shape">shape</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="set-histogram-num-bars">
+        <h3>
+          <a>set-histogram-num-bars<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">set-histogram-num-bars <i>number</i></span>
+        </h4>
+        <p>
+          Set the current plot pen's plot interval so that, given the
+          current x range for the plot, there would be <i>number</i> number
+          of bars drawn if the histogram command is called.
+        </p>
+        <p>
+          See also <a href="#histogram">histogram</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="set-line-thickness">
+        <h3>
+          <a>__set-line-thickness</a>
+        </h3>
+        <h4>
+          <span class="prim_example">__set-line-thickness <i>number</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Specifies the thickness of lines and outlined elements in the
+          turtle's shape.
+        </p>
+        <p>
+          The default value is 0. This always produces lines one pixel thick.
+        </p>
+        <p>
+          Non-zero values are interpreted as thickness in patches. A
+          thickness of 1, for example, produces lines which appear one patch
+          thick. (It's common to use a smaller value such as 0.5 or 0.2.)
+        </p>
+        <p>
+          Lines are always at least one pixel thick.
+        </p>
+        <p>
+          This command is experimental and may change in later releases.
+        </p>
+      </div>
+      <div class="dict_entry" id="set-patch-size">
+        <h3>
+          <a>set-patch-size<span class="since">4.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">set-patch-size <i>size</i></span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Sets the size of the patches of the view in pixels. The size is
+          typically an integer, but may also be a floating point number.
+        </p>
+        <p>
+          See also <a href="#patch-size">patch-size</a>, <a href="#resize-world">resize-world</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="set-plot-background-color">
+        <h3>
+          <a>set-plot-background-color<span class="since">6.0.2</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">set-plot-background-color <i>color</i></span>
+        </h4>
+        <p>
+          Sets the background color of the current plot.
+          The color may be specified as a number or a list.
+          See the <a href="programming.html#colors">Colors</a> section of the programming guide for more details.
+          This change is temporary and is not saved with the model. When the
+          plot is cleared, the background color will revert to white.
+        </p>
+        <p>
+          <b>Note:</b> Plot backgrounds do not support transparency.
+          If a list is used to set the color, the alpha component will be ignored.
+        </p>
+      </div>
+      <div class="dict_entry" id="set-plot-pen-color">
+        <h3>
+          <a>set-plot-pen-color<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">set-plot-pen-color <i>color</i></span>
+        </h4>
+        <p>
+          Sets the color of the current plot pen to <i>color</i>.
+        </p>
+      </div>
+      <div class="dict_entry" id="set-plot-pen-interval">
+        <h3>
+          <a>set-plot-pen-interval<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">set-plot-pen-interval <i>number</i></span>
+        </h4>
+        <p>
+          Tells the current plot pen to move a distance of <i>number</i> in
+          the x direction during each use of the plot command. (The plot pen
+          interval also affects the behavior of the histogram command.)
+        </p>
+      </div>
+      <div class="dict_entry" id="set-plot-pen-mode">
+        <h3>
+          <a>set-plot-pen-mode<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">set-plot-pen-mode <i>number</i></span>
+        </h4>
+        <p>
+          Sets the mode the current plot pen draws in to <i>number</i>. The
+          allowed plot pen modes are:
+        </p>
+        <ul>
+          <li>0 (line mode) the plot pen draws a line connecting two points
+            together.
+          </li>
+          <li>1 (bar mode): the plot pen draws a bar of width
+            plot-pen-interval with the point plotted as the upper (or lower, if
+            you are plotting a negative number) left corner of the bar.
+          </li>
+          <li>2 (point mode): the plot pen draws a point at the point
+            plotted. Points are not connected.
+          </li>
+        </ul>
+        <p>
+          The default mode for new pens is 0 (line mode).
+        </p>
+      </div>
+      <div class="dict_entry" id="setup-plots">
+        <h3>
+          <a>setup-plots<span class="since">5.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">setup-plots</span>
+        </h4>
+        <p>
+          For each plot, runs that plot's setup commands, including the
+          setup code for any pens in the plot.
+        </p>
+        <p>
+          <a href="#reset-ticks">reset-ticks</a> has the same effect, so in
+          models that use the tick counter, this primitive is not normally
+          used.
+        </p>
+        <p>
+          See the <a href="programming.html#plotting">Plotting section</a> of
+          the Programming Guide for more details.
+        </p>
+        <p>
+          See also <a href="#update-plots">update-plots</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="set-plot--range">
+        <h3>
+          <a>set-plot-x-range<span class="since">1.0</span></a>
+          <a>set-plot-y-range<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">set-plot-x-range <i>min max</i></span>
+          <span class="prim_example">set-plot-y-range <i>min max</i></span>
+        </h4>
+        <p>
+          Sets the minimum and maximum values of the x or y axis of the
+          current plot.
+        </p>
+        <p>
+          The change is temporary and is not saved with the model. When the
+          plot is cleared, the ranges will revert to their default values as
+          set in the plot's Edit dialog.
+        </p>
+      </div>
+      <div class="dict_entry" id="setxy">
+        <h3>
+          <a>setxy<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">setxy <i>x y</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          The turtle sets its x-coordinate to <i>x</i> and its y-coordinate
+          to <i>y</i>.
+        </p>
+        <p>
+          Equivalent to <code>set xcor x set ycor y</code>, except it happens in
+          one time step instead of two.
+        </p>
+        <p>
+          If <i>x</i> or <i>y</i> is outside the world, NetLogo will throw a
+          runtime error, unless wrapping is turned on in the relevant
+          dimensions. For example, with wrapping turned on in both dimensions
+          and the default world size where <code>min-pxcor = -16</code>,
+          <code>max-pxcor = 16</code>, <code>min-pycor = -16</code> and <code>max-pycor
+            = 16</code>, asking a turtle to <code>setxy 17 17</code> will move it to
+          the center of patch (-16, -16).
+        </p>
+        <pre>
+          setxy 0 0
+          ;; turtle moves to the middle of the center patch
+          setxy random-xcor random-ycor
+          ;; turtle moves to a random point
+          setxy random-pxcor random-pycor
+          ;; turtle moves to the center of a random patch
+        </pre>
+        <p>
+          See also <a href="#move-to">move-to</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="shade-of">
+        <h3>
+          <a>shade-of?<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">shade-of? <i>color1</i> <i>color2</i></span>
+        </h4>
+        <p>
+          Reports true if both colors are shades of one another, false
+          otherwise.
+        </p>
+        <pre>
+          show shade-of? blue red
+          =&gt; false
+          show shade-of? blue (blue + 1)
+          =&gt; true
+          show shade-of? gray white
+          =&gt; true
+        </pre>
+      </div>
+      <div class="dict_entry" id="shape">
+        <h3>
+          <a>shape</a>
+        </h3>
+        <h4>
+          <span class="prim_example">shape</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+          <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          This is a built-in turtle and link variable. It holds a string that
+          is the name of the turtle or link's current shape. You can set
+          this variable to change the shape. New turtles and links have the
+          shape &quot;default&quot; unless the a different shape has been
+          specified using <a href="#set-default-shape">set-default-shape</a>.
+        </p>
+        <p>
+          Example:
+        </p>
+        <pre>
+          ask turtles [ set shape &quot;wolf&quot; ]
+          ;; assumes you have made a &quot;wolf&quot;
+          ;; shape in NetLogo's <a href="shapes.html">Turtle Shapes Editor</a>
+          ask links [ set shape &quot;link 1&quot; ]
+          ;; assumes you have made a &quot;link 1&quot; shape in
+          ;; the Link Shapes Editor
+        </pre>
+        <p>
+          See also <a href="#set-default-shape">set-default-shape</a>,
+          <a href="#shapes">shapes</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="shapes">
+        <h3>
+          <a>shapes<span class="since">2.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">shapes</span>
+        </h4>
+        <p>
+          Reports a list of strings containing all of the turtle shapes in
+          the model.
+        </p>
+        <p>
+          New shapes can be created, or imported from the shapes library or
+          from other models, in the <a href="shapes.html">Shapes Editor</a>.
+        </p>
+        <pre>
+          show shapes
+          =&gt; [&quot;default&quot; &quot;airplane&quot; &quot;arrow&quot; &quot;box&quot; &quot;bug&quot; ...
+          ask turtles [ set shape one-of shapes ]
+        </pre>
+      </div>
+      <div class="dict_entry" id="show">
+        <h3>
+          <a>show<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">show <i>value</i></span>
+        </h4>
+        <p>
+          Prints <i>value</i> in the Command Center, preceded by this agent,
+          and followed by a carriage return. (This agent is included to help
+          you keep track of what agents are producing which lines of output.)
+          Also, all strings have their quotes included similar to <a href="#write">write</a>.
+        </p>
+        <p>
+          See also <a href="#print">print</a>, <a href="#type">type</a>,
+          <a href="#write">write</a>, <a href="#output-cmds">output-show</a>,
+          and <a href="programming.html#output">Output (programming guide)</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="show-turtle">
+        <h3>
+          <a>show-turtle<span class="since">1.0</span></a>
+          <a>st<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">show-turtle</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          The turtle becomes visible again.
+        </p>
+        <p>
+          Note: This command is equivalent to setting the turtle variable
+          &quot;hidden?&quot; to false.
+        </p>
+        <p>
+          See also <a href="#hide-turtle">hide-turtle</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="show-link">
+        <h3>
+          <a>show-link<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">show-link</span>
+          <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          The link becomes visible again.
+        </p>
+        <p>
+          Note: This command is equivalent to setting the link variable
+          &quot;hidden?&quot; to false.
+        </p>
+        <p>
+          See also <a href="#hide-link">hide-link</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="shuffle">
+        <h3>
+          <a>shuffle<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">shuffle <i>list</i></span>
+        </h4>
+        <p>
+          Reports a new list containing the same items as the input list, but
+          in randomized order.
+        </p>
+        <pre>
+          show shuffle [1 2 3 4 5]
+          =&gt; [5 2 4 1 3]
+          show shuffle [1 2 3 4 5]
+          =&gt; [1 3 5 2 4]
+        </pre>
+      </div>
+      <div class="dict_entry" id="sin">
+        <h3>
+          <a>sin<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">sin <i>number</i></span>
+        </h4>
+        <p>
+          Reports the sine of the given angle. Assumes angle is given in
+          degrees.
+        </p>
+        <pre>
+          show sin 270
+          =&gt; -1
+        </pre>
+      </div>
+      <div class="dict_entry" id="size">
+        <h3>
+          <a>size</a>
+        </h3>
+        <h4>
+          <span class="prim_example">size</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          This is a built-in turtle variable. It holds a number that is the
+          turtle's apparent size. The default size is 1, which means that
+          the turtle is the same size as a patch. You can set this variable
+          to change a turtle's size.
+        </p>
+      </div>
+      <div class="dict_entry" id="sort">
+        <h3>
+          <a>sort<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">sort <i>list</i></span>
+          <span class="prim_example">sort <i>agentset</i></span>
+        </h4>
+        <p>
+          Reports a sorted list of numbers, strings, or agents.
+        </p>
+        <p>
+          If the input contains no numbers, strings, or agents, the result is
+          the empty list.
+        </p>
+        <p>
+          If the input contains at least one number, the numbers in the list
+          are sorted in ascending order and a new list reported; non-numbers
+          are ignored.
+        </p>
+        <p>
+          Or, if the input contains at least one string, the strings in the
+          list are sorted in ascending order and a new list reported;
+          non-strings are ignored.
+        </p>
+        <p>
+          Or, if the input is an agentset or a list containing at least one
+          agent, a sorted list of agents (never an agentset) is reported;
+          non-agents are ignored. Agents are sorted in the same order the
+          &lt; operator uses. (Patches are sorted with the top left-most patch first
+          and the bottom right-most patch last, turtles are sorted by <code>who</code>
+          number).
+        </p>
+        <pre>
+          show sort [3 1 4 2]
+          =&gt; [1 2 3 4]
+          show sort [2 1 "a"]
+          =&gt; [1 2]
+          show sort (list "a" "c" "b" (patch 0 0))
+          =&gt; ["a" "b" "c"]
+          show sort (list (patch 0 0) (patch 0 1) (patch 1 0))
+          =&gt; [(patch 0 1) (patch 0 0) (patch 1 0)]
 
-					;; label patches with numbers in left-to-right, top-to-bottom order
-					let n 0
-					foreach sort patches [ the-patch -&gt;
-					ask the-patch [
-					set plabel n
-					set n n + 1
-					]
-					]
+          ;; label patches with numbers in left-to-right, top-to-bottom order
+          let n 0
+          foreach sort patches [ the-patch -&gt;
+          ask the-patch [
+          set plabel n
+          set n n + 1
+          ]
+          ]
 
-					;; some additional examples to clarify behavior in strange cases
-					show sort (list patch 0 0 patch 0 1 patch 1 0 turtle 0 turtle 1) ; turtles are always sorted lower than patches
-					=&gt; [(turtle 0) (turtle 1) (patch 0 1) (patch 0 0) (patch 1 0)]
-					show sort (list nobody false true) ; booleans and nobody cannot be sorted
-					=&gt; []
-					show sort (list [1 2 3] turtles) ; lists and agentsets are not included if they are inside a list passed to sort
-					=&gt; []
-				</pre>
-				<p>
-					See also <a href="#sort-by">sort-by</a>, <a href="#sort-on">sort-on</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="sort-by">
-				<h3>
-					<a>sort-by<span class="since">1.3</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">sort-by <i>reporter</i> <i>list</i></span>
-					<span class="prim_example">sort-by <i>reporter</i> <i>agentset</i></span>
-				</h4>
-				<p>
-					If the input is a list, reports a new list containing the same
-					items as the input list, in a sorted order defined by the boolean
-					reporter. <i>reporter</i> may be an anonymous reporter or
-					the name of a reporter.
-				</p>
-				<p>
-					The two inputs to <i>reporter</i> are the values being compared.
-					The reporter should report true if the first argument comes strictly before
-					the second in the desired sort order, and false otherwise.
-				</p>
-				<p>
-					If the input is an agentset or a list of agents, reports a list
-					(never an agentset) of agents.
-				</p>
-				<p>
-					If the input is a list, the sort is stable, that is, the order of
-					items considered equal by the reporter is not disturbed. If the
-					input is an agentset, ties are broken randomly.
-				</p>
-				<pre>
-					show sort-by &lt; [3 1 4 2]
-					=&gt; [1 2 3 4]
-					show sort-by &gt; [3 1 4 2]
-					=&gt; [4 3 2 1]
-					show sort-by [ [string1 string2] -&gt; length string1 &lt; length string2 ] [&quot;Grumpy&quot; &quot;Doc&quot; &quot;Happy&quot;]
-					=&gt; [&quot;Doc&quot; &quot;Happy&quot; &quot;Grumpy&quot;]
-				</pre>
-				<p>
-					See also <a href="#sort">sort</a>, <a href="#sort-on">sort-on</a>, <a href="#arrow">-> (anonymous procedure)</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="sort-on">
-				<h3>
-					<a>sort-on<span class="since">5.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">sort-on [<i>reporter</i>] <i>agentset</i></span>
-				</h4>
-				<p>
-					Reports a list of agents, sorted according to each agent's
-					value for <i>reporter</i>. Ties are broken randomly.
-				</p>
-				<p>
-					The values must be all numbers, all strings, or all agents of the
-					same type.
-				</p>
-				<pre>
-					crt 3
-					show sort-on [who] turtles
-					=&gt; [(turtle 0) (turtle 1) (turtle 2)]
-					show sort-on [(- who)] turtles
-					=&gt; [(turtle 2) (turtle 1) (turtle 0)]
-					foreach sort-on [size] turtles
-					[ the-turtle -&gt; ask the-turtle [ do-something ] ]
-					;; turtles run &quot;do-something&quot; one at a time, in
-					;; ascending order by size
-				</pre>
-				<p>
-					See also <a href="#sort">sort</a>, <a href="#sort-by">sort-by</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="sprout">
-				<h3>
-					<a>sprout<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">sprout <i>number</i> [ <i>commands</i> ]</span>
-					<span class="prim_example">sprout-<i>&lt;breeds&gt;</i> <i>number</i> [ <i>commands</i> ]</span>
-					<img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					Creates <i>number</i> new turtles on the current patch. The new
-					turtles have random integer headings and the color is randomly
-					selected from the 14 primary colors. The turtles immediately run
-					<i>commands</i>. This is useful for giving the new turtles
-					different colors, headings, or whatever. (The new turtles are
-					created all at once then run one at a time, in random order.)
-				</p>
-				<p>
-					If the sprout-<i>&lt;breeds&gt;</i> form is used, the new turtles
-					are created as members of the given breed.
-				</p>
-				<pre>
-					sprout 5
-					sprout-wolves 10
-					sprout 1 [ set color red ]
-					sprout-sheep 1 [ set color black ]
-				</pre>
-				<p>
-					See also <a href="#create-turtles">create-turtles</a>, <a href="#hatch">hatch</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="sqrt">
-				<h3>
-					<a>sqrt<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">sqrt <i>number</i></span>
-				</h4>
-				<p>
-					Reports the square root of <i>number</i>.
-				</p>
-			</div>
-			<div class="dict_entry" id="stamp">
-				<h3>
-					<a>stamp<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">stamp</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					This turtle or link leaves an image of its shape in the drawing at
-					its current location.
-				</p>
-				<p>
-					Note: The shapes made by stamp may not be pixel-for-pixel identical
-					from computer to computer.
-				</p>
-			</div>
-			<div class="dict_entry" id="stamp-erase">
-				<h3>
-					<a>stamp-erase<span class="since">3.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">stamp-erase</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					This turtle or link removes any pixels below it in the drawing
-					inside the bounds of its shape.
-				</p>
-				<p>
-					Note: The shapes made by stamp-erase may not be pixel-for-pixel
-					identical from computer to computer.
-				</p>
-			</div>
-			<div class="dict_entry" id="standard-deviation">
-				<h3>
-					<a>standard-deviation<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">standard-deviation <i>list</i></span>
-				</h4>
-				<p>
-					Reports the sample standard deviation of a <i>list</i> of numbers.
-					Ignores other types of items.
-				</p>
-				<p>
-					(Note that this estimates the standard deviation for a
-					<i>sample</i>, rather than for a whole <i>population</i>, using
-					Bessel's correction.)
-				</p>
-				<pre>
-					show standard-deviation [1 2 3 4 5 6]
-					=&gt; 1.8708286933869707
-					show standard-deviation [energy] of turtles
-					;; prints the standard deviation of the variable &quot;energy&quot;
-					;; from all the turtles
-				</pre>
-			</div>
-			<div class="dict_entry" id="startup">
-				<h3>
-					<a>startup</a>
-				</h3>
-				<h4>
-					<span class="prim_example">startup</span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					User-defined procedure which, if it exists, will be called when a
-					model is first loaded in the NetLogo application.
-				</p>
-				<pre>
-					to startup
-					setup
-					end
-				</pre>
-				<p>
-					<code>startup</code> does not run when a model is run headless from the
-					command line, or by parallel BehaviorSpace.
-				</p>
-			</div>
-			<div class="dict_entry" id="stop">
-				<h3>
-					<a>stop<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">stop</span>
-				</h4>
-				<p>
-					This agent exits immediately from the enclosing procedure, ask, or
-					ask-like construct (e.g. crt, hatch, sprout). Only the enclosing
-					procedure or construct stops, not all execution for the agent.
-				</p>
-				<pre>
-					if not any? turtles [ stop ]
-					;; exits if there are no more turtles
-				</pre>
-				<p>
-					Note: <code>stop</code> can also be used to stop a forever button. See
-					<a href="programming.html#buttons">Buttons</a> in the
-					Programming Guide for details.
-				</p>
-				<p>
-					<code>stop</code> can also be used to stop a BehaviorSpace model run. If the go
-					commands directly call a procedure, then when that procedure calls <i>stop</i>,
-					the run ends.
-				</p>
-			</div>
-			<div class="dict_entry" id="stop-inspecting">
-				<h3>
-					<a>stop-inspecting<span class="since">5.2</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">stop-inspecting <i>agent</i></span>
-				</h4>
-				<p>
-					Closes the agent monitor for the given agent (turtle or patch).
-					In the case that no agent monitor is open, <code>stop-inspecting</code> does
-					nothing.
-				</p>
-				<pre>
-					stop-inspecting patch 2 4
-					;; the agent monitor for that patch closes
-					ask sheep [ stop-inspecting self ]
-					;; close all agent monitors for sheep
-				</pre>
-				<p>
-					See <a href="#inspect">inspect</a> and <a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="stop-inspecting-dead-agents">
-				<h3>
-					<a>stop-inspecting-dead-agents<span class="since">5.2</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">stop-inspecting-dead-agents</span>
-				</h4>
-				<p>
-					Closes all agent monitors for dead agents.
-					See <a href="#inspect">inspect</a> and <a href="#stop-inspecting">stop-inspecting</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="subject">
-				<h3>
-					<a>subject<span class="since">3.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">subject</span>
-				</h4>
-				<p>
-					Reports the turtle (or patch) that the observer is currently
-					watching, following, or riding. Reports <a href="#nobody">nobody</a> if there is no such turtle (or patch).
-				</p>
-				<p>
-					See also <a href="#watch">watch</a>, <a href="#follow">follow</a>,
-					<a href="#ride">ride</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="subliststring">
-				<h3>
-					<a>sublist<span class="since">2.1</span></a>
-					<a>substring<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">sublist <i>list position1 position2</i></span>
-					<span class="prim_example">substring <i>string position1 position2</i></span>
-				</h4>
-				<p>
-					Reports just a section of the given list or string, ranging between
-					the first position (inclusive) and the second position (exclusive).
-				</p>
-				<p>
-					Note: The positions are numbered beginning with 0, not with 1.
-				</p>
-				<pre>
-					show sublist [99 88 77 66] 1 3
-					=&gt; [88 77]
-					show substring &quot;apartment&quot; 1 5
-					=&gt; &quot;part&quot;
-				</pre>
-			</div>
-			<div class="dict_entry" id="subtract-headings">
-				<h3>
-					<a>subtract-headings<span class="since">2.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">subtract-headings <i>heading1 heading2</i></span>
-				</h4>
-				<p>
-					Computes the difference between the given headings, that is, the
-					number of degrees in the smallest angle by which heading2 could be
-					rotated to produce heading1. A positive answer means a clockwise
-					rotation, a negative answer counterclockwise. The result is always
-					in the range -180 to 180, but is never exactly -180.
-				</p>
-				<p>
-					Note that simply subtracting the two headings using the - (minus)
-					operator wouldn't work. Just subtracting corresponds to always
-					rotating clockwise from heading2 to heading1; but sometimes the
-					counterclockwise rotation is shorter. For example, the difference
-					between 5 degrees and 355 degrees is 10 degrees, not -350 degrees.
-				</p>
-				<pre>
-					show subtract-headings 80 60
-					=&gt; 20
-					show subtract-headings 60 80
-					=&gt; -20
-					show subtract-headings 5 355
-					=&gt; 10
-					show subtract-headings 355 5
-					=&gt; -10
-					show subtract-headings 180 0
-					=&gt; 180
-					show subtract-headings 0 180
-					=&gt; 180
-				</pre>
-			</div>
-			<div class="dict_entry" id="sum">
-				<h3>
-					<a>sum<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">sum <i>list</i></span>
-				</h4>
-				<p>
-					Reports the sum of the items in the list.
-				</p>
-				<pre>
-					show sum [energy] of turtles
-					;; prints the total of the variable &quot;energy&quot;
-					;; from all the turtles
-				</pre>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="T">
-			<a>T</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="tan">
-				<h3>
-					<a>tan<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">tan <i>number</i></span>
-				</h4>
-				<p>
-					Reports the tangent of the given angle. Assumes the angle is given
-					in degrees.
-				</p>
-			</div>
-			<div class="dict_entry" id="thickness">
-				<h3>
-					<a>thickness</a>
-				</h3>
-				<h4>
-					<span class="prim_example">thickness</span>
-					<img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					This is a built-in link variable. It holds a number that is the
-					link's apparent size as a fraction of the patch size. The
-					default thickness is 0, which means that regardless of patch-size
-					the links will always appear 1 pixel wide. You can set this
-					variable to change a link's thickness.
-				</p>
-			</div>
-			<div class="dict_entry" id="tick">
-				<h3>
-					<a>tick<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">tick</span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Advances the tick counter by one and updates all plots.
-				</p>
-				<p>
-					If the tick counter has not been started yet with
-					<code>reset-ticks</code>, an error results.
-				</p>
-				<p>
-					Normally <code>tick</code> goes at the end of a go procedure.
-				</p>
-				<p>
-					See also <a href="#ticks">ticks</a>, <a href="#tick-advance">tick-advance</a>, <a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>, <a href="#update-plots">update-plots</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="tick-advance">
-				<h3>
-					<a>tick-advance<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">tick-advance <i>number</i></span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Advances the tick counter by <i>number</i>. The input may be an
-					integer or a floating point number. (Some models divide ticks more
-					finely than by ones.) The input may not be negative.
-				</p>
-				<p>
-					When using <a href="programming.html#view-updates">tick-based view
-						updates</a>, the view is normally updated every 1.0 ticks, so using
-					<code>tick-advance</code> with a number less then 1.0 may not always
-					trigger an update. If you want to make sure that the view is
-					updated, you can use the <code>display</code> command.
-				</p>
-				<p>
-					If the tick counter has not been started yet with
-					<code>reset-ticks</code>, an error results.
-				</p>
-				<p>
-					Does not update plots.
-				</p>
-				<p>
-					See also <a href="#tick">tick</a>, <a href="#ticks">ticks</a>,
-					<a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="ticks">
-				<h3>
-					<a>ticks<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">ticks</span>
-				</h4>
-				<p>
-					Reports the current value of the tick counter. The result is always
-					a number and never negative.
-				</p>
-				<p>
-					If the tick counter has not been started yet with
-					<code>reset-ticks</code>, an error results.
-				</p>
-				<p>
-					Most models use the <code>tick</code> command to advance the tick
-					counter, in which case <code>ticks</code> will always report an
-					integer. If the <code>tick-advance</code> command is used, then
-					<code>ticks</code> may report a floating point number.
-				</p>
-				<p>
-					See also <a href="#tick">tick</a>, <a href="#tick-advance">tick-advance</a>, <a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="tie">
-				<h3>
-					<a>tie<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">tie</span>
-					<img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					Ties <i>end1</i> and <i>end2</i> of the link together. If the link
-					is a directed link <i>end1</i> is the <i>root turtle</i> and
-					<i>end2</i> is the <i>leaf turtle</i>. The movement of the <i>root
-						turtle</i> affects the location and heading of the <i>leaf
-						turtle</i>. If the link is undirected the tie is reciprocal so both
-					turtles can be considered <i>root turtles</i> and <i>leaf
-						turtles</i>. Movement or change in heading of either turtle affects
-					the location and heading of the other turtle.
-				</p>
-				<p>
-					When the root turtle moves, the leaf turtles moves the same
-					distance, in the same direction. The heading of the leaf turtle is
-					not affected. This works with forward, jump, and setting the xcor
-					or ycor of the root turtle.
-				</p>
-				<p>
-					When the root turtle turns right or left, the leaf turtle is
-					rotated around the root turtle the same amount. The heading of the
-					leaf turtle is also changed by the same amount.
-				</p>
-				<p>
-					If the link dies, the tie relation is removed.
-				</p>
-				<pre>
-					crt 2 [ fd 3 ]
-					;; creates a link and ties turtle 1 to turtle 0
-					ask turtle 0 [ create-link-to turtle 1 [ tie ] ]
-				</pre>
-				<p>
-					See also <a href="#untie">untie</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="tie-mode">
-				<h3>
-					<a>tie-mode</a>
-				</h3>
-				<h4>
-					<span class="prim_example">tie-mode</span>
-					<img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					This is a built-in link variable. It holds a string that is the
-					name of the tie mode the link is currently in. Using the <a href="#tie">tie</a> and <a href="#untie">untie</a> commands changes the
-					mode of the link. You can also set tie-mode to &quot;free&quot; to
-					create a non-rigid joint between two turtles (see the <a href="programming.html#tie">Tie section</a> of the Programming Guide for
-					details). By default links are not tied.
-				</p>
-				<p>
-					See also: <a href="#tie">tie</a>, <a href="#untie">untie</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="timer">
-				<h3>
-					<a>timer<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">timer</span>
-				</h4>
-				<p>
-					Reports how many seconds have passed since the command <a href="#reset-timer">reset-timer</a> was last run (or since NetLogo
-					started). The potential resolution of the clock is milliseconds.
-					(Whether you get resolution that high in practice may vary from
-					system to system, depending on the capabilities of the underlying
-					Java Virtual Machine.)
-				</p>
-				<p>
-					See also <a href="#reset-timer">reset-timer</a>.
-				</p>
-				<p>
-					Note that the timer is different from the tick counter. The timer
-					measures elapsed real time in seconds; the tick counter measures
-					elapsed model time in ticks.
-				</p>
-			</div>
-			<div class="dict_entry" id="to">
-				<h3>
-					<a>to</a>
-				</h3>
-				<h4>
-					<span class="prim_example">to <i>procedure-name</i></span>
-					<span class="prim_example">to <i>procedure-name</i> [<i>input1</i> ...]</span>
-				</h4>
-				<p>
-					Used to begin a command procedure.
-				</p>
-				<pre>
-					to setup
-					clear-all
-					crt 500
-					end
+          ;; some additional examples to clarify behavior in strange cases
+          show sort (list patch 0 0 patch 0 1 patch 1 0 turtle 0 turtle 1) ; turtles are always sorted lower than patches
+          =&gt; [(turtle 0) (turtle 1) (patch 0 1) (patch 0 0) (patch 1 0)]
+          show sort (list nobody false true) ; booleans and nobody cannot be sorted
+          =&gt; []
+          show sort (list [1 2 3] turtles) ; lists and agentsets are not included if they are inside a list passed to sort
+          =&gt; []
+        </pre>
+        <p>
+          See also <a href="#sort-by">sort-by</a>, <a href="#sort-on">sort-on</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="sort-by">
+        <h3>
+          <a>sort-by<span class="since">1.3</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">sort-by <i>reporter</i> <i>list</i></span>
+          <span class="prim_example">sort-by <i>reporter</i> <i>agentset</i></span>
+        </h4>
+        <p>
+          If the input is a list, reports a new list containing the same
+          items as the input list, in a sorted order defined by the boolean
+          reporter. <i>reporter</i> may be an anonymous reporter or
+          the name of a reporter.
+        </p>
+        <p>
+          The two inputs to <i>reporter</i> are the values being compared.
+          The reporter should report true if the first argument comes strictly before
+          the second in the desired sort order, and false otherwise.
+        </p>
+        <p>
+          If the input is an agentset or a list of agents, reports a list
+          (never an agentset) of agents.
+        </p>
+        <p>
+          If the input is a list, the sort is stable, that is, the order of
+          items considered equal by the reporter is not disturbed. If the
+          input is an agentset, ties are broken randomly.
+        </p>
+        <pre>
+          show sort-by &lt; [3 1 4 2]
+          =&gt; [1 2 3 4]
+          show sort-by &gt; [3 1 4 2]
+          =&gt; [4 3 2 1]
+          show sort-by [ [string1 string2] -&gt; length string1 &lt; length string2 ] [&quot;Grumpy&quot; &quot;Doc&quot; &quot;Happy&quot;]
+          =&gt; [&quot;Doc&quot; &quot;Happy&quot; &quot;Grumpy&quot;]
+        </pre>
+        <p>
+          See also <a href="#sort">sort</a>, <a href="#sort-on">sort-on</a>, <a href="#arrow">-> (anonymous procedure)</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="sort-on">
+        <h3>
+          <a>sort-on<span class="since">5.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">sort-on [<i>reporter</i>] <i>agentset</i></span>
+        </h4>
+        <p>
+          Reports a list of agents, sorted according to each agent's
+          value for <i>reporter</i>. Ties are broken randomly.
+        </p>
+        <p>
+          The values must be all numbers, all strings, or all agents of the
+          same type.
+        </p>
+        <pre>
+          crt 3
+          show sort-on [who] turtles
+          =&gt; [(turtle 0) (turtle 1) (turtle 2)]
+          show sort-on [(- who)] turtles
+          =&gt; [(turtle 2) (turtle 1) (turtle 0)]
+          foreach sort-on [size] turtles
+          [ the-turtle -&gt; ask the-turtle [ do-something ] ]
+          ;; turtles run &quot;do-something&quot; one at a time, in
+          ;; ascending order by size
+        </pre>
+        <p>
+          See also <a href="#sort">sort</a>, <a href="#sort-by">sort-by</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="sprout">
+        <h3>
+          <a>sprout<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">sprout <i>number</i> [ <i>commands</i> ]</span>
+          <span class="prim_example">sprout-<i>&lt;breeds&gt;</i> <i>number</i> [ <i>commands</i> ]</span>
+          <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          Creates <i>number</i> new turtles on the current patch. The new
+          turtles have random integer headings and the color is randomly
+          selected from the 14 primary colors. The turtles immediately run
+          <i>commands</i>. This is useful for giving the new turtles
+          different colors, headings, or whatever. (The new turtles are
+          created all at once then run one at a time, in random order.)
+        </p>
+        <p>
+          If the sprout-<i>&lt;breeds&gt;</i> form is used, the new turtles
+          are created as members of the given breed.
+        </p>
+        <pre>
+          sprout 5
+          sprout-wolves 10
+          sprout 1 [ set color red ]
+          sprout-sheep 1 [ set color black ]
+        </pre>
+        <p>
+          See also <a href="#create-turtles">create-turtles</a>, <a href="#hatch">hatch</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="sqrt">
+        <h3>
+          <a>sqrt<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">sqrt <i>number</i></span>
+        </h4>
+        <p>
+          Reports the square root of <i>number</i>.
+        </p>
+      </div>
+      <div class="dict_entry" id="stamp">
+        <h3>
+          <a>stamp<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">stamp</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          This turtle or link leaves an image of its shape in the drawing at
+          its current location.
+        </p>
+        <p>
+          Note: The shapes made by stamp may not be pixel-for-pixel identical
+          from computer to computer.
+        </p>
+      </div>
+      <div class="dict_entry" id="stamp-erase">
+        <h3>
+          <a>stamp-erase<span class="since">3.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">stamp-erase</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          This turtle or link removes any pixels below it in the drawing
+          inside the bounds of its shape.
+        </p>
+        <p>
+          Note: The shapes made by stamp-erase may not be pixel-for-pixel
+          identical from computer to computer.
+        </p>
+      </div>
+      <div class="dict_entry" id="standard-deviation">
+        <h3>
+          <a>standard-deviation<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">standard-deviation <i>list</i></span>
+        </h4>
+        <p>
+          Reports the sample standard deviation of a <i>list</i> of numbers.
+          Ignores other types of items.
+        </p>
+        <p>
+          (Note that this estimates the standard deviation for a
+          <i>sample</i>, rather than for a whole <i>population</i>, using
+          Bessel's correction.)
+        </p>
+        <pre>
+          show standard-deviation [1 2 3 4 5 6]
+          =&gt; 1.8708286933869707
+          show standard-deviation [energy] of turtles
+          ;; prints the standard deviation of the variable &quot;energy&quot;
+          ;; from all the turtles
+        </pre>
+      </div>
+      <div class="dict_entry" id="startup">
+        <h3>
+          <a>startup</a>
+        </h3>
+        <h4>
+          <span class="prim_example">startup</span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          User-defined procedure which, if it exists, will be called when a
+          model is first loaded in the NetLogo application.
+        </p>
+        <pre>
+          to startup
+          setup
+          end
+        </pre>
+        <p>
+          <code>startup</code> does not run when a model is run headless from the
+          command line, or by parallel BehaviorSpace.
+        </p>
+      </div>
+      <div class="dict_entry" id="stop">
+        <h3>
+          <a>stop<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">stop</span>
+        </h4>
+        <p>
+          This agent exits immediately from the enclosing procedure, ask, or
+          ask-like construct (e.g. crt, hatch, sprout). Only the enclosing
+          procedure or construct stops, not all execution for the agent.
+        </p>
+        <pre>
+          if not any? turtles [ stop ]
+          ;; exits if there are no more turtles
+        </pre>
+        <p>
+          Note: <code>stop</code> can also be used to stop a forever button. See
+          <a href="programming.html#buttons">Buttons</a> in the
+          Programming Guide for details.
+        </p>
+        <p>
+          <code>stop</code> can also be used to stop a BehaviorSpace model run. If the go
+          commands directly call a procedure, then when that procedure calls <i>stop</i>,
+          the run ends.
+        </p>
+      </div>
+      <div class="dict_entry" id="stop-inspecting">
+        <h3>
+          <a>stop-inspecting<span class="since">5.2</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">stop-inspecting <i>agent</i></span>
+        </h4>
+        <p>
+          Closes the agent monitor for the given agent (turtle or patch).
+          In the case that no agent monitor is open, <code>stop-inspecting</code> does
+          nothing.
+        </p>
+        <pre>
+          stop-inspecting patch 2 4
+          ;; the agent monitor for that patch closes
+          ask sheep [ stop-inspecting self ]
+          ;; close all agent monitors for sheep
+        </pre>
+        <p>
+          See <a href="#inspect">inspect</a> and <a href="#stop-inspecting-dead-agents">stop-inspecting-dead-agents</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="stop-inspecting-dead-agents">
+        <h3>
+          <a>stop-inspecting-dead-agents<span class="since">5.2</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">stop-inspecting-dead-agents</span>
+        </h4>
+        <p>
+          Closes all agent monitors for dead agents.
+          See <a href="#inspect">inspect</a> and <a href="#stop-inspecting">stop-inspecting</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="subject">
+        <h3>
+          <a>subject<span class="since">3.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">subject</span>
+        </h4>
+        <p>
+          Reports the turtle (or patch) that the observer is currently
+          watching, following, or riding. Reports <a href="#nobody">nobody</a> if there is no such turtle (or patch).
+        </p>
+        <p>
+          See also <a href="#watch">watch</a>, <a href="#follow">follow</a>,
+          <a href="#ride">ride</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="subliststring">
+        <h3>
+          <a>sublist<span class="since">2.1</span></a>
+          <a>substring<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">sublist <i>list position1 position2</i></span>
+          <span class="prim_example">substring <i>string position1 position2</i></span>
+        </h4>
+        <p>
+          Reports just a section of the given list or string, ranging between
+          the first position (inclusive) and the second position (exclusive).
+        </p>
+        <p>
+          Note: The positions are numbered beginning with 0, not with 1.
+        </p>
+        <pre>
+          show sublist [99 88 77 66] 1 3
+          =&gt; [88 77]
+          show substring &quot;apartment&quot; 1 5
+          =&gt; &quot;part&quot;
+        </pre>
+      </div>
+      <div class="dict_entry" id="subtract-headings">
+        <h3>
+          <a>subtract-headings<span class="since">2.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">subtract-headings <i>heading1 heading2</i></span>
+        </h4>
+        <p>
+          Computes the difference between the given headings, that is, the
+          number of degrees in the smallest angle by which heading2 could be
+          rotated to produce heading1. A positive answer means a clockwise
+          rotation, a negative answer counterclockwise. The result is always
+          in the range -180 to 180, but is never exactly -180.
+        </p>
+        <p>
+          Note that simply subtracting the two headings using the - (minus)
+          operator wouldn't work. Just subtracting corresponds to always
+          rotating clockwise from heading2 to heading1; but sometimes the
+          counterclockwise rotation is shorter. For example, the difference
+          between 5 degrees and 355 degrees is 10 degrees, not -350 degrees.
+        </p>
+        <pre>
+          show subtract-headings 80 60
+          =&gt; 20
+          show subtract-headings 60 80
+          =&gt; -20
+          show subtract-headings 5 355
+          =&gt; 10
+          show subtract-headings 355 5
+          =&gt; -10
+          show subtract-headings 180 0
+          =&gt; 180
+          show subtract-headings 0 180
+          =&gt; 180
+        </pre>
+      </div>
+      <div class="dict_entry" id="sum">
+        <h3>
+          <a>sum<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">sum <i>list</i></span>
+        </h4>
+        <p>
+          Reports the sum of the items in the list.
+        </p>
+        <pre>
+          show sum [energy] of turtles
+          ;; prints the total of the variable &quot;energy&quot;
+          ;; from all the turtles
+        </pre>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="T">
+      <a>T</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="tan">
+        <h3>
+          <a>tan<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">tan <i>number</i></span>
+        </h4>
+        <p>
+          Reports the tangent of the given angle. Assumes the angle is given
+          in degrees.
+        </p>
+      </div>
+      <div class="dict_entry" id="thickness">
+        <h3>
+          <a>thickness</a>
+        </h3>
+        <h4>
+          <span class="prim_example">thickness</span>
+          <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          This is a built-in link variable. It holds a number that is the
+          link's apparent size as a fraction of the patch size. The
+          default thickness is 0, which means that regardless of patch-size
+          the links will always appear 1 pixel wide. You can set this
+          variable to change a link's thickness.
+        </p>
+      </div>
+      <div class="dict_entry" id="tick">
+        <h3>
+          <a>tick<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">tick</span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Advances the tick counter by one and updates all plots.
+        </p>
+        <p>
+          If the tick counter has not been started yet with
+          <code>reset-ticks</code>, an error results.
+        </p>
+        <p>
+          Normally <code>tick</code> goes at the end of a go procedure.
+        </p>
+        <p>
+          See also <a href="#ticks">ticks</a>, <a href="#tick-advance">tick-advance</a>, <a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>, <a href="#update-plots">update-plots</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="tick-advance">
+        <h3>
+          <a>tick-advance<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">tick-advance <i>number</i></span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Advances the tick counter by <i>number</i>. The input may be an
+          integer or a floating point number. (Some models divide ticks more
+          finely than by ones.) The input may not be negative.
+        </p>
+        <p>
+          When using <a href="programming.html#view-updates">tick-based view
+            updates</a>, the view is normally updated every 1.0 ticks, so using
+          <code>tick-advance</code> with a number less then 1.0 may not always
+          trigger an update. If you want to make sure that the view is
+          updated, you can use the <code>display</code> command.
+        </p>
+        <p>
+          If the tick counter has not been started yet with
+          <code>reset-ticks</code>, an error results.
+        </p>
+        <p>
+          Does not update plots.
+        </p>
+        <p>
+          See also <a href="#tick">tick</a>, <a href="#ticks">ticks</a>,
+          <a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="ticks">
+        <h3>
+          <a>ticks<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">ticks</span>
+        </h4>
+        <p>
+          Reports the current value of the tick counter. The result is always
+          a number and never negative.
+        </p>
+        <p>
+          If the tick counter has not been started yet with
+          <code>reset-ticks</code>, an error results.
+        </p>
+        <p>
+          Most models use the <code>tick</code> command to advance the tick
+          counter, in which case <code>ticks</code> will always report an
+          integer. If the <code>tick-advance</code> command is used, then
+          <code>ticks</code> may report a floating point number.
+        </p>
+        <p>
+          See also <a href="#tick">tick</a>, <a href="#tick-advance">tick-advance</a>, <a href="#reset-ticks">reset-ticks</a>, <a href="#clear-ticks">clear-ticks</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="tie">
+        <h3>
+          <a>tie<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">tie</span>
+          <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          Ties <i>end1</i> and <i>end2</i> of the link together. If the link
+          is a directed link <i>end1</i> is the <i>root turtle</i> and
+          <i>end2</i> is the <i>leaf turtle</i>. The movement of the <i>root
+            turtle</i> affects the location and heading of the <i>leaf
+            turtle</i>. If the link is undirected the tie is reciprocal so both
+          turtles can be considered <i>root turtles</i> and <i>leaf
+            turtles</i>. Movement or change in heading of either turtle affects
+          the location and heading of the other turtle.
+        </p>
+        <p>
+          When the root turtle moves, the leaf turtles moves the same
+          distance, in the same direction. The heading of the leaf turtle is
+          not affected. This works with forward, jump, and setting the xcor
+          or ycor of the root turtle.
+        </p>
+        <p>
+          When the root turtle turns right or left, the leaf turtle is
+          rotated around the root turtle the same amount. The heading of the
+          leaf turtle is also changed by the same amount.
+        </p>
+        <p>
+          If the link dies, the tie relation is removed.
+        </p>
+        <pre>
+          crt 2 [ fd 3 ]
+          ;; creates a link and ties turtle 1 to turtle 0
+          ask turtle 0 [ create-link-to turtle 1 [ tie ] ]
+        </pre>
+        <p>
+          See also <a href="#untie">untie</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="tie-mode">
+        <h3>
+          <a>tie-mode</a>
+        </h3>
+        <h4>
+          <span class="prim_example">tie-mode</span>
+          <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          This is a built-in link variable. It holds a string that is the
+          name of the tie mode the link is currently in. Using the <a href="#tie">tie</a> and <a href="#untie">untie</a> commands changes the
+          mode of the link. You can also set tie-mode to &quot;free&quot; to
+          create a non-rigid joint between two turtles (see the <a href="programming.html#tie">Tie section</a> of the Programming Guide for
+          details). By default links are not tied.
+        </p>
+        <p>
+          See also: <a href="#tie">tie</a>, <a href="#untie">untie</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="timer">
+        <h3>
+          <a>timer<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">timer</span>
+        </h4>
+        <p>
+          Reports how many seconds have passed since the command <a href="#reset-timer">reset-timer</a> was last run (or since NetLogo
+          started). The potential resolution of the clock is milliseconds.
+          (Whether you get resolution that high in practice may vary from
+          system to system, depending on the capabilities of the underlying
+          Java Virtual Machine.)
+        </p>
+        <p>
+          See also <a href="#reset-timer">reset-timer</a>.
+        </p>
+        <p>
+          Note that the timer is different from the tick counter. The timer
+          measures elapsed real time in seconds; the tick counter measures
+          elapsed model time in ticks.
+        </p>
+      </div>
+      <div class="dict_entry" id="to">
+        <h3>
+          <a>to</a>
+        </h3>
+        <h4>
+          <span class="prim_example">to <i>procedure-name</i></span>
+          <span class="prim_example">to <i>procedure-name</i> [<i>input1</i> ...]</span>
+        </h4>
+        <p>
+          Used to begin a command procedure.
+        </p>
+        <pre>
+          to setup
+          clear-all
+          crt 500
+          end
 
-					to circle [radius]
-					crt 100 [ fd radius ]
-					end
-				</pre>
-			</div>
-			<div class="dict_entry" id="to-report">
-				<h3>
-					<a>to-report</a>
-				</h3>
-				<h4>
-					<span class="prim_example">to-report <i>procedure-name</i></span>
-					<span class="prim_example">to-report <i>procedure-name</i> [<i>input1</i> ...]</span>
-				</h4>
-				<p>
-					Used to begin a reporter procedure.
-				</p>
-				<p>
-					The body of the procedure should use <code>report</code> to report a
-					value for the procedure. See <a href="#report">report</a>.
-				</p>
-				<pre>
-					to-report average [a b]
-					report (a + b) / 2
-					end
+          to circle [radius]
+          crt 100 [ fd radius ]
+          end
+        </pre>
+      </div>
+      <div class="dict_entry" id="to-report">
+        <h3>
+          <a>to-report</a>
+        </h3>
+        <h4>
+          <span class="prim_example">to-report <i>procedure-name</i></span>
+          <span class="prim_example">to-report <i>procedure-name</i> [<i>input1</i> ...]</span>
+        </h4>
+        <p>
+          Used to begin a reporter procedure.
+        </p>
+        <p>
+          The body of the procedure should use <code>report</code> to report a
+          value for the procedure. See <a href="#report">report</a>.
+        </p>
+        <pre>
+          to-report average [a b]
+          report (a + b) / 2
+          end
 
-					to-report absolute-value [number]
-					ifelse number &gt;= 0
-					[ report number ]
-					[ report (- number) ]
-					end
+          to-report absolute-value [number]
+          ifelse number &gt;= 0
+          [ report number ]
+          [ report (- number) ]
+          end
 
-					to-report first-turtle?
-					report who = 0  ;; reports true or false
-					end
-				</pre>
-			</div>
-			<div class="dict_entry" id="towards">
-				<h3>
-					<a>towards<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">towards <i>agent</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					Reports the heading from this agent to the given agent.
-				</p>
-				<p>
-					If wrapping is allowed by the topology and the wrapped distance
-					(around the edges of the world) is shorter, towards will use the
-					wrapped path.
-				</p>
-				<p>
-					Note: asking for the heading from an agent to itself, or an agent
-					on the same location, will cause a runtime error.
-				</p>
-				<pre>
-					set heading towards turtle 1
-					;; same as &quot;face turtle 1&quot;
-				</pre>
-				<p>
-					See also <a href="#face">face</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="towardsxy">
-				<h3>
-					<a>towardsxy<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">towardsxy <i>x</i> <i>y</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					Reports the heading from the turtle or patch towards the point
-					(<i>x</i>,<i>y</i>).
-				</p>
-				<p>
-					If wrapping is allowed by the topology and the wrapped distance
-					(around the edges of the world) is shorter, towardsxy will use the
-					wrapped path.
-				</p>
-				<p>
-					Note: asking for the heading to the point the agent is already
-					standing on will cause a runtime error.
-				</p>
-				<p>
-					See also <a href="#facexy">facexy</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="turtle">
-				<h3>
-					<a>turtle<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">turtle <i>number</i></span>
-					<span class="prim_example">&lt;breed&gt; <i>number</i></span>
-				</h4>
-				<p>
-					Reports the turtle with the given who number, or <a href="#nobody">nobody</a> if there is no such turtle. For breeded
-					turtles you may also use the single breed form to refer to them.
-				</p>
-				<pre>
-					ask turtle 5 [ set color red ]
-					;; turtle with who number 5 turns red
-				</pre>
-			</div>
-			<div class="dict_entry" id="turtle-set">
-				<h3>
-					<a>turtle-set<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">turtle-set <i>value1</i></span>
-					<span class="prim_example">(turtle-set <i>value1</i> <i>value2</i> ...)</span>
-				</h4>
-				<p>
-					Reports an agentset containing all of the turtles anywhere in any
-					of the inputs. The inputs may be individual turtles, turtle
-					agentsets, nobody, or lists (or nested lists) containing any of the
-					above.
-				</p>
-				<pre>
-					turtle-set self
-					(turtle-set self turtles-on neighbors)
-					(turtle-set turtle 0 turtle 2 turtle 9)
-					(turtle-set frogs mice)
-				</pre>
-				<p>
-					See also <a href="#patch-set">patch-set</a>, <a href="#link-set">link-set</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="turtles">
-				<h3>
-					<a>turtles<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">turtles</span>
-				</h4>
-				<p>
-					Reports the agentset consisting of all turtles. This is a special agentset that can grow as turtles are added to the world, see <a href="programming.html#special-agentsets">the programming guide for more info</a>.
-				</p>
-				<pre>
-					show count turtles
-					;; prints the number of turtles
-				</pre>
-			</div>
-			<div class="dict_entry" id="turtles-at">
-				<h3>
-					<a>turtles-at<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">turtles-at <i>dx</i> <i>dy</i></span>
-					<span class="prim_example"><i>&lt;breeds&gt;</i>-at <i>dx</i> <i>dy</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					Reports an agentset containing the turtles on the patch (dx, dy)
-					from the caller. (The result may include the caller itself if the
-					caller is a turtle.)
-				</p>
-				<pre>
-					create-turtles 5 [ setxy 2 3 ]
-					show count [turtles-at 1 1] of patch 1 2
-					=&gt; 5
-				</pre>
-				<p>
-					If the name of a breed is substituted for &quot;turtles&quot;, then
-					only turtles of that breed are included.
-				</p>
-			</div>
-			<div class="dict_entry" id="turtles-here">
-				<h3>
-					<a>turtles-here<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">turtles-here</span>
-					<span class="prim_example"><i>&lt;breeds&gt;</i>-here</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					Reports an agentset containing all the turtles on the caller's
-					patch (including the caller itself if it's a turtle).
-				</p>
-				<pre>
-					crt 10
-					ask turtle 0 [ show count turtles-here ]
-					=&gt; 10
-				</pre>
-				<p>
-					If the name of a breed is substituted for &quot;turtles&quot;, then
-					only turtles of that breed are included.
-				</p>
-				<pre>
-					breed [cats cat]
-					breed [dogs dog]
-					create-cats 5
-					create-dogs 1
-					ask dogs [ show count cats-here ]
-					=&gt; 5
-				</pre>
-			</div>
-			<div class="dict_entry" id="turtles-on">
-				<h3>
-					<a>turtles-on<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">turtles-on <i>agent</i></span>
-					<span class="prim_example">turtles-on <i>agentset</i></span>
-					<span class="prim_example"><i>&lt;breeds&gt;</i>-on <i>agent</i></span>
-					<span class="prim_example"><i>&lt;breeds&gt;</i>-on <i>agentset</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					Reports an agentset containing all the turtles that are on the
-					given patch or patches, or standing on the same patch as the given
-					turtle or turtles.
-				</p>
-				<pre>
-					ask turtles [
-					if not any? turtles-on patch-ahead 1
-					[ fd 1 ]
-					]
-					ask turtles [
-					if not any? turtles-on neighbors [
-					die-of-loneliness
-					]
-					]
-				</pre>
-				<p>
-					If the name of a breed is substituted for &quot;turtles&quot;, then
-					only turtles of that breed are included.
-				</p>
-			</div>
-			<div class="dict_entry" id="turtles-own">
-				<h3>
-					<a>turtles-own</a>
-				</h3>
-				<h4>
-					<span class="prim_example">turtles-own [<i>var1</i> ...]</span>
-					<span class="prim_example"><i>&lt;breeds&gt;</i>-own [<i>var1</i> ...]</span>
-				</h4>
-				<p>
-					The turtles-own keyword, like the globals, breed,
-					<i>&lt;breeds&gt;</i>-own, and patches-own keywords, can only be
-					used at the beginning of a program, before any function
-					definitions. It defines the variables belonging to each turtle.
-				</p>
-				<p>
-					If you specify a breed instead of &quot;turtles&quot;, only turtles
-					of that breed have the listed variables. (More than one turtle
-					breed may list the same variable.)
-				</p>
-				<pre>
-					breed [cats cat ]
-					breed [dogs dog]
-					breed [hamsters hamster]
-					turtles-own [eyes legs]   ;; applies to all breeds
-					cats-own [fur kittens]
-					hamsters-own [fur cage]
-					dogs-own [hair puppies]
-				</pre>
-				<p>
-					See also <a href="#globals">globals</a>, <a href="#patches-own">patches-own</a>, <a href="#breed">breed</a>,
-					<a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="type">
-				<h3>
-					<a>type<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">type <i>value</i></span>
-				</h4>
-				<p>
-					Prints <i>value</i> in the Command Center, <i>not</i> followed by a
-					carriage return (unlike <a href="#print">print</a> and <a href="#show">show</a>). The lack of a carriage return allows you to
-					print several values on the same line.
-				</p>
-				<p>
-					This agent is <i>not</i> printed before the value. unlike <a href="#show">show</a>.
-				</p>
-				<pre>
-					type 3 type &quot; &quot; print 4
-					=&gt; 3 4
-				</pre>
-				<p>
-					See also <a href="#print">print</a>, <a href="#show">show</a>,
-					<a href="#write">write</a>, <a href="#output-cmds">output-type</a>, and
-					<a href="programming.html#output">Output (programming guide)</a>.
-				</p>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="U">
-			<a>U</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="undirected-link-breed">
-				<h3>
-					<a>undirected-link-breed</a>
-				</h3>
-				<h4>
-					<span class="prim_example">undirected-link-breed [<i>&lt;link-breeds&gt;</i> <i>&lt;link-breed&gt;</i>]</span>
-				</h4>
-				<p>
-					This keyword, like the globals and breeds keywords, can only be
-					used at the beginning of the Code tab, before any procedure
-					definitions. It defines an undirected link breed. Links of a
-					particular breed are always either all directed or all undirected.
-					The first input defines the name of the agentset associated with
-					the link breed. The second input defines the name of a single
-					member of the breed.
-				</p>
-				<p>
-					Any link of the given link breed:
-				</p>
-				<ul>
-					<li>is part of the agentset named by the link breed name</li>
-					<li>has its built-in variable <code>breed</code> set to that agentset</li>
-					<li>is directed or undirected as declared by the keyword</li>
-				</ul>
-				<p>
-					Most often, the agentset is used in conjunction with ask to give
-					commands to only the links of a particular breed.
-				</p>
-				<pre>
-					undirected-link-breed [streets street]
-					undirected-link-breed [highways highway]
-					to setup
-					clear-all
-					crt 2
-					ask turtle 0 [ create-street-with turtle 1 ]
-					ask turtle 0 [ create-highway-with turtle 1 ]
-					end
+          to-report first-turtle?
+          report who = 0  ;; reports true or false
+          end
+        </pre>
+      </div>
+      <div class="dict_entry" id="towards">
+        <h3>
+          <a>towards<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">towards <i>agent</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          Reports the heading from this agent to the given agent.
+        </p>
+        <p>
+          If wrapping is allowed by the topology and the wrapped distance
+          (around the edges of the world) is shorter, towards will use the
+          wrapped path.
+        </p>
+        <p>
+          Note: asking for the heading from an agent to itself, or an agent
+          on the same location, will cause a runtime error.
+        </p>
+        <pre>
+          set heading towards turtle 1
+          ;; same as &quot;face turtle 1&quot;
+        </pre>
+        <p>
+          See also <a href="#face">face</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="towardsxy">
+        <h3>
+          <a>towardsxy<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">towardsxy <i>x</i> <i>y</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          Reports the heading from the turtle or patch towards the point
+          (<i>x</i>,<i>y</i>).
+        </p>
+        <p>
+          If wrapping is allowed by the topology and the wrapped distance
+          (around the edges of the world) is shorter, towardsxy will use the
+          wrapped path.
+        </p>
+        <p>
+          Note: asking for the heading to the point the agent is already
+          standing on will cause a runtime error.
+        </p>
+        <p>
+          See also <a href="#facexy">facexy</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="turtle">
+        <h3>
+          <a>turtle<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">turtle <i>number</i></span>
+          <span class="prim_example">&lt;breed&gt; <i>number</i></span>
+        </h4>
+        <p>
+          Reports the turtle with the given who number, or <a href="#nobody">nobody</a> if there is no such turtle. For breeded
+          turtles you may also use the single breed form to refer to them.
+        </p>
+        <pre>
+          ask turtle 5 [ set color red ]
+          ;; turtle with who number 5 turns red
+        </pre>
+      </div>
+      <div class="dict_entry" id="turtle-set">
+        <h3>
+          <a>turtle-set<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">turtle-set <i>value1</i></span>
+          <span class="prim_example">(turtle-set <i>value1</i> <i>value2</i> ...)</span>
+        </h4>
+        <p>
+          Reports an agentset containing all of the turtles anywhere in any
+          of the inputs. The inputs may be individual turtles, turtle
+          agentsets, nobody, or lists (or nested lists) containing any of the
+          above.
+        </p>
+        <pre>
+          turtle-set self
+          (turtle-set self turtles-on neighbors)
+          (turtle-set turtle 0 turtle 2 turtle 9)
+          (turtle-set frogs mice)
+        </pre>
+        <p>
+          See also <a href="#patch-set">patch-set</a>, <a href="#link-set">link-set</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="turtles">
+        <h3>
+          <a>turtles<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">turtles</span>
+        </h4>
+        <p>
+          Reports the agentset consisting of all turtles. This is a special agentset that can grow as turtles are added to the world, see <a href="programming.html#special-agentsets">the programming guide for more info</a>.
+        </p>
+        <pre>
+          show count turtles
+          ;; prints the number of turtles
+        </pre>
+      </div>
+      <div class="dict_entry" id="turtles-at">
+        <h3>
+          <a>turtles-at<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">turtles-at <i>dx</i> <i>dy</i></span>
+          <span class="prim_example"><i>&lt;breeds&gt;</i>-at <i>dx</i> <i>dy</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          Reports an agentset containing the turtles on the patch (dx, dy)
+          from the caller. (The result may include the caller itself if the
+          caller is a turtle.)
+        </p>
+        <pre>
+          create-turtles 5 [ setxy 2 3 ]
+          show count [turtles-at 1 1] of patch 1 2
+          =&gt; 5
+        </pre>
+        <p>
+          If the name of a breed is substituted for &quot;turtles&quot;, then
+          only turtles of that breed are included.
+        </p>
+      </div>
+      <div class="dict_entry" id="turtles-here">
+        <h3>
+          <a>turtles-here<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">turtles-here</span>
+          <span class="prim_example"><i>&lt;breeds&gt;</i>-here</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          Reports an agentset containing all the turtles on the caller's
+          patch (including the caller itself if it's a turtle).
+        </p>
+        <pre>
+          crt 10
+          ask turtle 0 [ show count turtles-here ]
+          =&gt; 10
+        </pre>
+        <p>
+          If the name of a breed is substituted for &quot;turtles&quot;, then
+          only turtles of that breed are included.
+        </p>
+        <pre>
+          breed [cats cat]
+          breed [dogs dog]
+          create-cats 5
+          create-dogs 1
+          ask dogs [ show count cats-here ]
+          =&gt; 5
+        </pre>
+      </div>
+      <div class="dict_entry" id="turtles-on">
+        <h3>
+          <a>turtles-on<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">turtles-on <i>agent</i></span>
+          <span class="prim_example">turtles-on <i>agentset</i></span>
+          <span class="prim_example"><i>&lt;breeds&gt;</i>-on <i>agent</i></span>
+          <span class="prim_example"><i>&lt;breeds&gt;</i>-on <i>agentset</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          Reports an agentset containing all the turtles that are on the
+          given patch or patches, or standing on the same patch as the given
+          turtle or turtles.
+        </p>
+        <pre>
+          ask turtles [
+          if not any? turtles-on patch-ahead 1
+          [ fd 1 ]
+          ]
+          ask turtles [
+          if not any? turtles-on neighbors [
+          die-of-loneliness
+          ]
+          ]
+        </pre>
+        <p>
+          If the name of a breed is substituted for &quot;turtles&quot;, then
+          only turtles of that breed are included.
+        </p>
+      </div>
+      <div class="dict_entry" id="turtles-own">
+        <h3>
+          <a>turtles-own</a>
+        </h3>
+        <h4>
+          <span class="prim_example">turtles-own [<i>var1</i> ...]</span>
+          <span class="prim_example"><i>&lt;breeds&gt;</i>-own [<i>var1</i> ...]</span>
+        </h4>
+        <p>
+          The turtles-own keyword, like the globals, breed,
+          <i>&lt;breeds&gt;</i>-own, and patches-own keywords, can only be
+          used at the beginning of a program, before any function
+          definitions. It defines the variables belonging to each turtle.
+        </p>
+        <p>
+          If you specify a breed instead of &quot;turtles&quot;, only turtles
+          of that breed have the listed variables. (More than one turtle
+          breed may list the same variable.)
+        </p>
+        <pre>
+          breed [cats cat ]
+          breed [dogs dog]
+          breed [hamsters hamster]
+          turtles-own [eyes legs]   ;; applies to all breeds
+          cats-own [fur kittens]
+          hamsters-own [fur cage]
+          dogs-own [hair puppies]
+        </pre>
+        <p>
+          See also <a href="#globals">globals</a>, <a href="#patches-own">patches-own</a>, <a href="#breed">breed</a>,
+          <a href="#turtles-own"><i>&lt;breeds&gt;</i>-own</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="type">
+        <h3>
+          <a>type<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">type <i>value</i></span>
+        </h4>
+        <p>
+          Prints <i>value</i> in the Command Center, <i>not</i> followed by a
+          carriage return (unlike <a href="#print">print</a> and <a href="#show">show</a>). The lack of a carriage return allows you to
+          print several values on the same line.
+        </p>
+        <p>
+          This agent is <i>not</i> printed before the value. unlike <a href="#show">show</a>.
+        </p>
+        <pre>
+          type 3 type &quot; &quot; print 4
+          =&gt; 3 4
+        </pre>
+        <p>
+          See also <a href="#print">print</a>, <a href="#show">show</a>,
+          <a href="#write">write</a>, <a href="#output-cmds">output-type</a>, and
+          <a href="programming.html#output">Output (programming guide)</a>.
+        </p>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="U">
+      <a>U</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="undirected-link-breed">
+        <h3>
+          <a>undirected-link-breed</a>
+        </h3>
+        <h4>
+          <span class="prim_example">undirected-link-breed [<i>&lt;link-breeds&gt;</i> <i>&lt;link-breed&gt;</i>]</span>
+        </h4>
+        <p>
+          This keyword, like the globals and breeds keywords, can only be
+          used at the beginning of the Code tab, before any procedure
+          definitions. It defines an undirected link breed. Links of a
+          particular breed are always either all directed or all undirected.
+          The first input defines the name of the agentset associated with
+          the link breed. The second input defines the name of a single
+          member of the breed.
+        </p>
+        <p>
+          Any link of the given link breed:
+        </p>
+        <ul>
+          <li>is part of the agentset named by the link breed name</li>
+          <li>has its built-in variable <code>breed</code> set to that agentset</li>
+          <li>is directed or undirected as declared by the keyword</li>
+        </ul>
+        <p>
+          Most often, the agentset is used in conjunction with ask to give
+          commands to only the links of a particular breed.
+        </p>
+        <pre>
+          undirected-link-breed [streets street]
+          undirected-link-breed [highways highway]
+          to setup
+          clear-all
+          crt 2
+          ask turtle 0 [ create-street-with turtle 1 ]
+          ask turtle 0 [ create-highway-with turtle 1 ]
+          end
 
-					ask turtle 0 [ show sort my-links ]
-					;; prints [(street 0 1) (highway 0 1)]
-				</pre>
-				<p>
-					See also <a href="#breed">breed</a>, <a href="#directed-link-breed">directed-link-breed</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="untie">
-				<h3>
-					<a>untie<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">untie</span>
-					<img alt="Link Command" src="images/link.gif"/>
-				</h4>
-				<p>
-					Unties <i>end2</i> from <i>end1</i> (sets <a href="#tie-mode">tie-mode</a> to &quot;none&quot;) if they were
-					previously tied together. If the link is an undirected link, then
-					it will untie <i>end1</i> from <i>end2</i> as well. It does
-					<b>not</b> remove the link between the two turtles.
-				</p>
-				<p>
-					See also <a href="#tie">tie</a>
-				</p>
-				<p>
-					See the <a href="programming.html#tie">Tie</a> section of the
-					Programming Guide for more details.
-				</p>
-			</div>
-			<div class="dict_entry" id="up-to-n-of">
-				<h3>
-					<a>up-to-n-of<span class="since">6.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">up-to-n-of <i>size</i> <i>agentset</i></span>
-					<span class="prim_example">up-to-n-of <i>size</i> <i>list</i></span>
-				</h4>
-				<p>
-					From an agentset, reports an agentset of size <i>size</i>
-					randomly chosen from the input set, with no repeats.  If the
-					input does not have enough agents to satisfy the <i>size</i>,
-					reports the entire agentset.
-				</p>
-				<p>
-					From a list, reports a list of size <i>size</i> randomly chosen
-					from the input set, with no repeats. The items in the result
-					appear in the same order that they appeared in the input list.
-					(If you want them in random order, use shuffle on the result.)
-					If the input does not have enough items to satisfy the
-					<i>size</i>, reports the entire list.
-				</p>
-				<pre>
-					ask up-to-n-of 50 patches [ set pcolor green ]
-					;; 50 randomly chosen patches turn green
-					;; if less than 50 patches exist, they all turn green
-				</pre>
-				<p>
-					See also <a href="#n-of">n-of</a>, <a href="#one-of">one-of</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="update-plots">
-				<h3>
-					<a>update-plots<span class="since">5.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">update-plots</span>
-				</h4>
-				<p>
-					For each plot, runs that plot's update commands, including the
-					update code for any pens in the plot.
-				</p>
-				<p>
-					<a href="#tick">tick</a> has the same effect, so in models that use
-					the tick counter, this primitive is not normally used. Models that
-					use fractional ticks may need <code>update-plots</code>, since <a href="#tick-advance">tick-advance</a> does not update the plots.
-				</p>
-				<p>
-					See the <a href="programming.html#plotting">Plotting section</a> of
-					the Programming Guide for more details.
-				</p>
-				<p>
-					See also <a href="#setup-plots">setup-plots</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="uphill">
-				<h3>
-					<a>uphill<span class="since">1.0</span></a>
-					<a>uphill4<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">uphill <i>patch-variable</i></span>
-					<span class="prim_example">uphill4 <i>patch-variable</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Moves the turtle to the neighboring patch with the highest value
-					for <i>patch-variable</i>. If no neighboring patch has a higher
-					value than the current patch, the turtle stays put. If there are
-					multiple patches with the same highest value, the turtle picks one
-					randomly. Non-numeric values are ignored.
-				</p>
-				<p>
-					uphill considers the eight neighboring patches; uphill4 only
-					considers the four neighbors.
-				</p>
-				<p>
-					Equivalent to the following code (assumes variable values are
-					numeric):
-				</p>
-				<pre>
-					move-to patch-here  ;; go to patch center
-					let p max-one-of neighbors [<i>patch-variable</i>]  ;; or neighbors4
-					if [<i>patch-variable</i>] of p &gt; <i>patch-variable</i> [
-					face p
-					move-to p
-					]
-				</pre>
-				<p>
-					Note that the turtle always ends up on a patch center and has a
-					heading that is a multiple of 45 (uphill) or 90 (uphill4).
-				</p>
-				<p>
-					See also <a href="#downhill">downhill</a>, <a href="#downhill">downhill4</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="user-directory">
-				<h3>
-					<a>user-directory<span class="since">3.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">user-directory</span>
-				</h4>
-				<p>
-					Opens a dialog that allows the user to choose an existing directory
-					on the system.
-				</p>
-				<p>
-					It reports a string with the absolute path or false if the user
-					cancels.
-				</p>
-				<pre>
-					set-current-directory user-directory
-					;; Assumes the user will choose a directory
-				</pre>
-			</div>
-			<div class="dict_entry" id="user-file">
-				<h3>
-					<a>user-file<span class="since">3.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">user-file</span>
-				</h4>
-				<p>
-					Opens a dialog that allows the user to choose an existing file on
-					the system.
-				</p>
-				<p>
-					It reports a string with the absolute file path or false if the
-					user cancels.
-				</p>
-				<pre>
-					file-open user-file
-					;; Assumes the user will choose a file
-				</pre>
-			</div>
-			<div class="dict_entry" id="user-new-file">
-				<h3>
-					<a>user-new-file<span class="since">3.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">user-new-file</span>
-				</h4>
-				<p>
-					Opens a dialog that allows the user to choose a location and name
-					of a new file to be created. It reports a string with the absolute
-					file path or false if the user cancels.
-				</p>
-				<pre>
-					file-open user-new-file
-					;; Assumes the user will choose a file
-				</pre>
-				<p>
-					Note that this reporter doesn't actually create the file;
-					normally you would create the file using <code>file-open</code>, as in
-					the example.
-				</p>
-				<p>
-					If the user chooses an existing file, they will be asked if they
-					wish to replace it or not, but the reporter itself doesn't
-					cause the file to be replaced. To do that you would use
-					<code>file-delete</code>.
-				</p>
-			</div>
-			<div class="dict_entry" id="user-input">
-				<h3>
-					<a>user-input<span class="since">1.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">user-input <i>value</i></span>
-				</h4>
-				<p>
-					Reports the string that a user types into an entry field in a
-					dialog with title <i>value</i>.
-				</p>
-				<p>
-					<i>value</i> may be of any type, but is typically a string.
-				</p>
-				<pre>
-					show user-input &quot;What is your name?&quot;
-				</pre>
-				<p>
-					See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
-					Programming Guide for additional details.
-				</p>
-			</div>
-			<div class="dict_entry" id="user-message">
-				<h3>
-					<a>user-message<span class="since">1.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">user-message <i>value</i></span>
-				</h4>
-				<p>
-					Opens a dialog with <i>value</i> displayed as the message to the user.
-				</p>
-				<p>
-					<i>value</i> may be of any type, but is typically a string.
-				</p>
-				<pre>
-					user-message (word &quot;There are &quot; count turtles &quot; turtles.&quot;)
-				</pre>
-				<p>
-					Note that if a user closes the <code>user-message</code> dialog
-					with the &quot;X&quot; in the corner, the behavior will be the same as if they had clicked &quot;OK&quot;.
-				</p>
-				<p>
-					See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
-					Programming Guide for additional details.
-				</p>
-			</div>
-			<div class="dict_entry" id="user-one-of">
-				<h3>
-					<a>user-one-of<span class="since">3.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">user-one-of <i>value</i> <i>list-of-choices</i></span>
-				</h4>
-				<p>
-					Opens a dialog with <i>value</i> displayed as the message and
-					<i>list-of-choices</i> displayed as a popup menu for the user to
-					select from.
-				</p>
-				<p>
-					Reports the item in <i>list-of-choices</i> selected by the user.
-				</p>
-				<p>
-					<i>value</i> may be of any type, but is typically a string.
-				</p>
-				<pre>
-					if &quot;yes&quot; = user-one-of &quot;Set up the model?&quot; [&quot;yes&quot; &quot;no&quot;]
-					[ setup ]
-				</pre>
-				<p>
-					See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
-					Programming Guide for additional details.
-				</p>
-			</div>
-			<div class="dict_entry" id="user-yes-or-no">
-				<h3>
-					<a>user-yes-or-no?<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">user-yes-or-no? <i>value</i></span>
-				</h4>
-				<p>
-					Reports true or false based on the user's response to
-					<i>value</i>.
-				</p>
-				<p>
-					<i>value</i> may be of any type, but is typically a string.
-				</p>
-				<pre>
-					if user-yes-or-no? &quot;Set up the model?&quot;
-					[ setup ]
-				</pre>
-				<p>
-					See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
-					Programming Guide for additional details.
-				</p>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="V">
-			<a>V</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="variance">
-				<h3>
-					<a>variance<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">variance <i>list</i></span>
-				</h4>
-				<p>
-					Reports the sample variance of a <i>list</i> of numbers. Ignores
-					other types of items.
-				</p>
-				<p>
-					(Note that this computes an unbiased estimate of the variance for a
-					<i>sample</i>, rather than for a whole <i>population</i>, using
-					Bessel's correction.)
-				</p>
-				<p>
-					The sample variance is the sum of the squares of the deviations of
-					the numbers from their mean, divided by one less than the number of
-					numbers in the list.
-				</p>
-				<pre>
-					show variance [2 7 4 3 5]
-					=&gt; 3.7
-				</pre>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="W">
-			<a>W</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="wait">
-				<h3>
-					<a>wait<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">wait <i>number</i></span>
-				</h4>
-				<p>
-					Wait the given number of seconds. (This needn't be an integer;
-					you can specify fractions of seconds.) Note that you can't
-					expect complete precision; the agent will never wait less than the
-					given amount, but might wait slightly more.
-				</p>
-				<pre>
-					repeat 10 [ fd 1 wait 0.5 ]
-				</pre>
-				<p>
-					While the agent is waiting, no other agents can do anything.
-					Everything stops until the agent is done.
-				</p>
-				<p>
-					See also <a href="#every">every</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="watch">
-				<h3>
-					<a>watch<span class="since">3.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">watch <i>agent</i></span>
-					<img alt="Observer Command" src="images/observer.gif"/>
-				</h4>
-				<p>
-					Puts a spotlight on <i>agent</i>. In the 3D view the observer will
-					also turn to face the subject.
-				</p>
-				<p>
-					The observer may only watch or follow a single subject.
-					Calling <code>watch</code> will undo perspective changes caused
-					by prior calls to <code>follow</code>, <code>follow-me</code>,
-					<code>ride</code>, and <code>ride-me</code>.
-				</p>
-				<p>
-					See also <a href="#follow">follow</a>, <a href="#subject">subject</a>, <a href="#reset-perspective">reset-perspective</a>,
-					<a href="#ride">ride</a>, <a href="#ride-me">ride-me</a>, <a href="#watch-me">watch-me</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="watch-me">
-				<h3>
-					<a>watch-me<span class="since">3.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">watch-me</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
-				</h4>
-				<p>
-					Asks the observer to watch this agent.
-				</p>
-				<p>
-					The observer may only watch or follow a single subject.
-					Calling <code>watch</code> will undo perspective changes caused
-					by prior calls to <code>follow</code>, <code>follow-me</code>,
-					<code>ride</code>, and <code>ride-me</code>.
-				</p>
-				<p>
-					See also <a href="#follow">follow</a>, <a href="#subject">subject</a>, <a href="#reset-perspective">reset-perspective</a>,
-					<a href="#ride">ride</a>, <a href="#ride-me">ride-me</a>, <a href="#watch">watch</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="while">
-				<h3>
-					<a>while<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">while [<i>reporter</i>] [ <i>commands</i> ]</span>
-				</h4>
-				<p>
-					If <i>reporter</i> reports false, exit the loop. Otherwise run
-					<i>commands</i> and repeat.
-				</p>
-				<p>
-					The reporter may have different values for different agents, so
-					some agents may run <i>commands</i> a different number of times
-					than other agents.
-				</p>
-				<pre>
-					while [any? other turtles-here]
-					[ fd 1 ]
-					;; turtle moves until it finds a patch that has
-					;; no other turtles on it
-				</pre>
-			</div>
-			<div class="dict_entry" id="who">
-				<h3>
-					<a>who</a>
-				</h3>
-				<h4>
-					<span class="prim_example">who</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					This is a built-in turtle variable. It holds the turtle's
-					&quot;who number&quot; or ID number, an integer greater than or
-					equal to zero. You cannot set this variable; a turtle's who
-					number never changes.
-				</p>
-				<p>
-					Who numbers start at 0. A dead turtle's number will not be
-					reassigned to a new turtle until you use the <a href="#clear-turtles">clear-turtles</a> or <a href="#clear-all">clear-all</a> commands, at which time who numbering
-					starts over again at 0.
-				</p>
-				<p>
-					Example:
-				</p>
-				<pre>
-					show [who] of turtles with [color = red]
-					;; prints a list of the who numbers of all red turtles
-					;; in the Command Center, in random order
-					crt 100
-					[ ifelse who &lt; 50
-					[ set color red ]
-					[ set color blue ] ]
-					;; turtles 0 through 49 are red, turtles 50
-					;; through 99 are blue
-				</pre>
-				<p>
-					You can use the turtle reporter to retrieve a turtle with a given
-					who number. See also <a href="#turtle">turtle</a>.
-				</p>
-				<p>
-					Note that who numbers aren't breed-specific. No two turtles can
-					have the same who number, even if they are different breeds:
-				</p>
-				<pre>
-					clear-turtles
-					create-frogs 1
-					create-mice 1
-					ask turtles [ print who ]
-					;; prints (in some random order):
-					;; (frog 0): 0
-					;; (mouse 1): 1
-				</pre>
-				<p>
-					Even though we only have one mouse, it is <code>mouse 1</code> not
-					<code>mouse 0</code>, because the who number 0 was already taken by the
-					frog.
-				</p>
-			</div>
-			<div class="dict_entry" id="with">
-				<h3>
-					<a>with<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example"><i>agentset</i> with [<i>reporter</i>]</span>
-				</h4>
-				<p>
-					Takes two inputs: on the left, an agentset (usually
-					&quot;turtles&quot; or &quot;patches&quot;). On the right, a
-					boolean reporter. Reports a new agentset containing only those
-					agents that reported true -- in other words, the agents satisfying
-					the given condition.
-				</p>
-				<pre>
-					show count patches with [pcolor = red]
-					;; prints the number of red patches
-				</pre>
-			</div>
-			<div class="dict_entry" id="link-with">
-				<h3>
-					<a>&lt;breed&gt;-with</a>
-					<a>link-with<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">&lt;breed&gt;-with <i>turtle</i></span>
-					<span class="prim_example">link-with <i>turtle</i></span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					Reports a link between <i>turtle</i> and the caller (directed or
-					undirected, incoming or outgoing). If no link exists then it reports
-					nobody. If more than one such link exists, reports a random one.
-				</p>
-				<pre>
-					crt 2
-					ask turtle 0 [
-					create-link-with turtle 1
-					show link-with turtle 1 ;; prints link 0 1
-					]
-				</pre>
-				<p>
-					See also: <a href="#in-link-from">in-link-from</a>, <a href="#out-link-to">out-link-to</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="with-max">
-				<h3>
-					<a>with-max<span class="since">2.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example"><i>agentset</i> with-max [<i>reporter</i>]</span>
-				</h4>
-				<p>
-					Takes two inputs: on the left, an agentset (usually
-					&quot;turtles&quot; or &quot;patches&quot;). On the right, a
-					reporter. Reports a new agentset containing all agents reporting
-					the maximum value of the given reporter.
-				</p>
-				<pre>
-					show count patches with-max [pxcor]
-					;; prints the number of patches on the right edge
-				</pre>
-				<p>
-					See also <a href="#max-one-of">max-one-of</a>, <a href="#max-n-of">max-n-of</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="with-min">
-				<h3>
-					<a>with-min<span class="since">2.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example"><i>agentset</i> with-min [<i>reporter</i>]</span>
-				</h4>
-				<p>
-					Takes two inputs: on the left, an agentset (usually
-					&quot;turtles&quot; or &quot;patches&quot;). On the right, a
-					reporter. Reports a new agentset containing only those agents that
-					have the minimum value of the given reporter.
-				</p>
-				<pre>
-					show count patches with-min [pycor]
-					;; prints the number of patches on the bottom edge
-				</pre>
-				<p>
-					See also <a href="#min-one-of">min-one-of</a>, <a href="#min-n-of">min-n-of</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="with-local-randomness">
-				<h3>
-					<a>with-local-randomness<span class="since">4.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">with-local-randomness [ <i>commands</i> ]</span>
-				</h4>
-				<p>
-					The commands are run without affecting subsequent random events.
-					This is useful for performing extra operations (such as output)
-					without changing the outcome of a model.
-				</p>
-				<p>
-					Example:
-				</p>
-				<pre>
-					;; Run #1:
-					random-seed 50 setup repeat 10 [ go ]
-					;; Run #2:
-					random-seed 50 setup
-					with-local-randomness [ watch one-of turtles ]
-					repeat 10 [ go ]
-				</pre>
-				<p>
-					Since <code>one-of</code> is used inside
-					<code>with-local-randomness</code>, both runs will be identical.
-				</p>
-				<p>
-					Specifically how it works is, the state of the random number
-					generator is remembered before the commands run, then restored
-					afterwards. (If you want to run the commands with a fresh random
-					state instead of the same random state that will be restored later,
-					you can begin the commands with <code>random-seed new-seed</code>.)
-				</p>
-				<p>
-					The following example demonstrates that the random number generator
-					state is the same both before the commands run and afterwards.
-				</p>
-				<pre>
-					random-seed 10
-					with-local-randomness [ print n-values 10 [random 10] ]
-					;; prints [8 9 8 4 2 4 5 4 7 9]
-					print n-values 10 [random 10]
-					;; prints [8 9 8 4 2 4 5 4 7 9]
-				</pre>
-			</div>
-			<div class="dict_entry" id="without-interruption">
-				<h3>
-					<a>without-interruption<span class="since">1.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">without-interruption [ <i>commands</i> ]</span>
-				</h4>
-				<p>
-					This primitive exists only for backwards compatibility. We
-					don't recommend using it in new models.
-				</p>
-				<p>
-					The agent runs all the commands in the block without allowing other
-					agents using <code>ask-concurrent</code> to &quot;interrupt&quot;. That
-					is, other agents are put &quot;on hold&quot; and do not run any
-					commands until the commands in the block are finished.
-				</p>
-				<p>
-					Note: This command is only useful in conjunction with
-					<code>ask-concurrent</code>.
-				</p>
-				<p>
-					See also <a href="#ask-concurrent">ask-concurrent</a>.
-				</p>
-			</div>
-			<div class="dict_entry" id="word">
-				<h3>
-					<a>word<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">word <i>value1</i> <i>value2</i></span>
-					<span class="prim_example">(word <i>value1</i> ...)</span>
-				</h4>
-				<p>
-					Concatenates the inputs together and reports the result as a
-					string.
-				</p>
-				<pre>
-					show word &quot;tur&quot; &quot;tle&quot;
-					=&gt; &quot;turtle&quot;
-					word &quot;a&quot; 6
-					=&gt; &quot;a6&quot;
-					set directory &quot;c:\\foo\\fish\\&quot;
-					show word directory &quot;bar.txt&quot;
-					=&gt; &quot;c:\foo\fish\bar.txt&quot;
-					show word [1 54 8] &quot;fishy&quot;
-					=&gt; &quot;[1 54 8]fishy&quot;
-					show (word 3)
-					=&gt; &quot;3&quot;
-					show (word &quot;a&quot; &quot;b&quot; &quot;c&quot; 1 23)
-					=&gt; &quot;abc123&quot;
-				</pre>
-			</div>
-			<div class="dict_entry" id="world-dim">
-				<h3>
-					<a>world-width<span class="since">3.1</span></a>
-					<a>world-height<span class="since">3.1</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">world-width</span>
-					<span class="prim_example">world-height</span>
-				</h4>
-				<p>
-					These reporters give the total width and height of the NetLogo
-					world.
-				</p>
-				<p>
-					The width equals max-pxcor - min-pxcor + 1 and the height equals
-					max-pycor - min-pycor + 1.
-				</p>
-				<p>
-					See also <a href="#max-pcor">max-pxcor</a>, <a href="#max-pcor">max-pycor</a>, <a href="#min-pcor">min-pxcor</a>, and
-					<a href="#min-pcor">min-pycor</a>
-				</p>
-			</div>
-			<div class="dict_entry" id="wrap-color">
-				<h3>
-					<a>wrap-color<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">wrap-color <i>number</i></span>
-				</h4>
-				<p>
-					wrap-color checks whether <i>number</i> is in the NetLogo color
-					range of 0 to 140 (not including 140 itself). If it is not,
-					wrap-color &quot;wraps&quot; the numeric input to the 0 to 140
-					range.
-				</p>
-				<p>
-					The wrapping is done by repeatedly adding or subtracting 140 from
-					the given number until it is in the 0 to 140 range. (This is the
-					same wrapping that is done automatically if you assign an
-					out-of-range number to the color turtle variable or pcolor patch
-					variable.)
-				</p>
-				<pre>
-					show wrap-color 150
-					=&gt; 10
-					show wrap-color -10
-					=&gt; 130
-				</pre>
-			</div>
-			<div class="dict_entry" id="write">
-				<h3>
-					<a>write<span class="since">2.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">write <i>value</i></span>
-				</h4>
-				<p>
-					This command will output <i>value</i>, which can be a number,
-					string, list, boolean, or nobody to the Command Center, <i>not</i>
-					followed by a carriage return (unlike <a href="#print">print</a>
-					and <a href="#show">show</a>).
-				</p>
-				<p>
-					This agent is <i>not</i> printed before the value, unlike <a href="#show">show</a>. Its output also includes quotes around strings
-					and is prepended with a space.
-				</p>
-				<pre>
-					write &quot;hello world&quot;
-					=&gt;  &quot;hello world&quot;
-				</pre>
-				<p>
-					See also <a href="#print">print</a>, <a href="#show">show</a>,
-					<a href="#type">type</a>, <a href="#output-cmds">output-write</a>,
-					and <a href="programming.html#output">Output (programming guide)</a>.
-				</p>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="X">
-			<a>X</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="xcor">
-				<h3>
-					<a>xcor</a>
-				</h3>
-				<h4>
-					<span class="prim_example">xcor</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					This is a built-in turtle variable. It holds the current x
-					coordinate of the turtle. You can set this variable to change the
-					turtle's location.
-				</p>
-				<p>
-					This variable is always greater than or equal to (min-pxcor - 0.5)
-					and strictly less than (max-pxcor + 0.5).
-				</p>
-				<p>
-					See also <a href="#setxy">setxy</a>, <a href="#ycor">ycor</a>,
-					<a href="#pcor">pxcor</a>, <a href="#pcor">pycor</a>,
-				</p>
-			</div>
-			<div class="dict_entry" id="xor">
-				<h3>
-					<a>xor<span class="since">1.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example"><i>boolean1</i> xor <i>boolean2</i></span>
-				</h4>
-				<p>
-					Reports true if either <i>boolean1</i> or <i>boolean2</i> is true,
-					but not when both are true.
-				</p>
-				<pre>
-					if (pxcor &gt; 0) xor (pycor &gt; 0)
-					[ set pcolor blue ]
-					;; upper-left and lower-right quadrants turn blue
-				</pre>
-			</div><!-- ======================================== -->
-		</div>
-		<h2 id="Y">
-			<a>Y</a>
-		</h2><!-- ======================================== -->
-		<div>
-			<div class="dict_entry" id="ycor">
-				<h3>
-					<a>ycor</a>
-				</h3>
-				<h4>
-					<span class="prim_example">ycor</span>
-					<img alt="Turtle Command" src="images/turtle.gif"/>
-				</h4>
-				<p>
-					This is a built-in turtle variable. It holds the current y
-					coordinate of the turtle. You can set this variable to change the
-					turtle's location.
-				</p>
-				<p>
-					This variable is always greater than or equal to (min-pycor - 0.5)
-					and strictly less than (max-pycor + 0.5).
-				</p>
-				<p>
-					See also <a href="#setxy">setxy</a>, <a href="#xcor">xcor</a>,
-					<a href="#pcor">pxcor</a>, <a href="#pcor">pycor</a>,
-				</p>
-			</div><!-- ======================================== -->
-		</div>
-		<h2>
-			<a>-&gt;</a>
-		</h2><!-- ======================================== -->
-		<div id="ops">
-			<div class="dict_entry" id="arrow">
-				<h3>
-					<a>-><span class="since">6.0</span></a>
-				</h3>
-				<h4>
-					<span class="prim_example">[ [<i>args</i>] -> <i>commands</i> ]</span>
-					<span class="prim_example">[ [<i>args</i>] -> <i>reporter</i> ]</span>
-				</h4>
-				<p>
-					Creates and reports an anonymous procedure - a command or reporter
-					- depending on the input. Within <i>commands</i> or <i>reporter</i> the listed
-					<i>args</i> may be used just as you would use <code>let</code> or procedure variables.
-					The variable names in <i>args</i> have the same restrictions
-					as variable names of commands and reporters. In addition, they must not match the name of
-					any let or procedure variable in their procedure.
-				</p>
-				<p>
-					Anonymous procedures are commonly used with the primitives
-					<a href="#foreach">foreach</a>, <a href="#map">map</a>, <a href="#reduce">reduce</a>,
-					<a href="#filter">filter</a>, <a href="#sort-by">sort-by</a>, and <a href="#n-values">n-values</a>. See
-					those entries for example usage.
-				</p>
-				<p>
-					See the <a href="programming.html#anonymous-procedures">Anonymous Procedures section</a> of the
-					Programming Guide for details.
-				</p>
-			</div>
-		</div>
-	</body>
+          ask turtle 0 [ show sort my-links ]
+          ;; prints [(street 0 1) (highway 0 1)]
+        </pre>
+        <p>
+          See also <a href="#breed">breed</a>, <a href="#directed-link-breed">directed-link-breed</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="untie">
+        <h3>
+          <a>untie<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">untie</span>
+          <img alt="Link Command" src="images/link.gif"/>
+        </h4>
+        <p>
+          Unties <i>end2</i> from <i>end1</i> (sets <a href="#tie-mode">tie-mode</a> to &quot;none&quot;) if they were
+          previously tied together. If the link is an undirected link, then
+          it will untie <i>end1</i> from <i>end2</i> as well. It does
+          <b>not</b> remove the link between the two turtles.
+        </p>
+        <p>
+          See also <a href="#tie">tie</a>
+        </p>
+        <p>
+          See the <a href="programming.html#tie">Tie</a> section of the
+          Programming Guide for more details.
+        </p>
+      </div>
+      <div class="dict_entry" id="up-to-n-of">
+        <h3>
+          <a>up-to-n-of<span class="since">6.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">up-to-n-of <i>size</i> <i>agentset</i></span>
+          <span class="prim_example">up-to-n-of <i>size</i> <i>list</i></span>
+        </h4>
+        <p>
+          From an agentset, reports an agentset of size <i>size</i>
+          randomly chosen from the input set, with no repeats.  If the
+          input does not have enough agents to satisfy the <i>size</i>,
+          reports the entire agentset.
+        </p>
+        <p>
+          From a list, reports a list of size <i>size</i> randomly chosen
+          from the input set, with no repeats. The items in the result
+          appear in the same order that they appeared in the input list.
+          (If you want them in random order, use shuffle on the result.)
+          If the input does not have enough items to satisfy the
+          <i>size</i>, reports the entire list.
+        </p>
+        <pre>
+          ask up-to-n-of 50 patches [ set pcolor green ]
+          ;; 50 randomly chosen patches turn green
+          ;; if less than 50 patches exist, they all turn green
+        </pre>
+        <p>
+          See also <a href="#n-of">n-of</a>, <a href="#one-of">one-of</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="update-plots">
+        <h3>
+          <a>update-plots<span class="since">5.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">update-plots</span>
+        </h4>
+        <p>
+          For each plot, runs that plot's update commands, including the
+          update code for any pens in the plot.
+        </p>
+        <p>
+          <a href="#tick">tick</a> has the same effect, so in models that use
+          the tick counter, this primitive is not normally used. Models that
+          use fractional ticks may need <code>update-plots</code>, since <a href="#tick-advance">tick-advance</a> does not update the plots.
+        </p>
+        <p>
+          See the <a href="programming.html#plotting">Plotting section</a> of
+          the Programming Guide for more details.
+        </p>
+        <p>
+          See also <a href="#setup-plots">setup-plots</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="uphill">
+        <h3>
+          <a>uphill<span class="since">1.0</span></a>
+          <a>uphill4<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">uphill <i>patch-variable</i></span>
+          <span class="prim_example">uphill4 <i>patch-variable</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Moves the turtle to the neighboring patch with the highest value
+          for <i>patch-variable</i>. If no neighboring patch has a higher
+          value than the current patch, the turtle stays put. If there are
+          multiple patches with the same highest value, the turtle picks one
+          randomly. Non-numeric values are ignored.
+        </p>
+        <p>
+          uphill considers the eight neighboring patches; uphill4 only
+          considers the four neighbors.
+        </p>
+        <p>
+          Equivalent to the following code (assumes variable values are
+          numeric):
+        </p>
+        <pre>
+          move-to patch-here  ;; go to patch center
+          let p max-one-of neighbors [<i>patch-variable</i>]  ;; or neighbors4
+          if [<i>patch-variable</i>] of p &gt; <i>patch-variable</i> [
+          face p
+          move-to p
+          ]
+        </pre>
+        <p>
+          Note that the turtle always ends up on a patch center and has a
+          heading that is a multiple of 45 (uphill) or 90 (uphill4).
+        </p>
+        <p>
+          See also <a href="#downhill">downhill</a>, <a href="#downhill">downhill4</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="user-directory">
+        <h3>
+          <a>user-directory<span class="since">3.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">user-directory</span>
+        </h4>
+        <p>
+          Opens a dialog that allows the user to choose an existing directory
+          on the system.
+        </p>
+        <p>
+          It reports a string with the absolute path or false if the user
+          cancels.
+        </p>
+        <pre>
+          set-current-directory user-directory
+          ;; Assumes the user will choose a directory
+        </pre>
+      </div>
+      <div class="dict_entry" id="user-file">
+        <h3>
+          <a>user-file<span class="since">3.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">user-file</span>
+        </h4>
+        <p>
+          Opens a dialog that allows the user to choose an existing file on
+          the system.
+        </p>
+        <p>
+          It reports a string with the absolute file path or false if the
+          user cancels.
+        </p>
+        <pre>
+          file-open user-file
+          ;; Assumes the user will choose a file
+        </pre>
+      </div>
+      <div class="dict_entry" id="user-new-file">
+        <h3>
+          <a>user-new-file<span class="since">3.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">user-new-file</span>
+        </h4>
+        <p>
+          Opens a dialog that allows the user to choose a location and name
+          of a new file to be created. It reports a string with the absolute
+          file path or false if the user cancels.
+        </p>
+        <pre>
+          file-open user-new-file
+          ;; Assumes the user will choose a file
+        </pre>
+        <p>
+          Note that this reporter doesn't actually create the file;
+          normally you would create the file using <code>file-open</code>, as in
+          the example.
+        </p>
+        <p>
+          If the user chooses an existing file, they will be asked if they
+          wish to replace it or not, but the reporter itself doesn't
+          cause the file to be replaced. To do that you would use
+          <code>file-delete</code>.
+        </p>
+      </div>
+      <div class="dict_entry" id="user-input">
+        <h3>
+          <a>user-input<span class="since">1.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">user-input <i>value</i></span>
+        </h4>
+        <p>
+          Reports the string that a user types into an entry field in a
+          dialog with title <i>value</i>.
+        </p>
+        <p>
+          <i>value</i> may be of any type, but is typically a string.
+        </p>
+        <pre>
+          show user-input &quot;What is your name?&quot;
+        </pre>
+        <p>
+          See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
+          Programming Guide for additional details.
+        </p>
+      </div>
+      <div class="dict_entry" id="user-message">
+        <h3>
+          <a>user-message<span class="since">1.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">user-message <i>value</i></span>
+        </h4>
+        <p>
+          Opens a dialog with <i>value</i> displayed as the message to the user.
+        </p>
+        <p>
+          <i>value</i> may be of any type, but is typically a string.
+        </p>
+        <pre>
+          user-message (word &quot;There are &quot; count turtles &quot; turtles.&quot;)
+        </pre>
+        <p>
+          Note that if a user closes the <code>user-message</code> dialog
+          with the &quot;X&quot; in the corner, the behavior will be the same as if they had clicked &quot;OK&quot;.
+        </p>
+        <p>
+          See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
+          Programming Guide for additional details.
+        </p>
+      </div>
+      <div class="dict_entry" id="user-one-of">
+        <h3>
+          <a>user-one-of<span class="since">3.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">user-one-of <i>value</i> <i>list-of-choices</i></span>
+        </h4>
+        <p>
+          Opens a dialog with <i>value</i> displayed as the message and
+          <i>list-of-choices</i> displayed as a popup menu for the user to
+          select from.
+        </p>
+        <p>
+          Reports the item in <i>list-of-choices</i> selected by the user.
+        </p>
+        <p>
+          <i>value</i> may be of any type, but is typically a string.
+        </p>
+        <pre>
+          if &quot;yes&quot; = user-one-of &quot;Set up the model?&quot; [&quot;yes&quot; &quot;no&quot;]
+          [ setup ]
+        </pre>
+        <p>
+          See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
+          Programming Guide for additional details.
+        </p>
+      </div>
+      <div class="dict_entry" id="user-yes-or-no">
+        <h3>
+          <a>user-yes-or-no?<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">user-yes-or-no? <i>value</i></span>
+        </h4>
+        <p>
+          Reports true or false based on the user's response to
+          <i>value</i>.
+        </p>
+        <p>
+          <i>value</i> may be of any type, but is typically a string.
+        </p>
+        <pre>
+          if user-yes-or-no? &quot;Set up the model?&quot;
+          [ setup ]
+        </pre>
+        <p>
+          See the <a href="programming.html#user-interaction-primitives">User Interaction Primitives section</a> of the
+          Programming Guide for additional details.
+        </p>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="V">
+      <a>V</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="variance">
+        <h3>
+          <a>variance<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">variance <i>list</i></span>
+        </h4>
+        <p>
+          Reports the sample variance of a <i>list</i> of numbers. Ignores
+          other types of items.
+        </p>
+        <p>
+          (Note that this computes an unbiased estimate of the variance for a
+          <i>sample</i>, rather than for a whole <i>population</i>, using
+          Bessel's correction.)
+        </p>
+        <p>
+          The sample variance is the sum of the squares of the deviations of
+          the numbers from their mean, divided by one less than the number of
+          numbers in the list.
+        </p>
+        <pre>
+          show variance [2 7 4 3 5]
+          =&gt; 3.7
+        </pre>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="W">
+      <a>W</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="wait">
+        <h3>
+          <a>wait<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">wait <i>number</i></span>
+        </h4>
+        <p>
+          Wait the given number of seconds. (This needn't be an integer;
+          you can specify fractions of seconds.) Note that you can't
+          expect complete precision; the agent will never wait less than the
+          given amount, but might wait slightly more.
+        </p>
+        <pre>
+          repeat 10 [ fd 1 wait 0.5 ]
+        </pre>
+        <p>
+          While the agent is waiting, no other agents can do anything.
+          Everything stops until the agent is done.
+        </p>
+        <p>
+          See also <a href="#every">every</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="watch">
+        <h3>
+          <a>watch<span class="since">3.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">watch <i>agent</i></span>
+          <img alt="Observer Command" src="images/observer.gif"/>
+        </h4>
+        <p>
+          Puts a spotlight on <i>agent</i>. In the 3D view the observer will
+          also turn to face the subject.
+        </p>
+        <p>
+          The observer may only watch or follow a single subject.
+          Calling <code>watch</code> will undo perspective changes caused
+          by prior calls to <code>follow</code>, <code>follow-me</code>,
+          <code>ride</code>, and <code>ride-me</code>.
+        </p>
+        <p>
+          See also <a href="#follow">follow</a>, <a href="#subject">subject</a>, <a href="#reset-perspective">reset-perspective</a>,
+          <a href="#ride">ride</a>, <a href="#ride-me">ride-me</a>, <a href="#watch-me">watch-me</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="watch-me">
+        <h3>
+          <a>watch-me<span class="since">3.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">watch-me</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/> <img alt="Patch Command" src="images/patch.gif"/>
+        </h4>
+        <p>
+          Asks the observer to watch this agent.
+        </p>
+        <p>
+          The observer may only watch or follow a single subject.
+          Calling <code>watch</code> will undo perspective changes caused
+          by prior calls to <code>follow</code>, <code>follow-me</code>,
+          <code>ride</code>, and <code>ride-me</code>.
+        </p>
+        <p>
+          See also <a href="#follow">follow</a>, <a href="#subject">subject</a>, <a href="#reset-perspective">reset-perspective</a>,
+          <a href="#ride">ride</a>, <a href="#ride-me">ride-me</a>, <a href="#watch">watch</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="while">
+        <h3>
+          <a>while<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">while [<i>reporter</i>] [ <i>commands</i> ]</span>
+        </h4>
+        <p>
+          If <i>reporter</i> reports false, exit the loop. Otherwise run
+          <i>commands</i> and repeat.
+        </p>
+        <p>
+          The reporter may have different values for different agents, so
+          some agents may run <i>commands</i> a different number of times
+          than other agents.
+        </p>
+        <pre>
+          while [any? other turtles-here]
+          [ fd 1 ]
+          ;; turtle moves until it finds a patch that has
+          ;; no other turtles on it
+        </pre>
+      </div>
+      <div class="dict_entry" id="who">
+        <h3>
+          <a>who</a>
+        </h3>
+        <h4>
+          <span class="prim_example">who</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          This is a built-in turtle variable. It holds the turtle's
+          &quot;who number&quot; or ID number, an integer greater than or
+          equal to zero. You cannot set this variable; a turtle's who
+          number never changes.
+        </p>
+        <p>
+          Who numbers start at 0. A dead turtle's number will not be
+          reassigned to a new turtle until you use the <a href="#clear-turtles">clear-turtles</a> or <a href="#clear-all">clear-all</a> commands, at which time who numbering
+          starts over again at 0.
+        </p>
+        <p>
+          Example:
+        </p>
+        <pre>
+          show [who] of turtles with [color = red]
+          ;; prints a list of the who numbers of all red turtles
+          ;; in the Command Center, in random order
+          crt 100
+          [ ifelse who &lt; 50
+          [ set color red ]
+          [ set color blue ] ]
+          ;; turtles 0 through 49 are red, turtles 50
+          ;; through 99 are blue
+        </pre>
+        <p>
+          You can use the turtle reporter to retrieve a turtle with a given
+          who number. See also <a href="#turtle">turtle</a>.
+        </p>
+        <p>
+          Note that who numbers aren't breed-specific. No two turtles can
+          have the same who number, even if they are different breeds:
+        </p>
+        <pre>
+          clear-turtles
+          create-frogs 1
+          create-mice 1
+          ask turtles [ print who ]
+          ;; prints (in some random order):
+          ;; (frog 0): 0
+          ;; (mouse 1): 1
+        </pre>
+        <p>
+          Even though we only have one mouse, it is <code>mouse 1</code> not
+          <code>mouse 0</code>, because the who number 0 was already taken by the
+          frog.
+        </p>
+      </div>
+      <div class="dict_entry" id="with">
+        <h3>
+          <a>with<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example"><i>agentset</i> with [<i>reporter</i>]</span>
+        </h4>
+        <p>
+          Takes two inputs: on the left, an agentset (usually
+          &quot;turtles&quot; or &quot;patches&quot;). On the right, a
+          boolean reporter. Reports a new agentset containing only those
+          agents that reported true -- in other words, the agents satisfying
+          the given condition.
+        </p>
+        <pre>
+          show count patches with [pcolor = red]
+          ;; prints the number of red patches
+        </pre>
+      </div>
+      <div class="dict_entry" id="link-with">
+        <h3>
+          <a>&lt;breed&gt;-with</a>
+          <a>link-with<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">&lt;breed&gt;-with <i>turtle</i></span>
+          <span class="prim_example">link-with <i>turtle</i></span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          Reports a link between <i>turtle</i> and the caller (directed or
+          undirected, incoming or outgoing). If no link exists then it reports
+          nobody. If more than one such link exists, reports a random one.
+        </p>
+        <pre>
+          crt 2
+          ask turtle 0 [
+          create-link-with turtle 1
+          show link-with turtle 1 ;; prints link 0 1
+          ]
+        </pre>
+        <p>
+          See also: <a href="#in-link-from">in-link-from</a>, <a href="#out-link-to">out-link-to</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="with-max">
+        <h3>
+          <a>with-max<span class="since">2.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example"><i>agentset</i> with-max [<i>reporter</i>]</span>
+        </h4>
+        <p>
+          Takes two inputs: on the left, an agentset (usually
+          &quot;turtles&quot; or &quot;patches&quot;). On the right, a
+          reporter. Reports a new agentset containing all agents reporting
+          the maximum value of the given reporter.
+        </p>
+        <pre>
+          show count patches with-max [pxcor]
+          ;; prints the number of patches on the right edge
+        </pre>
+        <p>
+          See also <a href="#max-one-of">max-one-of</a>, <a href="#max-n-of">max-n-of</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="with-min">
+        <h3>
+          <a>with-min<span class="since">2.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example"><i>agentset</i> with-min [<i>reporter</i>]</span>
+        </h4>
+        <p>
+          Takes two inputs: on the left, an agentset (usually
+          &quot;turtles&quot; or &quot;patches&quot;). On the right, a
+          reporter. Reports a new agentset containing only those agents that
+          have the minimum value of the given reporter.
+        </p>
+        <pre>
+          show count patches with-min [pycor]
+          ;; prints the number of patches on the bottom edge
+        </pre>
+        <p>
+          See also <a href="#min-one-of">min-one-of</a>, <a href="#min-n-of">min-n-of</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="with-local-randomness">
+        <h3>
+          <a>with-local-randomness<span class="since">4.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">with-local-randomness [ <i>commands</i> ]</span>
+        </h4>
+        <p>
+          The commands are run without affecting subsequent random events.
+          This is useful for performing extra operations (such as output)
+          without changing the outcome of a model.
+        </p>
+        <p>
+          Example:
+        </p>
+        <pre>
+          ;; Run #1:
+          random-seed 50 setup repeat 10 [ go ]
+          ;; Run #2:
+          random-seed 50 setup
+          with-local-randomness [ watch one-of turtles ]
+          repeat 10 [ go ]
+        </pre>
+        <p>
+          Since <code>one-of</code> is used inside
+          <code>with-local-randomness</code>, both runs will be identical.
+        </p>
+        <p>
+          Specifically how it works is, the state of the random number
+          generator is remembered before the commands run, then restored
+          afterwards. (If you want to run the commands with a fresh random
+          state instead of the same random state that will be restored later,
+          you can begin the commands with <code>random-seed new-seed</code>.)
+        </p>
+        <p>
+          The following example demonstrates that the random number generator
+          state is the same both before the commands run and afterwards.
+        </p>
+        <pre>
+          random-seed 10
+          with-local-randomness [ print n-values 10 [random 10] ]
+          ;; prints [8 9 8 4 2 4 5 4 7 9]
+          print n-values 10 [random 10]
+          ;; prints [8 9 8 4 2 4 5 4 7 9]
+        </pre>
+      </div>
+      <div class="dict_entry" id="without-interruption">
+        <h3>
+          <a>without-interruption<span class="since">1.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">without-interruption [ <i>commands</i> ]</span>
+        </h4>
+        <p>
+          This primitive exists only for backwards compatibility. We
+          don't recommend using it in new models.
+        </p>
+        <p>
+          The agent runs all the commands in the block without allowing other
+          agents using <code>ask-concurrent</code> to &quot;interrupt&quot;. That
+          is, other agents are put &quot;on hold&quot; and do not run any
+          commands until the commands in the block are finished.
+        </p>
+        <p>
+          Note: This command is only useful in conjunction with
+          <code>ask-concurrent</code>.
+        </p>
+        <p>
+          See also <a href="#ask-concurrent">ask-concurrent</a>.
+        </p>
+      </div>
+      <div class="dict_entry" id="word">
+        <h3>
+          <a>word<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">word <i>value1</i> <i>value2</i></span>
+          <span class="prim_example">(word <i>value1</i> ...)</span>
+        </h4>
+        <p>
+          Concatenates the inputs together and reports the result as a
+          string.
+        </p>
+        <pre>
+          show word &quot;tur&quot; &quot;tle&quot;
+          =&gt; &quot;turtle&quot;
+          word &quot;a&quot; 6
+          =&gt; &quot;a6&quot;
+          set directory &quot;c:\\foo\\fish\\&quot;
+          show word directory &quot;bar.txt&quot;
+          =&gt; &quot;c:\foo\fish\bar.txt&quot;
+          show word [1 54 8] &quot;fishy&quot;
+          =&gt; &quot;[1 54 8]fishy&quot;
+          show (word 3)
+          =&gt; &quot;3&quot;
+          show (word &quot;a&quot; &quot;b&quot; &quot;c&quot; 1 23)
+          =&gt; &quot;abc123&quot;
+        </pre>
+      </div>
+      <div class="dict_entry" id="world-dim">
+        <h3>
+          <a>world-width<span class="since">3.1</span></a>
+          <a>world-height<span class="since">3.1</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">world-width</span>
+          <span class="prim_example">world-height</span>
+        </h4>
+        <p>
+          These reporters give the total width and height of the NetLogo
+          world.
+        </p>
+        <p>
+          The width equals max-pxcor - min-pxcor + 1 and the height equals
+          max-pycor - min-pycor + 1.
+        </p>
+        <p>
+          See also <a href="#max-pcor">max-pxcor</a>, <a href="#max-pcor">max-pycor</a>, <a href="#min-pcor">min-pxcor</a>, and
+          <a href="#min-pcor">min-pycor</a>
+        </p>
+      </div>
+      <div class="dict_entry" id="wrap-color">
+        <h3>
+          <a>wrap-color<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">wrap-color <i>number</i></span>
+        </h4>
+        <p>
+          wrap-color checks whether <i>number</i> is in the NetLogo color
+          range of 0 to 140 (not including 140 itself). If it is not,
+          wrap-color &quot;wraps&quot; the numeric input to the 0 to 140
+          range.
+        </p>
+        <p>
+          The wrapping is done by repeatedly adding or subtracting 140 from
+          the given number until it is in the 0 to 140 range. (This is the
+          same wrapping that is done automatically if you assign an
+          out-of-range number to the color turtle variable or pcolor patch
+          variable.)
+        </p>
+        <pre>
+          show wrap-color 150
+          =&gt; 10
+          show wrap-color -10
+          =&gt; 130
+        </pre>
+      </div>
+      <div class="dict_entry" id="write">
+        <h3>
+          <a>write<span class="since">2.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">write <i>value</i></span>
+        </h4>
+        <p>
+          This command will output <i>value</i>, which can be a number,
+          string, list, boolean, or nobody to the Command Center, <i>not</i>
+          followed by a carriage return (unlike <a href="#print">print</a>
+          and <a href="#show">show</a>).
+        </p>
+        <p>
+          This agent is <i>not</i> printed before the value, unlike <a href="#show">show</a>. Its output also includes quotes around strings
+          and is prepended with a space.
+        </p>
+        <pre>
+          write &quot;hello world&quot;
+          =&gt;  &quot;hello world&quot;
+        </pre>
+        <p>
+          See also <a href="#print">print</a>, <a href="#show">show</a>,
+          <a href="#type">type</a>, <a href="#output-cmds">output-write</a>,
+          and <a href="programming.html#output">Output (programming guide)</a>.
+        </p>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="X">
+      <a>X</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="xcor">
+        <h3>
+          <a>xcor</a>
+        </h3>
+        <h4>
+          <span class="prim_example">xcor</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          This is a built-in turtle variable. It holds the current x
+          coordinate of the turtle. You can set this variable to change the
+          turtle's location.
+        </p>
+        <p>
+          This variable is always greater than or equal to (min-pxcor - 0.5)
+          and strictly less than (max-pxcor + 0.5).
+        </p>
+        <p>
+          See also <a href="#setxy">setxy</a>, <a href="#ycor">ycor</a>,
+          <a href="#pcor">pxcor</a>, <a href="#pcor">pycor</a>,
+        </p>
+      </div>
+      <div class="dict_entry" id="xor">
+        <h3>
+          <a>xor<span class="since">1.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example"><i>boolean1</i> xor <i>boolean2</i></span>
+        </h4>
+        <p>
+          Reports true if either <i>boolean1</i> or <i>boolean2</i> is true,
+          but not when both are true.
+        </p>
+        <pre>
+          if (pxcor &gt; 0) xor (pycor &gt; 0)
+          [ set pcolor blue ]
+          ;; upper-left and lower-right quadrants turn blue
+        </pre>
+      </div><!-- ======================================== -->
+    </div>
+    <h2 id="Y">
+      <a>Y</a>
+    </h2><!-- ======================================== -->
+    <div>
+      <div class="dict_entry" id="ycor">
+        <h3>
+          <a>ycor</a>
+        </h3>
+        <h4>
+          <span class="prim_example">ycor</span>
+          <img alt="Turtle Command" src="images/turtle.gif"/>
+        </h4>
+        <p>
+          This is a built-in turtle variable. It holds the current y
+          coordinate of the turtle. You can set this variable to change the
+          turtle's location.
+        </p>
+        <p>
+          This variable is always greater than or equal to (min-pycor - 0.5)
+          and strictly less than (max-pycor + 0.5).
+        </p>
+        <p>
+          See also <a href="#setxy">setxy</a>, <a href="#xcor">xcor</a>,
+          <a href="#pcor">pxcor</a>, <a href="#pcor">pycor</a>,
+        </p>
+      </div><!-- ======================================== -->
+    </div>
+    <h2>
+      <a>-&gt;</a>
+    </h2><!-- ======================================== -->
+    <div id="ops">
+      <div class="dict_entry" id="arrow">
+        <h3>
+          <a>-><span class="since">6.0</span></a>
+        </h3>
+        <h4>
+          <span class="prim_example">[ [<i>args</i>] -> <i>commands</i> ]</span>
+          <span class="prim_example">[ [<i>args</i>] -> <i>reporter</i> ]</span>
+        </h4>
+        <p>
+          Creates and reports an anonymous procedure - a command or reporter
+          - depending on the input. Within <i>commands</i> or <i>reporter</i> the listed
+          <i>args</i> may be used just as you would use <code>let</code> or procedure variables.
+          The variable names in <i>args</i> have the same restrictions
+          as variable names of commands and reporters. In addition, they must not match the name of
+          any let or procedure variable in their procedure.
+        </p>
+        <p>
+          Anonymous procedures are commonly used with the primitives
+          <a href="#foreach">foreach</a>, <a href="#map">map</a>, <a href="#reduce">reduce</a>,
+          <a href="#filter">filter</a>, <a href="#sort-by">sort-by</a>, and <a href="#n-values">n-values</a>. See
+          those entries for example usage.
+        </p>
+        <p>
+          See the <a href="programming.html#anonymous-procedures">Anonymous Procedures section</a> of the
+          Programming Guide for details.
+        </p>
+      </div>
+    </div>
+  </body>
 </html>

--- a/autogen/docs/dictionary.html.mustache
+++ b/autogen/docs/dictionary.html.mustache
@@ -904,7 +904,7 @@ show abs 5
         </p>
         <pre>
 if all? turtles [color = red]
-[ show &quot;every turtle is red!&quot; ]
+  [ show &quot;every turtle is red!&quot; ]
 </pre>
         <p>
           See also <a href="#any">any?</a>.
@@ -927,8 +927,8 @@ if all? turtles [color = red]
         </p>
         <pre>
 if (pxcor &gt; 0) and (pycor &gt; 0)
-[ set pcolor blue ]  ;; the upper-right quadrant of
-;; patches turn blue
+  [ set pcolor blue ]  ;; the upper-right quadrant of
+                       ;; patches turn blue
 </pre>
       </div>
       <div class="dict_entry" id="any">
@@ -947,7 +947,7 @@ if (pxcor &gt; 0) and (pycor &gt; 0)
         </p>
         <pre>
 if any? turtles with [color = red]
-[ show &quot;at least one turtle is red!&quot; ]
+  [ show &quot;at least one turtle is red!&quot; ]
 </pre>
         <p>
           Note: nobody is not an agentset. You only get nobody back in
@@ -1119,11 +1119,11 @@ show 5 * (6 + 6) / 3
         </p>
         <pre>
 ask turtles [ fd 1 ]
-;; all turtles move forward one step
+  ;; all turtles move forward one step
 ask patches [ set pcolor red ]
-;; all patches turn red
+  ;; all patches turn red
 ask turtle 4 [ rt 90 ]
-;; only the turtle with id 4 turns right
+  ;; only the turtle with id 4 turns right
 </pre>
         <p>
           Note: only the observer can ask all turtles or all patches. This
@@ -1187,9 +1187,9 @@ ask turtle 4 [ rt 90 ]
         </p>
         <pre>
 ask turtles at-points [[2 4] [1 2] [10 15]]
-[ fd 1 ]  ;; only the turtles on the patches at the
-;; coordinates (2,4), (1,2) and (10,15),
-;; relative to the caller, move
+  [ fd 1 ]  ;; only the turtles on the patches at the
+            ;; coordinates (2,4), (1,2) and (10,15),
+            ;; relative to the caller, move
 </pre>
       </div>
       <div class="dict_entry" id="atan">
@@ -1234,7 +1234,7 @@ crt 1 [ set heading 30  fd 1  print atan xcor ycor ]
         </p>
         <pre>
 to-report heading-to-angle [ h ]
-report (90 - h) mod 360
+  report (90 - h) mod 360
 end
 </pre>
       </div>
@@ -1338,9 +1338,9 @@ ask turtles [ set color one-of remove gray base-colors ]
         <pre>
 beep                       ;; emits one beep
 repeat 3 [ beep ]          ;; emits 3 beeps at once,
-;; so you only hear one sound
+                           ;; so you only hear one sound
 repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
-;; separated by 1/10th of a second
+                           ;; separated by 1/10th of a second
 </pre>
         <p>
           When running headless, this command has no effect.
@@ -1390,7 +1390,7 @@ repeat 3 [ beep wait 0.1 ] ;; produces 3 beeps in succession,
 crt 2
 ask turtle 0 [ create-link-with turtle 1 ]
 ask link 0 1 [
-ask both-ends [ set color red ] ;; turtles 0 and 1 both turn red
+  ask both-ends [ set color red ] ;; turtles 0 and 1 both turn red
 ]
 </pre>
       </div>
@@ -1463,13 +1463,13 @@ if breed = roads [ set color gray ]
 breed [mice mouse]
 breed [frogs frog]
 to setup
-clear-all
-create-mice 50
-ask mice [ set color white ]
-create-frogs 50
-ask frogs [ set color green ]
-show [breed] of one-of mice    ;; prints mice
-show [breed] of one-of frogs   ;; prints frogs
+  clear-all
+  create-mice 50
+  ask mice [ set color white ]
+  create-frogs 50
+  ask frogs [ set color green ]
+  show [breed] of one-of mice    ;; prints mice
+  show [breed] of one-of frogs   ;; prints frogs
 end
 
 show mouse 1
@@ -1914,17 +1914,17 @@ cro 100 [ fd 10 ]  ;; makes an evenly spaced circle
       </p>
       <pre>
 to setup
-clear-all
-create-turtles 5
-;; turtle 1 creates links with all other turtles
-;; the link between the turtle and itself is ignored
-ask turtle 0 [ create-links-with other turtles ]
-show count links ;; shows 4
-;; this does nothing since the link already exists
-ask turtle 0 [ create-link-with turtle 1 ]
-show count links ;; shows 4 since the previous link already existed
-ask turtle 2 [ create-link-with turtle 1 ]
-show count links ;; shows 5
+  clear-all
+  create-turtles 5
+  ;; turtle 1 creates links with all other turtles
+  ;; the link between the turtle and itself is ignored
+  ask turtle 0 [ create-links-with other turtles ]
+  show count links ;; shows 4
+  ;; this does nothing since the link already exists
+  ask turtle 0 [ create-link-with turtle 1 ]
+  show count links ;; shows 4 since the previous link already existed
+  ask turtle 2 [ create-link-with turtle 1 ]
+  show count links ;; shows 5
 end
 </pre>
       <pre>
@@ -1932,16 +1932,16 @@ directed-link-breed [red-links red-link]
 undirected-link-breed [blue-links blue-link]
 
 to setup
-clear-all
-create-turtles 5
-;; create links in both directions between turtle 0
-;; and all other turtles
-ask turtle 0 [ create-red-links-to other turtles ]
-ask turtle 0 [ create-red-links-from other turtles ]
-show count links ;; shows 8
-;; now create undirected links between turtle 0 and other turtles
-ask turtle 0 [ create-blue-links-with other turtles ]
-show count links ;; shows 12
+  clear-all
+  create-turtles 5
+  ;; create links in both directions between turtle 0
+  ;; and all other turtles
+  ask turtle 0 [ create-red-links-to other turtles ]
+  ask turtle 0 [ create-red-links-from other turtles ]
+  show count links ;; shows 8
+  ;; now create undirected links between turtle 0 and other turtles
+  ask turtle 0 [ create-blue-links-with other turtles ]
+  show count links ;; shows 12
 end
 </pre>
     </div>
@@ -1979,9 +1979,9 @@ crt 100 [ fd 10 ]     ;; makes a randomly spaced circle
 breed [canaries canary]
 breed [snakes snake]
 to setup
-clear-all
-create-canaries 50 [ set color yellow ]
-create-snakes 50 [ set color green ]
+  clear-all
+  create-canaries 50 [ set color yellow ]
+  create-snakes 50 [ set color green ]
 end
 </pre>
       <p>
@@ -2176,12 +2176,12 @@ diffuse4 chemical 0.5
 directed-link-breed [streets street]
 directed-link-breed [highways highway]
 to setup
-clear-all
-crt 2
-;; create a link from turtle 0 to turtle 1
-ask turtle 0 [ create-street-to turtle 1 ]
-;; create a link from turtle 1 to turtle 0
-ask turtle 0 [ create-highway-from turtle 1 ]
+  clear-all
+  crt 2
+  ;; create a link from turtle 0 to turtle 1
+  ask turtle 0 [ create-street-to turtle 1 ]
+  ;; create a link from turtle 1 to turtle 0
+  ask turtle 0 [ create-highway-from turtle 1 ]
 end
 
 ask turtle 0 [ show one-of my-in-links ]
@@ -2281,7 +2281,7 @@ ask turtles [ show max-one-of turtles [distance myself] ]
         </p>
         <pre>
 if (distancexy 0 0) &gt; 10
-[ set color green ]
+  [ set color green ]
 ;; all turtles more than 10 units from
 ;; the center of the world turn green.
 </pre>
@@ -3102,7 +3102,7 @@ print file-read-line
         <pre>
 file-open &quot;locations.txt&quot;
 ask turtles
-[ file-write xcor file-write ycor ]
+  [ file-write xcor file-write ycor ]
 </pre>
         <p>
           See also <a href="#file-print">file-print</a>, <a href="#file-show">file-show</a>,
@@ -3250,12 +3250,12 @@ foreach [1.1 2.2 2.6] [ x -&gt; show (word x &quot; -&gt; &quot; round x) ]
         </p>
         <pre>
 (foreach [1 2 3] [2 4 6]
-[ [a b] -&gt; show word &quot;the sum is: &quot; (a + b) ])
+   [ [a b] -&gt; show word &quot;the sum is: &quot; (a + b) ])
 =&gt; &quot;the sum is: 3&quot;
 =&gt; &quot;the sum is: 6&quot;
 =&gt; &quot;the sum is: 9&quot;
 (foreach list (turtle 1) (turtle 2) [3 4]
-[ [the-turtle num-steps] -&gt; ask the-turtle [ fd num-steps ] ])
+  [ [the-turtle num-steps] -&gt; ask the-turtle [ fd num-steps ] ])
 ;; turtle 1 moves forward 3 patches
 ;; turtle 2 moves forward 4 patches
 </pre>
@@ -3986,9 +3986,9 @@ if xcor &gt; 0[ set color blue ]
         </p>
         <pre>
 ask patches
-[ ifelse pxcor &gt; 0
-[ set pcolor blue ]
-[ set pcolor red ] ]
+  [ ifelse pxcor &gt; 0
+      [ set pcolor blue ]
+      [ set pcolor red ] ]
 ;; the left half of the world turns red and
 ;; the right half turns blue
 </pre>
@@ -3999,25 +3999,25 @@ ask patches
         </p>
         <pre>
 ask patches [
-let choice random 4
-(ifelse
-choice = 0 [
-set pcolor red
-set plabel "r"
-]
-choice = 1 [
-set pcolor blue
-set plabel "b"
-]
-choice = 2 [
-set pcolor green
-set plabel "g"
-]
-; elsecommands
-[
-set pcolor yellow
-set plabel "y"
-])
+  let choice random 4
+  (ifelse
+    choice = 0 [
+      set pcolor red
+      set plabel "r"
+    ]
+    choice = 1 [
+      set pcolor blue
+      set plabel "b"
+    ]
+    choice = 2 [
+      set pcolor green
+      set plabel "g"
+    ]
+    ; elsecommands
+    [
+      set pcolor yellow
+      set plabel "y"
+  ])
 ]
 </pre>
         <p>
@@ -4052,14 +4052,14 @@ set plabel "y"
         </p>
         <pre>
 ask patches [
-set pcolor ifelse-value (pxcor &gt; 0) [blue] [red]
+  set pcolor ifelse-value (pxcor &gt; 0) [blue] [red]
 ]
 ;; the left half of the world turns red and
 ;; the right half turns blue
 show n-values 10 [ifelse-value (? &lt; 5) [0] [1]]
 =&gt; [0 0 0 0 0 1 1 1 1 1]
 show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
-[1 3 2 5 3 8 3 2 1]
+  [1 3 2 5 3 8 3 2 1]
 =&gt; 8
 </pre>
         <p>
@@ -4068,12 +4068,12 @@ show reduce [ [a b] -&gt; ifelse-value (a &gt; b) [a] [b] ]
         </p>
         <pre>
 ask patches [
-let choice random 4
-set pcolor (ifelse-value
-choice = 0 [ red ]
-choice = 1 [ blue ]
-choice = 2 [ green ]
-[ yellow ])
+  let choice random 4
+  set pcolor (ifelse-value
+    choice = 0 [ red ]
+    choice = 1 [ blue ]
+    choice = 2 [ green ]
+               [ yellow ])
 ]
 </pre>
         <p>
@@ -4081,12 +4081,12 @@ choice = 2 [ green ]
         </p>
         <pre>
 ask patches [
-let x = 2
-set pcolor (ifelse-value
-x = 0 [ red ]
-x = 1 [ blue ]
-; no final else reporter is given, and x is 2 so there will be a runtime error
-)
+  let x = 2
+  set pcolor (ifelse-value
+    x = 0 [ red ]
+    x = 1 [ blue ]
+    ; no final else reporter is given, and x is 2 so there will be a runtime error
+  )
 </pre>
         <p>
           See also <a href="#if">if</a>, <a href="#ifelse">ifelse</a>.
@@ -4238,8 +4238,8 @@ x = 1 [ blue ]
         </p>
         <pre>
 ask turtles
-[ ask patches in-cone 3 60
-[ set pcolor red ] ]
+  [ ask patches in-cone 3 60
+      [ set pcolor red ] ]
 ;; each turtle makes a red &quot;splotch&quot; of patches in a 60 degree
 ;; cone of radius 3 ahead of itself
 </pre>
@@ -4263,13 +4263,13 @@ ask turtles
         <pre>
 crt 2
 ask turtle 0 [
-create-link-to turtle 1
-show in-link-neighbor? turtle 1  ;; prints false
-show out-link-neighbor? turtle 1 ;; prints true
+  create-link-to turtle 1
+  show in-link-neighbor? turtle 1  ;; prints false
+  show out-link-neighbor? turtle 1 ;; prints true
 ]
 ask turtle 1 [
-show in-link-neighbor? turtle 0  ;; prints true
-show out-link-neighbor? turtle 0 ;; prints false
+  show in-link-neighbor? turtle 0  ;; prints true
+  show out-link-neighbor? turtle 0 ;; prints false
 ]
 </pre>
       </div>
@@ -4367,8 +4367,8 @@ __includes [ &quot;utils1.nls&quot; &quot;utils2.nls&quot; ]
         </p>
         <pre>
 ask turtles
-[ ask patches in-radius 3
-[ set pcolor red ] ]
+  [ ask patches in-radius 3
+      [ set pcolor red ] ]
 ;; each turtle makes a red &quot;splotch&quot; around itself
 </pre>
       </div>
@@ -4665,19 +4665,19 @@ layout-circle sort-by [ [a b] -&gt; [size] of a &lt; [size] of b ] turtles 10
       </p>
       <pre>
 to make-a-tree
-set-default-shape turtles &quot;circle&quot;
-crt 6
-ask turtle 0 [
-create-link-with turtle 1
-create-link-with turtle 2
-create-link-with turtle 3
-]
-ask turtle 1 [
-create-link-with turtle 4
-create-link-with turtle 5
-]
-; do a radial tree layout, centered on turtle 0
-layout-radial turtles links (turtle 0)
+  set-default-shape turtles &quot;circle&quot;
+  crt 6
+  ask turtle 0 [
+    create-link-with turtle 1
+    create-link-with turtle 2
+    create-link-with turtle 3
+  ]
+  ask turtle 1 [
+    create-link-with turtle 4
+    create-link-with turtle 5
+  ]
+  ; do a radial tree layout, centered on turtle 0
+  layout-radial turtles links (turtle 0)
 end
 </pre>
     </div>
@@ -4727,17 +4727,17 @@ end
       </p>
       <pre>
 to make-a-triangle
-set-default-shape turtles &quot;circle&quot;
-crt 3
-ask turtle 0
-[
-create-links-with other turtles
-]
-ask turtle 1
-[
-create-link-with turtle 2
-]
-repeat 30 [ layout-spring turtles links 0.2 5 1 ] ;; lays the nodes in a triangle
+  set-default-shape turtles &quot;circle&quot;
+  crt 3
+  ask turtle 0
+  [
+    create-links-with other turtles
+  ]
+  ask turtle 1
+  [
+    create-link-with turtle 2
+  ]
+  repeat 30 [ layout-spring turtles links 0.2 5 1 ] ;; lays the nodes in a triangle
 end
 </pre>
     </div>
@@ -4773,22 +4773,22 @@ end
       </p>
       <pre>
 to make-a-tree
-set-default-shape turtles &quot;circle&quot;
-crt 6
-ask turtle 0 [
-create-link-with turtle 1
-create-link-with turtle 2
-create-link-with turtle 3
-]
-ask turtle 1 [
-create-link-with turtle 4
-create-link-with turtle 5
-]
-; place all the turtles with just one
-; neighbor on the perimeter of a circle
-; and then place the remaining turtles inside
-; this circle, spread between their neighbors.
-repeat 10 [ layout-tutte (turtles with [link-neighbors = 1]) links 12 ]
+  set-default-shape turtles &quot;circle&quot;
+  crt 6
+  ask turtle 0 [
+    create-link-with turtle 1
+    create-link-with turtle 2
+    create-link-with turtle 3
+  ]
+  ask turtle 1 [
+    create-link-with turtle 4
+    create-link-with turtle 5
+  ]
+  ; place all the turtles with just one
+  ; neighbor on the perimeter of a circle
+  ; and then place the remaining turtles inside
+  ; this circle, spread between their neighbors.
+  repeat 10 [ layout-tutte (turtles with [link-neighbors = 1]) links 12 ]
 end
 </pre>
     </div>
@@ -4840,7 +4840,7 @@ end
       <pre>
 let prey one-of sheep-here
 if prey != nobody
-[ ask prey [ die ] ]
+  [ ask prey [ die ] ]
 </pre>
     </div>
     <div class="dict_entry" id="link">
@@ -5055,12 +5055,14 @@ show log 64 2
           exits through use of the <a href="#stop">stop</a> or
           <a href="#report">report</a> commands.
         </p>
-        <pre>to move-to-world-edge  ;; turtle procedure
-          loop [
-          if not can-move? 1 [ stop ]
-          fd 1
-          ]
-          end</pre>
+        <pre>
+to move-to-world-edge  ;; turtle procedure
+  loop [
+    if not can-move? 1 [ stop ]
+    fd 1
+  ]
+end
+</pre>
         <p>In this example, <code>stop</code> exits not just the loop,
           but the entire procedure.
         </p>
@@ -5225,7 +5227,7 @@ show max-n-of 5 patches with [pycor = 0] [pxcor]
         </p>
         <pre>
 crt 100 [ setxy random-float max-pxcor
-random-float max-pycor ]
+                random-float max-pycor ]
 ;; distributes 100 turtles randomly in the
 ;; first quadrant
 </pre>
@@ -5402,7 +5404,7 @@ show min-one-of turtles [xcor + ycor]
         </p>
         <pre>
 crt 100 [ setxy random-float min-pxcor
-random-float min-pycor ]
+                random-float min-pycor ]
 ;; distributes 100 turtles randomly in the
 ;; third quadrant
 </pre>
@@ -5518,7 +5520,7 @@ show modes [pxcor] of turtles
         <pre>
 ;; to make the mouse &quot;draw&quot; in red:
 if mouse-down?
-[ ask patch mouse-xcor mouse-ycor [ set pcolor red ] ]
+  [ ask patch mouse-xcor mouse-ycor [ set pcolor red ] ]
 </pre>
       </div>
       <div class="dict_entry" id="move-to">
@@ -5577,13 +5579,13 @@ move-to max-one-of turtles [size]
 crt 5
 ask turtle 0
 [
-create-links-with other turtles
-show my-links ;; prints the agentset containing all links
-;; (since all the links we created were with turtle 0 )
+  create-links-with other turtles
+  show my-links ;; prints the agentset containing all links
+                ;; (since all the links we created were with turtle 0 )
 ]
 ask turtle 1
 [
-show my-links ;; shows an agentset containing the link 0 1
+  show my-links ;; shows an agentset containing the link 0 1
 ]
 end
 </pre>
@@ -5610,12 +5612,12 @@ end
 crt 5
 ask turtle 0
 [
-create-links-to other turtles
-show my-in-links ;; shows an empty agentset
+  create-links-to other turtles
+  show my-in-links ;; shows an empty agentset
 ]
 ask turtle 1
 [
-show my-in-links ;; shows an agentset containing the link 0 1
+  show my-in-links ;; shows an agentset containing the link 0 1
 ]
 </pre>
       </div>
@@ -5639,12 +5641,12 @@ show my-in-links ;; shows an agentset containing the link 0 1
 crt 5
 ask turtle 0
 [
-create-links-to other turtles
-show my-out-links ;; shows agentset containing all the links
+  create-links-to other turtles
+  show my-out-links ;; shows agentset containing all the links
 ]
 ask turtle 1
 [
-show my-out-links ;; shows an empty agentset
+  show my-out-links ;; shows an empty agentset
 ]
 </pre>
       </div>
@@ -5678,8 +5680,8 @@ show my-out-links ;; shows an empty agentset
         </p>
         <pre>
 ask turtles
-[ ask patches in-radius 3
-[ set pcolor [color] of myself ] ]
+  [ ask patches in-radius 3
+      [ set pcolor [color] of myself ] ]
 ;; each turtle makes a colored &quot;splotch&quot; around itself
 </pre>
         <p>
@@ -5773,12 +5775,12 @@ show n-values 5 [ x -&gt; x * x ]
         </p>
         <pre>
 show sum [count turtles-here] of neighbors
-;; prints the total number of turtles on the eight
-;; patches around this turtle or patch
+  ;; prints the total number of turtles on the eight
+  ;; patches around this turtle or patch
 show count turtles-on neighbors
-;; a shorter way to say the same thing
+  ;; a shorter way to say the same thing
 ask neighbors4 [ set pcolor red ]
-;; turns the four neighboring patches red
+  ;; turns the four neighboring patches red
 </pre>
       </div>
       <div class="dict_entry" id="link-neighbors">
@@ -5800,12 +5802,12 @@ ask neighbors4 [ set pcolor red ]
 crt 3
 ask turtle 0
 [
-create-links-with other turtles
-ask link-neighbors [ set color red ] ;; turtles 1 and 2 turn red
+  create-links-with other turtles
+  ask link-neighbors [ set color red ] ;; turtles 1 and 2 turn red
 ]
 ask turtle 1
 [
-ask link-neighbors [ set color blue ] ;; turtle 0 turns blue
+  ask link-neighbors [ set color blue ] ;; turtle 0 turns blue
 ]
 end
 </pre>
@@ -5828,12 +5830,12 @@ end
 crt 2
 ask turtle 0
 [
-create-link-with turtle 1
-show link-neighbor? turtle 1  ;; prints true
+  create-link-with turtle 1
+  show link-neighbor? turtle 1  ;; prints true
 ]
 ask turtle 1
 [
-show link-neighbor? turtle 0     ;; prints true
+  show link-neighbor? turtle 0     ;; prints true
 ]
 </pre>
       </div>
@@ -5941,7 +5943,7 @@ show netlogo-version
         <pre>
 set target one-of other turtles-here
 if target != nobody
-[ ask target [ set color red ] ]
+  [ ask target [ set color red ] ]
 </pre>
       </div>
       <div class="dict_entry" id="no-links">
@@ -6051,7 +6053,7 @@ show sort [who * who] of turtles
 ask one-of patches [ set pcolor green ]
 ;; a random patch turns green
 ask patches with [any? turtles-here]
-[ show one-of turtles-here ]
+  [ show one-of turtles-here ]
 ;; for each patch containing turtles, prints one of
 ;; those turtles
 
@@ -6152,13 +6154,13 @@ ask link 0 1 [ ask turtle 0 [ show other-end ] ] ;; prints turtle 1
         <pre>
 crt 2
 ask turtle 0 [
-create-link-to turtle 1
-show in-link-neighbor? turtle 1  ;; prints false
-show out-link-neighbor? turtle 1 ;; prints true
+  create-link-to turtle 1
+  show in-link-neighbor? turtle 1  ;; prints false
+  show out-link-neighbor? turtle 1 ;; prints true
 ]
 ask turtle 1 [
-show in-link-neighbor? turtle 0  ;; prints true
-show out-link-neighbor? turtle 0 ;; prints false
+  show in-link-neighbor? turtle 0  ;; prints true
+  show out-link-neighbor? turtle 0 ;; prints false
 ]
 </pre>
       </div>
@@ -6181,13 +6183,13 @@ show out-link-neighbor? turtle 0 ;; prints false
 crt 4
 ask turtle 0
 [
-create-links-to other turtles
-ask out-link-neighbors [ set color pink ] ;; turtles 1-3 turn pink
+  create-links-to other turtles
+  ask out-link-neighbors [ set color pink ] ;; turtles 1-3 turn pink
 ]
 ask turtle 1
 [
-ask out-link-neighbors [ set color orange ]  ;; no turtles change colors
-;; since turtle 1 only has in-links
+  ask out-link-neighbors [ set color orange ]  ;; no turtles change colors
+                                               ;; since turtle 1 only has in-links
 ]
 end
 </pre>
@@ -6212,12 +6214,12 @@ end
         <pre>
 crt 2
 ask turtle 0 [
-create-link-to turtle 1
-show out-link-to turtle 1 ;; shows link 0 1
+  create-link-to turtle 1
+  show out-link-to turtle 1 ;; shows link 0 1
 ]
 ask turtle 1
 [
-show out-link-to turtle 0 ;; shows nobody
+  show out-link-to turtle 0 ;; shows nobody
 ]
 </pre>
         <p>
@@ -6959,8 +6961,8 @@ show random-poisson 3.4
         </p>
         <pre>
 ask turtles [
-;; move each turtle to the center of a random patch
-setxy random-pxcor random-pycor
+  ;; move each turtle to the center of a random patch
+  setxy random-pxcor random-pycor
 ]
 </pre>
         <p>
@@ -7018,8 +7020,8 @@ show random 100
         </p>
         <pre>
 ask turtles [
-;; move each turtle to a random point
-setxy random-xcor random-ycor
+  ;; move each turtle to a random point
+  setxy random-xcor random-ycor
 ]
 </pre>
         <p>
@@ -7129,9 +7131,9 @@ show reduce [ [result-so-far next-item] -&gt; fput next-item result-so-far ] (fp
         <pre>
 ;; find the longest string in a list
 to-report longest-string [strings]
-report reduce
-[ [longest-so-far next-string] -&gt; ifelse-value (length longest-so-far &gt;= length next-string) [longest-so-far] [next-string] ]
-strings
+  report reduce
+    [ [longest-so-far next-string] -&gt; ifelse-value (length longest-so-far &gt;= length next-string) [longest-so-far] [next-string] ]
+    strings
 end
 
 show longest-string [&quot;hi&quot; &quot;there&quot; &quot;!&quot;]
@@ -7139,8 +7141,8 @@ show longest-string [&quot;hi&quot; &quot;there&quot; &quot;!&quot;]
 
 ;; count the number of occurrences of an item in a list
 to-report occurrences [x the-list]
-report reduce
-[ [occurrence-count next-item] -&gt; ifelse-value (next-item = x) [occurrence-count + 1] [occurrence-count] ] (fput 0 the-list)
+  report reduce
+    [ [occurrence-count next-item] -&gt; ifelse-value (next-item = x) [occurrence-count + 1] [occurrence-count] ] (fput 0 the-list)
 end
 
 show occurrences 1 [1 2 1 3 1 2 3 1 1 4 5 1]
@@ -7148,7 +7150,7 @@ show occurrences 1 [1 2 1 3 1 2 3 1 1 4 5 1]
 
 ;; evaluate the polynomial, with given coefficients, at x
 to-report evaluate-polynomial [coefficients x]
-report reduce [ [value coefficient] -&gt; (x * value) + coefficient ] coefficients
+  report reduce [ [value coefficient] -&gt; (x * value) + coefficient ] coefficients
 end
 
 ;; evaluate 3x^2 + 2x + 1 at x = 4

--- a/autogen/docs/header.html.mustache
+++ b/autogen/docs/header.html.mustache
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<title>
-  NetLogo {{version}} User Manual: {{title}}
-</title>
-<link rel="stylesheet" href="netlogo.css" type="text/css">
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<head>
+		<title>
+			NetLogo {{version}} User Manual: {{title}}
+		</title>
+		<link rel="stylesheet" href="netlogo.css" type="text/css"/>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 
-# {{title}}
+		# {{title}}
 
-</head>
-<body>
-<div class="version">
-  NetLogo {{version}} User Manual
-</div>
-</body>
+	</head>
+	<body>
+		<div class="version">
+			NetLogo {{version}} User Manual
+		</div>
+	</body>
 </html>

--- a/autogen/docs/header.html.mustache
+++ b/autogen/docs/header.html.mustache
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<title>
-			NetLogo {{version}} User Manual: {{title}}
-		</title>
-		<link rel="stylesheet" href="netlogo.css" type="text/css"/>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <head>
+    <title>
+      NetLogo {{version}} User Manual: {{title}}
+    </title>
+    <link rel="stylesheet" href="netlogo.css" type="text/css"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 
-		# {{title}}
+    # {{title}}
 
-	</head>
-	<body>
-		<div class="version">
-			NetLogo {{version}} User Manual
-		</div>
-	</body>
+  </head>
+  <body>
+    <div class="version">
+      NetLogo {{version}} User Manual
+    </div>
+  </body>
 </html>

--- a/autogen/docs/header.html.mustache
+++ b/autogen/docs/header.html.mustache
@@ -1,3 +1,6 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
 <title>
   NetLogo {{version}} User Manual: {{title}}
 </title>
@@ -6,6 +9,10 @@
 
 # {{title}}
 
+</head>
+<body>
 <div class="version">
   NetLogo {{version}} User Manual
 </div>
+</body>
+</html>

--- a/autogen/docs/headings.html.mustache
+++ b/autogen/docs/headings.html.mustache
@@ -1,162 +1,162 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<title>
-			NetLogo {{version}} User Manual
-		</title>
-		<link rel="stylesheet" href="netlogo.css" type="text/css"/>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-		<style>
-			body { background: rgb(166,172,255) }
-			p.headings { font-size: 80% ; }
+  <head>
+    <title>
+      NetLogo {{version}} User Manual
+    </title>
+    <link rel="stylesheet" href="netlogo.css" type="text/css"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <style>
+      body { background: rgb(166,172,255) }
+      p.headings { font-size: 80% ; }
 
-			div.heading-section {
-			font-size: 80%;
-			}
+      div.heading-section {
+      font-size: 80%;
+      }
 
-			div.bottom-section {
-			margin-top: 2em;
-			}
+      div.bottom-section {
+      margin-top: 2em;
+      }
 
-			div.headerbanner {
-			background-color: #2D002D;
-			text-align: center;
-			padding-top: 1em;
-			padding-bottom: 1em;
-			margin-bottom: 1em;
-			}
+      div.headerbanner {
+      background-color: #2D002D;
+      text-align: center;
+      padding-top: 1em;
+      padding-bottom: 1em;
+      margin-bottom: 1em;
+      }
 
-			ul.small-items {
-			margin-bottom: 0em;
-			display: block;
-			font-size: x-small;
-			list-style: none;
-			margin-top: 0;
-			margin-bottom: 0;
-			padding-left: 0;
-			}
+      ul.small-items {
+      margin-bottom: 0em;
+      display: block;
+      font-size: x-small;
+      list-style: none;
+      margin-top: 0;
+      margin-bottom: 0;
+      padding-left: 0;
+      }
 
-			ul.small-items > li {
-			font-weight: bold;
-			white-space: nowrap;
-			}
+      ul.small-items > li {
+      font-weight: bold;
+      white-space: nowrap;
+      }
 
-			ul.heading-items {
-			margin-top: 5px;
-			margin-bottom: 5px;
-			padding-left: 15px;
-			list-style: none;
-			}
+      ul.heading-items {
+      margin-top: 5px;
+      margin-bottom: 5px;
+      padding-left: 15px;
+      list-style: none;
+      }
 
-			ul.heading-items > li {
-			font-weight: bold;
-			white-space: nowrap;
-			}
+      ul.heading-items > li {
+      font-weight: bold;
+      white-space: nowrap;
+      }
 
-			ul.interface-items {
-			padding-left: 15px;
-			list-style: none;
-			}
+      ul.interface-items {
+      padding-left: 15px;
+      list-style: none;
+      }
 
-			.heading-title {
-			display: block;
-			font-weight: bold;
-			white-space: nowrap;
-			}
+      .heading-title {
+      display: block;
+      font-weight: bold;
+      white-space: nowrap;
+      }
 
-			.offwhitetext {
-			color: #E8E8E8;
-			}
-		</style>
-	</head>
-	<body>
-		<div class="headerbanner">
-			<span class="heading-title offwhitetext xlargefont">NetLogo</span>
-			<span class="heading-title offwhitetext xlargefont">User Manual</span>
-			<span class="heading-title offwhitetext largefont">version {{version}}</span>
-			<span class="heading-title offwhitetext">{{date}}</span>
-		</div>
-		<div style="margin-bottom: 0em; margin-top: .25em;">
-			<ul class="small-items">
-				<li><a href="versions.html"     target="entry">Release Notes</a></li>
-				<li><a href="requirements.html" target="entry">System Requirements</a></li>
-				<li><a href="contact.html"      target="entry">Contacting Us</a></li>
-				<li><a href="copyright.html"    target="entry">Copyright / License</a></li>
-			</ul>
-		</div>
-		<hr/>
-		<div class="heading-section">
-			<span class="heading-title">Introduction</span>
-			<ul class="heading-items">
-				<li><a href="whatis.html" target="entry">What is NetLogo?</a></li>
-				<li><a href="sample.html" target="entry">Sample Model: Party</a></li>
-			</ul>
-		</div>
-		<div class="heading-section">
-			<span class="heading-title">Learning NetLogo</span>
-			<ul class="heading-items">
-				<li><a href="tutorial1.html" target="entry">Tutorial #1: Models</a></li>
-				<li><a href="tutorial2.html" target="entry">Tutorial #2: Commands</a></li>
-				<li><a href="tutorial3.html" target="entry">Tutorial #3: Procedures</a></li>
-			</ul>
-		</div>
-		<div class="heading-section">
-			<span class="heading-title">Reference</span>
-			<ul class="heading-items">
-				<li><a href="interface.html" target="entry">Interface Guide</a>
-					<ul class="interface-items">
-						<li><a href="interfacetab.html" target="entry">Interface Tab Guide</a></li>
-						<li><a href="infotab.html" target="entry">Info Tab Guide</a></li>
-						<li><a href="codetab.html" target="entry">Code Tab Guide</a></li>
-					</ul>
-				</li>
-				<li><a href="programming.html" target="entry">Programming Guide</a></li>
-				<li><a href="transition.html" target="entry">Transition Guide</a></li>
-				<li><a href="dictionary.html" target="entry">NetLogo Dictionary</a></li>
-				<li>(<a href="diccionario.pdf" target="entry">en Español</a>)</li>
-			</ul>
-		</div>
-		<div class="heading-section">
-			<span class="heading-title">Features</span>
-			<ul class="heading-items">
-				<li><a href="extension-manager.html" target="entry">Extension Manager</a></li>
-				<li><a href="shapes.html" target="entry">Shapes Editor</a></li>
-				<li><a href="behaviorspace.html" target="entry">BehaviorSpace</a></li>
-				<li><a href="systemdynamics.html" target="entry">System Dynamics</a></li>
-				<li><a href="hubnet.html" target="entry">HubNet</a></li>
-				<li><a href="hubnet-authoring.html" target="entry">HubNet Authoring</a></li>
-				<li><a href="logging.html" target="entry">Logging</a></li>
-				<li><a href="controlling.html" target="entry">Controlling</a></li>
-				<li><a href="mathematica.html" target="entry">Mathematica Link</a></li>
-				<li><a href="3d.html" target="entry">NetLogo 3D</a></li>
-				<li><a href="modelingcommons.html" target="entry">Save to Modeling Commons</a></li>
-			</ul>
-		</div>
-		<div class="heading-section">
-			<span class="heading-title">Extensions</span>
-			<ul class="heading-items">
-				<li><a href="extensions.html" target="entry">Extensions Guide</a>
-					{{#documentedExtensions}}</li>
-				<li><a href="{{_1}}.html" target="entry">{{_2}}</a>
-					{{/documentedExtensions}}</li>
-			</ul>
-		</div>
-		<div class="heading-section">
-			<span class="heading-title">FAQ</span>
-			<ul class="heading-items">
-				<li><a href="faq.html" target="entry">Frequently Asked Questions</a></li>
-			</ul>
-		</div>
-		<div class="heading-section">
-			<strong><em>manual in <a target="_blank" href="NetLogo%20User%20Manual.pdf">printable form</a> (PDF)</em></strong>
-		</div>
-		<div class="heading-section bottom-section">
-			<a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/" target="_blank"><img alt="Creative Commons License" style="border-width:0" src="images/cc-by-sa-3.0.png"/></a>
-			<br/>
-			<strong>
-				The NetLogo User Manual by <a href="http://ccl.northwestern.edu/netlogo/" target="_blank">Uri Wilensky</a> is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons
-					Attribution-ShareAlike 3.0 Unported License</a>.
-			</strong>
-		</div>
-	</body>
+      .offwhitetext {
+      color: #E8E8E8;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="headerbanner">
+      <span class="heading-title offwhitetext xlargefont">NetLogo</span>
+      <span class="heading-title offwhitetext xlargefont">User Manual</span>
+      <span class="heading-title offwhitetext largefont">version {{version}}</span>
+      <span class="heading-title offwhitetext">{{date}}</span>
+    </div>
+    <div style="margin-bottom: 0em; margin-top: .25em;">
+      <ul class="small-items">
+        <li><a href="versions.html"     target="entry">Release Notes</a></li>
+        <li><a href="requirements.html" target="entry">System Requirements</a></li>
+        <li><a href="contact.html"      target="entry">Contacting Us</a></li>
+        <li><a href="copyright.html"    target="entry">Copyright / License</a></li>
+      </ul>
+    </div>
+    <hr/>
+    <div class="heading-section">
+      <span class="heading-title">Introduction</span>
+      <ul class="heading-items">
+        <li><a href="whatis.html" target="entry">What is NetLogo?</a></li>
+        <li><a href="sample.html" target="entry">Sample Model: Party</a></li>
+      </ul>
+    </div>
+    <div class="heading-section">
+      <span class="heading-title">Learning NetLogo</span>
+      <ul class="heading-items">
+        <li><a href="tutorial1.html" target="entry">Tutorial #1: Models</a></li>
+        <li><a href="tutorial2.html" target="entry">Tutorial #2: Commands</a></li>
+        <li><a href="tutorial3.html" target="entry">Tutorial #3: Procedures</a></li>
+      </ul>
+    </div>
+    <div class="heading-section">
+      <span class="heading-title">Reference</span>
+      <ul class="heading-items">
+        <li><a href="interface.html" target="entry">Interface Guide</a>
+          <ul class="interface-items">
+            <li><a href="interfacetab.html" target="entry">Interface Tab Guide</a></li>
+            <li><a href="infotab.html" target="entry">Info Tab Guide</a></li>
+            <li><a href="codetab.html" target="entry">Code Tab Guide</a></li>
+          </ul>
+        </li>
+        <li><a href="programming.html" target="entry">Programming Guide</a></li>
+        <li><a href="transition.html" target="entry">Transition Guide</a></li>
+        <li><a href="dictionary.html" target="entry">NetLogo Dictionary</a></li>
+        <li>(<a href="diccionario.pdf" target="entry">en Español</a>)</li>
+      </ul>
+    </div>
+    <div class="heading-section">
+      <span class="heading-title">Features</span>
+      <ul class="heading-items">
+        <li><a href="extension-manager.html" target="entry">Extension Manager</a></li>
+        <li><a href="shapes.html" target="entry">Shapes Editor</a></li>
+        <li><a href="behaviorspace.html" target="entry">BehaviorSpace</a></li>
+        <li><a href="systemdynamics.html" target="entry">System Dynamics</a></li>
+        <li><a href="hubnet.html" target="entry">HubNet</a></li>
+        <li><a href="hubnet-authoring.html" target="entry">HubNet Authoring</a></li>
+        <li><a href="logging.html" target="entry">Logging</a></li>
+        <li><a href="controlling.html" target="entry">Controlling</a></li>
+        <li><a href="mathematica.html" target="entry">Mathematica Link</a></li>
+        <li><a href="3d.html" target="entry">NetLogo 3D</a></li>
+        <li><a href="modelingcommons.html" target="entry">Save to Modeling Commons</a></li>
+      </ul>
+    </div>
+    <div class="heading-section">
+      <span class="heading-title">Extensions</span>
+      <ul class="heading-items">
+        <li><a href="extensions.html" target="entry">Extensions Guide</a>
+          {{#documentedExtensions}}</li>
+        <li><a href="{{_1}}.html" target="entry">{{_2}}</a>
+          {{/documentedExtensions}}</li>
+      </ul>
+    </div>
+    <div class="heading-section">
+      <span class="heading-title">FAQ</span>
+      <ul class="heading-items">
+        <li><a href="faq.html" target="entry">Frequently Asked Questions</a></li>
+      </ul>
+    </div>
+    <div class="heading-section">
+      <strong><em>manual in <a target="_blank" href="NetLogo%20User%20Manual.pdf">printable form</a> (PDF)</em></strong>
+    </div>
+    <div class="heading-section bottom-section">
+      <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/" target="_blank"><img alt="Creative Commons License" style="border-width:0" src="images/cc-by-sa-3.0.png"/></a>
+      <br/>
+      <strong>
+        The NetLogo User Manual by <a href="http://ccl.northwestern.edu/netlogo/" target="_blank">Uri Wilensky</a> is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons
+          Attribution-ShareAlike 3.0 Unported License</a>.
+      </strong>
+    </div>
+  </body>
 </html>

--- a/autogen/docs/headings.html.mustache
+++ b/autogen/docs/headings.html.mustache
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
+<html lang="en">
+<head>
 <title>
   NetLogo {{version}} User Manual
 </title>
 <link rel="stylesheet" href="netlogo.css" type="text/css">
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<style type="text/css">
+<style>
   body { background: rgb(166,172,255) }
   p.headings { font-size: 80% ; }
 
@@ -66,6 +68,8 @@
     color: #E8E8E8;
   }
 </style>
+</head>
+<body>
 <div class="headerbanner">
   <span class="heading-title offwhitetext xlargefont">NetLogo</span>
   <span class="heading-title offwhitetext xlargefont">User Manual</span>
@@ -150,8 +154,9 @@
   <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/" target="_blank"><img alt="Creative Commons License" style="border-width:0" src="images/cc-by-sa-3.0.png"></a>
   <br>
   <strong>
-    <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">The NetLogo User Manual</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="http://ccl.northwestern.edu/netlogo/" property="cc:attributionName" rel="cc:attributionURL" target="_blank">Uri Wilensky</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons
+      The NetLogo User Manual by <a href="http://ccl.northwestern.edu/netlogo/" target="_blank">Uri Wilensky</a> is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons
     Attribution-ShareAlike 3.0 Unported License</a>.
   </strong>
 </div>
-
+</body>
+</html>

--- a/autogen/docs/headings.html.mustache
+++ b/autogen/docs/headings.html.mustache
@@ -1,162 +1,162 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<title>
-  NetLogo {{version}} User Manual
-</title>
-<link rel="stylesheet" href="netlogo.css" type="text/css">
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<style>
-  body { background: rgb(166,172,255) }
-  p.headings { font-size: 80% ; }
+	<head>
+		<title>
+			NetLogo {{version}} User Manual
+		</title>
+		<link rel="stylesheet" href="netlogo.css" type="text/css"/>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+		<style>
+			body { background: rgb(166,172,255) }
+			p.headings { font-size: 80% ; }
 
-  div.heading-section {
-    font-size: 80%;
-  }
+			div.heading-section {
+			font-size: 80%;
+			}
 
-  div.bottom-section {
-    margin-top: 2em;
-  }
+			div.bottom-section {
+			margin-top: 2em;
+			}
 
-  div.headerbanner {
-    background-color: #2D002D;
-    text-align: center;
-    padding-top: 1em;
-    padding-bottom: 1em;
-    margin-bottom: 1em;
-  }
+			div.headerbanner {
+			background-color: #2D002D;
+			text-align: center;
+			padding-top: 1em;
+			padding-bottom: 1em;
+			margin-bottom: 1em;
+			}
 
-  ul.small-items {
-    margin-bottom: 0em;
-    display: block;
-    font-size: x-small;
-    list-style: none;
-    margin-top: 0;
-    margin-bottom: 0;
-    padding-left: 0;
-  }
+			ul.small-items {
+			margin-bottom: 0em;
+			display: block;
+			font-size: x-small;
+			list-style: none;
+			margin-top: 0;
+			margin-bottom: 0;
+			padding-left: 0;
+			}
 
-  ul.small-items > li {
-    font-weight: bold;
-    white-space: nowrap;
-  }
+			ul.small-items > li {
+			font-weight: bold;
+			white-space: nowrap;
+			}
 
-  ul.heading-items {
-    margin-top: 5px;
-    margin-bottom: 5px;
-    padding-left: 15px;
-    list-style: none;
-  }
+			ul.heading-items {
+			margin-top: 5px;
+			margin-bottom: 5px;
+			padding-left: 15px;
+			list-style: none;
+			}
 
-  ul.heading-items > li {
-    font-weight: bold;
-    white-space: nowrap;
-  }
-  
-  ul.interface-items {
-    padding-left: 15px;
-    list-style: none;
-  }
+			ul.heading-items > li {
+			font-weight: bold;
+			white-space: nowrap;
+			}
 
-  .heading-title {
-    display: block;
-    font-weight: bold;
-    white-space: nowrap;
-  }
+			ul.interface-items {
+			padding-left: 15px;
+			list-style: none;
+			}
 
-  .offwhitetext {
-    color: #E8E8E8;
-  }
-</style>
-</head>
-<body>
-<div class="headerbanner">
-  <span class="heading-title offwhitetext xlargefont">NetLogo</span>
-  <span class="heading-title offwhitetext xlargefont">User Manual</span>
-  <span class="heading-title offwhitetext largefont">version {{version}}</span>
-  <span class="heading-title offwhitetext">{{date}}</span>
-</div>
-<div style="margin-bottom: 0em; margin-top: .25em;">
-  <ul class="small-items">
-    <li><a href="versions.html"     target="entry">Release Notes</a></li>
-    <li><a href="requirements.html" target="entry">System Requirements</a></li>
-    <li><a href="contact.html"      target="entry">Contacting Us</a></li>
-    <li><a href="copyright.html"    target="entry">Copyright / License</a></li>
-  </ul>
-</div>
-<hr>
-<div class="heading-section">
-  <span class="heading-title">Introduction</span>
-  <ul class="heading-items">
-    <li><a href="whatis.html" target="entry">What is NetLogo?</a></li>
-    <li><a href="sample.html" target="entry">Sample Model: Party</a></li>
-  </ul>
-</div>
-<div class="heading-section">
-  <span class="heading-title">Learning NetLogo</span>
-  <ul class="heading-items">
-    <li><a href="tutorial1.html" target="entry">Tutorial #1: Models</a></li>
-    <li><a href="tutorial2.html" target="entry">Tutorial #2: Commands</a></li>
-    <li><a href="tutorial3.html" target="entry">Tutorial #3: Procedures</a></li>
-  </ul>
-</div>
-<div class="heading-section">
-  <span class="heading-title">Reference</span>
-  <ul class="heading-items">
-    <li><a href="interface.html" target="entry">Interface Guide</a>
-      <ul class="interface-items">
-        <li><a href="interfacetab.html" target="entry">Interface Tab Guide</a></li>
-        <li><a href="infotab.html" target="entry">Info Tab Guide</a></li>
-        <li><a href="codetab.html" target="entry">Code Tab Guide</a></li>
-      </ul>
-    </li>
-    <li><a href="programming.html" target="entry">Programming Guide</a></li>
-    <li><a href="transition.html" target="entry">Transition Guide</a></li>
-    <li><a href="dictionary.html" target="entry">NetLogo Dictionary</a></li>
-    <li>(<a href="diccionario.pdf" target="entry">en Español</a>)</li>
-  </ul>
-</div>
-<div class="heading-section">
-  <span class="heading-title">Features</span>
-  <ul class="heading-items">
-    <li><a href="extension-manager.html" target="entry">Extension Manager</a></li>
-    <li><a href="shapes.html" target="entry">Shapes Editor</a></li>
-    <li><a href="behaviorspace.html" target="entry">BehaviorSpace</a></li>
-    <li><a href="systemdynamics.html" target="entry">System Dynamics</a></li>
-    <li><a href="hubnet.html" target="entry">HubNet</a></li>
-    <li><a href="hubnet-authoring.html" target="entry">HubNet Authoring</a></li>
-    <li><a href="logging.html" target="entry">Logging</a></li>
-    <li><a href="controlling.html" target="entry">Controlling</a></li>
-    <li><a href="mathematica.html" target="entry">Mathematica Link</a></li>
-    <li><a href="3d.html" target="entry">NetLogo 3D</a></li>
-    <li><a href="modelingcommons.html" target="entry">Save to Modeling Commons</a></li>
-  </ul>
-</div>
-<div class="heading-section">
-  <span class="heading-title">Extensions</span>
-  <ul class="heading-items">
-    <li><a href="extensions.html" target="entry">Extensions Guide</a></li>
-    {{#documentedExtensions}}
-    <li><a href="{{_1}}.html" target="entry">{{_2}}</a></li>
-    {{/documentedExtensions}}
-  </ul>
-</div>
-<div class="heading-section">
-  <span class="heading-title">FAQ</span>
-  <ul class="heading-items">
-    <li><a href="faq.html" target="entry">Frequently Asked Questions</a>
-  </ul>
-</div>
-<div class="heading-section">
-  <strong><em>manual in <a target="_blank" href="NetLogo%20User%20Manual.pdf">printable form</a> (PDF)</em></strong>
-</div>
-<div class="heading-section bottom-section">
-  <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/" target="_blank"><img alt="Creative Commons License" style="border-width:0" src="images/cc-by-sa-3.0.png"></a>
-  <br>
-  <strong>
-      The NetLogo User Manual by <a href="http://ccl.northwestern.edu/netlogo/" target="_blank">Uri Wilensky</a> is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons
-    Attribution-ShareAlike 3.0 Unported License</a>.
-  </strong>
-</div>
-</body>
+			.heading-title {
+			display: block;
+			font-weight: bold;
+			white-space: nowrap;
+			}
+
+			.offwhitetext {
+			color: #E8E8E8;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="headerbanner">
+			<span class="heading-title offwhitetext xlargefont">NetLogo</span>
+			<span class="heading-title offwhitetext xlargefont">User Manual</span>
+			<span class="heading-title offwhitetext largefont">version {{version}}</span>
+			<span class="heading-title offwhitetext">{{date}}</span>
+		</div>
+		<div style="margin-bottom: 0em; margin-top: .25em;">
+			<ul class="small-items">
+				<li><a href="versions.html"     target="entry">Release Notes</a></li>
+				<li><a href="requirements.html" target="entry">System Requirements</a></li>
+				<li><a href="contact.html"      target="entry">Contacting Us</a></li>
+				<li><a href="copyright.html"    target="entry">Copyright / License</a></li>
+			</ul>
+		</div>
+		<hr/>
+		<div class="heading-section">
+			<span class="heading-title">Introduction</span>
+			<ul class="heading-items">
+				<li><a href="whatis.html" target="entry">What is NetLogo?</a></li>
+				<li><a href="sample.html" target="entry">Sample Model: Party</a></li>
+			</ul>
+		</div>
+		<div class="heading-section">
+			<span class="heading-title">Learning NetLogo</span>
+			<ul class="heading-items">
+				<li><a href="tutorial1.html" target="entry">Tutorial #1: Models</a></li>
+				<li><a href="tutorial2.html" target="entry">Tutorial #2: Commands</a></li>
+				<li><a href="tutorial3.html" target="entry">Tutorial #3: Procedures</a></li>
+			</ul>
+		</div>
+		<div class="heading-section">
+			<span class="heading-title">Reference</span>
+			<ul class="heading-items">
+				<li><a href="interface.html" target="entry">Interface Guide</a>
+					<ul class="interface-items">
+						<li><a href="interfacetab.html" target="entry">Interface Tab Guide</a></li>
+						<li><a href="infotab.html" target="entry">Info Tab Guide</a></li>
+						<li><a href="codetab.html" target="entry">Code Tab Guide</a></li>
+					</ul>
+				</li>
+				<li><a href="programming.html" target="entry">Programming Guide</a></li>
+				<li><a href="transition.html" target="entry">Transition Guide</a></li>
+				<li><a href="dictionary.html" target="entry">NetLogo Dictionary</a></li>
+				<li>(<a href="diccionario.pdf" target="entry">en Español</a>)</li>
+			</ul>
+		</div>
+		<div class="heading-section">
+			<span class="heading-title">Features</span>
+			<ul class="heading-items">
+				<li><a href="extension-manager.html" target="entry">Extension Manager</a></li>
+				<li><a href="shapes.html" target="entry">Shapes Editor</a></li>
+				<li><a href="behaviorspace.html" target="entry">BehaviorSpace</a></li>
+				<li><a href="systemdynamics.html" target="entry">System Dynamics</a></li>
+				<li><a href="hubnet.html" target="entry">HubNet</a></li>
+				<li><a href="hubnet-authoring.html" target="entry">HubNet Authoring</a></li>
+				<li><a href="logging.html" target="entry">Logging</a></li>
+				<li><a href="controlling.html" target="entry">Controlling</a></li>
+				<li><a href="mathematica.html" target="entry">Mathematica Link</a></li>
+				<li><a href="3d.html" target="entry">NetLogo 3D</a></li>
+				<li><a href="modelingcommons.html" target="entry">Save to Modeling Commons</a></li>
+			</ul>
+		</div>
+		<div class="heading-section">
+			<span class="heading-title">Extensions</span>
+			<ul class="heading-items">
+				<li><a href="extensions.html" target="entry">Extensions Guide</a>
+					{{#documentedExtensions}}</li>
+				<li><a href="{{_1}}.html" target="entry">{{_2}}</a>
+					{{/documentedExtensions}}</li>
+			</ul>
+		</div>
+		<div class="heading-section">
+			<span class="heading-title">FAQ</span>
+			<ul class="heading-items">
+				<li><a href="faq.html" target="entry">Frequently Asked Questions</a></li>
+			</ul>
+		</div>
+		<div class="heading-section">
+			<strong><em>manual in <a target="_blank" href="NetLogo%20User%20Manual.pdf">printable form</a> (PDF)</em></strong>
+		</div>
+		<div class="heading-section bottom-section">
+			<a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/" target="_blank"><img alt="Creative Commons License" style="border-width:0" src="images/cc-by-sa-3.0.png"/></a>
+			<br/>
+			<strong>
+				The NetLogo User Manual by <a href="http://ccl.northwestern.edu/netlogo/" target="_blank">Uri Wilensky</a> is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons
+					Attribution-ShareAlike 3.0 Unported License</a>.
+			</strong>
+		</div>
+	</body>
 </html>

--- a/autogen/docs/index.html.mustache
+++ b/autogen/docs/index.html.mustache
@@ -1,30 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<title>
-  NetLogo {{version}} User Manual
-</title>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<style>
-#index { width: 20%; }
-#entry { width: 80%; }
-iframe { width: 99%; }
-body, table { width: 100%; }
-table { border-collapse: collapse; }
-* { height: 100%; margin: 0; padding: 0; }
-body {height: 99%; }
-</style>
-</head>
-<body>
-<table>
-<tr>
-<td id="index">
-<iframe src="headings.html"></iframe>
-</td>
-<td id="entry">
-<iframe name="entry" src="whatis.html"></iframe>
-</td>
-</tr>
-</table>
-</body>
+	<head>
+		<title>
+			NetLogo {{version}} User Manual
+		</title>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+		<style>
+			#index { width: 20%; }
+			#entry { width: 80%; }
+			iframe { width: 99%; }
+			body, table { width: 100%; }
+			table { border-collapse: collapse; }
+			* { height: 100%; margin: 0; padding: 0; }
+			body {height: 99%; }
+		</style>
+	</head>
+	<body>
+		<table>
+			<tr>
+				<td id="index">
+					<iframe src="headings.html"></iframe>
+				</td>
+				<td id="entry">
+					<iframe name="entry" src="whatis.html"></iframe>
+				</td>
+			</tr>
+		</table>
+	</body>
 </html>

--- a/autogen/docs/index.html.mustache
+++ b/autogen/docs/index.html.mustache
@@ -8,7 +8,7 @@
 <style>
 #index { width: 20%; }
 #entry { width: 80%; }
-table, iframe { width: 99%; }
+iframe { width: 99%; }
 body, table { width: 100%; }
 table { border-collapse: collapse; }
 * { height: 100%; margin: 0; padding: 0; }
@@ -22,7 +22,7 @@ body {height: 99%; }
 <iframe src="headings.html"></iframe>
 </td>
 <td id="entry">
-<iframe src="whatis.html"></iframe>
+<iframe name="entry" src="whatis.html"></iframe>
 </td>
 </tr>
 </table>

--- a/autogen/docs/index.html.mustache
+++ b/autogen/docs/index.html.mustache
@@ -1,14 +1,16 @@
 <!DOCTYPE html>
+<html lang="en">
+<head>
 <title>
   NetLogo {{version}} User Manual
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<frameset cols="260,*">
-  <frame src="headings.html" name="index" id="index">
-  <!--  <frameset rows="100,*" cols="*" frameborder="no">
-    <frame scrolling="NO" src="header.html">
-    <frame name="entry" src="whatis.html">
-  </frameset> -->
-  <frame src="whatis.html" name="entry" id="entry">
-</frameset>
-
+<style>
+#id { width: 300px; }
+</style>
+</head>
+<body>
+<iframe src="headings.html" name="index" id="index"></iframe>
+<iframe src="whatis.html" name="entry" id="entry"></iframe>
+</body>
+</html>

--- a/autogen/docs/index.html.mustache
+++ b/autogen/docs/index.html.mustache
@@ -1,30 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<title>
-			NetLogo {{version}} User Manual
-		</title>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-		<style>
-			#index { width: 20%; }
-			#entry { width: 80%; }
-			iframe { width: 99%; }
-			body, table { width: 100%; }
-			table { border-collapse: collapse; }
-			* { height: 100%; margin: 0; padding: 0; }
-			body {height: 99%; }
-		</style>
-	</head>
-	<body>
-		<table>
-			<tr>
-				<td id="index">
-					<iframe src="headings.html"></iframe>
-				</td>
-				<td id="entry">
-					<iframe name="entry" src="whatis.html"></iframe>
-				</td>
-			</tr>
-		</table>
-	</body>
+  <head>
+    <title>
+      NetLogo {{version}} User Manual
+    </title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <style>
+      #index { width: 20%; }
+      #entry { width: 80%; }
+      iframe { width: 99%; }
+      body, table { width: 100%; }
+      table { border-collapse: collapse; }
+      * { height: 100%; margin: 0; padding: 0; }
+      body {height: 99%; }
+    </style>
+  </head>
+  <body>
+    <table>
+      <tr>
+        <td id="index">
+          <iframe src="headings.html"></iframe>
+        </td>
+        <td id="entry">
+          <iframe name="entry" src="whatis.html"></iframe>
+        </td>
+      </tr>
+    </table>
+  </body>
 </html>

--- a/autogen/docs/index.html.mustache
+++ b/autogen/docs/index.html.mustache
@@ -6,11 +6,25 @@
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <style>
-#id { width: 300px; }
+#index { width: 20%; }
+#entry { width: 80%; }
+table, iframe { width: 99%; }
+body, table { width: 100%; }
+table { border-collapse: collapse; }
+* { height: 100%; margin: 0; padding: 0; }
+body {height: 99%; }
 </style>
 </head>
 <body>
-<iframe src="headings.html" name="index" id="index"></iframe>
-<iframe src="whatis.html" name="entry" id="entry"></iframe>
+<table>
+<tr>
+<td id="index">
+<iframe src="headings.html"></iframe>
+</td>
+<td id="entry">
+<iframe src="whatis.html"></iframe>
+</td>
+</tr>
+</table>
 </body>
 </html>

--- a/autogen/docs/index2.html.mustache
+++ b/autogen/docs/index2.html.mustache
@@ -1,18 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<title>
-  NetLogo {{version}} User Manual
-</title>
-<style>
-iframe { width: 99%; }
-body  { width: 100%; }
-* { height: 100%; margin: 0; padding: 0; }
-body {height: 98%; }
-</style>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-</head>
-<body>
-<iframe src="headings.html"></iframe>
-</body>
+	<head>
+		<title>
+			NetLogo {{version}} User Manual
+		</title>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+		<style>
+			#index { width: 20%; }
+			#entry { width: 80%; }
+			iframe { width: 99%; }
+			body, table { width: 100%; }
+			table { border-collapse: collapse; }
+			* { height: 100%; margin: 0; padding: 0; }
+			body {height: 99%; }
+		</style>
+	</head>
+	<body>
+		<table>
+			<tr>
+				<td id="index">
+					<iframe src="headings.html"></iframe>
+				</td>
+				<td id="entry">
+					<iframe name="entry" src="whatis.html"></iframe>
+				</td>
+			</tr>
+		</table>
+	</body>
 </html>

--- a/autogen/docs/index2.html.mustache
+++ b/autogen/docs/index2.html.mustache
@@ -1,14 +1,12 @@
 <!DOCTYPE html>
+<html lang="en">
+<head>
 <title>
   NetLogo {{version}} User Manual
 </title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<frameset cols="260,*">
-  <frame src="headings.html" name="index" id="index">
-  <!--  <frameset rows="100,*" cols="*" frameborder="no">
-    <frame scrolling="NO" src="header.html">
-    <frame name="entry" src="whatis.html">
-  </frameset> -->
-  <frame src="dictionary.html" name="entry" id="entry">
-</frameset>
-
+</head>
+<body>
+<iframe src="headings.html" name="index" id="index"></iframe>
+</body>
+</html>

--- a/autogen/docs/index2.html.mustache
+++ b/autogen/docs/index2.html.mustache
@@ -1,30 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<title>
-			NetLogo {{version}} User Manual
-		</title>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-		<style>
-			#index { width: 20%; }
-			#entry { width: 80%; }
-			iframe { width: 99%; }
-			body, table { width: 100%; }
-			table { border-collapse: collapse; }
-			* { height: 100%; margin: 0; padding: 0; }
-			body {height: 99%; }
-		</style>
-	</head>
-	<body>
-		<table>
-			<tr>
-				<td id="index">
-					<iframe src="headings.html"></iframe>
-				</td>
-				<td id="entry">
-					<iframe name="entry" src="dictionary.html"></iframe>
-				</td>
-			</tr>
-		</table>
-	</body>
+  <head>
+    <title>
+      NetLogo {{version}} User Manual
+    </title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <style>
+      #index { width: 20%; }
+      #entry { width: 80%; }
+      iframe { width: 99%; }
+      body, table { width: 100%; }
+      table { border-collapse: collapse; }
+      * { height: 100%; margin: 0; padding: 0; }
+      body {height: 99%; }
+    </style>
+  </head>
+  <body>
+    <table>
+      <tr>
+        <td id="index">
+          <iframe src="headings.html"></iframe>
+        </td>
+        <td id="entry">
+          <iframe name="entry" src="dictionary.html"></iframe>
+        </td>
+      </tr>
+    </table>
+  </body>
 </html>

--- a/autogen/docs/index2.html.mustache
+++ b/autogen/docs/index2.html.mustache
@@ -4,9 +4,15 @@
 <title>
   NetLogo {{version}} User Manual
 </title>
+<style>
+iframe { width: 99%; }
+body  { width: 100%; }
+* { height: 100%; margin: 0; padding: 0; }
+body {height: 98%; }
+</style>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 </head>
 <body>
-<iframe src="headings.html" name="index" id="index"></iframe>
+<iframe src="headings.html"></iframe>
 </body>
 </html>

--- a/autogen/docs/index2.html.mustache
+++ b/autogen/docs/index2.html.mustache
@@ -22,7 +22,7 @@
 					<iframe src="headings.html"></iframe>
 				</td>
 				<td id="entry">
-					<iframe name="entry" src="whatis.html"></iframe>
+					<iframe name="entry" src="dictionary.html"></iframe>
 				</td>
 			</tr>
 		</table>

--- a/autogen/docs/infotab.html.mustache
+++ b/autogen/docs/infotab.html.mustache
@@ -1,12 +1,15 @@
 <!DOCTYPE html>
+<html lang="en">
+<head>
 <title>
   NetLogo {{version}} User Manual: Info Tab
 </title>
 <link rel="stylesheet" href="netlogo.css" type="text/css">
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-
+</head>
+<body>
 <h1>
-  <a name="information" id="information">Info Tab</a>
+  <a id="information">Info Tab</a>
 </h1>
 <div class="version">
   NetLogo {{version}} User Manual
@@ -17,23 +20,29 @@
   created, and and how to use it.
   It may also suggest things to explore and ways to extend the model, or
   call your attention to particular NetLogo features the model uses.
+</p>
 <p class="screenshot">
   <img alt="screen shot" src="images/infotab/infotab.gif">
+</p>
 <p>
   You may wish to read the Info tab before starting a model.
+</p>
 <h2>
-  <a name="info-editing" id="information">Editing</a>
+  <a id="info-editing">Editing</a>
 </h2>
 <p>
   The normal, formatted view of the Info tab is not editable. To make edits, click
   the &quot;Edit&quot; button. When done editing, click the
   &quot;Edit&quot; button again.
+</p>
 <p class="screenshot">
   <img alt="screen shot" src="images/infotab/infotabedit.gif">
+</p>
 <p>
   You edit the Info tab as unformatted plain text. When you're done
   editing, the plain text you entered is displayed in a more attractive
   format.
+</p>
 <p>
   To control how the formatted display looks, you use a &quot;markup
   language&quot; called Markdown. You may have encountered Markdown
@@ -41,7 +50,10 @@
   markup languages in use on the web; for example, Wikipedia used a
   markup language called MediaWiki. Markup languages differ
   in details.)
+</p>
 <p>
   The remainder of this guide is a tour of Markdown.
 
   {{{infoTabModelHTML}}}
+</body>
+</html>

--- a/autogen/docs/infotab.html.mustache
+++ b/autogen/docs/infotab.html.mustache
@@ -1,59 +1,60 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<title>
-  NetLogo {{version}} User Manual: Info Tab
-</title>
-<link rel="stylesheet" href="netlogo.css" type="text/css">
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-</head>
-<body>
-<h1>
-  <a id="information">Info Tab</a>
-</h1>
-<div class="version">
-  NetLogo {{version}} User Manual
-</div>
-<p>
-  The Info tab provides an introduction to a model.
-  It explains what system is being modeled, how the model was
-  created, and and how to use it.
-  It may also suggest things to explore and ways to extend the model, or
-  call your attention to particular NetLogo features the model uses.
-</p>
-<p class="screenshot">
-  <img alt="screen shot" src="images/infotab/infotab.gif">
-</p>
-<p>
-  You may wish to read the Info tab before starting a model.
-</p>
-<h2>
-  <a id="info-editing">Editing</a>
-</h2>
-<p>
-  The normal, formatted view of the Info tab is not editable. To make edits, click
-  the &quot;Edit&quot; button. When done editing, click the
-  &quot;Edit&quot; button again.
-</p>
-<p class="screenshot">
-  <img alt="screen shot" src="images/infotab/infotabedit.gif">
-</p>
-<p>
-  You edit the Info tab as unformatted plain text. When you're done
-  editing, the plain text you entered is displayed in a more attractive
-  format.
-</p>
-<p>
-  To control how the formatted display looks, you use a &quot;markup
-  language&quot; called Markdown. You may have encountered Markdown
-  elsewhere; it is used on a number of web sites. (There are other
-  markup languages in use on the web; for example, Wikipedia used a
-  markup language called MediaWiki. Markup languages differ
-  in details.)
-</p>
-<p>
-  The remainder of this guide is a tour of Markdown.
+	<head>
+		<title>
+			NetLogo {{version}} User Manual: Info Tab
+		</title>
+		<link rel="stylesheet" href="netlogo.css" type="text/css"/>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+	</head>
+	<body>
+		<h1>
+			<a id="information">Info Tab</a>
+		</h1>
+		<div class="version">
+			NetLogo {{version}} User Manual
+		</div>
+		<p>
+			The Info tab provides an introduction to a model.
+			It explains what system is being modeled, how the model was
+			created, and and how to use it.
+			It may also suggest things to explore and ways to extend the model, or
+			call your attention to particular NetLogo features the model uses.
+		</p>
+		<p class="screenshot">
+			<img alt="screen shot" src="images/infotab/infotab.gif"/>
+		</p>
+		<p>
+			You may wish to read the Info tab before starting a model.
+		</p>
+		<h2>
+			<a id="info-editing">Editing</a>
+		</h2>
+		<p>
+			The normal, formatted view of the Info tab is not editable. To make edits, click
+			the &quot;Edit&quot; button. When done editing, click the
+			&quot;Edit&quot; button again.
+		</p>
+		<p class="screenshot">
+			<img alt="screen shot" src="images/infotab/infotabedit.gif"/>
+		</p>
+		<p>
+			You edit the Info tab as unformatted plain text. When you're done
+			editing, the plain text you entered is displayed in a more attractive
+			format.
+		</p>
+		<p>
+			To control how the formatted display looks, you use a &quot;markup
+			language&quot; called Markdown. You may have encountered Markdown
+			elsewhere; it is used on a number of web sites. (There are other
+			markup languages in use on the web; for example, Wikipedia used a
+			markup language called MediaWiki. Markup languages differ
+			in details.)
+		</p>
+		<p>
+			The remainder of this guide is a tour of Markdown.
 
-  {{{infoTabModelHTML}}}
-</body>
+			{{{infoTabModelHTML}}}
+		</p>
+	</body>
 </html>

--- a/autogen/docs/infotab.html.mustache
+++ b/autogen/docs/infotab.html.mustache
@@ -1,60 +1,60 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<title>
-			NetLogo {{version}} User Manual: Info Tab
-		</title>
-		<link rel="stylesheet" href="netlogo.css" type="text/css"/>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-	</head>
-	<body>
-		<h1>
-			<a id="information">Info Tab</a>
-		</h1>
-		<div class="version">
-			NetLogo {{version}} User Manual
-		</div>
-		<p>
-			The Info tab provides an introduction to a model.
-			It explains what system is being modeled, how the model was
-			created, and and how to use it.
-			It may also suggest things to explore and ways to extend the model, or
-			call your attention to particular NetLogo features the model uses.
-		</p>
-		<p class="screenshot">
-			<img alt="screen shot" src="images/infotab/infotab.gif"/>
-		</p>
-		<p>
-			You may wish to read the Info tab before starting a model.
-		</p>
-		<h2>
-			<a id="info-editing">Editing</a>
-		</h2>
-		<p>
-			The normal, formatted view of the Info tab is not editable. To make edits, click
-			the &quot;Edit&quot; button. When done editing, click the
-			&quot;Edit&quot; button again.
-		</p>
-		<p class="screenshot">
-			<img alt="screen shot" src="images/infotab/infotabedit.gif"/>
-		</p>
-		<p>
-			You edit the Info tab as unformatted plain text. When you're done
-			editing, the plain text you entered is displayed in a more attractive
-			format.
-		</p>
-		<p>
-			To control how the formatted display looks, you use a &quot;markup
-			language&quot; called Markdown. You may have encountered Markdown
-			elsewhere; it is used on a number of web sites. (There are other
-			markup languages in use on the web; for example, Wikipedia used a
-			markup language called MediaWiki. Markup languages differ
-			in details.)
-		</p>
-		<p>
-			The remainder of this guide is a tour of Markdown.
+  <head>
+    <title>
+      NetLogo {{version}} User Manual: Info Tab
+    </title>
+    <link rel="stylesheet" href="netlogo.css" type="text/css"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  </head>
+  <body>
+    <h1>
+      <a id="information">Info Tab</a>
+    </h1>
+    <div class="version">
+      NetLogo {{version}} User Manual
+    </div>
+    <p>
+      The Info tab provides an introduction to a model.
+      It explains what system is being modeled, how the model was
+      created, and and how to use it.
+      It may also suggest things to explore and ways to extend the model, or
+      call your attention to particular NetLogo features the model uses.
+    </p>
+    <p class="screenshot">
+      <img alt="screen shot" src="images/infotab/infotab.gif"/>
+    </p>
+    <p>
+      You may wish to read the Info tab before starting a model.
+    </p>
+    <h2>
+      <a id="info-editing">Editing</a>
+    </h2>
+    <p>
+      The normal, formatted view of the Info tab is not editable. To make edits, click
+      the &quot;Edit&quot; button. When done editing, click the
+      &quot;Edit&quot; button again.
+    </p>
+    <p class="screenshot">
+      <img alt="screen shot" src="images/infotab/infotabedit.gif"/>
+    </p>
+    <p>
+      You edit the Info tab as unformatted plain text. When you're done
+      editing, the plain text you entered is displayed in a more attractive
+      format.
+    </p>
+    <p>
+      To control how the formatted display looks, you use a &quot;markup
+      language&quot; called Markdown. You may have encountered Markdown
+      elsewhere; it is used on a number of web sites. (There are other
+      markup languages in use on the web; for example, Wikipedia used a
+      markup language called MediaWiki. Markup languages differ
+      in details.)
+    </p>
+    <p>
+      The remainder of this guide is a tour of Markdown.
 
-			{{{infoTabModelHTML}}}
-		</p>
-	</body>
+      {{{infoTabModelHTML}}}
+    </p>
+  </body>
 </html>

--- a/autogen/docs/title.html.mustache
+++ b/autogen/docs/title.html.mustache
@@ -1,7 +1,12 @@
 <!DOCTYPE html>
+<html lang="en">
 <head>
+<title>
+  NetLogo {{version}} User Manual
+</title>
 </head>
 <body>
-  <img src="images/title.jpg" style="position:relative; top:40%; left: 17%;"/>
+  <img src="images/title.jpg" style="position:relative; top:40%; left: 17%;" alt="Title image"/>
   <h1 style="position:relative; top:65%; left:20%;">The NetLogo {{version}} User Manual</h1>
 </body>
+</html>

--- a/autogen/docs/title.html.mustache
+++ b/autogen/docs/title.html.mustache
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<title>
-			NetLogo {{version}} User Manual
-		</title>
-	</head>
-	<body>
-		<img src="images/title.jpg" style="position:relative; top:40%; left: 17%;" alt="Title image"/>
-		<h1 style="position:relative; top:65%; left:20%;">The NetLogo {{version}} User Manual</h1>
-	</body>
+  <head>
+    <title>
+      NetLogo {{version}} User Manual
+    </title>
+  </head>
+  <body>
+    <img src="images/title.jpg" style="position:relative; top:40%; left: 17%;" alt="Title image"/>
+    <h1 style="position:relative; top:65%; left:20%;">The NetLogo {{version}} User Manual</h1>
+  </body>
 </html>

--- a/autogen/docs/title.html.mustache
+++ b/autogen/docs/title.html.mustache
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<title>
-  NetLogo {{version}} User Manual
-</title>
-</head>
-<body>
-  <img src="images/title.jpg" style="position:relative; top:40%; left: 17%;" alt="Title image"/>
-  <h1 style="position:relative; top:65%; left:20%;">The NetLogo {{version}} User Manual</h1>
-</body>
+	<head>
+		<title>
+			NetLogo {{version}} User Manual
+		</title>
+	</head>
+	<body>
+		<img src="images/title.jpg" style="position:relative; top:40%; left: 17%;" alt="Title image"/>
+		<h1 style="position:relative; top:65%; left:20%;">The NetLogo {{version}} User Manual</h1>
+	</body>
 </html>


### PR DESCRIPTION
These commits bring one cosmetic adjustment to the dictionary and some behind-the-scenes changes to the NetLogo documentation.

**Cosmetic adjustment: Dictionary titles now visible after following a section link.**
Open https://ccl.northwestern.edu/netlogo/docs/dictionary.html on Google Chrome and click _Turtle_ at the top of the page. Chrome jumps to the list of turtle terms, but the title _Turtle-related_ is not visible. The adjusted dictionary will scroll to the position where the title is visible.

**Behind-the-scenes changes:**

- Removed an old note from the era of Internet Explorer
- HTML5-compliant documentation: `<iframe>`, balanced `<p>` tags, corrected erroneous `<i>` tags.
- Online validation https://validator.w3.org/nu
- Additional changes for readability
  - Closed empty elements (required for automatic indentation). Ex: `<br>`→ `<br/>`.
  - Automatic indentation

Thanks, and keep up the good work with NetLogo!