### PR TITLE
Improve bookkeeping in TemporaryCodeTab

### DIFF
--- a/netlogo-gui/src/main/app/codetab/CodeTab.scala
+++ b/netlogo-gui/src/main/app/codetab/CodeTab.scala
@@ -28,7 +28,7 @@ with Zoomable
 with NlogoPrintable
 with MenuTab {
 
-  private var _dirty = false
+  private var _dirty = false // Has the buffer changed since it was compiled?
   def dirty = _dirty
 
   protected def dirty_=(b: Boolean) = {


### PR DESCRIPTION
If an included file with unsaved changes is closed and saved, compile it. If an included file with saved changes is closed don't ask if user wants to save it.

fixes  #2021, #2126