### PR TITLE
Behaviorspace no longer exits on plot compilation error. Fixes: 425, 1087

### DIFF
--- a/netlogo-core/src/main/api/Controllable.scala
+++ b/netlogo-core/src/main/api/Controllable.scala
@@ -28,7 +28,7 @@ trait Controllable {
   def evaluateReporter(owner: JobOwner, source: String): AnyRef
 
 /**
- * Action to take if PlotManager.compileAllPlotsplot returns error(s)
+ * Action to take if PlotManager.compileAllPlots returns error(s)
  * during a call to open in HeadlessWorkspace.
  * For the controlling API the default is to throw an exception.
  * For Behaviorspace we will set _plotCompilationErrorAction so that the errors are

--- a/netlogo-core/src/main/api/Controllable.scala
+++ b/netlogo-core/src/main/api/Controllable.scala
@@ -26,4 +26,29 @@ trait Controllable {
 
   @throws(classOf[CompilerException])
   def evaluateReporter(owner: JobOwner, source: String): AnyRef
+
+/**
+ * Action to take if PlotManager.compileAllPlotsplot returns error(s)
+ * during a call to open in HeadlessWorkspace.
+ * For the controlling API the default is to throw an exception.
+ * For Behaviorspace we will set _plotCompilationErrorAction so that the errors are
+ * are output for the first thread and ignored in subsequent threads.
+ */
+  private[this] var _plotCompilationErrorAction: PlotCompilationErrorAction = PlotCompilationErrorAction.Throw
+
+/**
+ * @return  plotCompilationErrorAction  action to take if a plot compilation error occurs
+*/
+  def getPlotCompilationErrorAction(): PlotCompilationErrorAction = { _plotCompilationErrorAction }
+
+/**
+ *  @param plotCompilationErrorAction  action to take if a plot compilation error occurs
+ *                                     Throw  - Throw the first error
+ *                                     Output - Output all errors
+ *                                     Ignore - Do nothing
+*/
+  def setPlotCompilationErrorAction(plotCompilationErrorAction: PlotCompilationErrorAction): Unit = { _plotCompilationErrorAction = plotCompilationErrorAction }
+
+
+
 }

--- a/netlogo-core/src/main/api/PlotCompilationErrorAction.scala
+++ b/netlogo-core/src/main/api/PlotCompilationErrorAction.scala
@@ -1,0 +1,28 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.api
+
+/**
+ * Action to take if PlotManager.compileAllPlotsplot returns error(s)
+ * during a call to open in HeadlessWorkspace.
+ *
+ * Throw  - Throw the first error
+ * Output - Output all errors
+ * Ignore - Do nothing
+ */
+
+abstract sealed trait PlotCompilationErrorAction
+
+object PlotCompilationErrorAction {
+  case object Throw extends PlotCompilationErrorAction
+  case object Output extends PlotCompilationErrorAction
+  case object Ignore extends PlotCompilationErrorAction
+}
+
+object PlotCompilationErrorActionJ {
+  import PlotCompilationErrorAction._
+  // convenience vals for Java access
+  val THROW = Throw
+  val OUTPUT = Output
+  val IGNORE = Ignore
+}

--- a/netlogo-core/src/main/api/PlotCompilationErrorAction.scala
+++ b/netlogo-core/src/main/api/PlotCompilationErrorAction.scala
@@ -3,7 +3,7 @@
 package org.nlogo.api
 
 /**
- * Action to take if PlotManager.compileAllPlotsplot returns error(s)
+ * Action to take if PlotManager.compileAllPlot returns error(s)
  * during a call to open in HeadlessWorkspace.
  *
  * Throw  - Throw the first error

--- a/netlogo-gui/src/main/headless/Main.scala
+++ b/netlogo-gui/src/main/headless/Main.scala
@@ -7,6 +7,7 @@ import java.io.{ File, FileWriter, PrintWriter }
 import org.nlogo.core.WorldDimensions
 import org.nlogo.api.{ APIVersion, Version }
 import org.nlogo.nvm.LabInterface.Settings
+ import org.nlogo.api.PlotCompilationErrorAction
 
 object Main {
 
@@ -44,9 +45,12 @@ See the Advanced Usage section of the BehaviorSpace documentation in the NetLogo
   }
 
   def runExperiment(settings: Settings) {
+    var plotCompilationErrorAction: PlotCompilationErrorAction = PlotCompilationErrorAction.Output
     def newWorkspace = {
       val w = HeadlessWorkspace.newInstance
+      w.setPlotCompilationErrorAction(plotCompilationErrorAction)
       w.open(settings.modelPath)
+      plotCompilationErrorAction = PlotCompilationErrorAction.Ignore
       w
     }
 

--- a/netlogo-gui/src/main/window/GUIWorkspace.java
+++ b/netlogo-gui/src/main/window/GUIWorkspace.java
@@ -36,7 +36,7 @@ import org.nlogo.nvm.Workspace;
 import java.util.HashMap;
 import java.util.ArrayList;
 
-public abstract class GUIWorkspace // can't be both abstract and strictfp
+public abstract class GUIWorkspace
     extends GUIWorkspaceScala
     implements
     org.nlogo.window.Event.LinkChild,

--- a/netlogo-gui/src/main/workspace/AbstractWorkspaceScala.scala
+++ b/netlogo-gui/src/main/workspace/AbstractWorkspaceScala.scala
@@ -9,13 +9,13 @@ import java.util.Base64
 
 import scala.collection.mutable.WeakHashMap
 import scala.util.Try
-
 import org.nlogo.agent.{ World, Agent, OutputObject }
 import org.nlogo.api.{ Dump, ExtensionManager => APIEM, FileIO, HubNetInterface, LibraryManager,
   LogoException, OutputDestination, PreviewCommands, Workspace => APIWorkspace, WorldDimensions3D }
 import org.nlogo.core.{ CompilerException, Model, View, Widget => CoreWidget, WorldDimensions }
 import org.nlogo.nvm.{ Activation, Instruction, Command, Context, Job, MutableLong, Procedure, Tracer }
 import org.nlogo.nvm.RuntimePrimitiveException
+import org.nlogo.api.PlotCompilationErrorAction
 
 import AbstractWorkspaceTraits._
 
@@ -102,6 +102,23 @@ abstract class AbstractWorkspaceScala(val world: World, val hubNetManagerFactory
   @throws(classOf[IOException])
   @throws(classOf[LogoException])
   def open(path: String, shouldAutoInstallLibs: Boolean): Unit
+
+/**
+ * getPlotCompilationErrorAction and setPlotCompilationErrorAction should
+ * be inherited from org.nlogo.api.Controllable, but are not because of a
+ * scala bug that involves inheritance when java classes such as AbstractWorkspace
+ * are in a hierarchy.
+ * If the bug is fixed or AbstractWorkspace is converted to scala remove
+ * these 3 lines of code involving PlotCompilationErrorAction and the import of
+ * org.nlogo.api.Controllable
+ * The bug: https://github.com/scala/bug/issues/12224
+ *   AbstractMethodError when overriding java method with default implementation
+ *   implementation is "muted" in inherited interface Issue Issue #12224 scala/bug
+ */
+  private[this] var _plotCompilationErrorAction: PlotCompilationErrorAction = PlotCompilationErrorAction.Throw
+
+  override def getPlotCompilationErrorAction = _plotCompilationErrorAction
+  override def setPlotCompilationErrorAction(plotCompilationErrorAction: PlotCompilationErrorAction): Unit = { _plotCompilationErrorAction = plotCompilationErrorAction }
 
   @throws(classOf[IOException])
   def getSource(filename: String): String = {

--- a/netlogo-gui/src/test/headless/AbstractTestModels.scala
+++ b/netlogo-gui/src/test/headless/AbstractTestModels.scala
@@ -22,7 +22,8 @@ trait AbstractTestModels extends AnyFunSuite with ModelCreator {
   }
 
 /**
-   * test a model created in code setting a specified PlotCompilationErrorAction
+   * Set the PlotCompilationErrorAction and then test a model created in code.
+   * See netlogo-core/src/main/api/Controllable.scala for information on PlotCompilationErrorAction.
    */
   def testModelSetPlotCompilationErrorAction(testName: String, model: Model, plotCompilationErrorAction: PlotCompilationErrorAction)(f: => Unit) = {
     test(testName){ runModelSetPlotCompilationErrorAction(model, plotCompilationErrorAction){ f } }
@@ -77,7 +78,7 @@ trait AbstractTestModels extends AnyFunSuite with ModelCreator {
     run(ws => ws.openModel(model)){ f }
   }
 
-  // runs the given model in a new workspace setting a specified PlotCompilationErrorAction
+ // Set the PlotCompilationErrorAction and run the given model in a new workspace.
   def runModelSetPlotCompilationErrorAction(model:Model, plotCompilationErrorAction: PlotCompilationErrorAction)(f: => Unit) = {
     run(ws => {ws.setPlotCompilationErrorAction(plotCompilationErrorAction)
     ws.openModel(model)}){ f }

--- a/netlogo-gui/src/test/headless/AbstractTestModels.scala
+++ b/netlogo-gui/src/test/headless/AbstractTestModels.scala
@@ -6,10 +6,12 @@ import scala.util.DynamicVariable
 import org.scalatest.funsuite.AnyFunSuite
 import org.nlogo.api.{LogoException, Version}
 import org.nlogo.api.ModelCreator
+import org.nlogo.api.PlotCompilationErrorAction
 
 /**
  * A DSL for testing models.
  */
+
 trait AbstractTestModels extends AnyFunSuite with ModelCreator {
 
   /**
@@ -17,6 +19,13 @@ trait AbstractTestModels extends AnyFunSuite with ModelCreator {
    */
   def testModel(testName: String, model: Model)(f: => Unit) = {
     test(testName){ runModel(model){ f } }
+  }
+
+/**
+   * test a model created in code setting a specified PlotCompilationErrorAction
+   */
+  def testModelSetPlotCompilationErrorAction(testName: String, model: Model, plotCompilationErrorAction: PlotCompilationErrorAction)(f: => Unit) = {
+    test(testName){ runModelSetPlotCompilationErrorAction(model, plotCompilationErrorAction){ f } }
   }
 
   def testModelCompileError(testName: String, model: Model)(f: Throwable => Unit) = {
@@ -67,7 +76,14 @@ trait AbstractTestModels extends AnyFunSuite with ModelCreator {
     // println(".")
     run(ws => ws.openModel(model)){ f }
   }
-  // lods the model from the given file, and runs it in a new workspace
+
+  // runs the given model in a new workspace setting a specified PlotCompilationErrorAction
+  def runModelSetPlotCompilationErrorAction(model:Model, plotCompilationErrorAction: PlotCompilationErrorAction)(f: => Unit) = {
+    run(ws => {ws.setPlotCompilationErrorAction(plotCompilationErrorAction)
+    ws.openModel(model)}){ f }
+  }
+
+  // loads the model from the given file, and runs it in a new workspace
   def runModelFromFile(path: String)(f: => Unit) = run(ws => ws.open(path)){ f }
 
   // run a model

--- a/netlogo-gui/src/test/headless/TestPlotModels.scala
+++ b/netlogo-gui/src/test/headless/TestPlotModels.scala
@@ -4,6 +4,7 @@ package org.nlogo.headless
 
 import org.nlogo.plot.{PlotPoint, PlotPen}
 import org.nlogo.core.I18N
+import org.nlogo.api.PlotCompilationErrorAction
 
 class TestPlotModels extends AbstractTestModels {
 
@@ -209,6 +210,16 @@ class TestPlotModels extends AbstractTestModels {
   testModelCompileError("Plot With Bad Pen Setup Code Should Throw Exception on Load (headless only)",
     Model(modelCode, Plot(pens = Pens(Pen(setupCode = "create-fails 8"))))){ ex =>
     assert(I18N.errors.getN("compiler.LocalsVisitor.notDefined", "CREATE-FAILS") === ex.getMessage)
+  }
+
+  testModelSetPlotCompilationErrorAction("Plot With Bad Pen Setup Code Should Output Exception on Load (headless only, Output option)",
+    Model(modelCode, Plot(pens = Pens(Pen(setupCode = "create-fails 8")))),
+    PlotCompilationErrorAction.Output){
+  }
+
+  testModelSetPlotCompilationErrorAction("Plot With Bad Pen Setup Code Should Ignore Exception on Load (headless only, Ignore Option)",
+    Model(modelCode, Plot(pens = Pens(Pen(setupCode = "create-fails 8")))),
+    PlotCompilationErrorAction.Ignore){
   }
 
   testModelCompileError("Plot With Bad Pen Update Code Should Throw Exception on Load (headless only)",

--- a/netlogo-headless/src/main/headless/Main.scala
+++ b/netlogo-headless/src/main/headless/Main.scala
@@ -5,6 +5,7 @@ package org.nlogo.headless
 import org.nlogo.core.WorldDimensions
 import org.nlogo.api.{ APIVersion, Version }
 import org.nlogo.nvm.LabInterface.Settings
+import org.nlogo.api.PlotCompilationErrorAction
 
 object Main {
   class CancelException extends RuntimeException
@@ -19,11 +20,15 @@ object Main {
   }
 
   def runExperiment(settings: Settings) {
+    var plotCompilationErrorAction: PlotCompilationErrorAction = PlotCompilationErrorAction.Output
     def newWorkspace = {
       val w = HeadlessWorkspace.newInstance
+      w.setPlotCompilationErrorAction(plotCompilationErrorAction)
       w.open(settings.modelPath)
+      plotCompilationErrorAction = PlotCompilationErrorAction.Ignore
       w
     }
+
     val openWs = newWorkspace
     val proto = try {
       BehaviorSpaceCoordinator.selectProtocol(settings, openWs)

--- a/netlogo-headless/src/test/headless/lang/Fixture.scala
+++ b/netlogo-headless/src/test/headless/lang/Fixture.scala
@@ -8,6 +8,7 @@ import org.nlogo.{ api, agent, core }
 import org.nlogo.core.{CompilerException, Femto, Model, View}
 import CompilerException.{RuntimeErrorAtCompileTimePrefix => runtimePrefix}
 import org.nlogo.nvm.CompilerInterface
+import org.nlogo.api.PlotCompilationErrorAction
 import org.nlogo.headless.test.{RunMode, NormalMode, TestMode, CompileError,
                                 Success, Result, Reporter, Command, Compile,
                                 AbstractFixture, RuntimeError, StackTrace}
@@ -157,4 +158,11 @@ class Fixture(name: String) extends AbstractFixture {
   def openModel(model: Model, shouldAutoInstallLibs: Boolean = false) =
     workspace.openModel(model, shouldAutoInstallLibs)
 
+/**
+   * Set the PlotCompilationErrorAction in the workspace.
+   * See netlogo-core/src/main/api/Controllable.scala for information on PlotCompilationErrorAction.
+   */
+  def setPlotCompilationErrorAction(plotCompilationErrorAction: PlotCompilationErrorAction): Unit = {
+      workspace.setPlotCompilationErrorAction(plotCompilationErrorAction)
+  }
 }

--- a/netlogo-headless/src/test/headless/lang/misc/TestPlotModels.scala
+++ b/netlogo-headless/src/test/headless/lang/misc/TestPlotModels.scala
@@ -6,6 +6,7 @@ package misc
 
 import org.nlogo.plot.PlotPen
 import org.nlogo.core._
+import org.nlogo.api.PlotCompilationErrorAction
 
 class TestPlotModels extends FixtureSuite {
 
@@ -294,4 +295,16 @@ class TestPlotModels extends FixtureSuite {
     testCompileError(Model(code = modelCode, widgets = List(View(), Plot(display = Some(""), pens = List(Pen(display = "p", updateCode = "create-fails 8")))))) { ex =>
       assert("Nothing named CREATE-FAILS has been defined." === ex.getMessage)
     }}
+
+  test("Plot With Bad Pen Update Code Should Output Exception on Load (headless only, Output Option)") { implicit fixture =>
+    import fixture._
+    setPlotCompilationErrorAction(PlotCompilationErrorAction.Output)
+    openModel(Model(code = modelCode, widgets = List(View(), Plot(display = Some(""), pens = List(Pen(display = "p", updateCode = "create-fails 8"))))))
+  }
+
+  test("Plot With Bad Pen Update Code Should Ignore Exception on Load (headless only, Ignore Option)") { implicit fixture =>
+    import fixture._
+    setPlotCompilationErrorAction(PlotCompilationErrorAction.Ignore)
+    openModel(Model(code = modelCode, widgets = List(View(), Plot(display = Some(""), pens = List(Pen(display = "p", updateCode = "create-fails 8"))))))
+  }
 }


### PR DESCRIPTION
add (get/set)PlotCompilationErrorAction to allow such errors to be
thrown, output or ignored