### PR TITLE
Add a sponsor button to the repository

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://ccl.northwestern.edu/netlogo/giving.shtml


### PR DESCRIPTION
Adds a FUNDING.yml file in the .github folder, which will trigger GitHub to display a Sponsor-button in the top of the repository. The button will link to https://ccl.northwestern.edu/netlogo/giving.shtml

See the GitHub docs for more information: [Displaying a sponsor button in your repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository)