### PR TITLE
Update to Scala 2.12.18

### DIFF
--- a/NetLogo.iml
+++ b/NetLogo.iml
@@ -38,6 +38,6 @@
     <orderEntry type="library" name="parboiled_2.12-2.3.0" level="project" />
     <orderEntry type="library" name="shapeless_2.12-2.3.2" level="project" />
     <orderEntry type="library" name="scalactic_2.12-3.0.9" level="project" />
-    <orderEntry type="library" name="scala-sdk-2.12.17" level="application" />
+    <orderEntry type="library" name="scala-sdk-2.12.18" level="application" />
   </component>
 </module>

--- a/bin/benches.scala
+++ b/bin/benches.scala
@@ -24,7 +24,7 @@ val classpath =
       "../parser-jvm/target/classes",
       "../shared/target/classes",
       "../netlogo-gui/resources",
-      home + "/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.17.jar",
+      home + "/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.18.jar",
       home + "/.ivy2/cache/org.typelevel/cats-core_2.12/jars/cats-core_2.12-1.0.0-MF.jar",
       home + "/.ivy2/local/org.nlogo/xml-lib_2.12/0.0.1/jars/xml-lib_2.12.jar",
       home + "/.ivy2/cache/com.typesafe/config/bundles/config-1.4.1.jar",

--- a/bin/issues.scala
+++ b/bin/issues.scala
@@ -7,7 +7,7 @@
 // don't panic; it may take a few minutes to download dependencies
 
 /***
-scalaVersion := "2.12.17"
+scalaVersion := "2.12.18"
 onLoadMessage := ""
 scalacOptions ++= Seq(
   "-deprecation", "-unchecked", "-feature", "-Xfatal-warnings")

--- a/bin/profiles.scala
+++ b/bin/profiles.scala
@@ -21,7 +21,7 @@ val classpath =
   Seq("../netlogo-gui/target/classes",
       "../shared/target/classes",
       "../netlogo-gui/resources",
-      home + "/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.17.jar",
+      home + "/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.18.jar",
       home + "/.ivy2/cache/org.ow2.asm/asm-all/jars/asm-all-5.2.jar",
       home + "/.ivy2/cache/org.picocontainer/picocontainer/jars/picocontainer-2.15.jar",
       home + "/.ivy2/cache/commons-codec/commons-codec/jars/commons-codec-1.15.jar",

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val commonSettings = Seq(
 // These settings are common to all builds involving scala
 // Any scala-specific settings should change here (and thus for all projects at once)
 lazy val scalaSettings = Seq(
-  scalaVersion          := "2.12.17",
+  scalaVersion          := "2.12.18",
   Compile / scalaSource := baseDirectory.value / "src" / "main",
   Test / scalaSource    := baseDirectory.value / "src" / "test",
   crossPaths            := false, // don't cross-build for different Scala versions

--- a/netlogo-core/src/main/shape/Circle.scala
+++ b/netlogo-core/src/main/shape/Circle.scala
@@ -37,7 +37,7 @@ class Circle(color: Color) extends Element(color) with BaseCircle with Cloneable
   }
 
   def origin: Point =
-    new Point(x + round(xDiameter / 2), y + round(yDiameter / 2))
+    new Point(x + round(xDiameter.toFloat / 2), y + round(yDiameter.toFloat / 2))
 
   def bounds: AwtRectangle =
     new AwtRectangle(x, y, xDiameter, yDiameter)

--- a/netlogo-gui/src/main/app/tools/AgentMonitorViewPanel.scala
+++ b/netlogo-gui/src/main/app/tools/AgentMonitorViewPanel.scala
@@ -18,7 +18,7 @@ class AgentMonitorViewPanel(workspace: GUIWorkspace) extends JPanel(new BorderLa
 
   locally {
     add(view, BorderLayout.CENTER)
-    view.setSize(workspace.world.worldWidth, workspace.world.worldHeight, 255 / workspace.world.worldWidth)
+    view.setSize(workspace.world.worldWidth, workspace.world.worldHeight, 255.toDouble / workspace.world.worldWidth)
     view.applyNewFontSize(workspace.view.fontSize, 0)
     watchButton.setFocusable(false)
     val controls = new JPanel

--- a/netlogo-gui/src/main/headless/HeadlessWorkspace.scala
+++ b/netlogo-gui/src/main/headless/HeadlessWorkspace.scala
@@ -268,7 +268,7 @@ with org.nlogo.api.ViewSettings {
   override def getMinimumWidth = 0
   override def insetWidth = 0
   override def computePatchSize(width: Int, numPatches: Int): Double =
-    width / numPatches
+    width.toDouble / numPatches
   override def calculateHeight(worldHeight: Int, patchSize: Double) =
     (worldHeight * patchSize).toInt
   def calculateWidth(worldWidth: Int, patchSize: Double): Int =

--- a/netlogo-gui/src/main/hubnet/client/ClientView.scala
+++ b/netlogo-gui/src/main/hubnet/client/ClientView.scala
@@ -100,8 +100,8 @@ class ClientView(clientPanel: ClientPanel) extends Widget with ViewWidgetInterfa
     world.setWorldSize(
       view.dimensions.minPxcor, view.dimensions.maxPxcor,
       view.dimensions.minPycor, view.dimensions.maxPycor)
-    if (getWidth > getHeight) world.patchSize(getWidth / world.worldWidth)
-    else world.patchSize(getHeight / world.worldHeight)
+    if (getWidth > getHeight) world.patchSize(getWidth.toDouble / world.worldWidth)
+    else world.patchSize(getHeight.toDouble / world.worldHeight)
     this
   }
 

--- a/netlogo-gui/src/main/hubnet/server/HubNetManager.scala
+++ b/netlogo-gui/src/main/hubnet/server/HubNetManager.scala
@@ -217,7 +217,7 @@ abstract class HubNetManager(workspace: AbstractWorkspaceScala, modelLoader: Mod
     val queueSizes = connectionManager.clientSendQueueSizes
     val totalClients = queueSizes.size
     val totalQueueSize = queueSizes.sum
-    if (totalClients == 0) 0 else (totalQueueSize / totalClients)
+    if (totalClients == 0) 0 else (totalQueueSize.toDouble / totalClients)
   }
 
   @throws(classOf[HubNetException])

--- a/netlogo-gui/src/main/prim/hubnet/primitives.scala
+++ b/netlogo-gui/src/main/prim/hubnet/primitives.scala
@@ -192,7 +192,7 @@ class _hubnetresetperspective extends Command with HubNetPrim {
         override def run() {
           hubNetManager.foreach(_.sendAgentPerspective(
             client, world.observer.perspective.export,
-            agentKind, id, (world.worldWidth - 1) / 2, true))
+            agentKind, id, ((world.worldWidth - 1).toDouble / 2), true))
         }})
     context.ip = next
   }

--- a/netlogo-gui/src/main/window/SpeedSliderPanel.scala
+++ b/netlogo-gui/src/main/window/SpeedSliderPanel.scala
@@ -75,7 +75,7 @@ class SpeedSliderPanel(workspace: GUIWorkspace) extends JPanel with MouseListene
       else if (value > 10) value - 10
       else                 0
 
-    workspace.speedSliderPosition(adjustedValue / 2);
+    workspace.speedSliderPosition(adjustedValue.toDouble / 2);
 
     LogManager.speedSliderChanged(adjustedValue)
     enableLabels(adjustedValue)

--- a/netlogo-gui/src/main/workspace/ExtensionManager.scala
+++ b/netlogo-gui/src/main/workspace/ExtensionManager.scala
@@ -58,7 +58,7 @@ import org.nlogo.nvm.{ ExtensionManager => NvmExtensionManager }
 object ExtensionManager {
 
   case class ExtensionData(extensionName: String, fileURL: URL, prefix: String, classManagerName: String, version: Option[String], private val modifiedRaw: Long) {
-    val modified = 1000 * Math.round(modifiedRaw / 1000)
+    val modified = 1000 * Math.round(modifiedRaw.toFloat / 1000)
   }
 
   class JarContainer(val jarClassLoader: ClassLoader, data: ExtensionData) {

--- a/netlogo-gui/src/test/workspace/ExtensionManagerTests.scala
+++ b/netlogo-gui/src/test/workspace/ExtensionManagerTests.scala
@@ -147,7 +147,7 @@ class ExtensionManagerTests extends AnyFunSuite with BeforeAndAfter {
   test("dumpExtensions prints a table with all loaded extensions") {
     new WithLoadedArrayExtension {
       val arrayJar = new java.io.File("extensions/array/array.jar")
-      val modified = 1000 * Math.round(arrayJar.lastModified() / 1000)
+      val modified = 1000 * Math.round(arrayJar.lastModified().toFloat / 1000)
       val path = arrayJar.toURI.toURL.toString
       assert(loadedManager.dumpExtensions ==
         s"""|EXTENSION${tab}LOADED${tab}MODIFIED${tab}JARPATH

--- a/netlogo-gui/src/test/workspace/JarLoaderTests.scala
+++ b/netlogo-gui/src/test/workspace/JarLoaderTests.scala
@@ -98,7 +98,7 @@ class JarLoaderTests extends AnyFunSuite with BeforeAndAfter {
   test("extensionData returns ExtensionData when it succeeds in connecting to a jar") {
     val extensionData = jarLoader.extensionData("array", arrayJarURL)
     val origMod       = new File(arrayJarURL.toURI).lastModified()
-    val modified      = 1000 * Math.round(origMod / 1000)
+    val modified      = 1000 * Math.round(origMod.toFloat / 1000)
     assert(extensionData.extensionName == "array")
     assert(extensionData.fileURL == arrayJarURL)
     assert(extensionData.prefix == "array")

--- a/netlogo-headless/src/main/headless/HeadlessWorkspace.scala
+++ b/netlogo-headless/src/main/headless/HeadlessWorkspace.scala
@@ -157,7 +157,7 @@ with org.nlogo.workspace.WorldLoaderInterface {
   override def getMinimumWidth = 0
   override def insetWidth = 0
   override def computePatchSize(width: Int, numPatches: Int): Double =
-    width / numPatches
+    width.toDouble / numPatches
   override def calculateHeight(worldHeight: Int, patchSize: Double) =
     (worldHeight * patchSize).toInt
   def calculateWidth(worldWidth: Int, patchSize: Double): Int =

--- a/netlogo-headless/src/test/headless/lang/misc/TestArgumentInjection.scala
+++ b/netlogo-headless/src/test/headless/lang/misc/TestArgumentInjection.scala
@@ -113,7 +113,7 @@ class TestArgumentInjection extends FixtureSuite {
     val caller = makeCommandCaller(workspace, "make-network")
     def check(n: Int) {
       runCommandCaller(owner(), caller, Double.box(n))
-      assertResult(Double.box(n * (n - 1) / 2))(
+      assertResult(Double.box(n * (n - 1).toDouble / 2))(
         workspace.report("count links"))
     }
     check(5)


### PR DESCRIPTION
Update from Scala 2.12.17 to [2.12.18](https://github.com/scala/scala/releases/tag/v2.12.18). This includes a update from ASM 9.3 to 9.5, which improved JDK 20 and 21 support.