### PR TITLE
Fixes Oddities with command center Tools menu actions #1906

### DIFF
--- a/netlogo-gui/src/main/app/AbstractTabsPanel.scala
+++ b/netlogo-gui/src/main/app/AbstractTabsPanel.scala
@@ -42,7 +42,15 @@ abstract class AbstractTabsPanel(val workspace:           GUIWorkspace,
   def getAppJFrame() = { jframe }
   var fileManager: FileManager = null
   var dirtyMonitor: DirtyMonitor = null
-  var currentTab: Component = interfaceTab
+  var currentTab: Component = null
+
+  def setCurrentTab(tab: Component): Unit = {
+    currentTab = tab
+  }
+
+  def getCurrentTab(): Component = {
+    currentTab
+  }
 
   def initManagerMonitor(manager: FileManager, monitor: DirtyMonitor): Unit =  {
     fileManager = manager
@@ -58,4 +66,5 @@ abstract class AbstractTabsPanel(val workspace:           GUIWorkspace,
   }
 
   override def requestFocus() = { currentTab.requestFocus() }
+
 }

--- a/netlogo-gui/src/main/app/AppTabManager.scala
+++ b/netlogo-gui/src/main/app/AppTabManager.scala
@@ -64,7 +64,7 @@ class AppTabManager(val appTabsPanel:          Tabs,
 
   // might want access to these owner methods to be only in the app package
   // Need to carefully decide which methods are private. AAB 10/2020
-  def getCodeTabsOwner = {
+  def getCodeTabsOwner() : AbstractTabsPanel = {
     codeTabsPanelOption match {
       case None           => appTabsPanel
       case Some(theValue) => theValue
@@ -110,16 +110,6 @@ class AppTabManager(val appTabsPanel:          Tabs,
   }
 
   def getSelectedAppTabIndex() = { appTabsPanel.getSelectedIndex }
-
-  private var currentTab: Component = { appTabsPanel.interfaceTab }
-
-  def getCurrentTab(): Component = {
-    currentTab
-  }
-
-  def setCurrentTab(tab: Component): Unit = {
-    currentTab = tab
-  }
 
   // Input: combinedTabIndex - index a tab would have if there were no separate code tab.
   // Returns (tabOwner, tabIndex)
@@ -198,16 +188,34 @@ class AppTabManager(val appTabsPanel:          Tabs,
 
   def setPanelsSelectedIndex(index: Int): Unit =  {
     val (tabOwner, tabIndex) = ownerAndIndexFromCombinedIndex(index)
-    if (tabOwner.isInstanceOf[CodeTabsPanel]) {
-      tabOwner.requestFocus
-      tabOwner.setSelectedIndex(tabIndex)
-    } else {
-      val selectedIndex = getSelectedAppTabIndex
-      if (selectedIndex == tabIndex) {
-       setSelectedAppTab(-1)
-      }
-       setSelectedAppTab(tabIndex)
-      }
+    setPanelsSelectedIndexHelper(tabOwner, tabIndex)
+  }
+
+  /**
+    * Makes a tab component, specified by owner and index, selected or selectable, whether or not a separate code window exists.
+    *
+    * Usual effect: the specified component becomes the selected tab of the tabOwner.
+    * An important alternative case occurs when a specified App Tab component is already selected.
+    * This should only happen when focus is in the separate code tab window.
+    * Swing will not allow the selection unless the Tab is first deselected. To deselect the tab without selecting
+    * another tab, the selected tab index of the tabOwner must be set to -1.
+    * The App Tab of interest is saved as the currentTab.
+    * Documentation August 2021 - AAB
+    *
+    * @param tabOwner Owner of the Tab to be selected
+    *
+    * @param index    Index of the Tab to be selected
+    */
+  private def setPanelsSelectedIndexHelper(tabOwner: AbstractTabsPanel, tabIndex: Int): Unit = {
+    val selectedIndex = tabOwner.getSelectedIndex
+    if (selectedIndex == tabIndex) {
+      // Saves selected tab as current tab
+      tabOwner.setCurrentTab(tabOwner.getComponentAt(tabIndex))
+      // Deselects the tab
+      tabOwner.setSelectedIndex(-1)
+    }
+    tabOwner.setSelectedIndex(tabIndex)
+    tabOwner.requestFocus
   }
 
   def getIndexOfCodeTab(tab: CodeTab): Int = {
@@ -267,6 +275,14 @@ class AppTabManager(val appTabsPanel:          Tabs,
         appTabsPanel.externalFileTabs)
       codeTabsPanelOption = Some(codeTabsPanel)
       codeTabsPanel.setTabManager(this)
+
+      // If the Selected Component in the App Tabs Panel was the CodeTab
+      // set it to be the Interface Tab, otherwise moving the CodeTab will
+      // cause swing to make the Info Tab the Selected Component
+      if (appTabsPanel.getSelectedComponent == appTabsPanel.mainCodeTab) {
+        appTabsPanel.setSelectedComponent(appTabsPanel.interfaceTab)
+      }
+
       // Move tabs from appTabsPanel to codeTabsPanel.
       // Iterate starting at last tab so that indexing remains valid when
       // tabs are removed (add to codeTabsPanel), AAB 10/2020
@@ -280,7 +296,6 @@ class AppTabManager(val appTabsPanel:          Tabs,
            appTabsPanel.getToolTipTextAt(n),
            0)
         }
-
       }
 
       appTabsPanel.mainCodeTab.getPoppingCheckBox.setSelected(true)
@@ -289,6 +304,7 @@ class AppTabManager(val appTabsPanel:          Tabs,
       appTabsPanel.getAppFrame.addLinkComponent(codeTabsPanel.getCodeTabContainer)
       createCodeTabAccelerators()
       Event.rehash()
+      codeTabsPanel.mainCodeTab.requestFocus
     }
   }
 
@@ -514,23 +530,22 @@ class AppTabManager(val appTabsPanel:          Tabs,
   }
 
   /**
-   * Makes a tab component selected, whether or not separate code window exists.
-   *
-   * @param tab the Component to be selected
-   */
+    * Makes a tab component selected or selectable, whether or not a separate code window exists.
+    *
+    * Usual effect: the specified component becomes the selected tab of the tabOwner.
+    * An important alternative case occurs when a specified App Tab component is already selected.
+    * This should only happen when focus is in the separate code tab window.
+    * Swing will not allow the selection unless the Tab is first deselected. To deselect the tab without selecting
+    * another tab, the selected tab index of the tabOwner must be set to -1.
+    * The App Tab of interest is saved as the currentTab.
+    * Documentation update August 2021 - AAB
+    *
+    * @param tab the Component to be selected
+    */
   def setPanelsSelectedComponent(tab: Component): Unit = {
     require(tab != null)
     val (tabOwner, tabIndex) = ownerAndIndexOfTab(tab)
-    if (tabOwner.isInstanceOf[CodeTabsPanel]) {
-      tabOwner.requestFocus
-      tabOwner.setSelectedIndex(tabIndex)
-    } else {
-      val selectedIndex = getSelectedAppTabIndex
-      if (selectedIndex == tabIndex) {
-        setSelectedAppTab(-1)
-      }
-        setSelectedAppTab(tabIndex)
-      }
+    setPanelsSelectedIndexHelper(tabOwner, tabIndex)
   }
 
   /**
@@ -701,7 +716,8 @@ class AppTabManager(val appTabsPanel:          Tabs,
     }
   }
 
-  // For a Menu - prints Menu Items and their Accelerators
+  // For a Menu Item - prints Menu Item its Accelerator or
+  // if it is a JMenu prints Menu Items and their Accelerators
   def __printMenuItem(menuItem: JMenuItem, level: Int): Unit = {
     if (menuItem == null) { return }
     if (menuItem.isInstanceOf[JMenu]) {
@@ -809,6 +825,14 @@ class AppTabManager(val appTabsPanel:          Tabs,
     }
   }
 
+  def __getSimpleName(c: Any) : String = {
+    if (c == null){
+      return "<null>"
+    } else {
+      return c.getClass.getSimpleName
+    }
+  }
+
   def __printNonNullSwingObject(obj: java.awt.Component, description: String): Unit = {
     val pattern = """(^[^\[]*)\[(.*$)""".r
     val pattern(name, _) = obj.toString
@@ -819,10 +843,12 @@ class AppTabManager(val appTabsPanel:          Tabs,
 
   def __printSwingObject(obj: java.awt.Component, description: String): Unit = {
     val some = Option(obj) // Because Option(null) = None 11/2020 AAB
+    var objID = ""
     some match {
-      case None           => println(description + " <null>")
-      case Some(theValue) =>  __printNonNullSwingObject(obj, description)
+      case None           =>
+      case Some(theValue) => objID = System.identityHashCode(obj) + ", "
     }
+    println(description + " " + objID + __getSimpleName(obj))
   }
 
   def __printOptionSwingObject(obj: Option[java.awt.Component], description: String): Unit = {
@@ -850,6 +876,50 @@ class AppTabManager(val appTabsPanel:          Tabs,
     }
   }
 
+  def __PrintWindowEventInfo(e: java.awt.event.WindowEvent): Unit = {
+    println("    " + "ID: " + e.getID)
+    println("    " + "source: " + __getSimpleName(e.getSource))
+    println("    " + "window: " + __getSimpleName(e.getWindow))
+    println("    " + "opposite window: " + __getSimpleName(e.getOppositeWindow))
+  }
 
+  def __PrintStateInfo(previousTab: Component, currentTab: Component): Unit = {
+    println("    Previous Tab: " + __getSimpleName(previousTab))
+
+    println("    Current Tab: " + __getSimpleName(currentTab))
+    val owner = getCodeTabsOwner
+    println("    CodeTabOwner " + __getSimpleName(owner) + " Selected Index: " + owner.getSelectedIndex)
+  }
+
+  def __printFocusOwner(topContainer: javax.swing.JFrame): Unit = {
+    __printFocusOwner(topContainer, false)
+  }
+
+  def __printFocusOwner(topContainer: javax.swing.JFrame, fullInfo: Boolean): Unit = {
+    if (fullInfo) {
+      println("    " + __getSimpleName(topContainer) + " is Active " + topContainer.isActive())
+      println("    " + __getSimpleName(topContainer) + " is Focused " + topContainer.isFocused())
+    }
+    if (topContainer.isFocused()) {
+      val focusOwner = topContainer.getFocusOwner
+      if (focusOwner != null) {
+        println("    Focus owner is " + __getSimpleName(focusOwner))
+      } else {
+        println("    No focus owner.")
+      }
+    } else {
+      val prevFocusOwner = topContainer.getMostRecentFocusOwner
+      if (prevFocusOwner != null) {
+        println("    Focus owner is " + __getSimpleName(prevFocusOwner))
+      } else {
+        println("    No previous focus owner.")
+      }
+    }
+  }
+
+  def __PrintHideUndoMenuCounts(): Unit = {
+    println("    Hide count: " + __countMenuItembyNameAndMenuName("Tools", "Hide Command Center"))
+    println("    Undo count: " + __countMenuItembyNameAndMenuName("Edit", "Undo"))
+  }
   // *** End debugging tools AAB 10/2020.
 }

--- a/netlogo-gui/src/main/app/Tabs.scala
+++ b/netlogo-gui/src/main/app/Tabs.scala
@@ -101,7 +101,6 @@ class Tabs(workspace:           GUIWorkspace,
   jframe.addWindowFocusListener(new WindowAdapter() {
     override def windowGainedFocus(e: WindowEvent) {
       val currentTab = getTabs.getSelectedComponent
-      tabManager.setCurrentTab(currentTab)
       if (tabManager.getMainCodeTab.dirty) {
         // The SwitchedTabsEvent can lead to compilation. AAB 10/2020
          new AppEvents.SwitchedTabsEvent(tabManager.getMainCodeTab, currentTab).raise(getTabs)
@@ -116,9 +115,9 @@ class Tabs(workspace:           GUIWorkspace,
     // In that case do nothing. The correct action will happen when
     // the selected index is reset. AAB 10/2020
     if (tabManager.getSelectedAppTabIndex != -1) {
-      val previousTab = tabManager.getCurrentTab
+      val previousTab = currentTab
       currentTab = getSelectedComponent
-      tabManager.setCurrentTab(currentTab)
+
       previousTab match {
         case mt: MenuTab => mt.activeMenuActions foreach menu.revokeAction
         case _ =>
@@ -133,7 +132,6 @@ class Tabs(workspace:           GUIWorkspace,
         case (false, true) => saveModelActions foreach menu.revokeAction
         case _             =>
       }
-      currentTab.requestFocus()
       new AppEvents.SwitchedTabsEvent(previousTab, currentTab).raise(this)
     }
   }
@@ -143,8 +141,8 @@ class Tabs(workspace:           GUIWorkspace,
       // A single mouse control-click on the MainCodeTab in a separate window
       // opens the code window, and takes care of the bookkeeping. AAB 10/2020
       if (me.getClickCount() == 1 && me.isControlDown) {
-        val currentTab = me.getSource.asInstanceOf[JTabbedPane].getSelectedComponent
-        if (currentTab.isInstanceOf[MainCodeTab]) {
+        val clickedTab = me.getSource.asInstanceOf[JTabbedPane].getSelectedComponent
+        if (clickedTab.isInstanceOf[MainCodeTab]) {
           tabManager.switchToSeparateCodeWindow
         }
       }
@@ -350,6 +348,7 @@ class Tabs(workspace:           GUIWorkspace,
     val newAction = TabsMenu.tabAction(tabManager, i)
     tabActions = tabActions :+ newAction
     menu.offerAction(newAction)
+    // This may not be necessary AAB 08/21
     tabManager.copyMenuAcceleratorsByName(I18N.gui.get("menu.tabs"))
   }
 


### PR DESCRIPTION
Make sure Tools-> Hide Command Center and Edit-> Undo menu items
appear appropriately.
Don't revoke or offer Actions in CodeTabsPanel.scala.
Eliminate unnecessary tab switching with InterfaceTab.
Set current tab when the new tab is already selected.