### PR TITLE
Proposal for solution to issue #211.

### DIFF
--- a/netlogo-gui/src/main/render/TurtleDrawer.java
+++ b/netlogo-gui/src/main/render/TurtleDrawer.java
@@ -19,21 +19,21 @@ public strictfp class TurtleDrawer {
   public void drawTurtle(GraphicsInterface g, TopologyRenderer topology,
                          org.nlogo.api.Turtle turtle, double patchSize) {
     if (!turtle.hidden()) {
-      if (turtle.size() * patchSize >= MIN_PATCH_SIZE_FOR_TURTLE_SHAPES) {
-        drawTurtleShape(g, topology, turtle, patchSize);
-      } else {
-        topology.drawWrappedRect(g, org.nlogo.api.Color.getColor(turtle.color()),
-            0.0f, turtle.xcor(), turtle.ycor(), turtle.size(), patchSize, true);
-      }
-      if (turtle.hasLabel()) {
-        drawTurtleLabel(g, topology, turtle, patchSize);
-      }
+      drawTurtleShape(g, topology, turtle, patchSize);
+    }
+    if (turtle.hasLabel()) {
+      drawTurtleLabel(g, topology, turtle, patchSize);
     }
   }
 
   void drawTurtleShape(GraphicsInterface g, TopologyRenderer topology, org.nlogo.api.Turtle turtle, double patchSize) {
-    Drawable d = getShapeFromCacheOrCreateDrawable(turtle, patchSize, shapes.getShape(turtle));
-    topology.wrapDrawable(d, g, turtle.xcor(), turtle.ycor(), turtle.size(), patchSize);
+    if (Math.abs(turtle.size() * patchSize) >= MIN_PATCH_SIZE_FOR_TURTLE_SHAPES) {
+	  Drawable d = getShapeFromCacheOrCreateDrawable(turtle, patchSize, shapes.getShape(turtle));
+      topology.wrapDrawable(d, g, turtle.xcor(), turtle.ycor(), turtle.size(), patchSize);
+	} else {
+      topology.drawWrappedRect(g, org.nlogo.api.Color.getColor(turtle.color()),
+		0.0f, turtle.xcor(), turtle.ycor(), turtle.size(), patchSize, true);
+	}
   }
 
   private Drawable getShapeFromCacheOrCreateDrawable(Turtle turtle, double patchSize, VectorShape shape) {

--- a/netlogo-headless/src/main/render/TurtleDrawer.java
+++ b/netlogo-headless/src/main/render/TurtleDrawer.java
@@ -19,21 +19,21 @@ public strictfp class TurtleDrawer {
   public void drawTurtle(GraphicsInterface g, TopologyRenderer topology,
                          org.nlogo.api.Turtle turtle, double patchSize) {
     if (!turtle.hidden()) {
-      if (turtle.size() * patchSize >= MIN_PATCH_SIZE_FOR_TURTLE_SHAPES) {
-        drawTurtleShape(g, topology, turtle, patchSize);
-      } else {
-        topology.drawWrappedRect(g, org.nlogo.api.Color.getColor(turtle.color()),
-            0.0f, turtle.xcor(), turtle.ycor(), turtle.size(), patchSize, true);
-      }
-      if (turtle.hasLabel()) {
-        drawTurtleLabel(g, topology, turtle, patchSize);
-      }
+      drawTurtleShape(g, topology, turtle, patchSize);
+    }
+    if (turtle.hasLabel()) {
+      drawTurtleLabel(g, topology, turtle, patchSize);
     }
   }
 
   void drawTurtleShape(GraphicsInterface g, TopologyRenderer topology, org.nlogo.api.Turtle turtle, double patchSize) {
-    Drawable d = getShapeFromCacheOrCreateDrawable(turtle, patchSize, shapes.getShape(turtle));
-    topology.wrapDrawable(d, g, turtle.xcor(), turtle.ycor(), turtle.size(), patchSize);
+    if (Math.abs(turtle.size() * patchSize) >= MIN_PATCH_SIZE_FOR_TURTLE_SHAPES) {
+	  Drawable d = getShapeFromCacheOrCreateDrawable(turtle, patchSize, shapes.getShape(turtle));
+      topology.wrapDrawable(d, g, turtle.xcor(), turtle.ycor(), turtle.size(), patchSize);
+	} else {
+      topology.drawWrappedRect(g, org.nlogo.api.Color.getColor(turtle.color()),
+		0.0f, turtle.xcor(), turtle.ycor(), turtle.size(), patchSize, true);
+	}
   }
 
   private Drawable getShapeFromCacheOrCreateDrawable(Turtle turtle, double patchSize, VectorShape shape) {


### PR DESCRIPTION
Make minimal changes to make 2D NetLogo fall in line with 3D NetLogo concerning negatively sized turtles and their stamps.

Addresses issue #211.
Instead of removing the stamp, this change makes turtles with negative size display inverted (as 3D NetLogo does this.)


If removing the stamp is still preferred:
Removing the Math.abs() from this change would instead make the stamp not display as suggested as a solution.