### PR TITLE
SliderWidget: Fix logic on "ok"

### DIFF
--- a/netlogo-gui/src/main/window/SliderWidget.scala
+++ b/netlogo-gui/src/main/window/SliderWidget.scala
@@ -168,9 +168,9 @@ class SliderWidget(eventOnReleaseOnly: Boolean, random: MersenneTwisterFast) ext
     super.editFinished
     removeAllErrors()
     setName(name, nameChanged)
-    this.value = StrictMath.min(StrictMath.max(value, minimum), maximum)
     nameChanged = false
     updateConstraints()
+    this.value = StrictMath.min(StrictMath.max(value, minimum), maximum)
     true
   }
 


### PR DESCRIPTION
The "Apply" button was working, so the logic between "Ok" and
"Apply" was slightly different. The new values need to be adjusted (min, max)
before the value can be applied to ensure that it is accepted when the
value is out of the original range.

#2025 