### PR TITLE
correct 3D hatched turtle zcor. Fixes #1822

### DIFF
--- a/netlogo-core/src/main/agent/Turtle.java
+++ b/netlogo-core/src/main/agent/Turtle.java
@@ -117,7 +117,7 @@ public abstract strictfp class Turtle
 
   // The observant reader will notice that the abstract methods are
   // primarily those which depend on the world arity (2D/3D).
-  public abstract Turtle hatch();
+  public abstract Turtle hatch(TreeAgentSet breed);
   public abstract Patch getPatchAtOffsets(double dx, double dy) throws AgentException;
   public abstract Patch getPatchAtHeadingAndDistance(double delta, double distance) throws AgentException;
   public abstract void jump(double distance) throws AgentException;
@@ -131,22 +131,8 @@ public abstract strictfp class Turtle
   abstract void drawLine(double x0, double y0, double x1, double y1);
   abstract Turtle makeTurtle(World world);
 
-  public Turtle hatch(TreeAgentSet breed) {
-    Turtle child = makeTurtle(_world);
-    child.heading = heading;
-    child.xcor = xcor;
-    child.ycor = ycor;
-    child.setVariables(_variables.clone());
-    child.setId(_world.newTurtleId());
-    _world.turtles().add(child);
-    if (breed != getBreed()) {
-      child.setBreed(breed);
-    }
-    if (breed != _world.turtles()) {
-      breed.add(child);
-    }
-    child.getPatchHere().addTurtle(child);
-    return child;
+  public Turtle hatch() {
+    return hatch(getBreed());
   }
 
   public void die() {

--- a/netlogo-core/src/main/agent/Turtle2D.java
+++ b/netlogo-core/src/main/agent/Turtle2D.java
@@ -29,8 +29,23 @@ public strictfp class Turtle2D
     super(world);
   }
 
-  public Turtle hatch() {
-    return hatch(getBreed());
+  @Override
+  public Turtle hatch(TreeAgentSet breed) {
+    Turtle2D child = new Turtle2D((World2D) _world);
+    child.heading = heading;
+    child.xcor = xcor;
+    child.ycor = ycor;
+    child.setVariables(_variables.clone());
+    child.setId(_world.newTurtleId());
+    _world.turtles().add(child);
+    if (breed != getBreed()) {
+      child.setBreed(breed);
+    }
+    if (breed != _world.turtles()) {
+      breed.add(child);
+    }
+    child.getPatchHere().addTurtle(child);
+    return child;
   }
 
   Turtle makeTurtle(World world) {

--- a/netlogo-core/src/main/agent/Turtle3D.java
+++ b/netlogo-core/src/main/agent/Turtle3D.java
@@ -109,7 +109,7 @@ public final strictfp class Turtle3D
   }
 
   @Override
-  public Turtle hatch() {
+  public Turtle hatch(TreeAgentSet breed) {
     Turtle3D child = new Turtle3D((World3D) _world);
     child.heading = heading;
     child.xcor = xcor;
@@ -118,8 +118,11 @@ public final strictfp class Turtle3D
     child.setVariables(_variables.clone());
     child.setId(_world.newTurtleId());
     _world.turtles().add(child);
-    if (getBreed() != _world.turtles()) {
-      getBreed().add(child);
+    if (breed != getBreed()) {
+      child.setBreed(breed);
+    }
+    if (breed != _world.turtles()) {
+      breed.add(child);
     }
     child.getPatchHere().addTurtle(child);
     return child;

--- a/test/commands/Turtles.txt
+++ b/test/commands/Turtles.txt
@@ -210,3 +210,45 @@ HatchInheritShape
   T> set shape "circle"
   T> hatch 1
   [shape] of turtles => ["circle" "circle"]
+
+# When hatch takes no commands it uses an optimized implementation hatchfast
+# AAB 04/08/2020
+HatchFastInheritLocation_2D
+  O> crt 1 [ setxy 3 4 ]
+  T> hatch 1
+  [(list xcor ycor)] of turtle 1 => [3 4]
+
+HatchInheritLocation_2D
+  O> crt 1 [ setxy 3 4 ]
+  T> hatch 1
+  [(list xcor ycor)] of turtle 1 => [3 4]
+
+HatchFastInheritOrientation_2D
+  O> crt 1 [ set heading 3.14259 ]
+  T> hatch 1
+  [heading] of turtle 1 => 3.14259
+
+HatchInheritOrientation_2D
+  O> crt 1 [ set heading 3.14259 ]
+  T> hatch 1 [ set color yellow ]
+  [heading] of turtle 1 => 3.14259
+
+HatchFastInheritLocation_3D
+  O> crt 1 [ setxyz 3 4 5 ]
+  T> hatch 1
+  [(list xcor ycor zcor)] of turtle 1 => [3 4 5]
+
+HatchInheritLocation_3D
+  O> crt 1 [ setxyz 3 4 5 ]
+  T> hatch 1 [ set color yellow ]
+  [(list xcor ycor zcor)] of turtle 1 => [3 4 5]
+
+HatchFastInheritOrientation_3D
+  O> crt 1 [ set heading 0 tilt-up 30  roll-right 20 rt 45 ]
+  T> hatch 1
+  [(list precision heading 12 precision pitch 12 precision roll 12)]  of turtle 1 =>  [42.180779225595 8.285726273243 34.676049813587]
+
+HatchInheritOrientation_3D
+  O> crt 1 [ set heading 0 tilt-up 30  roll-right 20 rt 45 ]
+  T> hatch 1 [ set color yellow ]
+  [(list precision heading 12 precision pitch 12 precision roll 12)]  of turtle 1 =>  [42.180779225595 8.285726273243 34.676049813587]


### PR DESCRIPTION
  In NetLogo3D when a turtle with a non-zero z-coordinate hatches a
  turtle and gives it no commands, the new turtle had a z-coordinate of
  0. This was fixed by adding a hatch(TreeAgentSet breed) method to the
  Turtle3D class. Fixes #1822

 Note for those who wonder why this change fixed the bug:
 The _hatch primitive called hatch(), which had to be implemented in 
Turtle3D.java, because it is declared abstract in Turtle.java.
 On the other hand when there is no command after hatch, the optimized
 version _hatchfast is used. It calls hatch(TreeAgentSet breed). Since that
 is not abstract and not implemented in Turtle3D.java, the version in Turtle.java,
 which only sets the x and y coordinates was called.
