### PR TITLE
CI: Cache pip dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,12 @@ jobs:
         with:
           python-version: '3.x'
 
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+
       # The `update-alternatives` step is not needed to build and test but it avoids some superfluous error messages in the logs.
       # The Python stuff is just for testing the Python extension, it's not part of NetLogo's build process.
       - name: Install Dependencies


### PR DESCRIPTION
I was wondering why the "Install dependencies" step in the GitHub Actions CI was taking so long, over 20 minutes. I noticed that the latest python version was used, 3.10 (it switched over a few weeks ago).  While this is fine in itself, currently there aren't [wheels available](https://pypi.org/project/scikit-learn/1.0.1/) for [scikit-learn](https://scikit-learn.org/) for Python 3.10. So it's building it from source, which takes over 15 minutes.

One way to solve that was to roll back to Python 3.9, but an other way is just caching the dependencies installed with pip, which includes scikit-learn. This sped up the "Install dependencies" stel from [25 minutes](https://github.com/EwoutH/NetLogo/runs/4091592097) to about [30 seconds](https://github.com/EwoutH/NetLogo/runs/4091906641).

@LaCuneta please review.