### PR TITLE
When saving from detached codetab, move it to the front

### DIFF
--- a/netlogo-gui/src/main/app/FileManager.scala
+++ b/netlogo-gui/src/main/app/FileManager.scala
@@ -337,8 +337,11 @@ class FileManager(workspace: AbstractWorkspaceScala,
     // if there's no thunk, the user canceled the save
     saveThunk.foreach { thunk =>
       val saver = new Saver(thunk)
+      val focusOwner = java.awt.KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner()
+      val tempParent = if (focusOwner == null) parent else focusOwner
 
-      saver.run()
+      ModalProgressTask.onUIThread(Hierarchy.getFrame(tempParent),
+        I18N.gui.get("dialog.interface.saving.task"), saver)
 
       if (! saver.result.isDefined)
         throw new UserCancelException()


### PR DESCRIPTION
I am working on fixing [issue 1995](https://github.com/NetLogo/NetLogo/issues/1955)
This bug occurs on MacOs, but not Windows 11. 
It is not a regression, but should be fixed for the new release.
**The key change is the code diff in FileManager.**
This fixes the problem when cmd-s is used from the detached code tab only if there are actually _no_ changes. Can you help me figure out why that case is different?

I believe that the method [saveModel](https://github.com/NetLogo/NetLogo/blob/hexy/netlogo-gui/src/main/app/FileManager.scala#L331)

is called by the action associated with cmd-S.


Two of the files implement toFront, which moves the Frame/JDialog containing an NL JTabbedPane to the front
The other file has an improvement to a debug method so that it will handle Options.