### PR TITLE
Scala dependency updates: Batch 1

### DIFF
--- a/NetLogo.iml
+++ b/NetLogo.iml
@@ -20,11 +20,11 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="org.ow2.asm:asm-all:5.0.4" level="project" />
+    <orderEntry type="library" name="org.ow2.asm:asm-all:5.2" level="project" />
     <orderEntry type="library" name="org.picocontainer:picocontainer:2.13.6" level="project" />
     <orderEntry type="library" name="log4j:log4j:1.2.16" level="project" />
     <orderEntry type="library" name="javax.media:jmf:2.1.1e" level="project" />
-    <orderEntry type="library" name="org.pegdown:pegdown:1.6.0" level="project" />
+    <orderEntry type="library" name="org.pegdown:pegdown:1.6.6" level="project" />
     <orderEntry type="library" name="org.jogamp.jogl:jogl-all:2.3.2" level="project" />
     <orderEntry type="library" name="org.jogamp.gluegen:gluegen-rt:2.3.2" level="project" />
     <orderEntry type="library" name="org.apache.httpcomponents:httpclient:4.2" level="project" />
@@ -32,8 +32,8 @@
     <orderEntry type="library" name="com.googlecode.json-simple:json-simple:1.1.1" level="project" />
     <orderEntry type="library" name="jmock-junit4-2.5.1" level="project" />
     <orderEntry type="library" name="jhotdraw-6.0b1" level="project" />
-    <orderEntry type="library" name="rsyntaxtextarea-2.6.0" level="project" />
-    <orderEntry type="library" name="scalacheck_2.12-1.13.4" level="project" />
+    <orderEntry type="library" name="rsyntaxtextarea-2.6.1" level="project" />
+    <orderEntry type="library" name="scalacheck_2.12-1.13.5" level="project" />
     <orderEntry type="library" name="scalatest_2.12-3.0.1" level="project" />
     <orderEntry type="library" name="scala-parser-combinators_2.12-1.0.4" level="project" />
     <orderEntry type="library" name="parboiled_2.12-2.1.3" level="project" />

--- a/bin/benches.scala
+++ b/bin/benches.scala
@@ -28,14 +28,14 @@ val classpath =
       home + "/.ivy2/cache/org.typelevel/cats-core_2.12/jars/cats-core_2.12-1.0.0-MF.jar",
       home + "/.ivy2/local/org.nlogo/xml-lib_2.12/0.0.1/jars/xml-lib_2.12.jar",
       home + "/.ivy2/cache/com.typesafe/config/bundles/config-1.3.1.jar",
-      home + "/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12/bundles/scala-parser-combinators_2.12-1.0.5.jar",
+      home + "/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12/bundles/scala-parser-combinators_2.12-1.0.7.jar",
       home + "/.ivy2/cache/org.scala-lang.modules/scala-xml_2.12/bundles/scala-xml_2.12-1.0.6.jar",
       home + "/.ivy2/cache/org.typelevel/cats-core_2.12/jars/cats-core_2.12-1.0.0-MF.jar",
-      home + "/.ivy2/cache/org.ow2.asm/asm-all/jars/asm-all-5.0.4.jar",
+      home + "/.ivy2/cache/org.ow2.asm/asm-all/jars/asm-all-5.2.jar",
       home + "/.ivy2/cache/log4j/log4j/jars/log4j-1.2.16.jar",
-      home + "/.ivy2/cache/commons-codec/commons-codec/jars/commons-codec-1.10.jar",
-      home + "/.ivy2/cache/org.parboiled/parboiled_2.12/jars/parboiled_2.12-2.1.3.jar",
-      home + "/.ivy2/cache/org.picocontainer/picocontainer/jars/picocontainer-2.13.6.jar")
+      home + "/.ivy2/cache/commons-codec/commons-codec/jars/commons-codec-1.15.jar",
+      home + "/.ivy2/cache/org.parboiled/parboiled_2.12/jars/parboiled_2.12-2.1.8.jar",
+      home + "/.ivy2/cache/org.picocontainer/picocontainer/jars/picocontainer-2.15.jar")
 
     .mkString(":")
 // Since the classpath is relative to the bin directory, this must be run there

--- a/bin/profiles.scala
+++ b/bin/profiles.scala
@@ -22,13 +22,13 @@ val classpath =
       "../shared/target/classes",
       "../netlogo-gui/resources",
       home + "/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.10.jar",
-      home + "/.ivy2/cache/org.ow2.asm/asm-all/jars/asm-all-5.0.4.jar",
-      home + "/.ivy2/cache/org.picocontainer/picocontainer/jars/picocontainer-2.13.6.jar",
+      home + "/.ivy2/cache/org.ow2.asm/asm-all/jars/asm-all-5.2.jar",
+      home + "/.ivy2/cache/org.picocontainer/picocontainer/jars/picocontainer-2.15.jar",
       home + "/.ivy2/cache/log4j/log4j/jars/log4j-1.2.16.jar",
-      home + "/.ivy2/cache/commons-codec/commons-codec/jars/commons-codec-1.10.jar",
-      home + "/.ivy2/cache/org.parboiled/parboiled_2.12/jars/parboiled_2.12-2.1.3.jar",
+      home + "/.ivy2/cache/commons-codec/commons-codec/jars/commons-codec-1.15.jar",
+      home + "/.ivy2/cache/org.parboiled/parboiled_2.12/jars/parboiled_2.12-2.1.8.jar",
       home + "/.ivy2/cache/com.typesafe/config/bundles/config-1.3.1.jar",
-      home + "/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12/bundles/scala-parser-combinators_2.12-1.0.5.jar")
+      home + "/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12/bundles/scala-parser-combinators_2.12-1.0.7.jar")
     .mkString(":")
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -138,7 +138,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
     nogen  := { System.setProperty("org.nlogo.noGenerator", "true") },
     noopt  := { System.setProperty("org.nlogo.noOptimizer", "true") },
     libraryDependencies ++= Seq(
-      "org.ow2.asm" % "asm-all" % "5.0.4",
+      "org.ow2.asm" % "asm-all" % "5.2",
       "org.picocontainer" % "picocontainer" % "2.15",
       "log4j" % "log4j" % "1.2.16",
       "javax.media" % "jmf" % "2.1.1e",
@@ -207,7 +207,7 @@ lazy val headless = (project in file ("netlogo-headless")).
     mainClass in Compile         := Some("org.nlogo.headless.Main"),
     nogen                        := { System.setProperty("org.nlogo.noGenerator", "true") },
     libraryDependencies          ++= Seq(
-      "org.ow2.asm" % "asm-all" % "5.0.4",
+      "org.ow2.asm" % "asm-all" % "5.2",
       "org.parboiled" %% "parboiled" % "2.1.8",
       "commons-codec" % "commons-codec" % "1.10",
       "com.typesafe" % "config" % "1.3.1",

--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "org.picocontainer" % "picocontainer" % "2.15",
       "log4j" % "log4j" % "1.2.16",
       "javax.media" % "jmf" % "2.1.1e",
-      "commons-codec" % "commons-codec" % "1.10",
+      "commons-codec" % "commons-codec" % "1.15",
       "org.parboiled" %% "parboiled" % "2.1.8",
       "org.jogamp.jogl" % "jogl-all" % "2.4.0" from "https://jogamp.org/deployment/archive/rc/v2.4.0-rc-20210111/jar/jogl-all.jar",
       "org.jogamp.gluegen" % "gluegen-rt" % "2.4.0" from "https://jogamp.org/deployment/archive/rc/v2.4.0-rc-20210111/jar/gluegen-rt.jar",
@@ -209,7 +209,7 @@ lazy val headless = (project in file ("netlogo-headless")).
     libraryDependencies          ++= Seq(
       "org.ow2.asm" % "asm-all" % "5.2",
       "org.parboiled" %% "parboiled" % "2.1.8",
-      "commons-codec" % "commons-codec" % "1.10",
+      "commons-codec" % "commons-codec" % "1.15",
       "com.typesafe" % "config" % "1.3.1",
       "net.lingala.zip4j" % "zip4j" % "1.3.3"
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -153,7 +153,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "org.apache.httpcomponents" % "httpclient" % "4.2",
       "org.apache.httpcomponents" % "httpmime" % "4.2",
       "com.googlecode.json-simple" % "json-simple" % "1.1.1",
-      "com.fifesoft" % "rsyntaxtextarea" % "2.6.0",
+      "com.fifesoft" % "rsyntaxtextarea" % "2.6.1",
       "com.typesafe" % "config" % "1.3.1",
       "net.lingala.zip4j" % "zip4j" % "1.3.3"
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -139,7 +139,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
     noopt  := { System.setProperty("org.nlogo.noOptimizer", "true") },
     libraryDependencies ++= Seq(
       "org.ow2.asm" % "asm-all" % "5.0.4",
-      "org.picocontainer" % "picocontainer" % "2.13.6",
+      "org.picocontainer" % "picocontainer" % "2.15",
       "log4j" % "log4j" % "1.2.16",
       "javax.media" % "jmf" % "2.1.1e",
       "commons-codec" % "commons-codec" % "1.10",

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val scalatestSettings = Seq(
   logBuffered in testOnly in Test := false,
   libraryDependencies ++= Seq(
     "org.scalatest"  %% "scalatest"  % "3.0.1"  % "test",
-    "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
+    "org.scalacheck" %% "scalacheck" % "1.13.5" % "test"
   )
 )
 
@@ -308,7 +308,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform).
           "org.scala-lang.modules"   %%% "scala-parser-combinators" % "1.0.5",
           "org.scalatest"  %%% "scalatest" % "3.0.0" % "test",
           // scalatest doesn't yet play nice with scalacheck 1.13.0
-          "org.scalacheck" %%% "scalacheck" % "1.13.4" % "test",
+          "org.scalacheck" %%% "scalacheck" % "1.13.5" % "test",
       )}).
   jvmConfigure(_.dependsOn(sharedResources)).
   jvmSettings(jvmSettings: _*).

--- a/build.sbt
+++ b/build.sbt
@@ -305,7 +305,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform).
       libraryDependencies ++= {
       import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport.toScalaJSGroupID
         Seq(
-          "org.scala-lang.modules"   %%% "scala-parser-combinators" % "1.0.5",
+          "org.scala-lang.modules"   %%% "scala-parser-combinators" % "1.0.7",
           "org.scalatest"  %%% "scalatest" % "3.0.0" % "test",
           // scalatest doesn't yet play nice with scalacheck 1.13.0
           "org.scalacheck" %%% "scalacheck" % "1.13.5" % "test",
@@ -316,7 +316,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform).
   jvmSettings(
       mappings in (Compile, packageBin) ++= mappings.in(sharedResources, Compile, packageBin).value,
       mappings in (Compile, packageSrc) ++= mappings.in(sharedResources, Compile, packageSrc).value,
-      libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5"
+      libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.7"
     )
 
 lazy val parserJVM = parser.jvm

--- a/build.sbt
+++ b/build.sbt
@@ -143,7 +143,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "log4j" % "log4j" % "1.2.16",
       "javax.media" % "jmf" % "2.1.1e",
       "commons-codec" % "commons-codec" % "1.10",
-      "org.parboiled" %% "parboiled" % "2.1.3",
+      "org.parboiled" %% "parboiled" % "2.1.8",
       "org.jogamp.jogl" % "jogl-all" % "2.4.0" from "https://jogamp.org/deployment/archive/rc/v2.4.0-rc-20210111/jar/jogl-all.jar",
       "org.jogamp.gluegen" % "gluegen-rt" % "2.4.0" from "https://jogamp.org/deployment/archive/rc/v2.4.0-rc-20210111/jar/gluegen-rt.jar",
       "org.jhotdraw" % "jhotdraw" % "6.0b1" % "provided,optional" from cclArtifacts("jhotdraw-6.0b1.jar"),
@@ -208,7 +208,7 @@ lazy val headless = (project in file ("netlogo-headless")).
     nogen                        := { System.setProperty("org.nlogo.noGenerator", "true") },
     libraryDependencies          ++= Seq(
       "org.ow2.asm" % "asm-all" % "5.0.4",
-      "org.parboiled" %% "parboiled" % "2.1.3",
+      "org.parboiled" %% "parboiled" % "2.1.8",
       "commons-codec" % "commons-codec" % "1.10",
       "com.typesafe" % "config" % "1.3.1",
       "net.lingala.zip4j" % "zip4j" % "1.3.2"

--- a/build.sbt
+++ b/build.sbt
@@ -155,7 +155,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "com.googlecode.json-simple" % "json-simple" % "1.1.1",
       "com.fifesoft" % "rsyntaxtextarea" % "2.6.0",
       "com.typesafe" % "config" % "1.3.1",
-      "net.lingala.zip4j" % "zip4j" % "1.3.2"
+      "net.lingala.zip4j" % "zip4j" % "1.3.3"
     ),
     all := {
       IO.copyFile(
@@ -211,7 +211,7 @@ lazy val headless = (project in file ("netlogo-headless")).
       "org.parboiled" %% "parboiled" % "2.1.8",
       "commons-codec" % "commons-codec" % "1.10",
       "com.typesafe" % "config" % "1.3.1",
-      "net.lingala.zip4j" % "zip4j" % "1.3.2"
+      "net.lingala.zip4j" % "zip4j" % "1.3.3"
     ),
     (fullClasspath in Runtime)   ++= (fullClasspath in Runtime in parserJVM).value,
     resourceDirectory in Compile := baseDirectory.value / "resources" / "main",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
 , "org.apache.commons"                % "commons-lang3"         % "3.1"
 , "commons-io"                        % "commons-io"            % "2.6"
 // prevents noise from bintray stuff
-, "org.slf4j"                         % "slf4j-nop"             % "1.6.0"
+, "org.slf4j"                         % "slf4j-nop"             % "1.6.6"
 )
 
 {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@ resolvers ++= Seq(
 )
 
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin"           % "1.0.0")
-addSbtPlugin("org.portable-scala" %  "sbt-scalajs-crossproject"        % "0.6.0")
+addSbtPlugin("org.portable-scala" %  "sbt-scalajs-crossproject"        % "0.6.1")
 addSbtPlugin("org.scala-js"       %  "sbt-scalajs"                     % "0.6.33")
 addSbtPlugin("org.nlogo"          %  "publish-versioned-plugin"        % "3.0.0")
 addSbtPlugin("org.nlogo"          %  "netlogo-extension-documentation" % "0.8.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -30,7 +30,7 @@ libraryDependencies ++= Seq(
   "https://s3.amazonaws.com/ccl-artifacts/classycle-1.4.2.jar"
 , "com.github.spullara.mustache.java" % "scala-extensions-2.10" % "0.9.5"
 , "org.jsoup"                         % "jsoup"                 % "1.14.3"
-, "org.apache.commons"                % "commons-lang3"         % "3.1"
+, "org.apache.commons"                % "commons-lang3"         % "3.12.0"
 , "commons-io"                        % "commons-io"            % "2.6"
 // prevents noise from bintray stuff
 , "org.slf4j"                         % "slf4j-nop"             % "1.6.6"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
 , "com.github.spullara.mustache.java" % "scala-extensions-2.10" % "0.9.5"
 , "org.jsoup"                         % "jsoup"                 % "1.14.3"
 , "org.apache.commons"                % "commons-lang3"         % "3.12.0"
-, "commons-io"                        % "commons-io"            % "2.6"
+, "commons-io"                        % "commons-io"            % "2.11.0"
 // prevents noise from bintray stuff
 , "org.slf4j"                         % "slf4j-nop"             % "1.6.6"
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= Seq(
 , "classycle"                         % "classycle"             % "1.4.2" from
   "https://s3.amazonaws.com/ccl-artifacts/classycle-1.4.2.jar"
 , "com.github.spullara.mustache.java" % "scala-extensions-2.10" % "0.9.5"
-, "org.jsoup"                         % "jsoup"                 % "1.10.3"
+, "org.jsoup"                         % "jsoup"                 % "1.14.3"
 , "org.apache.commons"                % "commons-lang3"         % "3.1"
 , "commons-io"                        % "commons-io"            % "2.6"
 // prevents noise from bintray stuff


### PR DESCRIPTION
As part of #1968, here the first batch dependency updates. All dependency updates passed the CI individually, [and](https://github.com/EwoutH/NetLogo/actions/runs/1409780189) in their combined form.

- Update asm-all to 5.2
- Update commons-codec to 1.15
- Update commons-io to 2.11.0
- Update commons-lang3 to 3.12.0
- Update jsoup to 1.14.3
- Update parboiled to 2.1.8
- Update picocontainer to 2.15
- Update sbt-scalajs-crossproject to 0.6.1
- Update scala-parser-combinators to 1.0.7
- Update scalacheck to 1.13.5
- Update slf4j-nop to 1.6.6
- Update zip4j to 1.3.3

They are currently individual commits, but I could reset and reduce the number of commits if that's preferred.