### PR TITLE
Headless workspace : add a 3d property

### DIFF
--- a/netlogo-core/src/main/agent/World.scala
+++ b/netlogo-core/src/main/agent/World.scala
@@ -128,6 +128,7 @@ abstract class World
     reader: java.io.BufferedReader): Unit
   def sprout(patch: Patch, breed: AgentSet): Turtle
   def copy(): World
+  def is3d: Boolean
 }
 
 // A note on wrapping: normally whether x and y coordinates wrap is a
@@ -136,6 +137,8 @@ abstract class World
 // methods like distance() and towards() take a boolean argument "wrap";
 // it's true for the normal prims, false for the nowrap prims. - ST 5/24/06
 class World2D extends World with CompilationManagement {
+
+  def is3d: Boolean = false
 
   val protractor: Protractor = new Protractor(this)
 

--- a/netlogo-core/src/main/agent/World3D.scala
+++ b/netlogo-core/src/main/agent/World3D.scala
@@ -16,6 +16,8 @@ class World3D extends World
   with org.nlogo.api.World3D
   with CompilationManagement {
 
+  def is3d: Boolean = true
+
   val drawing: Drawing3D = new Drawing3D(this)
 
   override val protractor: Protractor3D = new Protractor3D(this)

--- a/netlogo-core/src/main/api/World.scala
+++ b/netlogo-core/src/main/api/World.scala
@@ -64,4 +64,5 @@ trait World {
   @throws(classOf[AgentException])
   def setObserverVariableByName(variableName: String, value: AnyRef)
   def timer: Timer
+  def is3d: Boolean
 }

--- a/netlogo-gui/src/main/headless/HeadlessWorkspace.scala
+++ b/netlogo-gui/src/main/headless/HeadlessWorkspace.scala
@@ -30,16 +30,19 @@ object HeadlessWorkspace {
    * Makes a new instance of NetLogo capable of running a model "headless", with no GUI.
    */
   def newInstance: HeadlessWorkspace =
-    newInstance(classOf[HeadlessWorkspace])
+    newInstance(classOf[HeadlessWorkspace],false)
+
+  def newInstance(is3d: Boolean): HeadlessWorkspace = newInstance(classOf[HeadlessWorkspace],is3d)
 
   /**
    * If you derive your own subclass of HeadlessWorkspace, use this method to instantiate it.
    */
-  def newInstance(subclass: Class[_ <: HeadlessWorkspace]): HeadlessWorkspace = {
+  def newInstance(subclass: Class[_ <: HeadlessWorkspace],is3d: Boolean = false): HeadlessWorkspace = {
     val pico = new Pico
-    pico.addComponent(if (Version.is3D) classOf[World3D] else classOf[World2D])
+    //pico.addComponent(if (Version.is3D) classOf[World3D] else classOf[World2D])
+    pico.addComponent(if (is3d) classOf[World3D] else classOf[World2D])
     pico.add("org.nlogo.compile.Compiler")
-    if (Version.is3D)
+    if (is3d)//(Version.is3D)
       pico.addScalaObject("org.nlogo.api.NetLogoThreeDDialect")
     else
       pico.addScalaObject("org.nlogo.api.NetLogoLegacyDialect")
@@ -51,10 +54,16 @@ object HeadlessWorkspace {
     pico.getComponent(subclass)
   }
 
-  def newLab: LabInterface = {
+  /**
+    * the newLab by default uses the [[Version.is3D]]
+    * @return
+    */
+  def newLab: LabInterface = newLab(Version.is3D)
+
+  def newLab(is3d: Boolean): LabInterface = {
     val pico = new Pico
     pico.add("org.nlogo.compile.Compiler")
-    if (Version.is3D)
+    if (is3d)
       pico.addScalaObject("org.nlogo.api.NetLogoThreeDDialect")
     else
       pico.addScalaObject("org.nlogo.api.NetLogoLegacyDialect")
@@ -135,6 +144,9 @@ with org.nlogo.api.ViewSettings {
    */
   override def isHeadless = true
 
+
+  def is3d: Boolean = _world.is3d
+
   /**
    * Internal use only.
    */
@@ -169,7 +181,7 @@ with org.nlogo.api.ViewSettings {
    * Internal use only.
    */
   def initForTesting(worldSize: Int, modelString: String) {
-    if (Version.is3D)
+    if (is3d) //(Version.is3D)
       initForTesting(new WorldDimensions3D(
           -worldSize, worldSize, -worldSize, worldSize, -worldSize, worldSize),
           modelString)
@@ -192,7 +204,7 @@ with org.nlogo.api.ViewSettings {
     world.linkShapes.add(org.nlogo.shape.LinkShape.getDefaultLinkShape)
     world.createPatches(d)
     val dialect =
-      if (Version.is3D) NetLogoThreeDDialect
+      if (is3d) NetLogoThreeDDialect//(Version.is3D) NetLogoThreeDDialect
       else NetLogoLegacyDialect
     val newProgram = Program.fromDialect(dialect)
     val results = compiler.compileProgram(source, newProgram,

--- a/netlogo-gui/src/main/hubnet/mirroring/ClientWorld.java
+++ b/netlogo-gui/src/main/hubnet/mirroring/ClientWorld.java
@@ -893,4 +893,6 @@ public strictfp class ClientWorld
   public Timer timer() {
     throw new UnsupportedOperationException();
   }
+
+  public boolean is3d() {return(false);}
 }


### PR DESCRIPTION
Quick fix affecting only the HeadlessWorkspace used from the api, answering to [issue 1742](https://github.com/NetLogo/NetLogo/issues/1742)
( see [this openmole issue](https://github.com/openmole/openmole/issues/412) of why it was needed in a model embedding context )