### PR TITLE
Add try catch to show an error message when an IOException occurs while using BehaviourSpace.

### DIFF
--- a/netlogo-gui/src/main/lab/gui/Supervisor.scala
+++ b/netlogo-gui/src/main/lab/gui/Supervisor.scala
@@ -12,6 +12,7 @@ import org.nlogo.nvm.{EngineException, Workspace}
 import org.nlogo.workspace.{CurrentModelOpener, WorkspaceFactory}
 import org.nlogo.nvm.LabInterface.ProgressListener
 import org.nlogo.api.LogoException
+import java.io.{IOException}
 
 object Supervisor {
   case class RunOptions(threadCount: Int, table: Boolean, spreadsheet: Boolean, updateView: Boolean, updatePlotsAndMonitors: Boolean)
@@ -74,21 +75,31 @@ class Supervisor(dialog: java.awt.Dialog,
       val fileName = org.nlogo.swing.FileDialog.showFiles(
         workspace.getFrame, "Exporting as spreadsheet", java.awt.FileDialog.SAVE,
         workspace.guessExportName(worker.protocol.name + "-spreadsheet.csv"))
-      addExporter(new SpreadsheetExporter(
+      try{
+	    addExporter(new SpreadsheetExporter(
         workspace.getModelFileName,
         workspace.world.getDimensions,
         worker.protocol,
-        new java.io.PrintWriter(new java.io.FileWriter(fileName))))
+		new java.io.PrintWriter(new java.io.FileWriter(fileName))))
+	  }
+	  catch{
+		case e: IOException => failure(e); return
+      }
     }
     if(options.table) {
       val fileName = org.nlogo.swing.FileDialog.showFiles(
         workspace.getFrame, "Exporting as table", java.awt.FileDialog.SAVE,
         workspace.guessExportName(worker.protocol.name + "-table.csv"))
-      addExporter(new TableExporter(
+      try{
+	  addExporter(new TableExporter(
         workspace.getModelFileName,
         workspace.world.getDimensions,
         worker.protocol,
         new java.io.PrintWriter(new java.io.FileWriter(fileName))))
+	  }
+	  catch{
+		case e: IOException => failure(e); return
+      }
     }
     progressDialog.setUpdateView(options.updateView)
     progressDialog.setPlotsAndMonitorsSwitch(options.updatePlotsAndMonitors)


### PR DESCRIPTION
Essentially this changes the error message from:

![image](https://user-images.githubusercontent.com/15855950/107157016-0544ec00-6982-11eb-9cc0-97eb207f8630.png)

to:

![image](https://user-images.githubusercontent.com/15855950/107156596-88b10e00-697f-11eb-93a8-6e236b5e763e.png)

This is related to issue #243
I have no idea what the impact would be on Mac or Linux. But for windows, it seems to work. If Mac and Linux give any IOException it should come in a nice little window now instead of an error that asks you to report it.