### PR TITLE
Dependencies: Update scala-parser-combinators to 2.1.0, zip4j to 2.9.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -155,7 +155,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "com.googlecode.json-simple" % "json-simple" % "1.1.1",
       "com.fifesoft" % "rsyntaxtextarea" % "3.1.3",
       "com.typesafe" % "config" % "1.4.1",
-      "net.lingala.zip4j" % "zip4j" % "1.3.3"
+      "net.lingala.zip4j" % "zip4j" % "2.9.0"
     ),
     all := {
       IO.copyFile(
@@ -211,7 +211,7 @@ lazy val headless = (project in file ("netlogo-headless")).
       "org.parboiled" %% "parboiled" % "2.3.0",
       "commons-codec" % "commons-codec" % "1.15",
       "com.typesafe" % "config" % "1.4.1",
-      "net.lingala.zip4j" % "zip4j" % "1.3.3"
+      "net.lingala.zip4j" % "zip4j" % "2.9.0"
     ),
     (fullClasspath in Runtime)   ++= (fullClasspath in Runtime in parserJVM).value,
     resourceDirectory in Compile := baseDirectory.value / "resources" / "main",

--- a/build.sbt
+++ b/build.sbt
@@ -305,7 +305,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform).
       libraryDependencies ++= {
       import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
         Seq(
-          "org.scala-lang.modules"   %%% "scala-parser-combinators" % "1.1.2",
+          "org.scala-lang.modules"   %%% "scala-parser-combinators" % "2.1.0",
           "org.scalatest"     %% "scalatest"       % "3.2.10"   % Test,
           "org.scalatestplus" %% "scalacheck-1-15" % "3.2.10.0" % Test,
       )}).

--- a/netlogo-core/src/main/api/ExtensionInstaller.scala
+++ b/netlogo-core/src/main/api/ExtensionInstaller.scala
@@ -7,7 +7,7 @@ import java.net.HttpURLConnection
 import java.nio.file.{ Files, FileVisitResult, Path, SimpleFileVisitor, StandardCopyOption }
 import java.nio.file.attribute.BasicFileAttributes
 
-import net.lingala.zip4j.core.ZipFile
+import net.lingala.zip4j.ZipFile
 
 import org.nlogo.core.LibraryInfo
 


### PR DESCRIPTION
Two dependency updates in this PR, both to a new major version:

- scala-parser-combinators from 1.1.2 to [2.1.0](https://github.com/scala/scala-parser-combinators/releases/tag/v2.1.0). This has been made possible by the update to Scala.js v1.
- zip4j from 1.3.3 to [2.9.0](https://github.com/srikanth-lingala/zip4j/releases/tag/v2.9.0). `core.ZipFile` was replace by `ZipFile`.

Part of #1968.