### PR TITLE
Feature: Set default max heap size to percent instead of hard limit

### DIFF
--- a/autogen/docs/behaviorspace.md.mustache
+++ b/autogen/docs/behaviorspace.md.mustache
@@ -320,7 +320,7 @@ entry](faq.html#how-big-can-my-model-be-how-many-turtles-patches-procedures-butt
 By default NetLogo will not exceed 50% of your system's memory.
 
 Sixth, each parallel run will get its own world for the model to run in.  This world is *not* cleared automatically by
-BehaviorSpace if a parallel run gets re-used for another repitition, which happens quite frequently.  This means, for
+BehaviorSpace if a parallel run gets re-used for another repetition, which happens quite frequently.  This means, for
 example, if you do `ask patches [ set pcolor red ]` in one run and do not use `clear-all` or `clear-patches` in the
 setup commands of the next run, then the patches will all still be red.  In general using `clear-all` before each run
 would be a best practice, but there are times when you might not want to, such as loading data from a file that doesn't
@@ -596,10 +596,9 @@ launch java when running NetLogo Headless. You can adjust various JVM parameters
 in this script. You may also pass in Java properties starting with `-D` to the
 launcher.
 
-With Java 17 memory should be dynamically allocated for your model as it is
-needed and available on your system.  If you want to set a maximum amount of
-memory for BehaviorSpace to use you can use [the `-Xmx` setting to specify a
-particular heap size](faq.html#how-big-can-my-model-be-how-many-turtles-patches-procedures-buttons-and-so-on-can-my-model-contain).
+NetLogo allocates a maximum of half your total system memory for running your model as it is needed.  If you want to set
+a maximum amount of memory for BehaviorSpace to use you can use [the `-Xmx` setting to specify a particular heap
+size](faq.html#how-big-can-my-model-be-how-many-turtles-patches-procedures-buttons-and-so-on-can-my-model-contain).
 
 Note the use of `-Dfile.encoding=UTF-8`. This forces all file I/O to use UTF-8
 encoding. Doing so ensures that NetLogo can load all models consistently, and

--- a/autogen/docs/behaviorspace.md.mustache
+++ b/autogen/docs/behaviorspace.md.mustache
@@ -290,51 +290,49 @@ spreadsheet and database programs.
 
 #### Run options: parallel runs
 
-The run options dialog also lets you select whether you want multiple model runs
-to happen in parallel, and if so, how many are allowed to be simultaneously
-active. This number will default to the number of processor cores in your
+The run options dialog also lets you select whether you want multiple model runs to happen in parallel, and if so, how
+many are allowed to be simultaneously active. This number will default to the number of processor cores in your
 computer.
 
 There are a few cautions associated with parallel runs.
 
-First, if multiple runs are active, only one of them will be in the "foreground"
-and cause the view and plots to update. The other runs will happen invisibly in
-the background.
+First, if multiple runs are active, only one of them will be in the "foreground" and cause the view and plots to update.
+The other runs will happen invisibly in the background.
 
-Second, invisible background runs can't use primitives that only work in the
-GUI. For example, a background run can't make a movie.
+Second, invisible background runs can't use primitives that only work in the GUI. For example, a background run can't
+make a movie.
 
-Third, since parallel runs progress independently of each other, table format
-output may contain interleaved, out-of-order results. When you analyze your
-table data, you may wish to sort it by run number first. (Spreadsheet format
-output is not affected by this issue, since it is not written until the
-experiment completes or is aborted.)
+Third, since parallel runs progress independently of each other, table format output may contain interleaved,
+out-of-order results. When you analyze your table data, you may wish to sort it by run number first. (Spreadsheet format
+output is not affected by this issue, since it is not written until the experiment completes or is aborted.)
 
-Fourth, using all available processor cores may make your computer slow to use
-for other tasks while the experiment is running.
+Fourth, using all available processor cores may make your computer slow to use for other tasks while the experiment is
+running or slow to complete runs as contention will build for memory between the runs themselves.  The number of threads
+used by NetLogo if the `--threads` parameter is omitted will be the total number of processors on your system.  If your
+model uses a large amount of memory, you may find that passing in a smaller value of `--threads` will enable the runs to
+complete in less time overall since work will be done by the system keeping the memory for each run available.  A good
+rule of thumb might be to start with a `--threads` value at half the number of logical cores your system has, and bump
+up or down from there to see where your "sweet spot" is for least time to complete all runs.
 
-Fifth, doing runs in parallel will multiply the experiment's memory requirements
-accordingly. You may need to increase NetLogo's memory ceiling (see [this FAQ
+Fifth, doing runs in parallel will multiply the experiment's memory requirements accordingly. You may need to increase
+NetLogo's memory ceiling (see [this FAQ
 entry](faq.html#how-big-can-my-model-be-how-many-turtles-patches-procedures-buttons-and-so-on-can-my-model-contain)).
+By default NetLogo will not exceed 50% of your system's memory.
 
-Sixth, each parallel run will get its own world for the model to run in.  This world is
-*not* cleared automatically by BehaviorSpace if a parallel run gets re-used for another
-repitition, which happens quite frequently.  This means, for example, if you do `ask
-patches [ set pcolor red ]` in one run and do not use `clear-all` or `clear-patches` in
-the setup commands of the next run, then the patches will all still be red.  In general
-using `clear-all` before each run would be a best practice, but there are times when you
-might not want to, such as loading data from a file that doesn't change run-to-run.  Just
-be careful with whatever data is not cleared out.
+Sixth, each parallel run will get its own world for the model to run in.  This world is *not* cleared automatically by
+BehaviorSpace if a parallel run gets re-used for another repitition, which happens quite frequently.  This means, for
+example, if you do `ask patches [ set pcolor red ]` in one run and do not use `clear-all` or `clear-patches` in the
+setup commands of the next run, then the patches will all still be red.  In general using `clear-all` before each run
+would be a best practice, but there are times when you might not want to, such as loading data from a file that doesn't
+change run-to-run.  Just be careful with whatever data is not cleared out.
 
-Seventh, there is a very, very small chance that at startup multiple parallel runs could
-wind up with the same random number generator state if they startup at the eact same
-moment in time.  This means the runs would produce identical output for all random
-operations and likely the same results.  This would have a chance to happen when running
-on very fast processors and with lots of parallel runs at once.  If you need to make sure
-this doesn't impact your results, you can add `random-seed new-seed` to your setup
-commands to re-generate a new unique random seed for each run.  In fact, storing the
-`new-seed` as a global variable so you can output it with the rest of your results would
-let you re-run a run later on by manually using that value to set the `random-seed`.
+Seventh, there is a very, very small chance that at startup multiple parallel runs could wind up with the same random
+number generator state if they startup at the eact same moment in time.  This means the runs would produce identical
+output for all random operations and likely the same results.  This would have a chance to happen when running on very
+fast processors and with lots of parallel runs at once.  If you need to make sure this doesn't impact your results, you
+can add `random-seed new-seed` to your setup commands to re-generate a new unique random seed for each run.  In fact,
+storing the `new-seed` as a global variable so you can output it with the rest of your results would let you re-run a
+run later on by manually using that value to set the `random-seed`.
 
 #### Observing runs
 
@@ -598,11 +596,10 @@ launch java when running NetLogo Headless. You can adjust various JVM parameters
 in this script. You may also pass in Java properties starting with `-D` to the
 launcher.
 
-Note the use of `-Xmx` to specify a maximum heap size of one gigabyte. If you
-don't specify a maximum heap size, you will get your VM's default size, which
-may be unusably small. (One gigabyte is an arbitrary size which should be more
-than large enough for most models; you can specify a different limit if you
-want.)
+With Java 17 memory should be dynamically allocated for your model as it is
+needed and available on your system.  If you want to set a maximum amount of
+memory for BehaviorSpace to use you can use [the `-Xmx` setting to specify a
+particular heap size](faq.html#how-big-can-my-model-be-how-many-turtles-patches-procedures-buttons-and-so-on-can-my-model-contain).
 
 Note the use of `-Dfile.encoding=UTF-8`. This forces all file I/O to use UTF-8
 encoding. Doing so ensures that NetLogo can load all models consistently, and

--- a/autogen/docs/faq.md.mustache
+++ b/autogen/docs/faq.md.mustache
@@ -552,35 +552,34 @@ the import items on the File menu or the `import-*` primitives.
 
 ### How big can my model be? How many turtles, patches, procedures, buttons, and so on can my model contain?
 
-We have tested NetLogo with models that use hundreds of megabytes of RAM and they work
-fine. We have reports from NetLogo users that they have run models that required up to 50
-gigabytes of RAM to use millions of patches and tens of thousands of agents, and they
-worked as desired (with the proper Java settings). Theoretically the only limit is the RAM
-available on your system, but you might hit some limits that are inherent in the
-underlying Java runtime or the operating system (either designed-in limits, or bugs).
+We have tested NetLogo with models that use hundreds of megabytes of RAM and they work fine. We have reports from
+NetLogo users that they have run models that required up to 50 gigabytes of RAM to use millions of patches and tens of
+thousands of agents, and they worked as desired with the proper Java settings. Theoretically the only limit is the RAM
+available on your system, but you might hit some limits that are inherent in the underlying Java runtime or the
+operating system (either designed-in limits, or bugs).
 
-The NetLogo engine has no fixed limits on size. By default, though, NetLogo
-ships with a one-gigabyte ceiling on how much total RAM it can use. If your
-model exceeds that limit, you'll get an OutOfMemoryError dialog.
+The NetLogo engine has no fixed limits on model size.  By default NetLogo sets Java  to use up to half of your available
+system memory.  If your model exceeds that memory limit, you'll get an `OutOfMemoryError` dialog.
 
-If you are using BehaviorSpace, note that doing runs in parallel will multiply
-your RAM usage accordingly.
+If you are using BehaviorSpace, note that doing runs in parallel will multiply your RAM usage accordingly.  Similarly,
+using LevelSpace with many child models increases RAM usage greatly.
 
-<a id="where-is-cfg-file"></a> Each platform contains ".cfg" files containing JVM
-settings. There is one cfg file for each sub-application (NetLogo, NetLogo 3D, HubNet
-Client, etc.).  Windows also has a cfg file for the NetLogo_Console app; on macOS and
-Linux the cfg file for NetLogo_Console is just the NetLogo.cfg file.  Although the file
-location varies by platform, the process for changing it is the same. Locate the section
-of the file that looks like the following:
+If you want to increase the memory limit Java uses, you can do so using the NetLogo app configuration files.
+
+<a id="where-is-cfg-file"></a>Each platform contains ".cfg" files containing JVM settings. There is one cfg file for
+each sub-application (NetLogo, NetLogo 3D, HubNet Client, etc.).  Windows also has a cfg file for the NetLogo_Console
+app; on macOS and Linux the cfg file for NetLogo_Console is just the NetLogo.cfg file.  Although the file location
+varies by platform, the process for changing it is the same. Locate the section of the file that looks like the
+following:
 
     [JavaOptions]
     # there may be one or more lines, leave them unchanged
-    -Xmx1024m
+    java-options=-XX:MaxRAMPercentage=50
     # there may be one or more lines, leave them unchanged
 
-Modify the value immediately following `-Xmx`, changing it to the amount of
-space you need, save the file, and restart NetLogo. Platform specific notes
-follow:
+You can change the percentage number from 50 to whatever you want.  Save the file and restart NetLogo for the setting to take effect.  If you need to set an exact amount of memory (as opposed to a percentage), you can also comment out the `java-options=-XX:MaxRAMPercentage=50` line with a `#` at the start and add a new line with `java-options=-Xmx####m`.  Replace the `####m` with whatever amount of memory you like; using `4096m` would limit NetLogo to 4096 megabytes of memory, or 4 gigabytes.
+
+Platform specific notes follow:
 
 - **Windows:** The file will typically be in `C:\Program Files\NetLogo {{version}}\app`,
   unless you are running 32 bit NetLogo on a 64 bit Windows, then it will be
@@ -600,11 +599,9 @@ follow:
 - **Linux:** The cfg files will be located in the `NetLogo {{version}}/lib/app`
   folder after untarring.
 
-By default, Mac builds of NetLogo bundle a 64-bit JVM, which should be able to
-make use of as much memory as the lesser of available system memory and the
-value following `-Xmx`. Windows and Linux will bundle a 32-bit or 64-bit JVM,
-depending on which version you have downloaded. It is recommended that you
-install 64-bit NetLogo on all 64-bit operating systems for best performance.
+By default, Mac builds of NetLogo bundle a 64-bit JVM.  Windows and Linux will bundle a 32-bit or 64-bit JVM, depending
+on which version you have downloaded. It is recommended that you install 64-bit NetLogo on all 64-bit operating systems
+for best performance.
 
 ### Can I use GIS data in NetLogo?
 

--- a/autogen/docs/faq.md.mustache
+++ b/autogen/docs/faq.md.mustache
@@ -577,7 +577,11 @@ following:
     java-options=-XX:MaxRAMPercentage=50
     # there may be one or more lines, leave them unchanged
 
-You can change the percentage number from 50 to whatever you want.  Save the file and restart NetLogo for the setting to take effect.  If you need to set an exact amount of memory (as opposed to a percentage), you can also comment out the `java-options=-XX:MaxRAMPercentage=50` line with a `#` at the start and add a new line with `java-options=-Xmx####m`.  Replace the `####m` with whatever amount of memory you like; using `4096m` would limit NetLogo to 4096 megabytes of memory, or 4 gigabytes.
+You can change the percentage number from 50 to whatever you want.  Save the file and restart NetLogo for the setting to
+take effect.  If you need to set an exact amount of memory (as opposed to a percentage), you can also comment out the
+`java-options=-XX:MaxRAMPercentage=50` line with a `#` at the start and add a new line with `java-options=-Xmx####m`.
+Replace the `####m` with whatever amount of memory you like; using `4096m` would limit NetLogo to 4096 megabytes of
+memory, or 4 gigabytes.
 
 Platform specific notes follow:
 

--- a/dist/configuration/netlogo-headless.sh.mustache
+++ b/dist/configuration/netlogo-headless.sh.mustache
@@ -9,10 +9,9 @@ else
   JAVA="java"
 fi;
 
-# -Xmx1024m             use up to 1GB RAM (edit to increase)
 # -Dfile.encoding=UTF-8 ensure Unicode characters in model files are compatible cross-platform
 
-JVM_OPTS=(-Xmx1024m -Dfile.encoding=UTF-8 -Dnetlogo.extensions.dir="${BASE_DIR}/extensions" -Dnetlogo.models.dir="${BASE_DIR}/models" --add-exports=java.base/java.lang=ALL-UNNAMED --add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-exports=java.desktop/sun.java2d=ALL-UNNAMED  {{{javaOptions}}})
+JVM_OPTS=(-XX:MaxRAMPercentage=50 -Dfile.encoding=UTF-8 -Dnetlogo.extensions.dir="${BASE_DIR}/extensions" -Dnetlogo.models.dir="${BASE_DIR}/models" --add-exports=java.base/java.lang=ALL-UNNAMED --add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-exports=java.desktop/sun.java2d=ALL-UNNAMED  {{{javaOptions}}})
 ARGS=()
 
 for arg in "$@"; do

--- a/dist/configuration/windows/netlogo-headless.bat.mustache
+++ b/dist/configuration/windows/netlogo-headless.bat.mustache
@@ -12,11 +12,10 @@ if defined JAVA_HOME (
   set "JAVA=java.exe"
 )
 
-REM -Xmx1024m                     use up to 1GB RAM (edit to increase)
 REM -Dfile.encoding=UTF-8         ensure Unicode characters in model files are compatible cross-platform
 REM -Dnetlogo.extensions.dir=...  tell netlogo where to find extensions
 
-SET "JVM_OPTS=-Xmx1024m -Dfile.encoding=UTF-8 -Dnetlogo.models.dir=^"%BASE_DIR%\models^" -Dnetlogo.extensions.dir=^"%BASE_DIR%\extensions^" --add-exports=java.base/java.lang=ALL-UNNAMED --add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-exports=java.desktop/sun.java2d=ALL-UNNAMED"
+SET "JVM_OPTS=-XX:MaxRAMPercentage=50 -Dfile.encoding=UTF-8 -Dnetlogo.models.dir=^"%BASE_DIR%\models^" -Dnetlogo.extensions.dir=^"%BASE_DIR%\extensions^" --add-exports=java.base/java.lang=ALL-UNNAMED --add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-exports=java.desktop/sun.java2d=ALL-UNNAMED"
 
 set ARGS=
 

--- a/project/Launcher.scala
+++ b/project/Launcher.scala
@@ -35,7 +35,7 @@ trait Launcher {
 
 object Launcher {
   val defaultJavaOptions: Seq[String] = Seq(
-    "-Xmx1024m"
+    "-XX:MaxRAMPercentage=50"
   , "-Dfile.encoding=UTF-8"
   , "--add-exports=java.base/java.lang=ALL-UNNAMED"
   , "--add-exports=java.desktop/sun.awt=ALL-UNNAMED"
@@ -102,9 +102,9 @@ class BehaviorsearchLauncher(
   def id: String = "Behaviorsearch"
   def mustachePrefix: String = "behaviorsearch-launcher"
   def javaOptions: Seq[String] = Seq(
-    "-Xmx1024m"
     // Behaviorsearch has issues with the post Java 8 GCs, particularly on 32-bit systems.
     // -Jeremy B September 2022
+    "-XX:MaxRAMPercentage=50"
   , "-XX:+UseParallelGC"
   , "-Dfile.encoding=UTF-8"
   ) ++ extraJavaOptions

--- a/project/Running.scala
+++ b/project/Running.scala
@@ -10,7 +10,7 @@ object Running {
     fork in run := true,
     javaOptions in run ++= Seq(
       "-XX:-OmitStackTraceInFastThrow",  // issue #104
-      "-Xmx1024m",
+      "-XX:MaxRAMPercentage=50",
       "-Dfile.encoding=UTF-8",
       "-Dapple.awt.graphics.UseQuartz=true") ++
     (if(System.getProperty("os.name").startsWith("Mac"))

--- a/sbt
+++ b/sbt
@@ -41,7 +41,7 @@ JAVA=$JAVA_HOME/bin/java
 
 # Most of these settings are fine for everyone
 XSS=-Xss10m
-XMX=-Xmx2048m
+XMRP=-XX:MaxRAMPercentage=50
 ENCODING=-Dfile.encoding=UTF-8
 HEADLESS=-Djava.awt.headless=true
 USE_QUARTZ=-Dapple.awt.graphics.UseQuartz=false
@@ -65,7 +65,7 @@ fi
 
 # UseQuartz=false so that we get pixel for pixel identical drawings between OS's, so TestChecksums works - ST 6/9/10
 "$JAVA" \
-    $XSS $XMX $XX \
+    $XSS $XMRP $XX \
     $ENCODING \
     $JAVA_OPTS \
     $HEADLESS \


### PR DESCRIPTION
~~Java 17 can handle allocating memory as necessary, so we no longer have to specify a maximum to get around their (previously low) default limits.  For those who do want to limit the memory NetLogo uses, I updated the docs to reflect how to re-add the setting.~~

After more research, J17 doesn't dynamically allocate the memory, but by default it allocates a percentage based on total system memory.  That default is 25%.  That is fine for most modern systems and for those with 4gb or more of system memory  NetLogo will have the same limit it had before (1gb) or greater.  But for older systems with less memory we don't want them hitting the smaller maximums.  As such we'll switch the default NetLogo uses to 50% of system memory.  For most users they'll never notice it.  For users on older machines they'll have a similar starting limit.  For BehaviorSpace users with memory-heavy models they'll be more likely to have things "just work" without resorting to tweaking config file settings.  So overall this should be an improvement.  

I did testing of both memory-heavy models on a system with plenty of memory available as well as running basic models on a memory-limited VM and everything worked well with the new setting.  Users running with less than 2gb of memory will have a lower maximum than before.  I ran a suite of models from the library on such a system, including running basic BehaviorSpace experiments and LevelSpace models, and everything stayed under 512mb of memory.  So for those users this limit should suffice as they are unlikely to be trying to run big models anyway.

