### PR TITLE
add a `getDouble` method to `nvm.Argument` and `api.Argument`

### DIFF
--- a/netlogo-core/src/main/api/Argument.scala
+++ b/netlogo-core/src/main/api/Argument.scala
@@ -78,6 +78,16 @@ trait Argument {
   def getIntValue: Int
 
   /**
+   * Returns the value of the argument as a boxed <code>java.lang.Double</code>.
+   *
+   * @throws api.ExtensionException if the argument is not a number.
+   * @throws api.LogoException      if a LogoException occurred while evaluating this argument
+   */
+  @throws(classOf[ExtensionException])
+  @throws(classOf[LogoException])
+  def getDouble: java.lang.Double
+  
+  /**
    * Returns the value of the argument as an unboxed <code>double</code>.
    *
    * @throws api.ExtensionException if the argument is not a number.

--- a/netlogo-core/src/main/nvm/Argument.scala
+++ b/netlogo-core/src/main/nvm/Argument.scala
@@ -71,6 +71,15 @@ class Argument(context: Context, arg: Reporter) extends api.Argument {
     }
 
   @throws(classOf[ExtensionException])
+  def getDouble: java.lang.Double =
+    unsafeGet match {
+      case d: java.lang.Double => d
+      case x =>
+        throw new ExtensionException(
+          getExceptionMessage(Syntax.NumberType, x))
+    }
+
+  @throws(classOf[ExtensionException])
   def getDoubleValue: Double =
     unsafeGet match {
       case d: java.lang.Double => d.doubleValue


### PR DESCRIPTION
returning the boxed double directly instead of unboxing it like `getDoubleValue`.

(note that we already had the `getBoolean`/`getBooleanValue` pair of methods).

The `vid` extension has a `FakeArgument` class that needed a stub for the new method (https://github.com/NetLogo/vid/commit/91fdcd4455e3b3023de4e82dd49609d008617e57). I haven't spotted any other external impacts, but let me know if anything else needs to be done on this.