### PR TITLE
Scala dependency updates: Batch 7

### DIFF
--- a/bin/issues.scala
+++ b/bin/issues.scala
@@ -14,7 +14,7 @@ scalacOptions ++= Seq(
 libraryDependencies ++= Seq(
   "net.databinder.dispatch" %% "dispatch-core" % "0.12.0",
   "net.databinder.dispatch" %% "dispatch-json4s-native" % "0.12.0",
-  "org.slf4j" % "slf4j-nop" % "1.7.32")
+  "org.slf4j" % "slf4j-nop" % "1.7.36")
 */
 
 import dispatch._, Defaults._

--- a/build.sbt
+++ b/build.sbt
@@ -115,7 +115,7 @@ lazy val mockDependencies = {
 }
 
 lazy val asmDependencies = {
-  val asmVersion = "9.1"
+  val asmVersion = "9.4"
   Seq(
     libraryDependencies ++= Seq(
       "org.ow2.asm" % "asm"         % asmVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -108,7 +108,7 @@ lazy val mockDependencies = {
         exclude ("org.hamcrest", "hamcrest")
     , "org.jmock"     % "jmock-legacy" % mockVersion % "test"
     , "org.jmock"     % "jmock-junit5" % mockVersion % "test"
-    , "net.bytebuddy" % "byte-buddy"   % "1.12.13"   % "test"
+    , "net.bytebuddy" % "byte-buddy"   % "1.12.18"   % "test"
     , "org.hamcrest"  % "hamcrest"     % "2.2"       % "test"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -182,7 +182,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "org.picocontainer" % "picocontainer" % "2.15",
       "javax.media" % "jmf" % "2.1.1e",
       "commons-codec" % "commons-codec" % "1.15",
-      "org.parboiled" %% "parboiled" % "2.3.0",
+      "org.parboiled" %% "parboiled" % "2.4.1",
       "org.jogamp.jogl" % "jogl-all" % "2.4.0" from "https://jogamp.org/deployment/archive/rc/v2.4.0-rc-20210111/jar/jogl-all.jar",
       "org.jogamp.gluegen" % "gluegen-rt" % "2.4.0" from "https://jogamp.org/deployment/archive/rc/v2.4.0-rc-20210111/jar/gluegen-rt.jar",
       "org.jhotdraw" % "jhotdraw" % "6.0b1" % "provided,optional" from cclArtifacts("jhotdraw-6.0b1.jar"),
@@ -240,7 +240,7 @@ lazy val headless = (project in file ("netlogo-headless")).
     javacOptions ++= Seq("--release", "11"),
     mainClass in Compile         := Some("org.nlogo.headless.Main"),
     libraryDependencies          ++= Seq(
-      "org.parboiled" %% "parboiled" % "2.3.0",
+      "org.parboiled" %% "parboiled" % "2.4.1",
       "commons-codec" % "commons-codec" % "1.15",
       "com.typesafe" % "config" % "1.4.2",
       "net.lingala.zip4j" % "zip4j" % "2.9.0",

--- a/build.sbt
+++ b/build.sbt
@@ -348,7 +348,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform).
     libraryDependencies ++= {
       import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
       Seq(
-        "org.scala-lang.modules" %%% "scala-parser-combinators" %    "2.1.0"
+        "org.scala-lang.modules" %%% "scala-parser-combinators" %    "2.1.1"
       ,          "org.scalatest" %%%                "scalatest" %   "3.2.14" % Test
       ,      "org.scalatestplus" %%%          "scalacheck-1-16" % "3.2.13.0" % Test
       )
@@ -358,7 +358,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform).
   jvmSettings(scalatestSettings: _*).
   jvmSettings(
     javacOptions ++= Seq("--release", "11"),
-    libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.0",
+    libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.1",
     // you can get these included by just depending on the `sharedResources` project directly
     // but then when you publish the parser JVM package, the POM file lists sharedResources
     // as a dependency.  It seems like a weird thing to publish separately, so this just

--- a/build.sbt
+++ b/build.sbt
@@ -189,7 +189,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "org.apache.httpcomponents" % "httpclient" % "4.2",
       "org.apache.httpcomponents" % "httpmime" % "4.2",
       "com.googlecode.json-simple" % "json-simple" % "1.1.1",
-      "com.fifesoft" % "rsyntaxtextarea" % "3.1.3",
+      "com.fifesoft" % "rsyntaxtextarea" % "3.1.6",
       "com.typesafe" % "config" % "1.4.1",
       "net.lingala.zip4j" % "zip4j" % "2.9.0"
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -189,7 +189,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "org.apache.httpcomponents" % "httpclient" % "4.2",
       "org.apache.httpcomponents" % "httpmime" % "4.2",
       "com.googlecode.json-simple" % "json-simple" % "1.1.1",
-      "com.fifesoft" % "rsyntaxtextarea" % "3.1.6",
+      "com.fifesoft" % "rsyntaxtextarea" % "3.3.0",
       "com.typesafe" % "config" % "1.4.2",
       "net.lingala.zip4j" % "zip4j" % "2.9.1"
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ lazy val scalatestSettings = Seq(
 , Test / testOnly / logBuffered := false
 , libraryDependencies ++= Seq(
     "org.scalatest"     %% "scalatest"       % "3.2.14"   % Test
-  , "org.scalatestplus" %% "scalacheck-1-16" % "3.2.13.0" % Test
+  , "org.scalatestplus" %% "scalacheck-1-16" % "3.2.14.0" % Test
   )
   // This lets us mock up some Java library classes for testing.
   // -Jeremy B August 2022
@@ -350,7 +350,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform).
       Seq(
         "org.scala-lang.modules" %%% "scala-parser-combinators" %    "2.1.1"
       ,          "org.scalatest" %%%                "scalatest" %   "3.2.14" % Test
-      ,      "org.scalatestplus" %%%          "scalacheck-1-16" % "3.2.13.0" % Test
+      ,      "org.scalatestplus" %%%          "scalacheck-1-16" % "3.2.14.0" % Test
       )
     }).
   jvmConfigure(_.dependsOn(sharedResources % "compile-internal->compile")).

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ lazy val scalatestSettings = Seq(
   Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oS")
 , Test / testOnly / logBuffered := false
 , libraryDependencies ++= Seq(
-    "org.scalatest"     %% "scalatest"       % "3.2.13"   % Test
+    "org.scalatest"     %% "scalatest"       % "3.2.14"   % Test
   , "org.scalatestplus" %% "scalacheck-1-16" % "3.2.13.0" % Test
   )
   // This lets us mock up some Java library classes for testing.
@@ -349,7 +349,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform).
       import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
       Seq(
         "org.scala-lang.modules" %%% "scala-parser-combinators" %    "2.1.0"
-      ,          "org.scalatest" %%%                "scalatest" %   "3.2.13" % Test
+      ,          "org.scalatest" %%%                "scalatest" %   "3.2.14" % Test
       ,      "org.scalatestplus" %%%          "scalacheck-1-16" % "3.2.13.0" % Test
       )
     }).

--- a/build.sbt
+++ b/build.sbt
@@ -190,7 +190,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "org.apache.httpcomponents" % "httpmime" % "4.2",
       "com.googlecode.json-simple" % "json-simple" % "1.1.1",
       "com.fifesoft" % "rsyntaxtextarea" % "3.1.6",
-      "com.typesafe" % "config" % "1.4.1",
+      "com.typesafe" % "config" % "1.4.2",
       "net.lingala.zip4j" % "zip4j" % "2.9.0"
     ),
     all := {},
@@ -242,7 +242,7 @@ lazy val headless = (project in file ("netlogo-headless")).
     libraryDependencies          ++= Seq(
       "org.parboiled" %% "parboiled" % "2.3.0",
       "commons-codec" % "commons-codec" % "1.15",
-      "com.typesafe" % "config" % "1.4.1",
+      "com.typesafe" % "config" % "1.4.2",
       "net.lingala.zip4j" % "zip4j" % "2.9.0",
       "org.reflections" % "reflections" % "0.9.10" % "test",
       "org.slf4j" % "slf4j-nop" % "1.7.36" % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -245,7 +245,7 @@ lazy val headless = (project in file ("netlogo-headless")).
       "com.typesafe" % "config" % "1.4.1",
       "net.lingala.zip4j" % "zip4j" % "2.9.0",
       "org.reflections" % "reflections" % "0.9.10" % "test",
-      "org.slf4j" % "slf4j-nop" % "1.7.32" % "test"
+      "org.slf4j" % "slf4j-nop" % "1.7.36" % "test"
     ),
     (fullClasspath in Runtime)   ++= (fullClasspath in Runtime in parserJVM).value,
     resourceDirectory in Compile := baseDirectory.value / "resources" / "main",

--- a/build.sbt
+++ b/build.sbt
@@ -191,7 +191,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "com.googlecode.json-simple" % "json-simple" % "1.1.1",
       "com.fifesoft" % "rsyntaxtextarea" % "3.1.6",
       "com.typesafe" % "config" % "1.4.2",
-      "net.lingala.zip4j" % "zip4j" % "2.9.0"
+      "net.lingala.zip4j" % "zip4j" % "2.9.1"
     ),
     all := {},
     all := {
@@ -243,7 +243,7 @@ lazy val headless = (project in file ("netlogo-headless")).
       "org.parboiled" %% "parboiled" % "2.4.1",
       "commons-codec" % "commons-codec" % "1.15",
       "com.typesafe" % "config" % "1.4.2",
-      "net.lingala.zip4j" % "zip4j" % "2.9.0",
+      "net.lingala.zip4j" % "zip4j" % "2.9.1",
       "org.reflections" % "reflections" % "0.9.10" % "test",
       "org.slf4j" % "slf4j-nop" % "1.7.36" % "test"
     ),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@ resolvers ++= Seq(
 )
 
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin"           % "1.0.0")
-addSbtPlugin("org.portable-scala" %  "sbt-scalajs-crossproject"        % "1.1.0")
+addSbtPlugin("org.portable-scala" %  "sbt-scalajs-crossproject"        % "1.2.0")
 addSbtPlugin("org.scala-js"       %  "sbt-scalajs"                     % "1.11.0")
 addSbtPlugin("org.nlogo"          %  "publish-versioned-plugin"        % "3.0.0")
 addSbtPlugin("org.nlogo"          %  "netlogo-extension-documentation" % "0.8.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= Seq(
 , "classycle"                         % "classycle"             % "1.4.2" from
   "https://s3.amazonaws.com/ccl-artifacts/classycle-1.4.2.jar"
 , "com.github.spullara.mustache.java" % "scala-extensions-2.10" % "0.9.5"
-, "org.jsoup"                         % "jsoup"                 % "1.14.3"
+, "org.jsoup"                         % "jsoup"                 % "1.15.3"
 , "org.apache.commons"                % "commons-lang3"         % "3.12.0"
 , "commons-io"                        % "commons-io"            % "2.11.0"
 // prevents noise from bintray stuff

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
 , "org.apache.commons"                % "commons-lang3"         % "3.12.0"
 , "commons-io"                        % "commons-io"            % "2.11.0"
 // prevents noise from bintray stuff
-, "org.slf4j"                         % "slf4j-nop"             % "1.7.32"
+, "org.slf4j"                         % "slf4j-nop"             % "1.7.36"
 )
 
 {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,7 +21,7 @@ addSbtPlugin("org.portable-scala" %  "sbt-scalajs-crossproject"        % "1.1.0"
 addSbtPlugin("org.scala-js"       %  "sbt-scalajs"                     % "1.11.0")
 addSbtPlugin("org.nlogo"          %  "publish-versioned-plugin"        % "3.0.0")
 addSbtPlugin("org.nlogo"          %  "netlogo-extension-documentation" % "0.8.3")
-addSbtPlugin("com.timushev.sbt"   %  "sbt-updates"                     % "0.6.0")
+addSbtPlugin("com.timushev.sbt"   %  "sbt-updates"                     % "0.6.4")
 
 libraryDependencies ++= Seq(
   "com.github.spullara.mustache.java" % "compiler"              % "0.9.5"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ resolvers ++= Seq(
 
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin"           % "1.0.0")
 addSbtPlugin("org.portable-scala" %  "sbt-scalajs-crossproject"        % "1.1.0")
-addSbtPlugin("org.scala-js"       %  "sbt-scalajs"                     % "1.8.0")
+addSbtPlugin("org.scala-js"       %  "sbt-scalajs"                     % "1.11.0")
 addSbtPlugin("org.nlogo"          %  "publish-versioned-plugin"        % "3.0.0")
 addSbtPlugin("org.nlogo"          %  "netlogo-extension-documentation" % "0.8.3")
 addSbtPlugin("com.timushev.sbt"   %  "sbt-updates"                     % "0.6.0")


### PR DESCRIPTION
It's exactly a year ago since the last batch of Scala dependency updates, so here's another batch!
- [Update asm, asm-commons, asm-util to 9.4](https://github.com/NetLogo/NetLogo/commit/cdceb254e606a3504a5331c1920a0a5942310cff)
- [Update slf4j-nop to 1.7.36](https://github.com/NetLogo/NetLogo/commit/5e5659c36c32f54fb28941f59c3a034d693b2be2)
- [Update sbt-scalajs to 1.11.0](https://github.com/NetLogo/NetLogo/commit/624afcede67ec051b6ff6bfd4077e85782f30307)
- [Update rsyntaxtextarea to 3.1.6](https://github.com/NetLogo/NetLogo/commit/aa840eb045aeea7ddd719de38548913b955f909d)
- [Update scalatest to 3.2.14](https://github.com/NetLogo/NetLogo/commit/16e195863ed7544cb2b4c3b10df3878c6afee6b7) 
- [Update jsoup to 1.15.3](https://github.com/NetLogo/NetLogo/commit/c8da444c966b5fbd02f0d00081d4d3d75bf23d8d) 
- [Update typesafe:config to 1.4.2](https://github.com/NetLogo/NetLogo/commit/d5c72374f56c07e25a48147638419deab877565f) 
- [Update sbt-updates to 0.6.4](https://github.com/NetLogo/NetLogo/commit/21553c523faec006ba8ee3a32acb5f2c0f8410a3) 
- [Update sbt-scalajs-crossproject to 1.2.0](https://github.com/NetLogo/NetLogo/commit/b87bb46591628e2b3e7827dfdcccf0bca15bfeaa) 
- [Update parboiled to 2.4.1](https://github.com/NetLogo/NetLogo/commit/df5bf58f6510c7ac11287217609437f9af93ba53) 
- [Update byte-buddy to 1.12.18](https://github.com/NetLogo/NetLogo/commit/b3ef47dc1488a3b048a8a9f8c423fc7e8d9f020f) 
- [Update scala-parser-combinators to 2.1.1](https://github.com/NetLogo/NetLogo/commit/fc1faf9c628db2d04ed210573b47953b2ae4667a) 
- [Update scalacheck-1-16 to 3.2.14.0](https://github.com/NetLogo/NetLogo/commit/ddb5dc176e9de6350d4252e2375e0b8deaec3cf7) 
- [Update zip4j to 2.9.1](https://github.com/NetLogo/NetLogo/commit/5b627e89f6881d7281c6c3480aa264800cb857b8) 
- [Update rsyntaxtextarea to 3.3.0](https://github.com/NetLogo/NetLogo/commit/81e444b5acd02bd928da50ed235d5139b8ee6f89)

All updates have passed the CI individually. The dependency updates are generated using [this workflow](https://github.com/EwoutH/NetLogo/blob/scala-steward-app/.github/workflows/scala-steward.yml) using the [Scala Steward](https://github.com/scala-steward-org/scala-steward).

When merging, the "Squash and Merge"-button can be used in the interface of this PR, to merge it as one single commit.

Part of #1968.

Some notable updates:

- [RSyntaxTextArea](https://github.com/bobbylight/RSyntaxTextArea) is updated to 3.3.0, which includes a Configurable "active" line number color, Mouse selection improvements in [3.2.0](https://github.com/bobbylight/RSyntaxTextArea/releases/tag/3.2.0) and improved folds in [3.3.0](https://github.com/bobbylight/RSyntaxTextArea/releases/tag/3.3.0).
- ASM is updated to 9.4, which [includes](https://asm.ow2.io/versions.html) improved Java 18, 19 and 20 support.
- [parboiled](https://github.com/sirthias/parboiled) 1.4.1, [with](https://github.com/sirthias/parboiled/blob/master/CHANGELOG) improved Java 16, 17 and 18 compatibility and cross-build for Scala 2.13 support (could this help [the migration](https://github.com/NetLogo/NetLogo/issues/1823) to Scala 2.13?)
- Scala.js 1.11.0 ([changelog]([Scala.js 1.10.0](http://www.scala-js.org/news/2022/04/04/announcing-scalajs-1.10.0/)))