### PR TITLE
BehaviorSpace Import/Export Experiments + Naming Requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,6 @@ tmp/
 *~
 .#*
 \#*
-.metals/*
-.vscode/*
 
 # no jars, except these small ones
 *.jar

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ tmp/
 *~
 .#*
 \#*
+.metals/*
+.vscode/*
 
 # no jars, except these small ones
 *.jar

--- a/autogen/docs/behaviorspace.md.mustache
+++ b/autogen/docs/behaviorspace.md.mustache
@@ -68,7 +68,7 @@ and run experiment setups. Experiments are listed by name and how many model
 runs the experiment will consist of.
 
 Experiment setups are considered part of a NetLogo model and are saved as part
-of the model.
+of the model, but can be saved as individual files (see "Importing and exporting").
 
 To create a new experiment setup, press the "New" button.
 
@@ -80,7 +80,7 @@ or left with their default values, depending on your needs.
 
 **Experiment name:** Experiments in the same model must have different names. If
 you open a model that contains experiments with duplicate names, the conflicting
-names will be altered.
+names will be altered to ensure that all experiment names remain unique.
 
 **Vary variables as follows:** This is where you specify which settings you want
 varied, and what values you want them to take. Variables can include sliders,
@@ -212,6 +212,23 @@ the run in some other way.
 **Time limit:** This lets you set a fixed maximum length for each run. If you
 don't want to set any maximum, but want the length of the runs to be controlled
 by the stop condition instead, enter 0.
+
+### Importing and exporting
+
+Although experiments are tied to a model and are usually saved along with a
+model, they can also be imported and exported individually. This allows you to
+easily transfer experiments between models, and also prepares experiments to be
+run headlessly.
+
+The **Import** button allows you to import experiments from an xml file. The
+selected files may contain any number of experiments, but any experiments that
+are formatted incorrectly will not be loaded. If you load an experiment that has
+the same name as an existing experiment, the name of the loaded experiment will
+be slightly altered to ensure that experiment names remain unique.
+
+The **Export** button allows you to export experiments to an xml file. Any number
+of experiments may be selected for export at once, but they will all be combined
+into a single output file.
 
 ### Special primitives for BehaviorSpace experiments
 

--- a/autogen/docs/behaviorspace.md.mustache
+++ b/autogen/docs/behaviorspace.md.mustache
@@ -63,9 +63,9 @@ item on NetLogo's Tools menu.
 
 ### Managing experiment setups
 
-The dialog that opens lets you create, edit, duplicate, delete, and run
-experiment setups. Experiments are listed by name and how by model runs the
-experiment will consist of.
+The dialog that opens lets you create, edit, duplicate, delete, import, export,
+and run experiment setups. Experiments are listed by name and how many model
+runs the experiment will consist of.
 
 Experiment setups are considered part of a NetLogo model and are saved as part
 of the model.
@@ -78,8 +78,9 @@ In the new dialog that appears, you can specify the following information. Note
 that you don't always need to specify everything; some parts can be left blank,
 or left with their default values, depending on your needs.
 
-**Experiment name:** If you have multiple experiments, giving them different
-names will help you keep them straight.
+**Experiment name:** Experiments in the same model must have different names. If
+you open a model that contains experiments with duplicate names, the conflicting
+names will be altered.
 
 **Vary variables as follows:** This is where you specify which settings you want
 varied, and what values you want them to take. Variables can include sliders,

--- a/autogen/docs/behaviorspace.md.mustache
+++ b/autogen/docs/behaviorspace.md.mustache
@@ -216,9 +216,10 @@ by the stop condition instead, enter 0.
 ### Importing and exporting
 
 Although experiments are tied to a model and are usually saved along with a
-model, they can also be imported and exported individually. This allows you to
-easily transfer experiments between models, and also prepares experiments to be
-run headlessly.
+model, they can also be imported and exported individually to xml files. This
+allows you to easily transfer experiments between models, and also prepares
+experiments to be run headlessly. After an experiment is exported to an xml file,
+it can be edited by hand or by another script, not just within NetLogo.
 
 The **Import** button allows you to import experiments from an xml file. The
 selected files may contain any number of experiments, but any experiments that

--- a/netlogo-core/src/main/fileformat/LabLoader.scala
+++ b/netlogo-core/src/main/fileformat/LabLoader.scala
@@ -11,6 +11,7 @@ import scala.collection.mutable.Set
 import scala.language.implicitConversions
 
 object LabLoader {
+  val XMLVER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
   val DOCTYPE = "<!DOCTYPE experiments SYSTEM \"behaviorspace.dtd\">"
 }
 

--- a/netlogo-core/src/main/fileformat/LabLoader.scala
+++ b/netlogo-core/src/main/fileformat/LabLoader.scala
@@ -16,7 +16,7 @@ object LabLoader {
 
 import LabLoader._
 
-class LabLoader(literalParser: LiteralParser, existingNames: Set[String] = Set[String]()) {
+class LabLoader(literalParser: LiteralParser, editNames: Boolean = false, existingNames: Set[String] = Set[String]()) {
   if (literalParser == null)
     throw new Exception("Invalid lab loader!")
   def apply(xml: String): Seq[LabProtocol] = {
@@ -80,16 +80,18 @@ class LabLoader(literalParser: LiteralParser, existingNames: Set[String] = Set[S
       yield valueSet
     }
     var name = element.getAttribute("name")
-    if (name.isEmpty) {
-      name = "no-name"
+    if (editNames) {
+      if (name.isEmpty) {
+        name = "no-name"
+      }
+      if (existingNames.contains(name))
+      {
+        var n = 1
+        while (existingNames.contains(s"$name-$n")) n += 1
+        name = s"$name-$n"
+      }
+      existingNames += name
     }
-    if (existingNames.contains(name))
-    {
-      var n = 1
-      while (existingNames.contains(s"$name-$n")) n += 1
-      name = s"$name-$n"
-    }
-    existingNames += name
     new LabProtocol(
       name,
       readOptional("setup"),

--- a/netlogo-core/src/main/fileformat/LabLoader.scala
+++ b/netlogo-core/src/main/fileformat/LabLoader.scala
@@ -7,6 +7,7 @@ import org.nlogo.core.LiteralParser
 import org.nlogo.api.{ RefEnumeratedValueSet, LabProtocol, SteppedValueSet }
 import org.w3c.dom
 import org.xml.sax
+import scala.collection.mutable.Set
 import scala.language.implicitConversions
 
 object LabLoader {
@@ -15,7 +16,7 @@ object LabLoader {
 
 import LabLoader._
 
-class LabLoader(literalParser: LiteralParser) {
+class LabLoader(literalParser: LiteralParser, existingNames: Set[String] = Set[String]()) {
   if (literalParser == null)
     throw new Exception("Invalid lab loader!")
   def apply(xml: String): Seq[LabProtocol] = {
@@ -78,8 +79,16 @@ class LabLoader(literalParser: LiteralParser) {
       case _ => None } }
       yield valueSet
     }
+    var name = element.getAttribute("name")
+    if (existingNames.contains(name))
+    {
+      var n = 1
+      while (existingNames.contains(s"$name-$n")) n += 1
+      name = s"$name-$n"
+    }
+    existingNames += name
     new LabProtocol(
-      element.getAttribute("name"),
+      name,
       readOptional("setup"),
       readOptional("go"),
       readOptional("final"),

--- a/netlogo-core/src/main/fileformat/LabLoader.scala
+++ b/netlogo-core/src/main/fileformat/LabLoader.scala
@@ -81,7 +81,7 @@ class LabLoader(literalParser: LiteralParser, existingNames: Set[String] = Set[S
     }
     var name = element.getAttribute("name")
     if (name.isEmpty) {
-      name = "experiment"
+      name = "no-name"
     }
     if (existingNames.contains(name))
     {

--- a/netlogo-core/src/main/fileformat/LabLoader.scala
+++ b/netlogo-core/src/main/fileformat/LabLoader.scala
@@ -80,6 +80,9 @@ class LabLoader(literalParser: LiteralParser, existingNames: Set[String] = Set[S
       yield valueSet
     }
     var name = element.getAttribute("name")
+    if (name.isEmpty) {
+      name = "experiment"
+    }
     if (existingNames.contains(name))
     {
       var n = 1

--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -549,6 +549,10 @@ tools.behaviorSpace.new = New
 tools.behaviorSpace.edit = Edit
 tools.behaviorSpace.duplicate = Duplicate
 tools.behaviorSpace.delete = Delete
+tools.behaviorSpace.import = Import
+tools.behaviorSpace.import.dialog = Select Experiment Files
+tools.behaviorSpace.export = Export
+tools.behaviorSpace.export.dialog = Select Output Directory
 tools.behaviorSpace.run = Run
 tools.behaviorSpace.close = Close
 

--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -342,6 +342,8 @@ edit.behaviorSpace.list.variablelist = The number of variable combinations for "
 edit.behaviorSpace.list.field = A list for "{0}" does not contain any elements
 edit.behaviorSpace.repetition.totalrun = Total number of runs exceeds limit
 edit.behaviorSpace.compiler.parser = The provided variables are not well-formed
+edit.behaviorSpace.name.empty = Experiment name cannot be empty
+edit.behaviorSpace.name.duplicate = An experiment with the name "{0}" already exists
 
 edit.chooser.globalVar = Global variable
 edit.chooser.example = <html>example: &quot;a&quot; &quot;b&quot; &quot;c&quot; 3 4 5</html>

--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -554,7 +554,7 @@ tools.behaviorSpace.delete = Delete
 tools.behaviorSpace.import = Import
 tools.behaviorSpace.import.dialog = Select Experiment Files
 tools.behaviorSpace.export = Export
-tools.behaviorSpace.export.dialog = Select Output Directory
+tools.behaviorSpace.export.dialog = Export Experiment
 tools.behaviorSpace.run = Run
 tools.behaviorSpace.close = Close
 

--- a/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
@@ -197,11 +197,8 @@ private class ManagerDialog(manager:       LabManager,
     try {
       var path = FileDialog.showFiles(manager.workspace.getFrame, I18N.gui("export.dialog"), java.awt.FileDialog.SAVE, selectedProtocol.name + ".xml")
 
-      if (path.lastIndexOf('.') == -1) {
+      if (!path.endsWith(".xml")) {
         path += ".xml"
-      }
-      else if (path.splitAt(path.lastIndexOf('.'))._2 != "xml") {
-        path = path.splitAt(path.lastIndexOf('.'))._1 + ".xml"
       }
 
       val out = new java.io.PrintWriter(path)

--- a/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
@@ -175,14 +175,20 @@ private class ManagerDialog(manager:       LabManager,
       for (file <- dialog.getFiles)
       {
         try {
-          for (protocol <- new LabLoader(manager.workspace.compiler.utilities, true, manager.protocols.map(_.name).to[collection.mutable.Set])(scala.io.Source.fromFile(file).mkString))
+          for (protocol <- new LabLoader(manager.workspace.compiler.utilities,
+                                         true,
+                                         manager.protocols.map(_.name).to[collection.mutable.Set])
+                                         (scala.io.Source.fromFile(file).mkString))
           {
             manager.addProtocol(protocol)
           }
         } catch {
           case e: org.xml.sax.SAXParseException => {
             if (!java.awt.GraphicsEnvironment.isHeadless) {
-              javax.swing.JOptionPane.showMessageDialog(manager.workspace.getFrame, s"""Invalid format in "${file.getName}".""", "Invalid", javax.swing.JOptionPane.ERROR_MESSAGE)
+              javax.swing.JOptionPane.showMessageDialog(manager.workspace.getFrame,
+                                                        s"""Invalid format in "${file.getName}".""",
+                                                        "Invalid",
+                                                        javax.swing.JOptionPane.ERROR_MESSAGE)
             }
           }
         }
@@ -197,13 +203,17 @@ private class ManagerDialog(manager:       LabManager,
     try {
       val indices = jlist.getSelectedIndices
 
+      val modelName =
+        if manager.workspace.getModelFileName == null
+          ""
+        else
+          manager.workspace.getModelFileName.split('.')(0) + '-'
+
       var path = FileDialog.showFiles(manager.workspace.getFrame, I18N.gui("export.dialog"), java.awt.FileDialog.SAVE,
                   if (indices.length == 1)
-                    selectedProtocol.name + "-experiment.xml"
-                  else if (manager.workspace.getModelFileName == null)
-                    "experiments.xml"
+                    modelName + selectedProtocol.name + "-experiment.xml"
                   else
-                    manager.workspace.getModelFileName.split('.')(0) + "-experiments.xml")
+                    modelName + "experiments.xml")
 
       if (!path.endsWith(".xml")) {
         path += ".xml"

--- a/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
@@ -195,7 +195,14 @@ private class ManagerDialog(manager:       LabManager,
   }
   private def export() {
     try {
-      val path = FileDialog.showFiles(manager.workspace.getFrame, I18N.gui("export.dialog"), java.awt.FileDialog.SAVE, selectedProtocol.name + ".xml")
+      var path = FileDialog.showFiles(manager.workspace.getFrame, I18N.gui("export.dialog"), java.awt.FileDialog.SAVE, selectedProtocol.name + ".xml")
+
+      if (path.lastIndexOf('.') == -1) {
+        path += ".xml"
+      }
+      else if (path.splitAt(path.lastIndexOf('.'))._2 != "xml") {
+        path = path.splitAt(path.lastIndexOf('.'))._1 + ".xml"
+      }
 
       val out = new java.io.PrintWriter(path)
 

--- a/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
@@ -211,7 +211,7 @@ private class ManagerDialog(manager:       LabManager,
 
       val out = new java.io.PrintWriter(path)
 
-      out.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE experiments SYSTEM \"behaviorspace.dtd\">\n")
+      out.write(s"${LabLoader.XMLVER}\n${LabLoader.DOCTYPE}\n")
       out.write(LabSaver.save(indices.map(manager.protocols(_))))
 
       out.close()

--- a/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
@@ -8,6 +8,8 @@ import org.nlogo.window.{ EditDialogFactoryInterface, MenuBarFactory }
 import java.awt.{ Component, Dimension }
 import javax.swing.{ JButton, JDialog, JLabel, JList, JMenuBar, JOptionPane, JPanel, JScrollPane, ListCellRenderer }
 import org.nlogo.core.I18N
+import org.nlogo.fileformat.{ LabSaver, LabLoader }
+import org.nlogo.swing.FileDialog
 
 private class ManagerDialog(manager:       LabManager,
                             dialogFactory: EditDialogFactoryInterface,
@@ -26,6 +28,8 @@ private class ManagerDialog(manager:       LabManager,
   private val newAction = action(I18N.gui("new"), { () => makeNew() })
   private val deleteAction = action(I18N.gui("delete"), { () => delete() })
   private val duplicateAction = action(I18N.gui("duplicate"), { () => duplicate() })
+  private val importAction = action(I18N.gui("import"), { () => importnl() })
+  private val exportAction = action(I18N.gui("export"), { () => export() })
   private val closeAction = action(I18N.gui("close"), { () => manager.close() })
   private val runAction = action(I18N.gui("run"), { () => run() })
   /// initialization
@@ -61,6 +65,10 @@ private class ManagerDialog(manager:       LabManager,
     buttonPanel.add(javax.swing.Box.createHorizontalStrut(5))
     buttonPanel.add(new JButton(deleteAction))
     buttonPanel.add(javax.swing.Box.createHorizontalStrut(5))
+    buttonPanel.add(new JButton(importAction))
+    buttonPanel.add(javax.swing.Box.createHorizontalStrut(5))
+    buttonPanel.add(new JButton(exportAction))
+    buttonPanel.add(javax.swing.Box.createHorizontalStrut(5))
     buttonPanel.add(runButton)
     buttonPanel.add(javax.swing.Box.createHorizontalStrut(20))
     buttonPanel.add(javax.swing.Box.createHorizontalGlue)
@@ -95,6 +103,7 @@ private class ManagerDialog(manager:       LabManager,
     duplicateAction.setEnabled(count == 1)
     runAction.setEnabled(count == 1)
     deleteAction.setEnabled(count > 0)
+    exportAction.setEnabled(count > 0)
   }
   /// action implementations
   private def run(): Unit = {
@@ -143,6 +152,62 @@ private class ManagerDialog(manager:       LabManager,
       if (newSize > 0) select(if (selected(0) >= newSize) (selected(0) - 1) min (newSize - 1)
                              else selected(0))
       manager.dirty()
+    }
+  }
+  private def importnl() {
+    try {
+      class XMLFilter extends java.io.FilenameFilter {
+        def accept(dir: java.io.File, name: String): Boolean = {
+          val split = name.split('.')
+
+          split.length == 2 && split(1) == "xml"
+        }
+      }
+
+      val dialog = new java.awt.FileDialog(manager.workspace.getFrame, I18N.gui("import.dialog"))
+
+      dialog.setDirectory(System.getProperty("user.home"))
+      dialog.setFilenameFilter(new XMLFilter)
+      dialog.setMultipleMode(true)
+      dialog.setVisible(true)
+
+      for (file <- dialog.getFiles)
+      {
+        try {
+          for (protocol <- new LabLoader(manager.workspace.compiler.utilities)(scala.io.Source.fromFile(file).mkString))
+          {
+            manager.addProtocol(protocol)
+          }
+        } catch {
+          case e: org.xml.sax.SAXParseException => {
+            if (!java.awt.GraphicsEnvironment.isHeadless) {
+              javax.swing.JOptionPane.showMessageDialog(manager.workspace.getFrame, s"""Invalid format in "${file.getName}".""", "Invalid", javax.swing.JOptionPane.ERROR_MESSAGE)
+            }
+          }
+        }
+      }
+
+      update
+    } catch {
+      case e: org.nlogo.awt.UserCancelException => org.nlogo.api.Exceptions.ignore(e)
+    }
+  }
+  private def export() {
+    try {
+      val base = FileDialog.showDirectories(manager.workspace.getFrame, I18N.gui("export.dialog"))
+
+      jlist.getSelectedIndices().foreach({ i =>
+        val protocol = manager.protocols(i)
+
+        val out = new java.io.PrintWriter(s"$base/${protocol.name}.xml")
+
+        out.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE experiments SYSTEM \"behaviorspace.dtd\">\n")
+        out.write(LabSaver.save(Iterable(protocol)))
+
+        out.close()
+      })
+    } catch {
+      case e: org.nlogo.awt.UserCancelException => org.nlogo.api.Exceptions.ignore(e)
     }
   }
   /// helpers

--- a/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
@@ -200,8 +200,10 @@ private class ManagerDialog(manager:       LabManager,
       var path = FileDialog.showFiles(manager.workspace.getFrame, I18N.gui("export.dialog"), java.awt.FileDialog.SAVE, 
                   if (indices.length == 1)
                     selectedProtocol.name + "-experiment.xml"
+                  else if (manager.workspace.getModelFileName == null)
+                    "experiments.xml"
                   else
-                    "tempmodelname-experiments.xml")
+                    manager.workspace.getModelFileName.split('.')(0) + "-experiments.xml")
 
       if (!path.endsWith(".xml")) {
         path += ".xml"

--- a/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
@@ -103,7 +103,7 @@ private class ManagerDialog(manager:       LabManager,
     duplicateAction.setEnabled(count == 1)
     runAction.setEnabled(count == 1)
     deleteAction.setEnabled(count > 0)
-    exportAction.setEnabled(count == 1)
+    exportAction.setEnabled(count > 0)
   }
   /// action implementations
   private def run(): Unit = {

--- a/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
@@ -195,7 +195,13 @@ private class ManagerDialog(manager:       LabManager,
   }
   private def export() {
     try {
-      var path = FileDialog.showFiles(manager.workspace.getFrame, I18N.gui("export.dialog"), java.awt.FileDialog.SAVE, selectedProtocol.name + ".xml")
+      val indices = jlist.getSelectedIndices
+
+      var path =
+        if (indices.length == 1)
+          FileDialog.showFiles(manager.workspace.getFrame, I18N.gui("export.dialog"), java.awt.FileDialog.SAVE, selectedProtocol.name + ".xml")
+        else
+          
 
       if (!path.endsWith(".xml")) {
         path += ".xml"

--- a/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
@@ -129,7 +129,7 @@ private class ManagerDialog(manager:       LabManager,
   private def editProtocol(protocol: LabProtocol, isNew: Boolean) {
     val editable = new ProtocolEditable(protocol, manager.workspace.getFrame,
                                         manager.workspace, manager.workspace.world,
-                                        manager.protocols.map(_.name))
+                                        manager.protocols.map(_.name).filter(isNew || _ != protocol.name))
     if (!dialogFactory.canceled(this, editable)) {
       val newProtocol = editable.get.get
       if (isNew) manager.protocols += newProtocol

--- a/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
@@ -128,7 +128,8 @@ private class ManagerDialog(manager:       LabManager,
   private def edit() { editProtocol(selectedProtocol, false) }
   private def editProtocol(protocol: LabProtocol, isNew: Boolean) {
     val editable = new ProtocolEditable(protocol, manager.workspace.getFrame,
-                                        manager.workspace, manager.workspace.world)
+                                        manager.workspace, manager.workspace.world,
+                                        manager.protocols.map(_.name))
     if (!dialogFactory.canceled(this, editable)) {
       val newProtocol = editable.get.get
       if (isNew) manager.protocols += newProtocol
@@ -174,7 +175,7 @@ private class ManagerDialog(manager:       LabManager,
       for (file <- dialog.getFiles)
       {
         try {
-          for (protocol <- new LabLoader(manager.workspace.compiler.utilities)(scala.io.Source.fromFile(file).mkString))
+          for (protocol <- new LabLoader(manager.workspace.compiler.utilities, manager.protocols.map(_.name).to[collection.mutable.Set])(scala.io.Source.fromFile(file).mkString))
           {
             manager.addProtocol(protocol)
           }

--- a/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
@@ -103,7 +103,7 @@ private class ManagerDialog(manager:       LabManager,
     duplicateAction.setEnabled(count == 1)
     runAction.setEnabled(count == 1)
     deleteAction.setEnabled(count > 0)
-    exportAction.setEnabled(count > 0)
+    exportAction.setEnabled(count == 1)
   }
   /// action implementations
   private def run(): Unit = {
@@ -195,18 +195,14 @@ private class ManagerDialog(manager:       LabManager,
   }
   private def export() {
     try {
-      val base = FileDialog.showDirectories(manager.workspace.getFrame, I18N.gui("export.dialog"))
+      val path = FileDialog.showFiles(manager.workspace.getFrame, I18N.gui("export.dialog"), java.awt.FileDialog.SAVE, selectedProtocol.name + ".xml")
 
-      jlist.getSelectedIndices().foreach({ i =>
-        val protocol = manager.protocols(i)
+      val out = new java.io.PrintWriter(path)
 
-        val out = new java.io.PrintWriter(s"$base/${protocol.name}.xml")
+      out.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE experiments SYSTEM \"behaviorspace.dtd\">\n")
+      out.write(LabSaver.save(Iterable(selectedProtocol)))
 
-        out.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE experiments SYSTEM \"behaviorspace.dtd\">\n")
-        out.write(LabSaver.save(Iterable(protocol)))
-
-        out.close()
-      })
+      out.close()
     } catch {
       case e: org.nlogo.awt.UserCancelException => org.nlogo.api.Exceptions.ignore(e)
     }

--- a/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
@@ -197,7 +197,7 @@ private class ManagerDialog(manager:       LabManager,
     try {
       val indices = jlist.getSelectedIndices
 
-      var path = FileDialog.showFiles(manager.workspace.getFrame, I18N.gui("export.dialog"), java.awt.FileDialog.SAVE, 
+      var path = FileDialog.showFiles(manager.workspace.getFrame, I18N.gui("export.dialog"), java.awt.FileDialog.SAVE,
                   if (indices.length == 1)
                     selectedProtocol.name + "-experiment.xml"
                   else if (manager.workspace.getModelFileName == null)

--- a/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
@@ -197,11 +197,11 @@ private class ManagerDialog(manager:       LabManager,
     try {
       val indices = jlist.getSelectedIndices
 
-      var path =
-        if (indices.length == 1)
-          FileDialog.showFiles(manager.workspace.getFrame, I18N.gui("export.dialog"), java.awt.FileDialog.SAVE, selectedProtocol.name + ".xml")
-        else
-          
+      var path = FileDialog.showFiles(manager.workspace.getFrame, I18N.gui("export.dialog"), java.awt.FileDialog.SAVE, 
+                  if (indices.length == 1)
+                    selectedProtocol.name + "-experiment.xml"
+                  else
+                    "tempmodelname-experiments.xml")
 
       if (!path.endsWith(".xml")) {
         path += ".xml"
@@ -210,7 +210,7 @@ private class ManagerDialog(manager:       LabManager,
       val out = new java.io.PrintWriter(path)
 
       out.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE experiments SYSTEM \"behaviorspace.dtd\">\n")
-      out.write(LabSaver.save(Iterable(selectedProtocol)))
+      out.write(LabSaver.save(indices.map(manager.protocols(_))))
 
       out.close()
     } catch {

--- a/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
@@ -175,7 +175,7 @@ private class ManagerDialog(manager:       LabManager,
       for (file <- dialog.getFiles)
       {
         try {
-          for (protocol <- new LabLoader(manager.workspace.compiler.utilities, manager.protocols.map(_.name).to[collection.mutable.Set])(scala.io.Source.fromFile(file).mkString))
+          for (protocol <- new LabLoader(manager.workspace.compiler.utilities, true, manager.protocols.map(_.name).to[collection.mutable.Set])(scala.io.Source.fromFile(file).mkString))
           {
             manager.addProtocol(protocol)
           }

--- a/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
@@ -204,7 +204,7 @@ private class ManagerDialog(manager:       LabManager,
       val indices = jlist.getSelectedIndices
 
       val modelName =
-        if manager.workspace.getModelFileName == null
+        if (manager.workspace.getModelFileName == null)
           ""
         else
           manager.workspace.getModelFileName.split('.')(0) + '-'

--- a/netlogo-gui/src/main/lab/gui/ProtocolEditable.scala
+++ b/netlogo-gui/src/main/lab/gui/ProtocolEditable.scala
@@ -126,7 +126,7 @@ class ProtocolEditable(protocol: LabProtocol,
       return Seq("Variable" -> I18N.gui.get("edit.behaviorSpace.name.empty"))
     }
     if (experimentNames.contains(name.trim)) {
-      return Seq("Variable" -> I18N.gui.getN("edit.behaviorSpace.name.duplicate", exp))
+      return Seq("Variable" -> I18N.gui.getN("edit.behaviorSpace.name.duplicate", name.trim))
     }
     val list =
         try { worldLock.synchronized {

--- a/netlogo-gui/src/main/lab/gui/ProtocolEditable.scala
+++ b/netlogo-gui/src/main/lab/gui/ProtocolEditable.scala
@@ -125,10 +125,8 @@ class ProtocolEditable(protocol: LabProtocol,
     if (name.trim.isEmpty) {
       return Seq("Variable" -> I18N.gui.get("edit.behaviorSpace.name.empty"))
     }
-    for (exp <- experimentNames) {
-      if (exp == name.trim) {
-        return Seq("Variable" -> I18N.gui.getN("edit.behaviorSpace.name.duplicate", exp))
-      }
+    if (experimentNames.contains(name.trim)) {
+      return Seq("Variable" -> I18N.gui.getN("edit.behaviorSpace.name.duplicate", exp))
     }
     val list =
         try { worldLock.synchronized {

--- a/netlogo-gui/src/main/lab/gui/ProtocolEditable.scala
+++ b/netlogo-gui/src/main/lab/gui/ProtocolEditable.scala
@@ -13,7 +13,8 @@ import org.nlogo.api.{ Dump, CompilerServices, Editable, Property }
 class ProtocolEditable(protocol: LabProtocol,
                        window: Window,
                        compiler: CompilerServices,
-                       worldLock: AnyRef)
+                       worldLock: AnyRef,
+                       experimentNames: Seq[String] = Seq[String]())
   extends Editable {
   // these are for Editable
   def helpLink = None
@@ -121,6 +122,14 @@ class ProtocolEditable(protocol: LabProtocol,
   }
 
   override def invalidSettings: Seq[(String,String)] = {
+    if (name.trim.isEmpty) {
+      return Seq("Variable" -> I18N.gui.get("edit.behaviorSpace.name.empty"))
+    }
+    for (exp <- experimentNames) {
+      if (exp == name.trim) {
+        return Seq("Variable" -> I18N.gui.getN("edit.behaviorSpace.name.duplicate", exp))
+      }
+    }
     val list =
         try { worldLock.synchronized {
           compiler.readFromString("[" + valueSets + "]").asInstanceOf[LogoList]


### PR DESCRIPTION
### Motivation

Currently, NetLogo has no functionality for importing and exporting individual BehaviorSpace experiments, but there is functionality for running individual experiments headlessly. To use this feature, you have to manually extract and format the desired experiments from the text version of your saved NetLogo model file. Having the ability to import and export experiments would make this easier, and it would make it easier to transfer individual experiments between models or devices.

### GUI Changes

In the initial BehaviorSpace window, there are now import and export buttons. You can import any number of experiments at once and at any time while the window is open. The export button is grayed out until one or more experiments have been added, at which point you can select any number of experiments to export them at the same time. If only one experiment is selected, it will be output into one file, named according to the name of the experiment. If multiple experiments are selected, they will also be output into one file, named according to the name of the model.

### Other Changes

Currently, you can name all of your experiments with the exact same name. If you were to export them all using the new export functionality, it would overwrite the same file over and over and you would end up with only one exported experiment. To prevent this, I added a new requirement that all experiments within a model have unique names. To ensure that importing goes smoothly with this new requirement, I also added code to automatically rename imported experiments if there are naming conflicts with the existing experiments in that model. For example, if you have an experiment named "experiment" and you try to import an experiment also named "experiment", the imported experiment will be renamed to "experiment-1".

You can also currently name experiments with an empty string, which would also cause issues with exporting experiments, so I added a requirement that experiments have non-empty names.

The documentation was also changed to reflect the new changes in the GUI and the new requirements for naming.