### PR TITLE
New method for default number of parallel runs in BehaviorSpace

### DIFF
--- a/autogen/docs/behaviorspace.md.mustache
+++ b/autogen/docs/behaviorspace.md.mustache
@@ -37,8 +37,8 @@ called "parameter sweeping". It lets you explore the model's "space" of possible
 behaviors and determine which combinations of settings cause the behaviors of
 interest.
 
-If your computer has multiple processor cores, then by default, model runs will
-happen in parallel, one per core.
+If your computer has multiple processor cores, you can specify how many model runs will
+happen in parallel.
 
 ### Why BehaviorSpace?
 
@@ -537,8 +537,8 @@ Check the box if you you want to export plot data using primitives such as [[exp
 #### Run options: parallel runs
 
 The "Run Options" dialog also lets you select whether you want multiple model runs to happen in parallel, and if so, how
-many are allowed to be simultaneously active. This number will default to the number of processor cores in your
-computer.
+many are allowed to be simultaneously active. The default and recommended maximum number of parallel runs are shown
+below the text box.
 
 There are a few cautions associated with parallel runs.
 
@@ -553,11 +553,10 @@ out-of-order results. When you analyze your table data, you may wish to sort it 
 output is not affected by this issue, since it is not written until the experiment completes or is aborted.)
 
 Fourth, using all available processor cores may make your computer slow to use for other tasks while the experiment is
-running or slow to complete runs as contention will build for memory between the runs themselves.  The number of threads
-used by NetLogo if the `--threads` parameter is omitted will be the total number of processors on your system.  If your
-model uses a large amount of memory, you may find that passing in a smaller value of `--threads` will enable the runs to
-complete in less time overall since work will be done by the system keeping the memory for each run available.  A good
-rule of thumb might be to start with a `--threads` value at half the number of logical cores your system has, and bump
+running or slow to complete runs as contention will build for memory between the runs themselves. If your
+model uses a large amount of memory, you may find that reducing the number of runs will enable the runs to
+complete in less time overall since work will be done by the system keeping the memory for each run available. A good
+rule of thumb might be to start with the default value shown in the "Run Options", and bump
 up or down from there to see where your "sweet spot" is for least time to complete all runs.
 
 Fifth, doing runs in parallel will multiply the experiment's memory requirements accordingly. You may need to increase
@@ -662,7 +661,7 @@ open the graphical interface otherwise).
 - --stats <path>: pathname to send statistics output to (or - for standard output)
  cannot be used without `--table` or `--spreadsheet`
 - `--threads <number>`: use this many threads to do model runs in parallel, or 1
-  to disable parallel runs. defaults to one thread per processor.
+  to disable parallel runs. defaults to `floor(0.75 * <number of processors>)`.
 - `--update-plots`: enable plot updates. Include this if you want to export plot data,
   or exclude it for better performance.
 - `--min-pxcor <number>`: override world size setting in model file

--- a/netlogo-core/src/main/api/LabDefaultThreads.scala
+++ b/netlogo-core/src/main/api/LabDefaultThreads.scala
@@ -4,7 +4,7 @@ package org.nlogo.api
 import scala.math.floor
 
 object LabDefaultThreads {
- val RATIO = 0.75
- // Determines the number of threads in BehaviorSpace if the user has not specified a value
- def getLabDefaultThreads: Int= { floor(Runtime.getRuntime.availableProcessors * RATIO).toInt }
+  val RATIO = 0.75
+  // Determines the number of threads in BehaviorSpace if the user has not specified a value
+  def getLabDefaultThreads: Int = { floor(Runtime.getRuntime.availableProcessors * RATIO).toInt }
 }

--- a/netlogo-core/src/main/api/LabDefaultThreads.scala
+++ b/netlogo-core/src/main/api/LabDefaultThreads.scala
@@ -1,0 +1,10 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.api
+import scala.math.floor
+
+object LabDefaultThreads {
+ val RATIO = 0.75
+ // Determines the number of threads in BehaviorSpace if the user has not specified a value
+ def getLabDefaultThreads :Int  = { floor(Runtime.getRuntime.availableProcessors * RATIO).toInt }
+}

--- a/netlogo-core/src/main/api/LabDefaultThreads.scala
+++ b/netlogo-core/src/main/api/LabDefaultThreads.scala
@@ -6,5 +6,5 @@ import scala.math.floor
 object LabDefaultThreads {
  val RATIO = 0.75
  // Determines the number of threads in BehaviorSpace if the user has not specified a value
- def getLabDefaultThreads :Int  = { floor(Runtime.getRuntime.availableProcessors * RATIO).toInt }
+ def getLabDefaultThreads: Int= { floor(Runtime.getRuntime.availableProcessors * RATIO).toInt }
 }

--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -638,7 +638,8 @@ tools.behaviorSpace.runoptions.updateplotsandmonitors.info = When unchecked perf
 and you will not be able to toggle plots in the "Running Experiment" window.
 tools.behaviorSpace.runoptions.simultaneousruns = Simultaneous runs in parallel
 tools.behaviorSpace.runoptions.simultaneousruns.info = If more than one, some runs happen invisibly in the background.<br> \
-Defaults to one processor per core.
+Default: {0} runs.<br> \
+Recommended maximum: {1} runs.
 
 tools.behaviorSpace.progressDialog.title = Running Experiment: {0}
 tools.behaviorSpace.progressDialog.plot.title = Behavior Plot

--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -638,8 +638,7 @@ tools.behaviorSpace.runoptions.updateplotsandmonitors.info = When unchecked perf
 and you will not be able to toggle plots in the "Running Experiment" window.
 tools.behaviorSpace.runoptions.simultaneousruns = Simultaneous runs in parallel
 tools.behaviorSpace.runoptions.simultaneousruns.info = If more than one, some runs happen invisibly in the background.<br> \
-Default: {0} runs.<br> \
-Recommended maximum: {1} runs.
+Default: {0} runs. Recommended maximum: {1} runs.
 
 tools.behaviorSpace.progressDialog.title = Running Experiment: {0}
 tools.behaviorSpace.progressDialog.plot.title = Behavior Plot

--- a/netlogo-gui/src/main/headless/Main.scala
+++ b/netlogo-gui/src/main/headless/Main.scala
@@ -5,7 +5,7 @@ package org.nlogo.headless
 import java.io.{ File, FileWriter, PrintWriter }
 
 import org.nlogo.core.WorldDimensions
-import org.nlogo.api.{ APIVersion, ExportPlotWarningAction, Version }
+import org.nlogo.api.{ APIVersion, ExportPlotWarningAction, LabDefaultThreads, Version }
 import org.nlogo.nvm.LabInterface.Settings
  import org.nlogo.api.PlotCompilationErrorAction
 
@@ -23,7 +23,7 @@ Run NetLogo using the NetLogo_Console app with the --headless command line argum
 * --spreadsheet <path>: pathname to send spreadsheet output to (or - for standard output)
 * --lists <path>: pathname to send lists output to (or - for standard output), cannot be used without --table or --spreadsheet
 * --stats <path>: pathname to send statistics output to (or - for standard output)
-* --threads <number>: use this many threads to do model runs in parallel, or 1 to disable parallel runs. defaults to one thread per processor.
+* --threads <number>: use this many threads to do model runs in parallel, or 1 to disable parallel runs. defaults to floor( .75 * number of processors).
 * --update-plots: enable plot updates. Include this if you want to export plot data, or exclude it for better performance.
 * --min-pxcor <number>: override world size setting in model file
 * --max-pxcor <number>: override world size setting in model file
@@ -32,7 +32,7 @@ Run NetLogo using the NetLogo_Console app with the --headless command line argum
 
 The --model flag is required. If you don't specify --experiment, you must specify --setup-file. By default no results are generated, so you'll usually want to specify either --table or --spreadsheet, or both. If you specify any of the world dimensions, you must specify all four.
 
-Here is an example of running an experiment already defined and saved within a model (path seperators and line-continue slashes are for macOS or Linux, Windows would be different):
+Here is an example of running an experiment already defined and saved within a model (path separators and line-continue slashes are for macOS or Linux, Windows would be different):
 
 ./NetLogo_Console --headless \
   --model "models/IABM Textbook/chapter 4/Wolf Sheep Simple 5.nlogo" \
@@ -105,7 +105,7 @@ See the Advanced Usage section of the BehaviorSpace documentation in the NetLogo
     var spreadsheetWriter: Option[PrintWriter] = None
     var statsWriter: Option[(PrintWriter, String)] = None
     var listsWriter: Option[(PrintWriter, String)] = None
-    var threads = Runtime.getRuntime.availableProcessors
+    var threads =  LabDefaultThreads.getLabDefaultThreads
     var suppressErrors = false
     var updatePlots = false
     val it = args.iterator

--- a/netlogo-gui/src/main/lab/gui/RunOptionsDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/RunOptionsDialog.scala
@@ -2,7 +2,7 @@
 
 package org.nlogo.lab.gui
 
-import org.nlogo.api.{Editable, Property, LabRunOptions}
+import org.nlogo.api.{Editable, Property, LabDefaultThreads, LabRunOptions}
 import org.nlogo.awt.UserCancelException
 import org.nlogo.core.{ I18N }
 import org.nlogo.window.EditDialogFactoryInterface
@@ -19,6 +19,8 @@ class RunOptionsDialog(parent: java.awt.Dialog,
   val tableFile = s"$filePrefix-table.csv"
   val statsFile = s"$filePrefix-stats.csv"
   val listsFile = s"$filePrefix-lists.csv"
+  val totalProcessors = Runtime.getRuntime.availableProcessors
+  val defaultProcessors = LabDefaultThreads.getLabDefaultThreads
 
   object Prefs {
     private val prefs = Preferences.userNodeForPackage(RunOptionsDialog.this.getClass)
@@ -69,7 +71,7 @@ class RunOptionsDialog(parent: java.awt.Dialog,
     }
     def updateView = prefs.getBoolean("updateView", true)
     def updatePlotsAndMonitors = prefs.getBoolean("updatePlotsAndMonitors", true)
-    def updateThreadCount = prefs.getInt("threadCount", Runtime.getRuntime.availableProcessors)
+    def updateThreadCount = prefs.getInt("threadCount", defaultProcessors)
     def updateFrom(runOptions: LabRunOptions): Unit = {
       prefs.put("spreadsheet", parentDirectory(runOptions.spreadsheet))
       prefs.put("table", parentDirectory(runOptions.table))
@@ -110,7 +112,10 @@ class RunOptionsDialog(parent: java.awt.Dialog,
         Property("updatePlotsAndMonitors", Property.Boolean, I18N.gui("updateplotsandmonitors"),
                  "<html>" + I18N.gui("updateplotsandmonitors.info") + "</html>"),
         Property("threadCount", Property.Integer, I18N.gui("simultaneousruns"),
-                 "<html>" + I18N.gui("simultaneousruns.info") + "</html>")).asJava
+                 "<html>" + I18N.gui("simultaneousruns.info",
+                                defaultProcessors.toString,
+                                (totalProcessors.toString))
+                + "</html>")).asJava
     }
     def get = LabRunOptions(threadCount, table, spreadsheet, stats, lists, updateView, updatePlotsAndMonitors)
     // boilerplate for Editable

--- a/netlogo-headless/src/main/headless/Main.scala
+++ b/netlogo-headless/src/main/headless/Main.scala
@@ -3,7 +3,7 @@
 package org.nlogo.headless
 
 import org.nlogo.core.WorldDimensions
-import org.nlogo.api.{ APIVersion, ExportPlotWarningAction, Version }
+import org.nlogo.api.{ APIVersion, ExportPlotWarningAction, LabDefaultThreads, Version }
 import org.nlogo.nvm.LabInterface.Settings
 import org.nlogo.api.PlotCompilationErrorAction
 
@@ -72,7 +72,7 @@ object Main {
     var spreadsheetWriter: Option[java.io.PrintWriter] = None
     var statsWriter: Option[(java.io.PrintWriter, String)] = None
     var listsWriter: Option[(java.io.PrintWriter, String)] = None
-    var threads = Runtime.getRuntime.availableProcessors
+    var threads = LabDefaultThreads.getLabDefaultThreads
     var suppressErrors = false
     var updatePlots = false
     val it = args.iterator


### PR DESCRIPTION
Motivation
Make the default number of parallel runs consistent with the advice for optimizing that number when running large models in BehaviorSpace. 
Changes
The default number of threads in gui and headless runs is now set to floor( RATIO * number of logical cores), where RATIO currently equal .75.


To change .75 to another value would require the following three lines to be changed
netlogo-core/src/main/api/LabDefaultThreads.scala
 val RATIO = 0.75
 
netlogo-gui/src/main/headless/Main.scala
--threads <number>: use this many threads to do model runs in parallel, or 1 to disable parallel runs. defaults to floor( .75 * number of processors).

autogen/docs/behaviorspace.md.mustache
  to disable parallel runs. defaults to `floor(0.75 * <number of processors>)`.