### PR TITLE
./sbt: use https to download sbt-launch from maven

### DIFF
--- a/sbt
+++ b/sbt
@@ -48,7 +48,7 @@ GOGO_JAVA=-Dnetlogo.extensions.gogo.javaexecutable=$JAVA
 
 
 SBT_LAUNCH=$HOME/.sbt/sbt-launch-1.1.1.jar
-URL='http://central.maven.org/maven2/org/scala-sbt/sbt-launch/1.1.1/sbt-launch-1.1.1.jar'
+URL='https://repo.maven.apache.org/maven2/org/scala-sbt/sbt-launch/1.1.1/sbt-launch-1.1.1.jar'
 
 if [ ! -f $BUILD_NUMBER ] ; then
   JAVA_OPTS="-Dsbt.log.noformat=true"


### PR DESCRIPTION
Fixes this build error:

$ ./sbt all
downloading http://central.maven.org/maven2/org/scala-sbt/sbt-launch/1.1.1/sbt-launch-1.1.1.jar
curl: (22) The requested URL returned error: 501 HTTPS Required

See:
https://support.sonatype.com/hc/en-us/articles/360041287334-Central-501-HTTPS-Required