### PR TITLE
Scala dependency updates: Batch 2

### DIFF
--- a/NetLogo.iml
+++ b/NetLogo.iml
@@ -24,7 +24,7 @@
     <orderEntry type="library" name="org.picocontainer:picocontainer:2.13.6" level="project" />
     <orderEntry type="library" name="log4j:log4j:1.2.16" level="project" />
     <orderEntry type="library" name="javax.media:jmf:2.1.1e" level="project" />
-    <orderEntry type="library" name="org.pegdown:pegdown:1.6.6" level="project" />
+    <orderEntry type="library" name="org.pegdown:pegdown:1.6.0" level="project" />
     <orderEntry type="library" name="org.jogamp.jogl:jogl-all:2.3.2" level="project" />
     <orderEntry type="library" name="org.jogamp.gluegen:gluegen-rt:2.3.2" level="project" />
     <orderEntry type="library" name="org.apache.httpcomponents:httpclient:4.2" level="project" />

--- a/NetLogo.iml
+++ b/NetLogo.iml
@@ -34,11 +34,11 @@
     <orderEntry type="library" name="jhotdraw-6.0b1" level="project" />
     <orderEntry type="library" name="rsyntaxtextarea-3.1.3" level="project" />
     <orderEntry type="library" name="scalacheck_2.12-1.13.5" level="project" />
-    <orderEntry type="library" name="scalatest_2.12-3.0.1" level="project" />
+    <orderEntry type="library" name="scalatest_2.12-3.0.5" level="project" />
     <orderEntry type="library" name="scala-parser-combinators_2.12-1.1.2" level="project" />
     <orderEntry type="library" name="parboiled_2.12-2.3.0" level="project" />
     <orderEntry type="library" name="shapeless_2.12-2.3.2" level="project" />
-    <orderEntry type="library" name="scalactic_2.12-3.0.1" level="project" />
+    <orderEntry type="library" name="scalactic_2.12-3.0.5" level="project" />
     <orderEntry type="library" name="scala-sdk-2.12.2" level="application" />
   </component>
 </module>

--- a/NetLogo.iml
+++ b/NetLogo.iml
@@ -22,7 +22,7 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="org.ow2.asm:asm-all:5.2" level="project" />
     <orderEntry type="library" name="org.picocontainer:picocontainer:2.13.6" level="project" />
-    <orderEntry type="library" name="log4j:log4j:1.2.16" level="project" />
+    <orderEntry type="library" name="log4j:log4j:1.2.17" level="project" />
     <orderEntry type="library" name="javax.media:jmf:2.1.1e" level="project" />
     <orderEntry type="library" name="org.pegdown:pegdown:1.6.0" level="project" />
     <orderEntry type="library" name="org.jogamp.jogl:jogl-all:2.3.2" level="project" />
@@ -32,11 +32,11 @@
     <orderEntry type="library" name="com.googlecode.json-simple:json-simple:1.1.1" level="project" />
     <orderEntry type="library" name="jmock-junit4-2.5.1" level="project" />
     <orderEntry type="library" name="jhotdraw-6.0b1" level="project" />
-    <orderEntry type="library" name="rsyntaxtextarea-2.6.1" level="project" />
+    <orderEntry type="library" name="rsyntaxtextarea-3.1.3" level="project" />
     <orderEntry type="library" name="scalacheck_2.12-1.13.5" level="project" />
     <orderEntry type="library" name="scalatest_2.12-3.0.1" level="project" />
-    <orderEntry type="library" name="scala-parser-combinators_2.12-1.0.4" level="project" />
-    <orderEntry type="library" name="parboiled_2.12-2.1.3" level="project" />
+    <orderEntry type="library" name="scala-parser-combinators_2.12-1.1.2" level="project" />
+    <orderEntry type="library" name="parboiled_2.12-2.3.0" level="project" />
     <orderEntry type="library" name="shapeless_2.12-2.3.2" level="project" />
     <orderEntry type="library" name="scalactic_2.12-3.0.1" level="project" />
     <orderEntry type="library" name="scala-sdk-2.12.2" level="application" />

--- a/bin/benches.scala
+++ b/bin/benches.scala
@@ -27,14 +27,14 @@ val classpath =
       home + "/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.10.jar",
       home + "/.ivy2/cache/org.typelevel/cats-core_2.12/jars/cats-core_2.12-1.0.0-MF.jar",
       home + "/.ivy2/local/org.nlogo/xml-lib_2.12/0.0.1/jars/xml-lib_2.12.jar",
-      home + "/.ivy2/cache/com.typesafe/config/bundles/config-1.3.1.jar",
-      home + "/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12/bundles/scala-parser-combinators_2.12-1.0.7.jar",
+      home + "/.ivy2/cache/com.typesafe/config/bundles/config-1.3.4.jar",
+      home + "/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12/bundles/scala-parser-combinators_2.12-1.1.2.jar",
       home + "/.ivy2/cache/org.scala-lang.modules/scala-xml_2.12/bundles/scala-xml_2.12-1.0.6.jar",
       home + "/.ivy2/cache/org.typelevel/cats-core_2.12/jars/cats-core_2.12-1.0.0-MF.jar",
       home + "/.ivy2/cache/org.ow2.asm/asm-all/jars/asm-all-5.2.jar",
-      home + "/.ivy2/cache/log4j/log4j/jars/log4j-1.2.16.jar",
+      home + "/.ivy2/cache/log4j/log4j/jars/log4j-1.2.17.jar",
       home + "/.ivy2/cache/commons-codec/commons-codec/jars/commons-codec-1.15.jar",
-      home + "/.ivy2/cache/org.parboiled/parboiled_2.12/jars/parboiled_2.12-2.1.8.jar",
+      home + "/.ivy2/cache/org.parboiled/parboiled_2.12/jars/parboiled_2.12-2.3.0.jar",
       home + "/.ivy2/cache/org.picocontainer/picocontainer/jars/picocontainer-2.15.jar")
 
     .mkString(":")

--- a/bin/issues.scala
+++ b/bin/issues.scala
@@ -14,7 +14,7 @@ scalacOptions ++= Seq(
 libraryDependencies ++= Seq(
   "net.databinder.dispatch" %% "dispatch-core" % "0.12.0",
   "net.databinder.dispatch" %% "dispatch-json4s-native" % "0.12.0",
-  "org.slf4j" % "slf4j-nop" % "1.7.10")
+  "org.slf4j" % "slf4j-nop" % "1.7.32")
 */
 
 import dispatch._, Defaults._

--- a/bin/profiles.scala
+++ b/bin/profiles.scala
@@ -24,11 +24,11 @@ val classpath =
       home + "/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.10.jar",
       home + "/.ivy2/cache/org.ow2.asm/asm-all/jars/asm-all-5.2.jar",
       home + "/.ivy2/cache/org.picocontainer/picocontainer/jars/picocontainer-2.15.jar",
-      home + "/.ivy2/cache/log4j/log4j/jars/log4j-1.2.16.jar",
+      home + "/.ivy2/cache/log4j/log4j/jars/log4j-1.2.17.jar",
       home + "/.ivy2/cache/commons-codec/commons-codec/jars/commons-codec-1.15.jar",
-      home + "/.ivy2/cache/org.parboiled/parboiled_2.12/jars/parboiled_2.12-2.1.8.jar",
-      home + "/.ivy2/cache/com.typesafe/config/bundles/config-1.3.1.jar",
-      home + "/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12/bundles/scala-parser-combinators_2.12-1.0.7.jar")
+      home + "/.ivy2/cache/org.parboiled/parboiled_2.12/jars/parboiled_2.12-2.3.0.jar",
+      home + "/.ivy2/cache/com.typesafe/config/bundles/config-1.3.4.jar",
+      home + "/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12/bundles/scala-parser-combinators_2.12-1.1.2.jar")
     .mkString(":")
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ lazy val mockDependencies = Seq(
     "org.jmock" % "jmock-legacy" % "2.8.1" % "test",
     "org.jmock" % "jmock-junit4" % "2.8.1" % "test",
     "org.reflections" % "reflections" % "0.9.10" % "test",
-    "org.slf4j" % "slf4j-nop" % "1.7.12" % "test"
+    "org.slf4j" % "slf4j-nop" % "1.7.32" % "test"
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -305,7 +305,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform).
       libraryDependencies ++= {
       import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport.toScalaJSGroupID
         Seq(
-          "org.scala-lang.modules"   %%% "scala-parser-combinators" % "1.0.7",
+          "org.scala-lang.modules"   %%% "scala-parser-combinators" % "1.1.2",
           "org.scalatest"  %%% "scalatest" % "3.0.0" % "test",
           // scalatest doesn't yet play nice with scalacheck 1.13.0
           "org.scalacheck" %%% "scalacheck" % "1.13.5" % "test",
@@ -316,7 +316,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform).
   jvmSettings(
       mappings in (Compile, packageBin) ++= mappings.in(sharedResources, Compile, packageBin).value,
       mappings in (Compile, packageSrc) ++= mappings.in(sharedResources, Compile, packageSrc).value,
-      libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.7"
+      libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
     )
 
 lazy val parserJVM = parser.jvm

--- a/build.sbt
+++ b/build.sbt
@@ -153,7 +153,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "org.apache.httpcomponents" % "httpclient" % "4.2",
       "org.apache.httpcomponents" % "httpmime" % "4.2",
       "com.googlecode.json-simple" % "json-simple" % "1.1.1",
-      "com.fifesoft" % "rsyntaxtextarea" % "2.6.1",
+      "com.fifesoft" % "rsyntaxtextarea" % "3.1.3,
       "com.typesafe" % "config" % "1.3.4",
       "net.lingala.zip4j" % "zip4j" % "1.3.3"
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -143,7 +143,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "log4j" % "log4j" % "1.2.17",
       "javax.media" % "jmf" % "2.1.1e",
       "commons-codec" % "commons-codec" % "1.15",
-      "org.parboiled" %% "parboiled" % "2.1.8",
+      "org.parboiled" %% "parboiled" % "2.3.0",
       "org.jogamp.jogl" % "jogl-all" % "2.4.0" from "https://jogamp.org/deployment/archive/rc/v2.4.0-rc-20210111/jar/jogl-all.jar",
       "org.jogamp.gluegen" % "gluegen-rt" % "2.4.0" from "https://jogamp.org/deployment/archive/rc/v2.4.0-rc-20210111/jar/gluegen-rt.jar",
       "org.jhotdraw" % "jhotdraw" % "6.0b1" % "provided,optional" from cclArtifacts("jhotdraw-6.0b1.jar"),
@@ -208,7 +208,7 @@ lazy val headless = (project in file ("netlogo-headless")).
     nogen                        := { System.setProperty("org.nlogo.noGenerator", "true") },
     libraryDependencies          ++= Seq(
       "org.ow2.asm" % "asm-all" % "5.2",
-      "org.parboiled" %% "parboiled" % "2.1.8",
+      "org.parboiled" %% "parboiled" % "2.3.0",
       "commons-codec" % "commons-codec" % "1.15",
       "com.typesafe" % "config" % "1.3.4",
       "net.lingala.zip4j" % "zip4j" % "1.3.3"

--- a/build.sbt
+++ b/build.sbt
@@ -306,7 +306,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform).
       import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport.toScalaJSGroupID
         Seq(
           "org.scala-lang.modules"   %%% "scala-parser-combinators" % "1.1.2",
-          "org.scalatest"  %%% "scalatest" % "3.0.0" % "test",
+          "org.scalatest"  %%% "scalatest" % "3.0.5" % "test",
           // scalatest doesn't yet play nice with scalacheck 1.13.0
           "org.scalacheck" %%% "scalacheck" % "1.13.5" % "test",
       )}).

--- a/build.sbt
+++ b/build.sbt
@@ -140,7 +140,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
     libraryDependencies ++= Seq(
       "org.ow2.asm" % "asm-all" % "5.2",
       "org.picocontainer" % "picocontainer" % "2.15",
-      "log4j" % "log4j" % "1.2.16",
+      "log4j" % "log4j" % "1.2.17",
       "javax.media" % "jmf" % "2.1.1e",
       "commons-codec" % "commons-codec" % "1.15",
       "org.parboiled" %% "parboiled" % "2.1.8",

--- a/build.sbt
+++ b/build.sbt
@@ -154,7 +154,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "org.apache.httpcomponents" % "httpmime" % "4.2",
       "com.googlecode.json-simple" % "json-simple" % "1.1.1",
       "com.fifesoft" % "rsyntaxtextarea" % "2.6.1",
-      "com.typesafe" % "config" % "1.3.1",
+      "com.typesafe" % "config" % "1.3.4",
       "net.lingala.zip4j" % "zip4j" % "1.3.3"
     ),
     all := {
@@ -210,7 +210,7 @@ lazy val headless = (project in file ("netlogo-headless")).
       "org.ow2.asm" % "asm-all" % "5.2",
       "org.parboiled" %% "parboiled" % "2.1.8",
       "commons-codec" % "commons-codec" % "1.15",
-      "com.typesafe" % "config" % "1.3.1",
+      "com.typesafe" % "config" % "1.3.4",
       "net.lingala.zip4j" % "zip4j" % "1.3.3"
     ),
     (fullClasspath in Runtime)   ++= (fullClasspath in Runtime in parserJVM).value,

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val scalatestSettings = Seq(
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oS"),
   logBuffered in testOnly in Test := false,
   libraryDependencies ++= Seq(
-    "org.scalatest"  %% "scalatest"  % "3.0.1"  % "test",
+    "org.scalatest"  %% "scalatest"  % "3.0.5"  % "test",
     "org.scalacheck" %% "scalacheck" % "1.13.5" % "test"
   )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -153,7 +153,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "org.apache.httpcomponents" % "httpclient" % "4.2",
       "org.apache.httpcomponents" % "httpmime" % "4.2",
       "com.googlecode.json-simple" % "json-simple" % "1.1.1",
-      "com.fifesoft" % "rsyntaxtextarea" % "3.1.3,
+      "com.fifesoft" % "rsyntaxtextarea" % "3.1.3",
       "com.typesafe" % "config" % "1.3.4",
       "net.lingala.zip4j" % "zip4j" % "1.3.3"
     ),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
 , "org.apache.commons"                % "commons-lang3"         % "3.12.0"
 , "commons-io"                        % "commons-io"            % "2.11.0"
 // prevents noise from bintray stuff
-, "org.slf4j"                         % "slf4j-nop"             % "1.6.6"
+, "org.slf4j"                         % "slf4j-nop"             % "1.7.32"
 )
 
 {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@ resolvers ++= Seq(
 )
 
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin"           % "1.0.0")
-addSbtPlugin("org.portable-scala" %  "sbt-scalajs-crossproject"        % "0.6.1")
+addSbtPlugin("org.portable-scala" %  "sbt-scalajs-crossproject"        % "1.1.0")
 addSbtPlugin("org.scala-js"       %  "sbt-scalajs"                     % "0.6.33")
 addSbtPlugin("org.nlogo"          %  "publish-versioned-plugin"        % "3.0.0")
 addSbtPlugin("org.nlogo"          %  "netlogo-extension-documentation" % "0.8.3")


### PR DESCRIPTION
As part of #1968, here the second batch dependency updates. All dependency updates passed the CI individually.

- Update typesafe:config to 1.3.4
- Update log4j to 1.2.17
- Update rsyntaxtextarea to 3.1.3
- Update parboiled to 2.3.0
- Update sbt-scalajs-crossproject to 1.1.0
- Update scala-parser-combinators to 1.1.2
- Update slf4j-nop to 1.7.32
- Update scalatest to 3.0.5

In contrary to batch 1, this batch includes two major version updates: sbt-scalajs-crossproject to v1 and rsyntaxtextarea to v3.

When the CI passes and the PR is approved, I will soft reset the branch and reduce the number of commits. Squashing while merging is also ok.