### PR TITLE
fix typo /Application -> /Applications

### DIFF
--- a/autogen/docs/faq.md.mustache
+++ b/autogen/docs/faq.md.mustache
@@ -584,7 +584,7 @@ follow:
   unless you are running 32 bit NetLogo on a 64 bit Windows, then it will be
   in `C:\Program Files (x86)\NetLogo {{version}}\app`.
 - **Mac OS X:** The file for NetLogo will be located at:
-  `/Application/NetLogo {{version}}/NetLogo {{version}}.app/Contents/Java/NetLogo.cfg` For
+  `/Applications/NetLogo {{version}}/NetLogo {{version}}.app/Contents/Java/NetLogo.cfg` For
   NetLogo 3D and the other applications, you will find the file in the
   corresponding location for each application package. You can reach the cfg
   file by control-clicking the application in the Finder and choosing "Show


### PR DESCRIPTION
FAQ correction: the config file is ' /Applications/NetLogo 6.2.1/NetLogo 6.2.1.app/Contents/Java/NetLogo.cfg '