### PR TITLE
BehaviorSpace change default threads

### DIFF
--- a/autogen/docs/behaviorspace.md.mustache
+++ b/autogen/docs/behaviorspace.md.mustache
@@ -15,7 +15,7 @@ A number of new features were introduce in NetLogo 6.4:
  combinations to be run separately, rather than being expanded combinatorically.
 - [**Run metrics when**](#run-metrics-when): Measurements can now be conditionally recorded,
  controlled by a reporter.
-- [**Importing and exporting**](#importing-and-exporting): Experiments can now be exported to 
+- [**Importing and exporting**](#importing-and-exporting): Experiments can now be exported to
 an XML file that can be used when running headlessly. Experiments can also be imported into a
  model.
 - [**Statistics output**](#statistics-output): The mean and standard deviation
@@ -24,7 +24,7 @@ of data from repetitions can be saved in an output file.
  element per cell.
 - [**Paused experiments**](#paused-experiments): Experiments can now be paused and resumed.
 
-Additional minor changes can be found by searching this page for *(Since 6.4)* 
+Additional minor changes can be found by searching this page for *(Since 6.4)*
 
 ## What is BehaviorSpace?
 
@@ -38,7 +38,7 @@ behaviors and determine which combinations of settings cause the behaviors of
 interest.
 
 If your computer has multiple processor cores, then by default, model runs will
-happen in parallel, one per core.
+happen in parallel, one per every two cores.
 
 ### Why BehaviorSpace?
 
@@ -526,10 +526,10 @@ spreadsheet and database programs.
 
 #### Run options: update plots and monitors
 
-The run options dialog lets you choose whether to update plots and monitors or not.
+The "Run Options" dialog lets you choose whether to update plots and monitors or not.
 Unchecking the box will result in better performance. Note that if you begin
 the experiment with the box unchecked, then you will not be able to toggle
-between enabling and disabling the update plots checkbox in the "Running Experiments" dialog 
+between enabling and disabling the update plots checkbox in the "Running Experiments" dialog
 *(Since 6.4)*.
 Check the box if you you want to export plot data using primitives such as [[export-interface|export-cmds]],
 [[export-plot|export-cmds]], [[export-all-plots|export-cmds]], and [[export-world|export-cmds]].
@@ -537,8 +537,8 @@ Check the box if you you want to export plot data using primitives such as [[exp
 #### Run options: parallel runs
 
 The "Run Options" dialog also lets you select whether you want multiple model runs to happen in parallel, and if so, how
-many are allowed to be simultaneously active. This number will default to the number of processor cores in your
-computer.
+many are allowed to be simultaneously active. This number will default to half the number of processor cores in your
+computer (rounded up).
 
 There are a few cautions associated with parallel runs.
 

--- a/netlogo-gui/src/main/headless/Main.scala
+++ b/netlogo-gui/src/main/headless/Main.scala
@@ -7,7 +7,8 @@ import java.io.{ File, FileWriter, PrintWriter }
 import org.nlogo.core.WorldDimensions
 import org.nlogo.api.{ APIVersion, ExportPlotWarningAction, Version }
 import org.nlogo.nvm.LabInterface.Settings
- import org.nlogo.api.PlotCompilationErrorAction
+import org.nlogo.api.PlotCompilationErrorAction
+import scala.math.ceil
 
 object Main {
 
@@ -105,7 +106,7 @@ See the Advanced Usage section of the BehaviorSpace documentation in the NetLogo
     var spreadsheetWriter: Option[PrintWriter] = None
     var statsWriter: Option[(PrintWriter, String)] = None
     var listsWriter: Option[(PrintWriter, String)] = None
-    var threads = Runtime.getRuntime.availableProcessors
+    var threads = ceil(Runtime.getRuntime.availableProcessors / 2.0).toInt
     var suppressErrors = false
     var updatePlots = false
     val it = args.iterator

--- a/netlogo-gui/src/main/lab/gui/RunOptionsDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/RunOptionsDialog.scala
@@ -9,6 +9,7 @@ import org.nlogo.window.EditDialogFactoryInterface
 
 import java.io.File
 import java.util.prefs.Preferences
+import scala.math.ceil
 
 class RunOptionsDialog(parent: java.awt.Dialog,
                        dialogFactory: EditDialogFactoryInterface,
@@ -69,7 +70,7 @@ class RunOptionsDialog(parent: java.awt.Dialog,
     }
     def updateView = prefs.getBoolean("updateView", true)
     def updatePlotsAndMonitors = prefs.getBoolean("updatePlotsAndMonitors", true)
-    def updateThreadCount = prefs.getInt("threadCount", Runtime.getRuntime.availableProcessors)
+    def updateThreadCount = prefs.getInt("threadCount", ceil(Runtime.getRuntime.availableProcessors / 2.0).toInt)
     def updateFrom(runOptions: LabRunOptions): Unit = {
       prefs.put("spreadsheet", parentDirectory(runOptions.spreadsheet))
       prefs.put("table", parentDirectory(runOptions.table))

--- a/netlogo-headless/src/main/headless/Main.scala
+++ b/netlogo-headless/src/main/headless/Main.scala
@@ -6,6 +6,7 @@ import org.nlogo.core.WorldDimensions
 import org.nlogo.api.{ APIVersion, ExportPlotWarningAction, Version }
 import org.nlogo.nvm.LabInterface.Settings
 import org.nlogo.api.PlotCompilationErrorAction
+import scala.math.ceil
 
 object Main {
   class CancelException extends RuntimeException
@@ -72,7 +73,7 @@ object Main {
     var spreadsheetWriter: Option[java.io.PrintWriter] = None
     var statsWriter: Option[(java.io.PrintWriter, String)] = None
     var listsWriter: Option[(java.io.PrintWriter, String)] = None
-    var threads = Runtime.getRuntime.availableProcessors
+    var threads = ceil(Runtime.getRuntime.availableProcessors / 2.0).toInt
     var suppressErrors = false
     var updatePlots = false
     val it = args.iterator


### PR DESCRIPTION
**Motivation**
The documentation currently recommends users to "start with a --threads value at half the number of logical cores your system has, and bump up or down from there to see where your “sweet spot” is for least time to complete all runs." Setting the default thread count to half the cores is more consistent with the documentation than the current behavior where it is set to the number of cores.

**Changes**
The default number of threads in gui and headless runs is now set to ceil(cores / 2)