### PR TITLE
Apply the font value from .nlogo3d file. Fixes #1811

### DIFF
--- a/netlogo-gui/src/main/window/WorldViewSettings3D.scala
+++ b/netlogo-gui/src/main/window/WorldViewSettings3D.scala
@@ -308,4 +308,11 @@ class WorldViewSettings3D(workspace: GUIWorkspace, gw: ViewWidget, tickCounter: 
       tickCounterLabel = label,
       frameRate = frameRate)
   }
+
+  override def fontSize(newSize: Int): Unit = {
+    // AAB 03/26/2020 - fix issue #1811
+    // Font value not being set from .nlogo3d file
+    gWidget.view.applyNewFontSize(newSize, 0)
+    super.fontSize(newSize)
+  }
 }


### PR DESCRIPTION
  A fix was required here because the for NetLogo3D the font value from
  a model was not being applied. This was remedied by a call to
  gWidget.view.applyNewFontSize in the method WorldViewSettings3D.fontSize.
  This supplements the call to workspace.viewManager.applyNewFontSize(newSize)
  in WorldViewSettings.fontSize.
  the method workspace.viewManager.applyNewFontSize delegates to the
  applyNewFontSize method of its "views."
  That call works properly in the 2D case because the "view" is a
  WorldViewSettings.gWidget.view, of class org.nlogo.window.View, which is the
  object that maintains the fontSize shown in "Settings"
  However in the 3D case the "view" is a org.nlogo.gl.view.ViewManager, for
  which the applyNewFontSize method is a no-op.  Fixes #1811