### PR TITLE
Add methods to BrowserLauncher.scala to help replace deprecated openURL

### DIFF
--- a/netlogo-gui/src/main/swing/BrowserLauncher.scala
+++ b/netlogo-gui/src/main/swing/BrowserLauncher.scala
@@ -7,7 +7,7 @@ import java.lang.Process
 import java.io.IOException
 import java.net.{ URI, URISyntaxException }
 import java.nio.file.{ Files, Path, Paths }
-import javax.swing.JOptionPane
+import javax.swing.{ JDialog, JOptionPane }
 
 object BrowserLauncher {
   private val osName = System.getProperty("os.name")

--- a/netlogo-gui/src/main/swing/BrowserLauncher.scala
+++ b/netlogo-gui/src/main/swing/BrowserLauncher.scala
@@ -39,6 +39,16 @@ object BrowserLauncher {
     }
   }
 
+    def openURI(uri: URI): Unit = {
+      openURI(new JDialog, uri)
+    }
+
+    def openURIString(s: String): Unit = {
+      val dialog = new JDialog
+      val uri = makeURI(dialog, s)
+      openURI(dialog, uri)
+    }
+
   def openPath(comp: Component, path: Path, anchor: String): Unit = {
     val u = path.toUri
     if (anchor == null || anchor == "")
@@ -51,6 +61,10 @@ object BrowserLauncher {
       Files.write(redirectFile, redirectHelper(uriWithAnchor).getBytes("UTF-8"))
       openURI(comp, redirectFile.toUri)
     }
+  }
+
+  def openPath(path: Path, anchor: String): Unit = {
+    openPath(new JDialog, path, anchor)
   }
 
   private def redirectHelper(targetUri: URI): String = {


### PR DESCRIPTION
Update BrowserLauncher in preparation for replacing uses of the deprecated method openURL.
Added method openURIString, and versions of openURI, and openPath with different signatures.

Note that the calls that need to be updated are in the behaviorsearch directory, so this needs to be integrated before they can be updated.

Once the calls are updated, the following method can be removed
```
  @deprecated("Use openURI or openPath instead", "6.0.2")
  def openURL(comp: Component, urlString: String, local: Boolean): Unit = {
```