### PR TITLE
Fix build failure on Linux

### DIFF
--- a/project/JavaPackager.scala
+++ b/project/JavaPackager.scala
@@ -145,7 +145,9 @@ object JavaPackager {
       try {
         Process("update-alternatives --list javac".split(" ")).!!
       } catch {
-        case ex: java.lang.RuntimeException => "" // RHEL bugs out with this command, just use path-specified
+        // This command may not work on all distros, just use path-specified
+        case ex: java.lang.RuntimeException => ""
+        case ex: java.io.IOException => ""
       }
 
     val jpackageFiles = alternatives


### PR DESCRIPTION
On distros that do not use `update-alternatives`, build currently fails with the following error message:
```
[error] java.io.IOException: Cannot run program "update-alternatives": error=2, No such file or directory
```

The error is caused by JavaPackager trying to use `update-alternatives` to find alternative JDKs, which would fail if it isn't available. This PR fixes this by catching the `IOException` that occurs in this situation and just use the path-specified JDK.