### PR TITLE
CI: Use multiple dependent jobs to run tests in parallel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: liberica@1.8=tgz+${{ env.LIBERICA_URL }}
 
       - name: Clone Git submodules
-        run: git submodule update --init --depth 1
+        run: git submodule update --init
 
       - name: Build NetLogo
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,31 +9,111 @@ env:
   LIBERICA_URL: https://download.bell-sw.com/java/8u292+10/bellsoft-jdk8u292+10-linux-amd64-full.tar.gz
 
 jobs:
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
     if: ${{ 'pull_request' != github.event_name || (github.event.pull_request.head.repo.git_url != github.event.pull_request.base.repo.git_url) }}
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.0
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2
 
-      - uses: olafurpg/setup-scala@v10
+      - uses: olafurpg/setup-scala@v13
+        id: setup-scala
+        with:
+          java-version: liberica@1.8=tgz+${{ env.LIBERICA_URL }}
+
+      - name: Clone Git submodules
+        run: git submodule update --init --depth 1
+
+      - name: Build NetLogo
+        run: |
+          ./sbt update all headless/compile parserJS/compile
+          ./sbt depend headless/depend
+
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+
+  test-parser:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+
+      - uses: olafurpg/setup-scala@v13
+        id: setup-scala
+        with:
+          java-version: liberica@1.8=tgz+${{ env.LIBERICA_URL }}
+
+      - name: Test Parser
+        run: ./sbt parserJS/test parserJVM/test
+
+  test-2D:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+
+      - uses: olafurpg/setup-scala@v13
+        id: setup-scala
+        with:
+          java-version: liberica@1.8=tgz+${{ env.LIBERICA_URL }}
+
+      - name: Test 2D
+        run: ./sbt netlogo/test:fast netlogo/test:medium netlogo/test:slow
+
+      - name: Test 2D NoGen
+        run: ./sbt nogen netlogo/test:fast netlogo/test:medium
+
+  test-3D:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+
+      - uses: olafurpg/setup-scala@v13
+        id: setup-scala
+        with:
+          java-version: liberica@1.8=tgz+${{ env.LIBERICA_URL }}
+
+      - name: Test 3D
+        run: ./sbt threed netlogo/test:fast netlogo/test:medium netlogo/test:slow
+
+  test-extensions:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+
+      - uses: olafurpg/setup-scala@v13
         id: setup-scala
         with:
           java-version: liberica@1.8=tgz+${{ env.LIBERICA_URL }}
 
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: ${{ runner.os }}-pip-
+          python-version: '3.9'
 
       # The `update-alternatives` step is not needed to build and test but it avoids some superfluous error messages in the logs.
       # The Python stuff is just for testing the Python extension, it's not part of NetLogo's build process.
@@ -47,26 +127,23 @@ jobs:
           pip2 install numpy
           sudo update-alternatives --install /usr/bin/javapackager javapackager ${{ env.JAVA_HOME }}/bin/javapackager 100 --slave /usr/share/man/man1/javapackager.1 javapackager.1 ${{ env.JAVA_HOME }}/man/man1/javapackager.1
 
-      - name: Build
-        run: |
-          git submodule update --init
-          ./sbt update all headless/compile parserJS/compile
-          ./sbt depend headless/depend
-
-      - name: Test Parser
-        run: ./sbt parserJS/test parserJVM/test
-
-      - name: Test 2D
-        run: ./sbt netlogo/test:fast netlogo/test:medium netlogo/test:slow
-
-      - name: Test 2D NoGen
-        run: ./sbt nogen netlogo/test:fast netlogo/test:medium
-
-      - name: Test 3D
-        run: ./sbt threed netlogo/test:fast netlogo/test:medium netlogo/test:slow
-
       - name: Test Extensions
         run: ./sbt netlogo/test:extensionTests
+
+  test-headless:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+
+      - uses: olafurpg/setup-scala@v13
+        id: setup-scala
+        with:
+          java-version: liberica@1.8=tgz+${{ env.LIBERICA_URL }}
 
       - name: Test Headless
         run: ./sbt headless/test:fast headless/test:medium headless/test:slow


### PR DESCRIPTION
This commit splits the test into multiple jobs that can be executed in parallel. It hugely speeds up build time and improves the overview which tests are failing.

A cache is used to transfer the build to the tests jobs. The workflow configuration now looks like this:

<img width="826" alt="Screenshot_653" src="https://user-images.githubusercontent.com/15776622/140112219-3406f5ea-3e2c-4fd3-97c6-4d316a14c418.png">