### PR TITLE
Update sbt-launch URL also to 1.3.13

### DIFF
--- a/sbt
+++ b/sbt
@@ -45,8 +45,8 @@ BOOT=xsbt.boot.Boot
 GOGO_JAVA=-Dnetlogo.extensions.gogo.javaexecutable=$JAVA
 
 
-SBT_LAUNCH=$HOME/.sbt/sbt-launch-1.3.10.jar
-URL='https://repo.maven.apache.org/maven2/org/scala-sbt/sbt-launch/1.3.10/sbt-launch-1.3.10.jar'
+SBT_LAUNCH=$HOME/.sbt/sbt-launch-1.3.13.jar
+URL='https://repo.maven.apache.org/maven2/org/scala-sbt/sbt-launch/1.3.13/sbt-launch-1.3.13.jar'
 
 if [ ! -f $BUILD_NUMBER ] ; then
   JAVA_OPTS="-Dsbt.log.noformat=true"


### PR DESCRIPTION
Very small PR, looks like it was forgotten. Speeds up `./sbt update` a bit since the latest version is downloaded right away.