### PR TITLE
Fix for numeric widgets accepting multiline input when changed from String type

### DIFF
--- a/netlogo-gui/src/main/window/InputBox.scala
+++ b/netlogo-gui/src/main/window/InputBox.scala
@@ -558,6 +558,7 @@ abstract class InputBox(textArea:AbstractEditorArea, editDialogTextArea:Abstract
       val num = compiler.readNumberFromString(text).asInstanceOf[java.lang.Double]
       NumericInput(num.doubleValue, NumericInput.NumberLabel)
     }
+    override def multiline = false
     override def enableMultiline = false
     override def defaultValue = org.nlogo.agent.World.Zero
   }


### PR DESCRIPTION
This is a fix for issue #1402 

The multiline value is auto cleared once the type is changed from string to numeric type.