### PR TITLE
Add optimization for count primitive with mortal agentsets

### DIFF
--- a/netlogo-core/src/main/agent/AgentSet.scala
+++ b/netlogo-core/src/main/agent/AgentSet.scala
@@ -33,6 +33,7 @@ abstract class AgentSet(
   def randomTwo(precomputedCount: Int, smallRandom: Int, bigRandom: Int): Array[Agent]
   def randomSubsetGeneral(resultSize: Int, precomputedCount: Int, rng: api.MersenneTwisterFast): Array[Agent]
   def toLogoList: LogoList
+  def checkCount(checkValue: Int, check: (Int, Int) => Boolean): Boolean
 
   ///
 

--- a/netlogo-core/src/main/agent/ArrayAgentSet.scala
+++ b/netlogo-core/src/main/agent/ArrayAgentSet.scala
@@ -57,6 +57,22 @@ extends IndexedAgentSet(kind, printName) {
       result
     }
 
+  override def checkCount(checkValue: Int, check: (Int, Int) => Boolean): Boolean = {
+    if (!kind.mortal)
+      check(arraySize, checkValue)
+    else {
+      var totalCount = 0
+      val iter = iterator
+      while (iter.hasNext) {
+        iter.next()
+        totalCount += 1
+        if (totalCount > checkValue)
+          check(totalCount, checkValue)
+      }
+      check(totalCount, checkValue)
+    }
+  }
+
   /// equality
 
   // assumes we've already checked for equal counts - ST 7/6/06

--- a/netlogo-core/src/main/agent/TreeAgentSet.scala
+++ b/netlogo-core/src/main/agent/TreeAgentSet.scala
@@ -28,6 +28,10 @@ extends AgentSet(kind, printName) {
 
   override def isEmpty = _agents.isEmpty
 
+  override def checkCount(checkValue: Int, check: (Int, Int) => Boolean): Boolean = {
+    check(count, checkValue)
+  }
+
   // Assumes we've already checked that the counts are equal. - ST 7/6/06
   override def containsSameAgents(otherSet: api.AgentSet): Boolean = {
     val iter = otherSet.agents.iterator

--- a/netlogo-core/src/main/compile/middle/optimize/package.scala
+++ b/netlogo-core/src/main/compile/middle/optimize/package.scala
@@ -334,4 +334,58 @@ package optimize {
       }
     }
   }
+  // _equal(_count, _constdouble: n) => _optimizecount(*, n)
+  object HasEqual extends RewritingReporterMunger {
+    val clazz = classOf[_equal]
+    def munge(root: Match) {
+      val count = root.matchOneArg(classOf[_count])
+      val constDouble = root.matchOtherArg(count, classOf[_constdouble])
+      root.strip()
+      root.replace(new _optimizecount((a: Int, b: Int) => a == b))
+      root.graftArg(count.matchArg(0))
+      root.graftArg(constDouble)
+    }
+  }
+  // _greaterthan(_count, _constdouble: n) => _optimizecount(*, n)
+  object HasGreaterThan extends RewritingReporterMunger {
+    val clazz = classOf[_greaterthan]
+    def munge(root: Match) {
+      val count = root.matchOneArg(classOf[_count])
+      val constDouble = root.matchOtherArg(count, classOf[_constdouble])
+      if (root.matchArg(0).reporter.isInstanceOf[_constdouble])
+        root.replace(new _optimizecount((a: Int, b: Int) => a < b))
+      else
+        root.replace(new _optimizecount((a: Int, b: Int) => a > b))
+      root.strip()
+      root.graftArg(count.matchArg(0))
+      root.graftArg(constDouble)
+    }
+  }
+  // _lessthan(_count, _constdouble: n) => _optimizecount(*, n)
+  object HasLessThan extends RewritingReporterMunger {
+    val clazz = classOf[_lessthan]
+    def munge(root: Match) {
+      val count = root.matchOneArg(classOf[_count])
+      val constDouble = root.matchOtherArg(count, classOf[_constdouble])
+      if (root.matchArg(0).reporter.isInstanceOf[_constdouble]) 
+        root.replace(new _optimizecount((a: Int, b: Int) => a > b))
+      else
+        root.replace(new _optimizecount((a: Int, b: Int) => a < b))
+      root.strip()
+      root.graftArg(count.matchArg(0))
+      root.graftArg(constDouble)
+    }
+  }
+  // _notequal(_count, _constdouble: n) => _optimizecount(*, n)
+  object HasNotEqual extends RewritingReporterMunger {
+    val clazz = classOf[_notequal]
+    def munge(root: Match) {
+      val count = root.matchOneArg(classOf[_count])
+      val constDouble = root.matchOtherArg(count, classOf[_constdouble])
+      root.strip()
+      root.replace(new _optimizecount((a: Int, b: Int) => a != b))
+      root.graftArg(count.matchArg(0))
+      root.graftArg(constDouble)
+    }
+  }
 }

--- a/netlogo-core/src/main/nvm/Optimizations.scala
+++ b/netlogo-core/src/main/nvm/Optimizations.scala
@@ -33,7 +33,11 @@ object Optimizations {
         "Nsum4",       // optimizes summing neighbor4 values
         "PatchAt",     // optimizes patch at offsets
         "RandomConst", // inlines const argument to random
-        "With"))       // optimizes "with" to patch-col / patch-row
+        "With",        // optimizes "with" to patch-col / patch-row
+        "HasEqual",
+        "HasGreaterThan",
+        "HasLessThan",
+        "HasNotEqual"))
 
   val standardOptimizations =
     fdOptimizations ++

--- a/netlogo-core/src/test/compile/middle/OptimizerTests.scala
+++ b/netlogo-core/src/test/compile/middle/OptimizerTests.scala
@@ -303,4 +303,44 @@ class OptimizerTests extends AbstractOptimizerTest {
     assertResult("_countotherwith[_turtles[], [_constboolean:true[]]]")(
       compileReporter("count other turtles with [true]"))
   } }
+  test("hasEqual1") { new OptTest {
+    withReporterOptimization("HasEqual")
+    assertResult("_optimizecount[_patches[], _constdouble:10.0[]]")(
+      compileReporter("count patches = 10"))
+  } }
+  test("hasEqual2") { new OptTest {
+    withReporterOptimization("HasEqual")
+    assertResult("_optimizecount[_patches[], _constdouble:10.0[]]")(
+      compileReporter("10 = count patches"))
+  } }
+  test("hasGreaterThan1") { new OptTest {
+    withReporterOptimization("HasGreaterThan")
+    assertResult("_optimizecount[_patches[], _constdouble:10.0[]]")(
+      compileReporter("count patches > 10"))
+  } }
+  test("hasGreaterThan2") { new OptTest {
+    withReporterOptimization("HasGreaterThan")
+    assertResult("_optimizecount[_patches[], _constdouble:10.0[]]")(
+      compileReporter("10 > count patches"))
+  } }
+  test("hasLessThan1") { new OptTest {
+    withReporterOptimization("HasLessThan")
+    assertResult("_optimizecount[_patches[], _constdouble:10.0[]]")(
+      compileReporter("count patches < 10"))
+  } }
+  test("hasLessThan2") { new OptTest {
+    withReporterOptimization("HasLessThan")
+    assertResult("_optimizecount[_patches[], _constdouble:10.0[]]")(
+      compileReporter("10 < count patches"))
+  } }
+  test("hasNotEqual1") { new OptTest {
+    withReporterOptimization("HasNotEqual")
+    assertResult("_optimizecount[_patches[], _constdouble:10.0[]]")(
+      compileReporter("count patches != 10"))
+  } }
+  test("hasNotEqual2") { new OptTest {
+    withReporterOptimization("HasNotEqual")
+    assertResult("_optimizecount[_patches[], _constdouble:10.0[]]")(
+      compileReporter("10 != count patches"))
+  } }
 }

--- a/netlogo-gui/src/main/prim/_optimizecount.scala
+++ b/netlogo-gui/src/main/prim/_optimizecount.scala
@@ -1,0 +1,17 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.prim
+
+import org.nlogo.agent.AgentSet
+import org.nlogo.nvm.{ Context, Reporter }
+
+class _optimizecount(operator: (Int, Int) => Boolean) extends Reporter {
+
+  override def report(context: Context): java.lang.Boolean =
+    Boolean.box(
+      report_1(context, argEvalAgentSet(context, 0), argEvalDoubleValue(context, 1)))
+
+  def report_1(context: Context, sourceSet: AgentSet, checkValue: Double): Boolean = {
+    sourceSet.checkCount(checkValue.toInt, operator)
+  }
+}

--- a/netlogo-headless/src/main/prim/_optimizecount.scala
+++ b/netlogo-headless/src/main/prim/_optimizecount.scala
@@ -1,0 +1,17 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.prim
+
+import org.nlogo.agent.AgentSet
+import org.nlogo.nvm.{ Context, Reporter }
+
+class _optimizecount(operator: (Int, Int) => Boolean) extends Reporter {
+
+  override def report(context: Context): java.lang.Boolean =
+    Boolean.box(
+      report_1(context, argEvalAgentSet(context, 0), argEvalDoubleValue(context, 1)))
+
+  def report_1(context: Context, sourceSet: AgentSet, checkValue: Double): Boolean = {
+    sourceSet.checkCount(checkValue.toInt, operator)
+  }
+}

--- a/netlogo-headless/test/benchdumps/Erosion.txt
+++ b/netlogo-headless/test/benchdumps/Erosion.txt
@@ -869,17 +869,14 @@ procedure SETUP:[_repeatlocal:0]{O---}:
 [18]_asm_proceduresetup_ask_16 "ask patches with [ count neighbors != 8 ] set drain? true [ set elevation -10000000 ]" AgentSet => void
       _with "patches with [ count neighbors != 8 ]" AgentSet,Reporter => AgentSet
         _patches "patches" => AgentSet
-        _asm_proceduresetup_notequal_17 "count neighbors != 8" double,double => boolean
-          _count "count neighbors" AgentSet => double
-            _neighbors "neighbors" => AgentSet
+        _asm_proceduresetup_optimizecount_17 "count neighbors != 8" AgentSet,double => boolean
+          _neighbors "neighbors" => AgentSet
           _constdouble:8.0 "8" => double
               // parameter final  context
               // parameter final  context
-              // parameter final  arg0
               // parameter final  context
-              // parameter final  context
-              // parameter final  d0
-              // parameter final  d1
+              // parameter final  sourceSet
+              // parameter final  checkValue
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -909,37 +906,28 @@ procedure SETUP:[_repeatlocal:0]{O---}:
               INVOKESPECIAL scala/MatchError.<init> (Ljava/lang/Object;)V
               ATHROW
              L2
-             FRAME FULL [org/nlogo/prim/_asm_proceduresetup_notequal_17 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
+             FRAME FULL [org/nlogo/prim/_asm_proceduresetup_optimizecount_17 org/nlogo/nvm/Context org/nlogo/agent/Patch org/nlogo/agent/Agent] []
               ALOAD 2
               INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/IndexedAgentSet;
              L4
+              LDC 8.0
+             L5
+              DSTORE 3
               ASTORE 2
               ALOAD 2
-              INVOKEVIRTUAL org/nlogo/agent/AgentSet.count ()I
-              I2D
-             L5
-              LDC 8.0
+              DLOAD 3
+              D2I
+              ALOAD 0
+              GETFIELD org/nlogo/prim/_asm_proceduresetup_optimizecount_17.kept1_operator : Lscala/Function2;
+              INVOKEVIRTUAL org/nlogo/agent/AgentSet.checkCount (ILscala/Function2;)Z
              L6
-              DSTORE 4
-              DSTORE 2
-              DLOAD 2
-              DLOAD 4
-              DCMPL
               IFEQ L7
-              ICONST_1
+              GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
               GOTO L8
              L7
-             FRAME FULL [org/nlogo/prim/_asm_proceduresetup_notequal_17 org/nlogo/nvm/Context D D] []
-              ICONST_0
-             L8
-             FRAME SAME1 I
-              IFEQ L9
-              GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
-              GOTO L10
-             L9
-             FRAME SAME
+             FRAME FULL [org/nlogo/prim/_asm_proceduresetup_optimizecount_17 org/nlogo/nvm/Context org/nlogo/agent/IndexedAgentSet D] []
               GETSTATIC java/lang/Boolean.FALSE : Ljava/lang/Boolean;
-             L10
+             L8
              FRAME SAME1 java/lang/Boolean
               ARETURN
           // parameter final  context

--- a/netlogo-headless/test/benchdumps/Wolf.txt
+++ b/netlogo-headless/test/benchdumps/Wolf.txt
@@ -2418,17 +2418,14 @@ procedure GO:[]{O---}:
           RETURN
 [21]_tick "tick"
 [22]_asm_procedurego_if_21 "if count turtles = 0 [ stop ]" boolean => void
-      _equal "count turtles = 0" double,double => boolean
-        _count "count turtles" AgentSet => double
-          _turtles "turtles" => AgentSet
+      _optimizecount "count turtles = 0" AgentSet,double => boolean
+        _turtles "turtles" => AgentSet
         _constdouble:0.0 "0" => double
           // parameter final  context
           // parameter final  context
-          // parameter final  arg0
           // parameter final  context
-          // parameter final  context
-          // parameter final  d0
-          // parameter final  d1
+          // parameter final  sourceSet
+          // parameter final  checkValue
           // parameter final  context
           // parameter final  arg0
          L0
@@ -2436,39 +2433,30 @@ procedure GO:[]{O---}:
           GETFIELD org/nlogo/prim/_asm_procedurego_if_21.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
          L1
+          DCONST_0
+         L2
+          DSTORE 3
           ASTORE 2
           ALOAD 2
-          INVOKEVIRTUAL org/nlogo/agent/AgentSet.count ()I
-          I2D
-         L2
-          DCONST_0
+          DLOAD 3
+          D2I
+          ALOAD 0
+          GETFIELD org/nlogo/prim/_asm_procedurego_if_21.kept2_operator : Lscala/Function2;
+          INVOKEVIRTUAL org/nlogo/agent/AgentSet.checkCount (ILscala/Function2;)Z
          L3
-          DSTORE 4
-          DSTORE 2
-          DLOAD 2
-          DLOAD 4
-          DCMPL
-          IFNE L4
-          ICONST_1
-          GOTO L5
-         L4
-         FRAME APPEND [D D]
-          ICONST_0
-         L5
-         FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L6
+          IFEQ L4
           BIPUSH 23
-          GOTO L7
-         L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_21 org/nlogo/nvm/Context I T D] [org/nlogo/nvm/Context]
+          GOTO L5
+         L4
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_21 org/nlogo/nvm/Context I D] [org/nlogo/nvm/Context]
           BIPUSH 24
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_21 org/nlogo/nvm/Context I T D] [org/nlogo/nvm/Context I]
+         L5
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_21 org/nlogo/nvm/Context I D] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L8
+         L6
           RETURN
 [23]_asm_procedurego_stop_22 "stop" => void
          L0

--- a/test/benchdumps/Erosion.txt
+++ b/test/benchdumps/Erosion.txt
@@ -4395,10 +4395,12 @@ procedure SETUP:[_repeatlocal:0]{O---}:
 [18]_asm_proceduresetup_ask_16 "ask patches with [ count neighbors != 8 ] set drain? true [ set elevation -10000000 ]" AgentSet => void
       _with "patches with [ count neighbors != 8 ]" AgentSet,Reporter => AgentSet
         _patches "patches" => AgentSet
-        _asm_proceduresetup_notequal_17 "count neighbors != 8" double,double => boolean
-          _count "count neighbors" AgentSet => double
-            _neighbors "neighbors" => AgentSet
+        _asm_proceduresetup_optimizecount_17 "count neighbors != 8" AgentSet,double => boolean
+          _neighbors "neighbors" => AgentSet
           _constdouble:8.0 "8" => double
+              // parameter final  context
+              // parameter final  sourceSet
+              // parameter final  checkValue
              L0
               ALOAD 1
               GETFIELD org/nlogo/nvm/Context.agent : Lorg/nlogo/agent/Agent;
@@ -4418,33 +4420,24 @@ procedure SETUP:[_repeatlocal:0]{O---}:
               INVOKEVIRTUAL org/nlogo/agent/Patch.getNeighbors ()Lorg/nlogo/agent/IndexedAgentSet;
              L2
              FRAME SAME1 org/nlogo/agent/IndexedAgentSet
+              LDC 8.0
+             L3
+              DSTORE 3
               ASTORE 2
               ALOAD 2
-              INVOKEVIRTUAL org/nlogo/agent/AgentSet.count ()I
-              I2D
-             L3
-              LDC 8.0
+              DLOAD 3
+              D2I
+              ALOAD 0
+              GETFIELD org/nlogo/prim/_asm_proceduresetup_optimizecount_17.kept1_operator : Lscala/Function2;
+              INVOKEVIRTUAL org/nlogo/agent/AgentSet.checkCount (ILscala/Function2;)Z
              L4
-              DSTORE 4
-              DSTORE 2
-              DLOAD 2
-              DLOAD 4
-              DCMPL
               IFEQ L5
-              ICONST_1
+              GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
               GOTO L6
              L5
-             FRAME APPEND [D D]
-              ICONST_0
-             L6
-             FRAME SAME1 I
-              IFEQ L7
-              GETSTATIC java/lang/Boolean.TRUE : Ljava/lang/Boolean;
-              GOTO L8
-             L7
-             FRAME SAME
+             FRAME APPEND [org/nlogo/agent/IndexedAgentSet D]
               GETSTATIC java/lang/Boolean.FALSE : Ljava/lang/Boolean;
-             L8
+             L6
              FRAME SAME1 java/lang/Boolean
               ARETURN
           // parameter final  context

--- a/test/benchdumps/Wolf.txt
+++ b/test/benchdumps/Wolf.txt
@@ -1722,49 +1722,42 @@ procedure GO:[]{O---}:
           RETURN
 [21]_tick "tick"
 [22]_asm_procedurego_if_21 "if count turtles = 0 [ stop ]" boolean => void
-      _equal "count turtles = 0" double,double => boolean
-        _count "count turtles" AgentSet => double
-          _turtles "turtles" => AgentSet
+      _optimizecount "count turtles = 0" AgentSet,double => boolean
+        _turtles "turtles" => AgentSet
         _constdouble:0.0 "0" => double
           // parameter final  context
+          // parameter final  context
+          // parameter final  sourceSet
+          // parameter final  checkValue
          L0
           ALOAD 0
           GETFIELD org/nlogo/prim/_asm_procedurego_if_21.world : Lorg/nlogo/agent/World;
           INVOKEVIRTUAL org/nlogo/agent/World.turtles ()Lorg/nlogo/agent/TreeAgentSet;
          L1
+          DCONST_0
+         L2
+          DSTORE 3
           ASTORE 2
           ALOAD 2
-          INVOKEVIRTUAL org/nlogo/agent/AgentSet.count ()I
-          I2D
-         L2
-          DCONST_0
+          DLOAD 3
+          D2I
+          ALOAD 0
+          GETFIELD org/nlogo/prim/_asm_procedurego_if_21.kept2_operator : Lscala/Function2;
+          INVOKEVIRTUAL org/nlogo/agent/AgentSet.checkCount (ILscala/Function2;)Z
          L3
-          DSTORE 4
-          DSTORE 2
-          DLOAD 2
-          DLOAD 4
-          DCMPL
-          IFNE L4
-          ICONST_1
-          GOTO L5
-         L4
-         FRAME APPEND [D D]
-          ICONST_0
-         L5
-         FRAME SAME1 I
           ISTORE 2
           ALOAD 1
           ILOAD 2
-          IFEQ L6
+          IFEQ L4
           BIPUSH 23
-          GOTO L7
-         L6
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_21 org/nlogo/nvm/Context I T D] [org/nlogo/nvm/Context]
+          GOTO L5
+         L4
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_21 org/nlogo/nvm/Context I D] [org/nlogo/nvm/Context]
           BIPUSH 24
-         L7
-         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_21 org/nlogo/nvm/Context I T D] [org/nlogo/nvm/Context I]
+         L5
+         FRAME FULL [org/nlogo/prim/_asm_procedurego_if_21 org/nlogo/nvm/Context I D] [org/nlogo/nvm/Context I]
           PUTFIELD org/nlogo/nvm/Context.ip : I
-         L8
+         L6
           RETURN
 [23]_asm_procedurego_stop_22 "stop" => void
          L0


### PR DESCRIPTION
This PR adds optimization for counting mortal agentset operation. Both code code and benchdumps are included in this request. This PR is also part of GSoC 2019 project.  