### PR TITLE
Update to Scala 2.12.17

### DIFF
--- a/NetLogo.iml
+++ b/NetLogo.iml
@@ -38,6 +38,6 @@
     <orderEntry type="library" name="parboiled_2.12-2.3.0" level="project" />
     <orderEntry type="library" name="shapeless_2.12-2.3.2" level="project" />
     <orderEntry type="library" name="scalactic_2.12-3.0.9" level="project" />
-    <orderEntry type="library" name="scala-sdk-2.12.15" level="application" />
+    <orderEntry type="library" name="scala-sdk-2.12.17" level="application" />
   </component>
 </module>

--- a/bin/benches.scala
+++ b/bin/benches.scala
@@ -24,7 +24,7 @@ val classpath =
       "../parser-jvm/target/classes",
       "../shared/target/classes",
       "../netlogo-gui/resources",
-      home + "/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.15.jar",
+      home + "/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.17.jar",
       home + "/.ivy2/cache/org.typelevel/cats-core_2.12/jars/cats-core_2.12-1.0.0-MF.jar",
       home + "/.ivy2/local/org.nlogo/xml-lib_2.12/0.0.1/jars/xml-lib_2.12.jar",
       home + "/.ivy2/cache/com.typesafe/config/bundles/config-1.4.1.jar",

--- a/bin/issues.scala
+++ b/bin/issues.scala
@@ -7,7 +7,7 @@
 // don't panic; it may take a few minutes to download dependencies
 
 /***
-scalaVersion := "2.12.15"
+scalaVersion := "2.12.17"
 onLoadMessage := ""
 scalacOptions ++= Seq(
   "-deprecation", "-unchecked", "-feature", "-Xfatal-warnings")

--- a/bin/profiles.scala
+++ b/bin/profiles.scala
@@ -21,7 +21,7 @@ val classpath =
   Seq("../netlogo-gui/target/classes",
       "../shared/target/classes",
       "../netlogo-gui/resources",
-      home + "/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.15.jar",
+      home + "/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.17.jar",
       home + "/.ivy2/cache/org.ow2.asm/asm-all/jars/asm-all-5.2.jar",
       home + "/.ivy2/cache/org.picocontainer/picocontainer/jars/picocontainer-2.15.jar",
       home + "/.ivy2/cache/commons-codec/commons-codec/jars/commons-codec-1.15.jar",

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val commonSettings = Seq(
 // These settings are common to all builds involving scala
 // Any scala-specific settings should change here (and thus for all projects at once)
 lazy val scalaSettings = Seq(
-  scalaVersion           := "2.12.16",
+  scalaVersion           := "2.12.17",
   scalaSource in Compile := baseDirectory.value / "src" / "main",
   scalaSource in Test    := baseDirectory.value / "src" / "test",
   crossPaths             := false, // don't cross-build for different Scala versions


### PR DESCRIPTION
Update to the latest patch of the Scala 2.12 release series, [2.12.17](https://github.com/scala/scala/releases/tag/v2.12.17).