### PR TITLE
Deps: Update to scalacheck 1.14.3 and typesafe:config 1.4.1

### DIFF
--- a/NetLogo.iml
+++ b/NetLogo.iml
@@ -33,7 +33,7 @@
     <orderEntry type="library" name="jmock-junit4-2.5.1" level="project" />
     <orderEntry type="library" name="jhotdraw-6.0b1" level="project" />
     <orderEntry type="library" name="rsyntaxtextarea-3.1.3" level="project" />
-    <orderEntry type="library" name="scalacheck_2.12-1.13.5" level="project" />
+    <orderEntry type="library" name="scalacheck_2.12-1.15.1" level="project" />
     <orderEntry type="library" name="scalatest_2.12-3.0.5" level="project" />
     <orderEntry type="library" name="scala-parser-combinators_2.12-1.1.2" level="project" />
     <orderEntry type="library" name="parboiled_2.12-2.3.0" level="project" />

--- a/NetLogo.iml
+++ b/NetLogo.iml
@@ -33,7 +33,7 @@
     <orderEntry type="library" name="jmock-junit4-2.5.1" level="project" />
     <orderEntry type="library" name="jhotdraw-6.0b1" level="project" />
     <orderEntry type="library" name="rsyntaxtextarea-3.1.3" level="project" />
-    <orderEntry type="library" name="scalacheck_2.12-1.15.1" level="project" />
+    <orderEntry type="library" name="scalacheck_2.12-1.14.3" level="project" />
     <orderEntry type="library" name="scalatest_2.12-3.0.5" level="project" />
     <orderEntry type="library" name="scala-parser-combinators_2.12-1.1.2" level="project" />
     <orderEntry type="library" name="parboiled_2.12-2.3.0" level="project" />

--- a/bin/benches.scala
+++ b/bin/benches.scala
@@ -27,7 +27,7 @@ val classpath =
       home + "/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.10.jar",
       home + "/.ivy2/cache/org.typelevel/cats-core_2.12/jars/cats-core_2.12-1.0.0-MF.jar",
       home + "/.ivy2/local/org.nlogo/xml-lib_2.12/0.0.1/jars/xml-lib_2.12.jar",
-      home + "/.ivy2/cache/com.typesafe/config/bundles/config-1.3.4.jar",
+      home + "/.ivy2/cache/com.typesafe/config/bundles/config-1.4.1.jar",
       home + "/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12/bundles/scala-parser-combinators_2.12-1.1.2.jar",
       home + "/.ivy2/cache/org.scala-lang.modules/scala-xml_2.12/bundles/scala-xml_2.12-1.0.6.jar",
       home + "/.ivy2/cache/org.typelevel/cats-core_2.12/jars/cats-core_2.12-1.0.0-MF.jar",

--- a/bin/profiles.scala
+++ b/bin/profiles.scala
@@ -27,7 +27,7 @@ val classpath =
       home + "/.ivy2/cache/log4j/log4j/jars/log4j-1.2.17.jar",
       home + "/.ivy2/cache/commons-codec/commons-codec/jars/commons-codec-1.15.jar",
       home + "/.ivy2/cache/org.parboiled/parboiled_2.12/jars/parboiled_2.12-2.3.0.jar",
-      home + "/.ivy2/cache/com.typesafe/config/bundles/config-1.3.4.jar",
+      home + "/.ivy2/cache/com.typesafe/config/bundles/config-1.4.1.jar",
       home + "/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12/bundles/scala-parser-combinators_2.12-1.1.2.jar")
     .mkString(":")
 

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val scalatestSettings = Seq(
   logBuffered in testOnly in Test := false,
   libraryDependencies ++= Seq(
     "org.scalatest"  %% "scalatest"  % "3.0.5"  % "test",
-    "org.scalacheck" %% "scalacheck" % "1.13.5" % "test"
+    "org.scalacheck" %% "scalacheck" % "1.15.1" % "test"
   )
 )
 
@@ -154,7 +154,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "org.apache.httpcomponents" % "httpmime" % "4.2",
       "com.googlecode.json-simple" % "json-simple" % "1.1.1",
       "com.fifesoft" % "rsyntaxtextarea" % "3.1.3",
-      "com.typesafe" % "config" % "1.3.4",
+      "com.typesafe" % "config" % "1.4.1",
       "net.lingala.zip4j" % "zip4j" % "1.3.3"
     ),
     all := {
@@ -210,7 +210,7 @@ lazy val headless = (project in file ("netlogo-headless")).
       "org.ow2.asm" % "asm-all" % "5.2",
       "org.parboiled" %% "parboiled" % "2.3.0",
       "commons-codec" % "commons-codec" % "1.15",
-      "com.typesafe" % "config" % "1.3.4",
+      "com.typesafe" % "config" % "1.4.1",
       "net.lingala.zip4j" % "zip4j" % "1.3.3"
     ),
     (fullClasspath in Runtime)   ++= (fullClasspath in Runtime in parserJVM).value,
@@ -308,7 +308,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform).
           "org.scala-lang.modules"   %%% "scala-parser-combinators" % "1.1.2",
           "org.scalatest"  %%% "scalatest" % "3.0.5" % "test",
           // scalatest doesn't yet play nice with scalacheck 1.13.0
-          "org.scalacheck" %%% "scalacheck" % "1.13.5" % "test",
+          "org.scalacheck" %%% "scalacheck" % "1.15.1" % "test",
       )}).
   jvmConfigure(_.dependsOn(sharedResources)).
   jvmSettings(jvmSettings: _*).

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val scalatestSettings = Seq(
   logBuffered in testOnly in Test := false,
   libraryDependencies ++= Seq(
     "org.scalatest"  %% "scalatest"  % "3.0.5"  % "test",
-    "org.scalacheck" %% "scalacheck" % "1.15.1" % "test"
+    "org.scalacheck" %% "scalacheck" % "1.14.3" % "test"
   )
 )
 
@@ -308,7 +308,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform).
           "org.scala-lang.modules"   %%% "scala-parser-combinators" % "1.1.2",
           "org.scalatest"  %%% "scalatest" % "3.0.5" % "test",
           // scalatest doesn't yet play nice with scalacheck 1.13.0
-          "org.scalacheck" %%% "scalacheck" % "1.15.1" % "test",
+          "org.scalacheck" %%% "scalacheck" % "1.14.3" % "test",
       )}).
   jvmConfigure(_.dependsOn(sharedResources)).
   jvmSettings(jvmSettings: _*).


### PR DESCRIPTION
Two remaining small dependency updates before the big Scala / SBT/ Scala.js updates.

- Update scalacheck from 1.13.5 to 1.14.3
- Update typesafe:config from 1.34. to 1.4.1

ScalaCheck 1.15.1 is still compatible with Scala.js 0.6, but also with v1. Newer versions, like 1.15.4, lose compatibility with Scala.js 0.6.

Part of #1968.