### PR TITLE
Allow optional alphabetical sorting of procedures in procedures menu

### DIFF
--- a/netlogo-gui/project/autogen/i18n/GUI_Strings_en.txt
+++ b/netlogo-gui/project/autogen/i18n/GUI_Strings_en.txt
@@ -458,6 +458,9 @@ tools.preferences.restartRequired = (restart required)
 tools.preferences.uiLanguage = User Interface Language:
 tools.preferences.editorLineNumbers = Show Line Numbers (in editor):
 tools.preferences.includedFilesMenu = Always show "Included Files" menu (in Code tab):
+tools.preferences.proceduresMenuSortOrder = Sort order of procedures menu (in Code tab):
+tools.preferences.proceduresSortAlphabetical = Alphabetical
+tools.preferences.proceduresSortByOrderOfAppearance = Order of appearance
 
 tools.libraries = Extensions
 tools.libraries.categories.extensions = Extensions

--- a/netlogo-gui/src/main/app/ToolActions.scala
+++ b/netlogo-gui/src/main/app/ToolActions.scala
@@ -37,7 +37,9 @@ with MenuAction {
   override def createDialog = new PreferencesDialog(frame,
     Preferences.Language,
     new Preferences.LineNumbers(tabs),
-    Preferences.IncludedFilesMenu)
+    Preferences.IncludedFilesMenu,
+    Preferences.ProceduresMenuSortOrder
+  )
 }
 
 class OpenLibrariesDialog( frame:              Frame

--- a/netlogo-gui/src/main/app/tools/Preferences.scala
+++ b/netlogo-gui/src/main/app/tools/Preferences.scala
@@ -63,4 +63,26 @@ object Preferences {
       prefs.put("includedFilesMenu", component.isSelected.toString)
     }
   }
+
+  object ProceduresMenuSortOrder extends Preference {
+    val i18nKey = "proceduresMenuSortOrder"
+
+    val options = Array(
+      I18N.gui.get("tools.preferences.proceduresSortByOrderOfAppearance"),
+      I18N.gui.get("tools.preferences.proceduresSortAlphabetical")
+    )
+
+    val component = new JComboBox(options)
+    val restartRequired = false
+
+    def load(prefs: JavaPreferences) = {
+      val sortOrder = prefs.get("proceduresMenuSortOrder", options(0))
+      component.setSelectedItem(sortOrder)
+    }
+
+    def save(prefs: JavaPreferences) = {
+      val chosenSortOrder = component.getSelectedItem.asInstanceOf[String]
+      prefs.put("proceduresMenuSortOrder", chosenSortOrder)
+    }
+  }
 }


### PR DESCRIPTION
Since https://github.com/NetLogo/NetLogo/commit/f2defbe4dbd3b2cf4a3380082f10dbb6039bb7a1, procedures are sorted by order of appearance in the **Procedures** menu of the code tab. This seems perfectly sensible to me, but @BruceEdmonds expressed a strong preference for the old behaviour.

This PR adds an option to the NetLogo preferences dialogue to optionally get the alphabetical sorting order back.

(I do understand that we're quite late in the 6.1.0 release cycle and that this might have to wait for 6.1.1, even if it seems like a fairly low-risk change to me... :-))