### PR TITLE
Make jar names consistent for packaging on MacOS

### DIFF
--- a/project/AggregateMacBuild.scala
+++ b/project/AggregateMacBuild.scala
@@ -240,7 +240,7 @@ object PackageMacAggregate {
     val dmgArgs = Seq("hdiutil", "create",
         s"$buildName.dmg",
         "-srcfolder", (aggregateTarget / "NetLogo Bundle").getAbsolutePath,
-        "-size", "600m",
+        "-size", "750m",
         "-fs", "HFS+",
         "-volname", buildName, "-ov")
     RunProcess(dmgArgs, aggregateTarget, "disk image (dmg) packaging")

--- a/project/AggregateMacBuild.scala
+++ b/project/AggregateMacBuild.scala
@@ -219,9 +219,9 @@ object PackageMacAggregate {
     // when we submit for notarization and these libraries don't change that often.
     // -Jeremy B July 2020
     val jarLibsToSign = Map(
-      ("extensions/.bundled/gogo/hid4java.jar", Seq("darwin/libhidapi.dylib")),
+      ("extensions/.bundled/gogo/hid4java-0.7.0.jar", Seq("darwin/libhidapi.dylib")),
       ("extensions/.bundled/nw/gephi-toolkit-0.8.2-all.jar", Seq("native/Mac/i386/libsqlitejdbc.jnilib", "native/Mac/x86_64/libsqlitejdbc.jnilib")),
-      ("extensions/.bundled/vid/core-video-capture-1.3.10.jar", Seq("org/openimaj/video/capture/nativelib/darwin_universal/libOpenIMAJGrabber.dylib")),
+      ("extensions/.bundled/vid/core-video-capture-1.4-20220209.101851-153.jar", Seq("org/openimaj/video/capture/nativelib/darwin_universal/libOpenIMAJGrabber.dylib")),
       ("Java/java-objc-bridge-1.0.0.jar", Seq("libjcocoa.dylib"))
     )
     jarLibsToSign.foreach { case (jarPath: String, libsToSign: Seq[String]) => signJarLibs(aggregateMacDir / jarPath, appSigningOptions, libsToSign) }


### PR DESCRIPTION
In _extensions/vid/build.sbt_ we have   `"org.openimaj" % "core-video-capture" % "1.4-SNAPSHOT"`
however in _project/AggregateMacBuild.scala_ I needed to refer to the jar as `"extensions/.bundled/vid/core-video-capture-1.4-20220209.101851-153.jar"`

Is this problematic?