### PR TITLE
BehaviorSpace Empty metric condition bugfix

### DIFF
--- a/netlogo-gui/src/main/properties/ReporterLineEditor.scala
+++ b/netlogo-gui/src/main/properties/ReporterLineEditor.scala
@@ -18,7 +18,7 @@ abstract class ReporterLineEditor(accessor: PropertyAccessor[String],
     editor,
     ScrollPaneConstants.VERTICAL_SCROLLBAR_NEVER,
     ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER)
-  override def get = super.get.map(_.trim).filter(_.nonEmpty)
+  override def get = super.get.map(_.trim)
   override def getConstraints = {
     setMinimumSize(new Dimension(0, 35));
     val c = new GridBagConstraints


### PR DESCRIPTION
There is currently a bug where if the user clears the metric condition reporter, the empty input is not saved, and the previous input is still used. However, saving still works as expected as long as the text box is not empty. With this PR, the empty reporter is now saved.