### PR TITLE
Don't save or run when "x" button is clicked

### DIFF
--- a/netlogo-gui/src/main/properties/EditDialog.scala
+++ b/netlogo-gui/src/main/properties/EditDialog.scala
@@ -95,10 +95,15 @@ trait EditDialog extends javax.swing.JDialog {
   addWindowListener(
     new java.awt.event.WindowAdapter() {
       override def windowClosing(e: java.awt.event.WindowEvent) {
-        if(editPanel.valid) {
-          editPanel.apply()
-          if(target.editFinished) bye()
-        }}})
+        if (sendEditFinishedOnCancel) {
+          if(editPanel.valid) {
+            editPanel.apply()
+            if(target.editFinished) bye()
+          }
+        } else {
+          abort()
+        }
+        }})
 
   org.nlogo.swing.Utils.addEscKeyAction(this, () => cancel(target))
 
@@ -120,7 +125,6 @@ trait EditDialog extends javax.swing.JDialog {
   }
 
   private def cancel(target: org.nlogo.api.Editable) {
-    editPanel.revert()
     if(!sendEditFinishedOnCancel || target.editFinished) {
       canceled = true
       bye()

--- a/netlogo-gui/src/main/properties/EditDialog.scala
+++ b/netlogo-gui/src/main/properties/EditDialog.scala
@@ -125,6 +125,7 @@ trait EditDialog extends javax.swing.JDialog {
   }
 
   private def cancel(target: org.nlogo.api.Editable) {
+    editPanel.revert()
     if(!sendEditFinishedOnCancel || target.editFinished) {
       canceled = true
       bye()


### PR DESCRIPTION
**Motivation**
In edit dialogs, the input data is currently saved when the user presses the "x" button, but the data should be reverted instead of saved. This behavior also makes BehaviorSpace experiments run when the user presses the "x" in the run options dialog.

**Changes**
This change will affect dialogs that inherit from `netlogo-gui/src/main/properties/EditDialog.scala`. Note that this will affect widget and plot edit dialogs in addition to run options dialog explained above.
With the changes, if the user clicks "x" without first hitting "apply", changes will not be saved. If "apply" was clicked, then the applied changes will be saved.
