### PR TITLE
CI: Add Windows and macOS build jobs, use setup-java

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,13 +5,15 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  LIBERICA_URL: https://download.bell-sw.com/java/17.0.5+8/bellsoft-jdk17.0.5+8-linux-amd64-full.tar.gz
-
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     if: ${{ 'pull_request' != github.event_name || (github.event.pull_request.head.repo.git_url != github.event.pull_request.base.repo.git_url) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -19,21 +21,23 @@ jobs:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v3
-
-      - uses: olafurpg/setup-scala@v13
-        id: setup-scala
         with:
-          java-version: liberica@17=tgz+${{ env.LIBERICA_URL }}
+          submodules: true
 
-      - name: Clone Git submodules
-        run: git submodule update --init
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'liberica' 
+          java-version: '17'
+          cache: 'sbt'
 
       - name: Build NetLogo
+        shell: bash
         run: |
-          ./sbt update all headless/compile parserJS/compile
-          ./sbt depend headless/depend
+          sbt update all headless/compile parserJS/compile
+          sbt depend headless/depend
 
       - uses: actions/cache@v3
+        if: matrix.os == 'ubuntu-latest'
         id: restore-build
         with:
           path: ./*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,14 +27,14 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'liberica' 
-          java-version: '17'
+          java-version: '17.0.5+8'
           cache: 'sbt'
 
       - name: Build NetLogo
         shell: bash
         run: |
-          sbt update all headless/compile parserJS/compile
-          sbt depend headless/depend
+          ./sbt update all headless/compile parserJS/compile
+          ./sbt depend headless/depend
 
       - uses: actions/cache@v3
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'liberica' 
-          java-version: '17'
+          java-version: '17.0.5+8'
           cache: 'sbt'
 
       - name: Test Parser
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'liberica' 
-          java-version: '17'
+          java-version: '17.0.5+8'
           cache: 'sbt'
 
       - name: Test 2D
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'liberica' 
-          java-version: '17'
+          java-version: '17.0.5+8'
           cache: 'sbt'
 
       - name: Test 3D
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'liberica' 
-          java-version: '17'
+          java-version: '17.0.5+8'
           cache: 'sbt'
 
       - uses: actions/setup-python@v4
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'liberica' 
-          java-version: '17'
+          java-version: '17.0.5+8'
           cache: 'sbt'
 
       - name: Test Headless

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,10 +53,11 @@ jobs:
           path: ./*
           key: ${{ github.sha }}
 
-      - uses: olafurpg/setup-scala@v13
-        id: setup-scala
+      - uses: actions/setup-java@v3
         with:
-          java-version: liberica@17=tgz+${{ env.LIBERICA_URL }}
+          distribution: 'liberica' 
+          java-version: '17'
+          cache: 'sbt'
 
       - name: Test Parser
         run: ./sbt parserJS/test parserJVM/test
@@ -71,10 +72,11 @@ jobs:
           path: ./*
           key: ${{ github.sha }}
 
-      - uses: olafurpg/setup-scala@v13
-        id: setup-scala
+      - uses: actions/setup-java@v3
         with:
-          java-version: liberica@17=tgz+${{ env.LIBERICA_URL }}
+          distribution: 'liberica' 
+          java-version: '17'
+          cache: 'sbt'
 
       - name: Test 2D
         run: ./sbt netlogo/test:fast netlogo/test:medium netlogo/test:slow
@@ -92,10 +94,11 @@ jobs:
           path: ./*
           key: ${{ github.sha }}
 
-      - uses: olafurpg/setup-scala@v13
-        id: setup-scala
+      - uses: actions/setup-java@v3
         with:
-          java-version: liberica@17=tgz+${{ env.LIBERICA_URL }}
+          distribution: 'liberica' 
+          java-version: '17'
+          cache: 'sbt'
 
       - name: Test 3D
         run: ./sbt threed netlogo/test:fast netlogo/test:medium netlogo/test:slow
@@ -110,10 +113,11 @@ jobs:
           path: ./*
           key: ${{ github.sha }}
 
-      - uses: olafurpg/setup-scala@v13
-        id: setup-scala
+      - uses: actions/setup-java@v3
         with:
-          java-version: liberica@17=tgz+${{ env.LIBERICA_URL }}
+          distribution: 'liberica' 
+          java-version: '17'
+          cache: 'sbt'
 
       - uses: actions/setup-python@v4
         with:
@@ -142,10 +146,11 @@ jobs:
           path: ./*
           key: ${{ github.sha }}
 
-      - uses: olafurpg/setup-scala@v13
-        id: setup-scala
+      - uses: actions/setup-java@v3
         with:
-          java-version: liberica@17=tgz+${{ env.LIBERICA_URL }}
+          distribution: 'liberica' 
+          java-version: '17'
+          cache: 'sbt'
 
       - name: Test Headless
         run: ./sbt headless/test:fast headless/test:medium headless/test:slow


### PR DESCRIPTION
Some upgrades to the CI!

- Adds Windows and macOS jobs to the build matrix
- Uses [actions/setup-java](https://github.com/actions/setup-java) instead of [olafurpg/setup-scala](https://github.com/olafurpg/setup-scala) to setup Java and sbt
- Clone the submodules directly in [actions/checkout](https://github.com/actions/checkout) instead of a separate step
- Always use the latest [Liberica 17](https://bell-sw.com/pages/downloads/#/java-17-lts) version

This is a first step in #2071.

**TODO (help welcome):**
- [ ] Make sure the test jobs run as soon as the Ubuntu build job is finished, and don't wait until the Windows and macOS jobs are also finished (to speed up workflow). [More details here](https://stackoverflow.com/questions/74881221/ci-github-actions-require-only-one-specific-job-in-matrix-to-finish-for-othe).

**Optional, can also be done in other PR:**
- [ ] Figure out useful artifacts to upload for each OS (`.exe` for Windows, `.dmg` for macOS? Are those already created, if so where?).
- [ ] Reduce the size of the cache that get's uploaded from the Ubuntu build job for the tests jobs (currently it's the whole directory, that probably can be way less).