### PR TITLE
Modify sbt script to work on MacOS Big Sur (11.0.1) (issue #1868)

### DIFF
--- a/sbt
+++ b/sbt
@@ -19,7 +19,7 @@ else
     fi
   else
     if [ `uname -s` = Darwin ] ; then
-      export JAVA_HOME=`/usr/libexec/java_home -F -v1.8*`
+      export JAVA_HOME=`/usr/libexec/java_home -F -v1.8`
     fi
   fi
   JH=$JAVA_HOME


### PR DESCRIPTION
See issue #1868 for the issue. 

Changing this one line seems to fix the issue for me and allowed me to run sbt and compile again. 

Looking around the web, the `/usr/libexec/java_home` behavior certainly was changed in Big Sur, (see https://developer.apple.com/forums/thread/666681 and https://dev.to/pablohs1986/macos-users-java-problems-in-big-sur-help-7pa) although I have not been able to find exactly how. 