### PR TITLE
Add newline support for labels. Fixes #1007

### DIFF
--- a/netlogo-core/src/main/api/Graphics2DWrapper.scala
+++ b/netlogo-core/src/main/api/Graphics2DWrapper.scala
@@ -41,14 +41,15 @@ class Graphics2DWrapper(g: Graphics2D, renderLabelsAsRectangles: Boolean = false
     }
     else {
       val fm = g.getFontMetrics
-      g.translate(x - fm.stringWidth(label), 0)
+      val lines = label.split("\n")
+      g.translate(x - fm.stringWidth(lines(0)), 0)
       if (patchSize >= (fm.getMaxAscent + fm.getMaxDescent))
         g.translate(0, y - fm.getMaxDescent)
       else { // maxAscent is centered on the patch
         val centerAdjustment = 0.0 min ((patchSize / 4) - (fm.getMaxAscent / 4))
         g.translate(0, y - centerAdjustment)
       }
-      g.drawString(label, 0, 0)
+      lines.zipWithIndex.foreach{case (line, i) => g.drawString(line, 0.0f, 1 * fm.getHeight * i)}
     }
   }
   def fillCircle(x: Double, y: Double, xDiameter: Double, yDiameter: Double, scale: Double, angle: Double) {

--- a/netlogo-gui/src/main/gl/render/AgentRenderer.scala
+++ b/netlogo-gui/src/main/gl/render/AgentRenderer.scala
@@ -17,15 +17,21 @@ private[render] object AgentRenderer {
   private val FontScale = 6500f
 
   def renderString(gl: GL2, world: World, str: String, color: AnyRef, fontSize: Int, patchSize: Double) = {
+    val lines = str.split("\n")
     val rgb: Array[Float] =
       org.nlogo.api.Color.getColor(color).getRGBColorComponents(null)
     val scale: Float = (fontSize * 12 / patchSize.toFloat) / FontScale
     gl.glColor3fv(java.nio.FloatBuffer.wrap(rgb))
     gl.glDisable(GLL.GL_LIGHTING)
     gl.glScalef(scale, scale, 3.0f)
-    val strwidth: Float = glut.glutStrokeLength(GLUT.STROKE_ROMAN, str)
+    val strwidth: Float = glut.glutStrokeLength(GLUT.STROKE_ROMAN, lines(0))
     gl.glTranslatef(-strwidth / -2.0f, 0.0f, 0.0f)
-    glut.glutStrokeString(GLUT.STROKE_ROMAN, str)
+    lines.foreach { l =>
+      glut.glutStrokeString(GLUT.STROKE_ROMAN, l)
+      // Why -120.0f and not, like, 1.0f? TBH I don't know. The glScalef takes care of factoring out font and patch
+      // size, so it makes sense this would be a constant. But beyond that, this just seemed to work...
+      gl.glTranslatef(-glut.glutStrokeLength(GLUT.STROKE_ROMAN, l), -120.0f, 0.0f)
+    }
     gl.glEnable(GLL.GL_LIGHTING)
   }
 


### PR DESCRIPTION
Needed this for a hobby project recently. Text is left justified and anchors to the agent based on the right edge of the first line (thus, first line position does not change if you add more lines).

![image](https://user-images.githubusercontent.com/28215/232323175-71643a32-fea4-4274-9d07-85be4164a675.png)

Tested on all topologies with patches and turtles with a large range of font sizes.

Happy to add support for tabs as well. I originally used right justified text for this so that all lines used the same right anchor position (which is what we base labels on), but it looked pretty bad. 