### PR TITLE
Use array appends of for headless JVM args

### DIFF
--- a/dist/configuration/shared/linux/netlogo-headless.sh.mustache
+++ b/dist/configuration/shared/linux/netlogo-headless.sh.mustache
@@ -13,18 +13,16 @@ fi;
 # -XX:+UseParallelGC    The parallel collector maximizes throughput
 # -Dfile.encoding=UTF-8 ensure Unicode characters in model files are compatible cross-platform
 JVM_OPTS=(-Xmx1024m -XX:+UseParallelGC -Dfile.encoding=UTF-8)
-OPTS_INDEX=2
 
 ARGS=()
-INDEX=0
 
 for arg in "$@"; do
   if [[ "$arg" == "--3D" ]]; then
-    JVM_OPTS[OPTS_INDEX++]="-Dorg.nlogo.is3d=true"
+    JVM_OPTS+=("-Dorg.nlogo.is3d=true")
   elif [[ "$arg" == -D* ]]; then
-    JVM_OPTS[OPTS_INDEX++]="$arg"
+    JVM_OPTS+=("$arg")
   else
-    ARGS[INDEX++]="$arg"
+    ARGS+=("$arg")
   fi
 done
 

--- a/dist/configuration/shared/macosx/netlogo-headless.sh.mustache
+++ b/dist/configuration/shared/macosx/netlogo-headless.sh.mustache
@@ -13,18 +13,16 @@ fi;
 # -XX:+UseParallelGC    The parallel collector maximizes throughput
 # -Dfile.encoding=UTF-8 ensure Unicode characters in model files are compatible cross-platform
 JVM_OPTS=(-Xmx1024m -XX:+UseParallelGC -Dfile.encoding=UTF-8)
-OPTS_INDEX=2
 
 ARGS=()
-INDEX=0
 
 for arg in "$@"; do
   if [[ "$arg" == "--3D" ]]; then
-    JVM_OPTS[OPTS_INDEX++]="-Dorg.nlogo.is3d=true"
+    JVM_OPTS+=("-Dorg.nlogo.is3d=true")
   elif [[ "$arg" == -D* ]]; then
-    JVM_OPTS[OPTS_INDEX++]="$arg"
+    JVM_OPTS+=("$arg")
   else
-    ARGS[INDEX++]="$arg"
+    ARGS+=("$arg")
   fi
 done
 


### PR DESCRIPTION
Indexes were not being calculated properly, so arguments were being
overwritten if the user added, e.g., `--3D`.

Note that I've tested these changes in my distribution of 6.1, but haven't actually tested the mustache build targets, since that requires a full packaging for distribution build.

The way I tested was by throwing `echo "${JVM_OPTS[*]}` in the appropriate places and watching to see if arguments got overwritten or not.