### PR TITLE
Increase default memory limit percentage from 50% to 70%

### DIFF
--- a/autogen/docs/faq.md.mustache
+++ b/autogen/docs/faq.md.mustache
@@ -574,12 +574,12 @@ following:
 
     [JavaOptions]
     # there may be one or more lines, leave them unchanged
-    java-options=-XX:MaxRAMPercentage=50
+    java-options=-XX:MaxRAMPercentage=70
     # there may be one or more lines, leave them unchanged
 
-You can change the percentage number from 50 to whatever you want.  Save the file and restart NetLogo for the setting to
+You can change the percentage number from 70 to whatever you want.  Save the file and restart NetLogo for the setting to
 take effect.  If you need to set an exact amount of memory (as opposed to a percentage), you can also comment out the
-`java-options=-XX:MaxRAMPercentage=50` line with a `#` at the start and add a new line with `java-options=-Xmx####m`.
+`java-options=-XX:MaxRAMPercentage=70` line with a `#` at the start and add a new line with `java-options=-Xmx####m`.
 Replace the `####m` with whatever amount of memory you like; using `4096m` would limit NetLogo to 4096 megabytes of
 memory, or 4 gigabytes.
 

--- a/dist/configuration/netlogo-headless.sh.mustache
+++ b/dist/configuration/netlogo-headless.sh.mustache
@@ -11,7 +11,7 @@ fi;
 
 # -Dfile.encoding=UTF-8 ensure Unicode characters in model files are compatible cross-platform
 
-JVM_OPTS=(-XX:MaxRAMPercentage=50 -Dfile.encoding=UTF-8 -Dnetlogo.extensions.dir="${BASE_DIR}/extensions" -Dnetlogo.models.dir="${BASE_DIR}/models" --add-exports=java.base/java.lang=ALL-UNNAMED --add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-exports=java.desktop/sun.java2d=ALL-UNNAMED  {{{javaOptions}}})
+JVM_OPTS=(-XX:MaxRAMPercentage=70 -Dfile.encoding=UTF-8 -Dnetlogo.extensions.dir="${BASE_DIR}/extensions" -Dnetlogo.models.dir="${BASE_DIR}/models" --add-exports=java.base/java.lang=ALL-UNNAMED --add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-exports=java.desktop/sun.java2d=ALL-UNNAMED  {{{javaOptions}}})
 ARGS=()
 
 for arg in "$@"; do

--- a/dist/configuration/windows/netlogo-headless.bat.mustache
+++ b/dist/configuration/windows/netlogo-headless.bat.mustache
@@ -15,7 +15,7 @@ if defined JAVA_HOME (
 REM -Dfile.encoding=UTF-8         ensure Unicode characters in model files are compatible cross-platform
 REM -Dnetlogo.extensions.dir=...  tell netlogo where to find extensions
 
-SET "JVM_OPTS=-XX:MaxRAMPercentage=50 -Dfile.encoding=UTF-8 -Dnetlogo.models.dir=^"%BASE_DIR%\models^" -Dnetlogo.extensions.dir=^"%BASE_DIR%\extensions^" --add-exports=java.base/java.lang=ALL-UNNAMED --add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-exports=java.desktop/sun.java2d=ALL-UNNAMED"
+SET "JVM_OPTS=-XX:MaxRAMPercentage=70 -Dfile.encoding=UTF-8 -Dnetlogo.models.dir=^"%BASE_DIR%\models^" -Dnetlogo.extensions.dir=^"%BASE_DIR%\extensions^" --add-exports=java.base/java.lang=ALL-UNNAMED --add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-exports=java.desktop/sun.java2d=ALL-UNNAMED"
 
 set ARGS=
 

--- a/project/Launcher.scala
+++ b/project/Launcher.scala
@@ -35,7 +35,7 @@ trait Launcher {
 
 object Launcher {
   val defaultJavaOptions: Seq[String] = Seq(
-    "-XX:MaxRAMPercentage=50"
+    "-XX:MaxRAMPercentage=70"
   , "-Dfile.encoding=UTF-8"
   , "--add-exports=java.base/java.lang=ALL-UNNAMED"
   , "--add-exports=java.desktop/sun.awt=ALL-UNNAMED"
@@ -104,7 +104,7 @@ class BehaviorsearchLauncher(
   def javaOptions: Seq[String] = Seq(
     // Behaviorsearch has issues with the post Java 8 GCs, particularly on 32-bit systems.
     // -Jeremy B September 2022
-    "-XX:MaxRAMPercentage=50"
+    "-XX:MaxRAMPercentage=70"
   , "-XX:+UseParallelGC"
   , "-Dfile.encoding=UTF-8"
   ) ++ extraJavaOptions

--- a/project/Running.scala
+++ b/project/Running.scala
@@ -10,7 +10,7 @@ object Running {
     fork in run := true,
     javaOptions in run ++= Seq(
       "-XX:-OmitStackTraceInFastThrow",  // issue #104
-      "-XX:MaxRAMPercentage=50",
+      "-XX:MaxRAMPercentage=70",
       "-Dfile.encoding=UTF-8",
       "-Dapple.awt.graphics.UseQuartz=true") ++
     (if(System.getProperty("os.name").startsWith("Mac"))

--- a/sbt
+++ b/sbt
@@ -41,7 +41,7 @@ JAVA=$JAVA_HOME/bin/java
 
 # Most of these settings are fine for everyone
 XSS=-Xss10m
-XMRP=-XX:MaxRAMPercentage=50
+XMRP=-XX:MaxRAMPercentage=70
 ENCODING=-Dfile.encoding=UTF-8
 HEADLESS=-Djava.awt.headless=true
 USE_QUARTZ=-Dapple.awt.graphics.UseQuartz=false


### PR DESCRIPTION
Increase the default memory limit that NetLogo uses by default from 50 to 70 percent. Follow up on #2068.

On most systems this gives an appreciable increase in available memory:

| GB | 50% | 70%  |
|----|-----|------|
| 4  | 2   | 2,8  |
| 8  | 4   | 5,6  |
| 16 | 8   | 11,2 |
| 32 | 16  | 22,4 |
| 64 | 32  | 44,8 |

There are few cases this will introduce problems, while it would allow more models to run by default.