### PR TITLE
NetLogo App not focus when new Agent Inspector created.

### DIFF
--- a/netlogo-gui/src/main/app/tools/AgentMonitorManager.scala
+++ b/netlogo-gui/src/main/app/tools/AgentMonitorManager.scala
@@ -7,7 +7,6 @@ import java.awt.Window
 import scala.collection.mutable
 
 import org.nlogo.agent.Agent
-import org.nlogo.awt.EventQueue
 import org.nlogo.core.AgentKind
 import org.nlogo.swing.Tiler
 import org.nlogo.window.{ Event, GUIWorkspace }
@@ -150,11 +149,7 @@ extends Event.LinkChild with Event.LinkParent
     else window.radius(radius)
     window.setVisible(true)
     org.nlogo.window.Event.rehash()
-    if(agent == null && (agentKind != AgentKind.Observer))
-      window.requestFocus()
-    else
-      EventQueue.invokeLater(
-        new Runnable() { def run() { frame.requestFocus() }})
+    if(agent == null && (agentKind != AgentKind.Observer)) { window.requestFocus() }
   }
 
   def stopInspecting(agent: Agent) {


### PR DESCRIPTION
Fixes #1986
Fixes #1987

Behavior with fix 
MacOS, Linux (test for Windows) - Inspector window opens with focus in Command Line.

- MacOS: overlapping inspectors first appear on top, can be moved behind. Moving one to front moves all to front.
- Linux: overlapping inspectors first appear on top, but then move to the back when a new inspector is opened
- Windows: Needs testing