### PR TITLE
Fix #565: CSV exporting works correctly.

### DIFF
--- a/netlogo-gui/src/main/window/OutputArea.scala
+++ b/netlogo-gui/src/main/window/OutputArea.scala
@@ -54,6 +54,8 @@ class OutputArea(val text: JTextArea) extends javax.swing.JPanel {
 
   def valueText = text.getText
 
+  def carriageReturnMissing: Boolean = addCarriageReturn
+
   def fontSize: Int =
     text.getFont.getSize
 

--- a/netlogo-gui/src/main/window/OutputWidget.scala
+++ b/netlogo-gui/src/main/window/OutputWidget.scala
@@ -59,7 +59,10 @@ class OutputWidget extends SingleErrorWidget with CommandCenterInterface with
   def handle(e:org.nlogo.window.Events.ExportWorldEvent){
     import org.nlogo.api.Dump
     e.writer.println(Dump.csv.encode("OUTPUT"))
-    Dump.csv.stringToCSV(e.writer, outputArea.text.getText())
+    if (outputArea.carriageReturnMissing)
+      Dump.csv.stringToCSV(e.writer, s"${outputArea.text.getText()}\n")
+    else
+      Dump.csv.stringToCSV(e.writer, outputArea.text.getText())
   }
 
   override def load(model: WidgetModel): AnyRef = {


### PR DESCRIPTION
OutputArea uses clever logic to ensure that output in the Command Center looks pretty. That logic causes its internal `text` to be behind by a newline sometimes; a private flag keeps track of this state. Adding a getter method and checking it before writing to the CSV appears to solve the problem.