### PR TITLE
Basic multi-variable let and set

### DIFF
--- a/autogen/docs/dictionary.html.mustache
+++ b/autogen/docs/dictionary.html.mustache
@@ -4910,10 +4910,21 @@ end
       <p>
         Example:
       </p>
-      <pre>
+<pre>
 let prey one-of sheep-here
 if prey != nobody
   [ ask prey [ die ] ]
+</pre>
+      <p>
+        You can also create multiple local variables if you put the variable names in a list format.  The values for the new variables will be taken from the list given as the second argument.  This can be particular useful when you want to calculate multiple values in a reporter procedure, as you can easily create multiple variables with the results.  A runtime error will occur if you do not give a list of values or the list you provide doesn't have enough values for all the variables.
+      </p>
+<pre>
+let [x y z] [10 15 20]
+show x ; prints 10
+show y ; prints 15
+show z ; prints 20
+
+let [a b c] [10] ; causes a runtime error as we need at least 3 values in the list
 </pre>
     </div>
     <div class="dict_entry" id="link">
@@ -7853,6 +7864,27 @@ show (sentence [1 2] 3 [4 5] (3 + 3) 7)
           <li>A local variable created by the <a href="#let">let</a> command.</li>
           <li>An input to the current procedure.</li>
         </ul>
+        <p>Example:</p>
+<pre>
+ask turtles [
+  set color red
+  set size 2
+  set shape "arrow"
+]
+</pre>
+        <p>
+          You can also give a list of variable names as the first argument for <code>set</code> and they will be assigned the values from a list given as the second argument.  This can be particular useful when you want to calculate multiple values in a reporter procedure, as you can easily set multiple variables with the results.  A runtime error will occur if the second argument is not a list value or if there are not enough values in the list for all the variables specified.
+        </p>
+<pre>
+ask turtles [
+  set [color size shape] [red 2 "arrow"]
+  show color ; prints 15
+  show size ; prints 2
+  show shape ; prints "arrow"
+]
+ask turtles [
+  set [color size shape] [red] ; causes a runtime error as we need at least 3 values in the list
+]
       </div>
       <div class="dict_entry" id="set-current-directory">
         <h3>

--- a/netlogo-core/src/main/generate/MethodSelector.scala
+++ b/netlogo-core/src/main/generate/MethodSelector.scala
@@ -8,6 +8,7 @@ import java.lang.reflect.Method
 object MethodSelector {
   // the Long is the total cost of using the method, including the costs of all its arguments
   type Result = List[(Method, Long)]
+
   def select(i: Instruction, returnType: Class[_], profilingEnabled: Boolean): Option[Method] =
     if (!BytecodeUtils.isRejiggered(i)) None
     else {
@@ -15,6 +16,7 @@ object MethodSelector {
       result.foreach(m => i.chosenMethod = m)
       result
     }
+
   def evaluate(i: Instruction, profilingEnabled: Boolean): Result = {
     val ms = methods(i, profilingEnabled).sortBy(_.getReturnType.toString)
     if (ms.isEmpty) List((BytecodeUtils.getUnrejiggeredMethod(i), 0))
@@ -25,12 +27,15 @@ object MethodSelector {
       group(pairs)(_._1.getReturnType).map(_.minBy(_._2))
     }
   }
+
   private def cheapest(p1: (Method, Long), p2: (Method, Long)) =
     if (p2._2 < p1._2) p2 else p1
+
   private def methods(i: Instruction, profilingEnabled: Boolean): List[Method] =
     BytecodeUtils.getMethods(i.getClass, profilingEnabled)
       // the "+ 1" is because rejiggered methods take a Context argument
       .filter(_.getParameterTypes.size == i.args.size + 1)
+
   // returns None if the method is inapplicable, or a Some(Long), the lower the better
   private def totalCostOption(m: Method, args: List[Result]): Option[Long] = {
     val costOptions =
@@ -39,12 +44,14 @@ object MethodSelector {
     if (!costOptions.forall(_.isDefined)) None
     else Some(costOptions.flatten.sum)
   }
+
   private def cheapestOption(typeTo: Class[_], arg: Result): Option[(Method, Long)] = {
     val results = for ((method, cost1) <- arg; cost2 <- conversionCost(method.getReturnType, typeTo))
       yield (method, cost1 + cost2)
     if (results.isEmpty) None
     else Some(results.reduceLeft(cheapest))
   }
+
   // non-private for unit testing
   def conversionCost(typeFrom: Class[_], typeTo: Class[_]): Option[Long] =
     if (typeTo == typeFrom || typeTo == classOf[Reporter]) Some(0)
@@ -53,21 +60,26 @@ object MethodSelector {
     else if (isBoxingConversion(typeFrom, typeTo)) Some(1000000)
     else if (isConversionPossible(typeFrom, typeTo)) Some(100000000L)
     else None
+
   private def isBoxingConversion(typeFrom: Class[_], typeTo: Class[_]) =
     (typeFrom, typeTo) == ((java.lang.Boolean.TYPE, classOf[java.lang.Boolean])) ||
       (typeFrom, typeTo) == ((java.lang.Boolean.TYPE, classOf[Object])) ||
       (typeFrom, typeTo) == ((java.lang.Double.TYPE, classOf[java.lang.Double])) ||
       (typeFrom, typeTo) == ((java.lang.Double.TYPE, classOf[Object]))
+
   private def isUnboxingConversion(typeFrom: Class[_], typeTo: Class[_]) =
     (typeFrom, typeTo) == ((classOf[java.lang.Double], java.lang.Double.TYPE)) ||
       (typeFrom, typeTo) == ((classOf[java.lang.Boolean], java.lang.Boolean.TYPE))
+
   private def isConversionPossible(typeFrom: Class[_], typeTo: Class[_]) =
     typeFrom.isAssignableFrom(typeTo) ||
       isBoxingConversion(typeTo, typeFrom) ||
       isUnboxingConversion(typeTo, typeFrom)
+
   private def countInheritanceLevels(child: Class[_], ancestor: Class[_]): Int =
     if (child == ancestor) 0
     else 1 + countInheritanceLevels(child.getSuperclass, ancestor)
+
   // like group in Haskell, but with a key function. without reordering, break into sublists where
   // all the elements in each sublist are equal according to the key function.
   // example: group(List((1,9),(1,8),(2,7),(3,6),(3,5)))(_._1)

--- a/netlogo-core/src/main/generate/PeepholeSafeChecker.scala
+++ b/netlogo-core/src/main/generate/PeepholeSafeChecker.scala
@@ -38,8 +38,9 @@ class PeepholeSafeChecker(profilingEnabled: Boolean = false) {
   // we have to synchronize because we could be compiling stuff on multiple threads
   def isSafe(m: Method): Boolean = synchronized {
     val hashKey = getHashKey(m)
-    if (!methodSafeTable.contains(hashKey))
+    if (!methodSafeTable.contains(hashKey)) {
       processClass(m.getDeclaringClass)
+    }
     methodSafeTable(hashKey)
   }
   private val methodSafeTable = new collection.mutable.HashMap[String, Boolean]
@@ -47,8 +48,9 @@ class PeepholeSafeChecker(profilingEnabled: Boolean = false) {
     m.getDeclaringClass.getName + "." + m.getName
   private def processClass(c: Class[_]) {
     val reader = PrimitiveCache.getClassReader(c)
-    for (m <- BytecodeUtils.getMethods(c, profilingEnabled))
+    for (m <- BytecodeUtils.getMethods(c, profilingEnabled)) {
       reader.accept(new MethodExtractorClassAdapter(m), ClassReader.SKIP_DEBUG)
+    }
   }
   private class MethodExtractorClassAdapter(method: Method) extends EmptyClassVisitor {
     override def visitMethod(arg0: Int, name: String, descriptor: String, signature: String, exceptions: Array[String]): MethodVisitor =

--- a/netlogo-core/src/main/prim/_multilet.scala
+++ b/netlogo-core/src/main/prim/_multilet.scala
@@ -1,4 +1,4 @@
-// // (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
 
 package org.nlogo.prim
 
@@ -7,16 +7,24 @@ import org.nlogo.core.LogoList
 import org.nlogo.nvm.{ Context, Command, RuntimePrimitiveException }
 
 object MultiLet {
-  var currentList: Option[LogoList] = None
+  private var currentList: Option[LogoList] = None
+  private var nextIndex: Int = -1
 
-  def get(index: Int): AnyRef = {
-    MultiLet.currentList.getOrElse(
-      throw new IllegalStateException("We're trying to get a list value for a multilet, but the list hasn't been set?")
-    ).get(index)
+  def setCurrentList(list: LogoList) {
+    MultiLet.currentList = Some(list)
+    MultiLet.nextIndex   = 0
+  }
+
+  def next(): AnyRef = {
+    val value = MultiLet.currentList.getOrElse(
+      throw new IllegalStateException("We're trying to get a list value for a multi-bind (let or set), but the list hasn't been set?")
+    ).get(nextIndex)
+    nextIndex = nextIndex + 1
+    value
   }
 }
 
-class _multilet(private[this] val totalNeeded: Int) extends Command {
+class _multilet(private[this] val name: String, private[this] val totalNeeded: Int) extends Command {
   override def perform(context: Context): Unit = {
     val list = argEvalList(context, 0)
     perform_1(context, list)
@@ -24,10 +32,10 @@ class _multilet(private[this] val totalNeeded: Int) extends Command {
 
   def perform_1(context: Context, list: LogoList): Unit = {
     if (totalNeeded > list.size) {
-      val message = s"The list of values for LET must be at least as long as the list of names.  We need $totalNeeded value(s) but only got ${list.size} from the list ${Dump.logoObject(list)}."
+      val message = s"The list of values for $name must be at least as long as the list of names.  We need $totalNeeded value(s) but only got ${list.size} from the list ${Dump.logoObject(list)}."
       throw new RuntimePrimitiveException(context, this, message)
     }
-    MultiLet.currentList = Some(list)
+    MultiLet.setCurrentList(list)
     context.ip = next
   }
 

--- a/netlogo-core/src/main/prim/_multilet.scala
+++ b/netlogo-core/src/main/prim/_multilet.scala
@@ -1,0 +1,34 @@
+// // (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.prim
+
+import org.nlogo.api.Dump
+import org.nlogo.core.LogoList
+import org.nlogo.nvm.{ Context, Command, RuntimePrimitiveException }
+
+object MultiLet {
+  var currentList: Option[LogoList] = None
+
+  def get(index: Int): AnyRef = {
+    MultiLet.currentList.getOrElse(
+      throw new IllegalStateException("We're trying to get a list value for a multilet, but the list hasn't been set?")
+    ).get(index)
+  }
+}
+
+class _multilet(private[this] val totalNeeded: Int) extends Command {
+  override def perform(context: Context): Unit = {
+    val list = argEvalList(context, 0)
+    perform_1(context, list)
+  }
+
+  def perform_1(context: Context, list: LogoList): Unit = {
+    if (totalNeeded > list.size) {
+      val message = s"The list of values for LET must be at least as long as the list of names.  We need $totalNeeded value(s) but only got ${list.size} from the list ${Dump.logoObject(list)}."
+      throw new RuntimePrimitiveException(context, this, message)
+    }
+    MultiLet.currentList = Some(list)
+    context.ip = next
+  }
+
+}

--- a/netlogo-core/src/main/prim/_multiletitem.scala
+++ b/netlogo-core/src/main/prim/_multiletitem.scala
@@ -1,16 +1,16 @@
-// // (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
 
 package org.nlogo.prim
 
 import org.nlogo.nvm.{ Context, Reporter }
 
-class _multiletitem(private[this] val index: Int) extends Reporter {
+class _multiletitem() extends Reporter {
   override def report(context: Context): AnyRef = {
     report_1(context)
   }
 
   def report_1(context: Context): AnyRef = {
-    MultiLet.get(index)
+    MultiLet.next()
   }
 
 }

--- a/netlogo-core/src/main/prim/_multiletitem.scala
+++ b/netlogo-core/src/main/prim/_multiletitem.scala
@@ -2,22 +2,15 @@
 
 package org.nlogo.prim
 
-import org.nlogo.api.Dump
-import org.nlogo.core.LogoList
-import org.nlogo.nvm.{ Context, Reporter, RuntimePrimitiveException }
+import org.nlogo.nvm.{ Context, Reporter }
 
-class _multiletitem(private[this] val index: Int, private[this] val totalNeeded: Int) extends Reporter {
+class _multiletitem(private[this] val index: Int) extends Reporter {
   override def report(context: Context): AnyRef = {
-    val list = argEvalList(context, 0)
-    report_1(context, list)
+    report_1(context)
   }
 
-  def report_1(context: Context, list: LogoList): AnyRef = {
-    if (totalNeeded > list.size) {
-      val message = s"The list of values for LET must be at least as long as the list of names.  We need $totalNeeded value(s) but only got ${list.size} from the list ${Dump.logoObject(list)}."
-      throw new RuntimePrimitiveException(context, this, message)
-    }
-    list.get(index)
+  def report_1(context: Context): AnyRef = {
+    MultiLet.get(index)
   }
 
 }

--- a/netlogo-core/src/main/prim/_multiletitem.scala
+++ b/netlogo-core/src/main/prim/_multiletitem.scala
@@ -1,0 +1,23 @@
+// // (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.prim
+
+import org.nlogo.api.Dump
+import org.nlogo.core.LogoList
+import org.nlogo.nvm.{ Context, Reporter, RuntimePrimitiveException }
+
+class _multiletitem(private[this] val index: Int, private[this] val totalNeeded: Int) extends Reporter {
+  override def report(context: Context): AnyRef = {
+    val list = argEvalList(context, 0)
+    report_1(context, list)
+  }
+
+  def report_1(context: Context, list: LogoList): AnyRef = {
+    if (totalNeeded > list.size) {
+      val message = s"The list of values for LET must be at least as long as the list of names.  We need $totalNeeded value(s) but only got ${list.size} from the list ${Dump.logoObject(list)}."
+      throw new RuntimePrimitiveException(context, this, message)
+    }
+    list.get(index)
+  }
+
+}

--- a/netlogo-gui/src/main/compile/Backifier.scala
+++ b/netlogo-gui/src/main/compile/Backifier.scala
@@ -141,7 +141,10 @@ class Backifier(program: Program,
         new nvmprim._let(let)
 
       case core.prim._multilet(lets) =>
-        new nvmprim._multilet(lets.size)
+        new nvmprim._multilet("LET", lets.size)
+
+      case core.prim._multiset(sets) =>
+        new nvmprim._multilet("SET", sets.size)
 
       case nlogoApi.NetLogoLegacyDialect._magicopen(name) =>
         new nvmprim._magicopen(name)
@@ -232,9 +235,6 @@ class Backifier(program: Program,
 
       case s: core.prim._symbol =>
         new nvmprim._constsymbol(s.token)
-
-      case core.prim._multiletitem(index) =>
-        new nvmprim._multiletitem(index)
 
       case _ =>
         fallback[core.Reporter, nvm.Reporter](r)

--- a/netlogo-gui/src/main/compile/Backifier.scala
+++ b/netlogo-gui/src/main/compile/Backifier.scala
@@ -222,6 +222,9 @@ class Backifier(program: Program,
       case s: core.prim._symbol =>
         new nvmprim._constsymbol(s.token)
 
+      case core.prim._multiletitem(index, total) =>
+        new nvmprim._multiletitem(index, total)
+
       case _ =>
         fallback[core.Reporter, nvm.Reporter](r)
 

--- a/netlogo-gui/src/main/compile/Backifier.scala
+++ b/netlogo-gui/src/main/compile/Backifier.scala
@@ -133,20 +133,31 @@ class Backifier(program: Program,
         new nvmprim._extern(
           extensionManager.replaceIdentifier(c.token.text.toUpperCase)
             .asInstanceOf[nlogoApi.Command])
+
       case core.prim._call(proc) =>
         new nvmprim._call(procedures(proc.name))
+
       case core.prim._let(Some(let), _) =>
         new nvmprim._let(let)
+
+      case core.prim._multilet(lets) =>
+        new nvmprim._multilet(lets.size)
+
       case nlogoApi.NetLogoLegacyDialect._magicopen(name) =>
         new nvmprim._magicopen(name)
+
       case cc: core.prim._carefully =>
         new nvmprim._carefully(cc.let)
+
       case bk: core.prim._bk =>
         new nvmprim._bk(c.token)
+
       case fd: core.prim._fd =>
         new nvmprim._fd(c.token)
+
       case rep: core.prim._repeat =>
         new nvmprim._repeat(c.token)
+
       case _ =>
         fallback[core.Command, nvm.Command](c)
     }
@@ -222,8 +233,8 @@ class Backifier(program: Program,
       case s: core.prim._symbol =>
         new nvmprim._constsymbol(s.token)
 
-      case core.prim._multiletitem(index, total) =>
-        new nvmprim._multiletitem(index, total)
+      case core.prim._multiletitem(index) =>
+        new nvmprim._multiletitem(index)
 
       case _ =>
         fallback[core.Reporter, nvm.Reporter](r)

--- a/netlogo-gui/src/test/headless/AbstractTestLanguage.scala
+++ b/netlogo-gui/src/test/headless/AbstractTestLanguage.scala
@@ -84,21 +84,26 @@ trait AbstractTestLanguage extends Assertions {
                                        mode: TestMode) {
     try {
       testReporter(reporter, expectedError, mode)
-      fail("failed to cause runtime error: \"" + reporter + "\"")
+      fail(s"failed to cause runtime error: `$reporter")
+
     } catch {
       // PureConstantOptimizer throws would-be runtime errors at compile-time, so we check those
       case ex: CompilerException
         if (ex.getMessage.startsWith(CompilerException.RuntimeErrorAtCompileTimePrefix)) =>
           assertResult(CompilerException.RuntimeErrorAtCompileTimePrefix + expectedError)(ex.getMessage)
+
       case ex: CompilerException =>
-        fail("expected runtime error, got compile error: " + ex.getMessage)
+        fail(s"expected runtime error, got compile error: ${ex.getMessage}")
+
       case ex: Throwable =>
         withClue(mode + ": reporter: " + reporter) {
           if (actualError.isEmpty)
-            fail("expected to find an error, but none found")
+            fail(s"expected to find an error, but none found for `$reporter`")
+
           else
             assertResult(expectedError)(actualError.get)
         }
+
     }
   }
   def testReporterError(reporter: String, error: String, mode: TestMode) {
@@ -123,7 +128,7 @@ trait AbstractTestLanguage extends Assertions {
                        mode: TestMode = NormalMode) {
     try {
       testCommand(command, agentClass, mode)
-      fail("failed to cause runtime error: \"" + command + "\"")
+      fail(s"failed to cause runtime error: `$command`")
     }
     catch {
       case ex: LogoException =>
@@ -137,7 +142,7 @@ trait AbstractTestLanguage extends Assertions {
                        mode: TestMode = NormalMode) {
     try {
       testCommand(command, agentClass, mode)
-      fail("failed to cause runtime error: \"" + command + "\"")
+      fail(s"failed to cause runtime error: `$command`")
     }
     catch {
       case ex: LogoException =>
@@ -152,7 +157,7 @@ trait AbstractTestLanguage extends Assertions {
   {
     try {
       workspace.compileCommands(command, agentClass)
-      fail("no CompilerException occurred")
+      fail(s"no CompilerException occurred for `$command`")
     }
     catch {
       case ex: CompilerException =>

--- a/netlogo-headless/src/main/compile/Backifier.scala
+++ b/netlogo-headless/src/main/compile/Backifier.scala
@@ -107,6 +107,9 @@ class Backifier(
       case s: core.prim._symbol =>
         new nvmprim._constsymbol(s.token)
 
+      case core.prim._multiletitem(index, total) =>
+        new nvmprim._multiletitem(index, total)
+
       // diabolical special case: if we have e.g. `breed [fish]` with no singular,
       // then the singular defaults to `turtle`, which will cause BreedIdentifierHandler
       // to interpret "turtle" as _breedsingular - ST 4/12/14

--- a/netlogo-headless/src/main/compile/Backifier.scala
+++ b/netlogo-headless/src/main/compile/Backifier.scala
@@ -32,18 +32,28 @@ class Backifier(
         new nvmprim._extern(
           extensionManager.replaceIdentifier(c.token.text.toUpperCase)
             .asInstanceOf[nlogoApi.Command])
+
       case core.prim._call(proc) =>
         new nvmprim._call(procedures(proc.name))
+
       case core.prim._let(Some(let), _) =>
         new nvmprim._let(let)
+
+      case core.prim._multilet(lets) =>
+        new nvmprim._multilet(lets.size)
+
       case cc: core.prim._carefully =>
         new nvmprim._carefully(cc.let)
+
       case bk: core.prim._bk =>
         new nvmprim._bk(c.token)
+
       case fd: core.prim._fd =>
         new nvmprim._fd(c.token)
+
       case rep: core.prim._repeat =>
         new nvmprim._repeat(c.token)
+
       case _ =>
         fallback[core.Command, nvm.Command](c)
     }
@@ -107,8 +117,8 @@ class Backifier(
       case s: core.prim._symbol =>
         new nvmprim._constsymbol(s.token)
 
-      case core.prim._multiletitem(index, total) =>
-        new nvmprim._multiletitem(index, total)
+      case core.prim._multiletitem(index) =>
+        new nvmprim._multiletitem(index)
 
       // diabolical special case: if we have e.g. `breed [fish]` with no singular,
       // then the singular defaults to `turtle`, which will cause BreedIdentifierHandler

--- a/netlogo-headless/src/main/compile/Backifier.scala
+++ b/netlogo-headless/src/main/compile/Backifier.scala
@@ -40,7 +40,10 @@ class Backifier(
         new nvmprim._let(let)
 
       case core.prim._multilet(lets) =>
-        new nvmprim._multilet(lets.size)
+        new nvmprim._multilet("LET", lets.size)
+
+      case core.prim._multiset(sets) =>
+        new nvmprim._multilet("SET", sets.size)
 
       case cc: core.prim._carefully =>
         new nvmprim._carefully(cc.let)
@@ -116,9 +119,6 @@ class Backifier(
 
       case s: core.prim._symbol =>
         new nvmprim._constsymbol(s.token)
-
-      case core.prim._multiletitem(index) =>
-        new nvmprim._multiletitem(index)
 
       // diabolical special case: if we have e.g. `breed [fish]` with no singular,
       // then the singular defaults to `turtle`, which will cause BreedIdentifierHandler

--- a/parser-core/src/main/core/prim/misc.scala
+++ b/parser-core/src/main/core/prim/misc.scala
@@ -226,6 +226,20 @@ case class _lessthan() extends Reporter with Pure {
       ret = Syntax.BooleanType,
       precedence = Syntax.NormalPrecedence - 4)
 }
+case class _multilet(lets: Seq[(Token, Let)]) extends Command {
+  override def syntax =
+    Syntax.commandSyntax(
+      right = List(Syntax.WildcardType)
+    , defaultOption = Some(1)
+    )
+}
+case class _multiletitem(index: Int, total: Int) extends Reporter {
+  override def syntax =
+  Syntax.commandSyntax(
+    right = List(Syntax.ListType)
+  , defaultOption = Some(1)
+  )
+}
 case class _let(let: Option[Let], tokenText: Option[String]) extends Command {
   def this() = this(None, None)
   override def syntax =

--- a/parser-core/src/main/core/prim/misc.scala
+++ b/parser-core/src/main/core/prim/misc.scala
@@ -228,17 +228,11 @@ case class _lessthan() extends Reporter with Pure {
 }
 case class _multilet(lets: Seq[(Token, Let)]) extends Command {
   override def syntax =
-    Syntax.commandSyntax(
-      right = List(Syntax.WildcardType)
-    , defaultOption = Some(1)
-    )
+    Syntax.commandSyntax(right = List(Syntax.ListType))
 }
-case class _multiletitem(index: Int, total: Int) extends Reporter {
+case class _multiletitem(index: Int) extends Reporter {
   override def syntax =
-  Syntax.commandSyntax(
-    right = List(Syntax.ListType)
-  , defaultOption = Some(1)
-  )
+    Syntax.reporterSyntax(ret = Syntax.WildcardType, right = List(Syntax.ListType))
 }
 case class _let(let: Option[Let], tokenText: Option[String]) extends Command {
   def this() = this(None, None)

--- a/parser-core/src/main/core/prim/misc.scala
+++ b/parser-core/src/main/core/prim/misc.scala
@@ -229,6 +229,10 @@ case class _lessthan() extends Reporter with Pure {
 case class _multilet(lets: Seq[(Token, Let)]) extends Command {
   override def syntax =
     Syntax.commandSyntax(right = List(Syntax.ListType))
+
+  def letList: String =
+    lets.map(_._1.text).mkString("[", " ", "]")
+
 }
 case class _multiletitem() extends Reporter {
   override def syntax =
@@ -445,6 +449,10 @@ case class _sentence() extends Reporter with Pure {
 case class _multiset(sets: Seq[Token]) extends Command {
   override def syntax =
     Syntax.commandSyntax(right = List(Syntax.ListType))
+
+  def setList: String =
+    sets.map(_.text).mkString("[", " ", "]")
+
 }
 case class _multisetitem() extends Reporter {
   override def syntax =

--- a/parser-core/src/main/core/prim/misc.scala
+++ b/parser-core/src/main/core/prim/misc.scala
@@ -230,7 +230,7 @@ case class _multilet(lets: Seq[(Token, Let)]) extends Command {
   override def syntax =
     Syntax.commandSyntax(right = List(Syntax.ListType))
 }
-case class _multiletitem(index: Int) extends Reporter {
+case class _multiletitem() extends Reporter {
   override def syntax =
     Syntax.reporterSyntax(ret = Syntax.WildcardType, right = List(Syntax.ListType))
 }
@@ -441,6 +441,14 @@ case class _sentence() extends Reporter with Pure {
       ret = Syntax.ListType,
       defaultOption = Some(2),
       minimumOption = Some(0))
+}
+case class _multiset(sets: Seq[Token]) extends Command {
+  override def syntax =
+    Syntax.commandSyntax(right = List(Syntax.ListType))
+}
+case class _multisetitem() extends Reporter {
+  override def syntax =
+    Syntax.reporterSyntax(ret = Syntax.WildcardType, right = List(Syntax.ListType))
 }
 case class _set() extends Command {
   override def syntax =

--- a/parser-core/src/main/parse/FrontEnd.scala
+++ b/parser-core/src/main/parse/FrontEnd.scala
@@ -26,9 +26,10 @@ trait FrontEndMain extends NetLogoParser {
     val (rawProcDefs, structureResults) = basicParse(compilationOperand)
 
     val topLevelDefs = transformers(compilationOperand).foldLeft(rawProcDefs) {
-      case (defs, transform) => defs.map(transform.visitProcedureDefinition)
+      case (defs, transform) =>
+        val newDefs = defs.map(transform.visitProcedureDefinition)
+        newDefs
     }
-
 
     val letVerifier = new LetVerifier
     topLevelDefs.foreach(letVerifier.visitProcedureDefinition)

--- a/parser-core/src/main/parse/LetNamer.scala
+++ b/parser-core/src/main/parse/LetNamer.scala
@@ -14,8 +14,10 @@ object LetNamer extends TokenTransformer[Boolean] {
     token match {
       case t @ Token(_, TokenType.Ident, _) if lastTokenWasLet =>
         (t.refine(core.prim._letname(), tpe = TokenType.Reporter), false)
+
       case t @ (Token(_, TokenType.Ident, "LET") |  Token(_, TokenType.Ident, "__LET")) =>
         (t, true)
+
       case t => (t, false)
     }
 }

--- a/parser-core/src/main/parse/LetScoper.scala
+++ b/parser-core/src/main/parse/LetScoper.scala
@@ -92,18 +92,18 @@ import org.nlogo.core
 import SymbolType.LocalVariable
 
 object LetScope {
-  def apply(c: Command, nameToken: Option[Token], tokens: BufferedIterator[Token], usedNames: SymbolTable): Option[(Command, SymbolTable)] = {
-    c match {
-      case l @ core.prim._let(None, _) =>
-        nameToken match {
-          case Some(nameToken @ Token(text, TokenType.Reporter, _)) =>
+  def apply(l: core.prim._let, tokens: BufferedIterator[Token], usedNames: SymbolTable): (Command, SymbolTable) = {
+    l match {
+      case core.prim._let(None, _) =>
+        tokens.head match {
+          case nameToken @ Token(text, TokenType.Reporter, _) =>
             val name = text.toUpperCase
             val newLet = Let(name)
             for (tpe <- usedNames.get(name))
               exception("There is already a " + SymbolType.typeName(tpe) + " called " + name, nameToken)
-            Some((l.copy(let = newLet, tokenText = Some(text)), usedNames.addSymbol(name, LocalVariable(newLet))))
+            (l.copy(let = newLet, tokenText = Some(text)), usedNames.addSymbol(name, LocalVariable(newLet)))
 
-          case Some(t @ Token(_, TokenType.OpenBracket, _)) =>
+          case _ @ Token(_, TokenType.OpenBracket, _) =>
             var multiUsedNames = usedNames
             var lets: Seq[(Token, Let)] = Seq()
             tokens.next()
@@ -114,7 +114,7 @@ object LetScope {
               val tokenLet = (tokens.head, newLet)
               lets         = lets :+ tokenLet
               for (tpe <- multiUsedNames.get(name))
-                exception("There is already a " + SymbolType.typeName(tpe) + " called " + name, t)
+                exception("There is already a " + SymbolType.typeName(tpe) + " called " + name, token)
               multiUsedNames = multiUsedNames.addSymbol(name, LocalVariable(newLet))
               tokens.next()
             }
@@ -128,20 +128,21 @@ object LetScope {
             }
 
             val multi = core.prim._multilet(lets)
-            c.token.refine(multi, text = "_multilet")
-            Some((multi, multiUsedNames))
+            l.token.refine(multi, text = "_multilet")
+            (multi, multiUsedNames)
 
-          case Some(otherToken) =>
+          case _ @ Token(_, TokenType.Eof, _) =>
+            // expression parser will generate the error
+            (l, usedNames)
+
+          case otherToken =>
             exception("Expected variable name here", otherToken)
-
-          case _ => None
 
         }
 
-      case l @ core.prim._let(Some(let), _) =>
-        Some((c, usedNames.addSymbol(let.name.toUpperCase, LocalVariable(let))))
+      case core.prim._let(Some(let), _) =>
+        (l, usedNames.addSymbol(let.name.toUpperCase, LocalVariable(let)))
 
-      case _ => None
     }
   }
 }

--- a/parser-core/src/main/parse/NameHandlers.scala
+++ b/parser-core/src/main/parse/NameHandlers.scala
@@ -84,16 +84,22 @@ class ExtensionPrimitiveHandler(extensionManager: ExtensionManager) extends Name
 class AgentVariableReporterHandler(program: Program) extends NameHandler {
   import scala.collection.immutable.ListMap
   import PartialFunction.condOpt
+
   override def apply(token: Token) =
     getAgentVariableReporter(token.value.asInstanceOf[String])
       .map{(TokenType.Reporter, _)}
+
   def boolOpt[T](b: Boolean)(x: => T) =
     if (b) Some(x) else None
+
   def mapIndexOpt[T, S](map: ListMap[String, T], key: String)(f: (Int, T) => S): Option[S] =
     if (map.contains(key)) {
       val index = map.keys.toSeq.indexOf(key)
       Some(f(index, map(key)))
-    } else None
+    } else {
+      None
+    }
+
   def getAgentVariableReporter(varName: String): Option[core.Reporter] =
     boolOpt(program.breeds.values.exists(_.owns.contains(varName)))(
       new core.prim._breedvariable(varName)) orElse

--- a/parser-core/src/main/parse/NetLogoParser.scala
+++ b/parser-core/src/main/parse/NetLogoParser.scala
@@ -35,10 +35,12 @@ trait NetLogoParser {
     val usedNames = globallyUsedNames.addSymbols(procedure.args, SymbolType.ProcedureVariable)
     val namedTokens = {
       val letNamedTokens = TransformableTokenStream(rawTokens.iterator, LetNamer)
-      val namer =
-        new Namer(structureResults.program,
-          oldProcedures ++ structureResults.procedures,
-          procedure, extensionManager)
+      val namer = new Namer(
+          structureResults.program
+        , oldProcedures ++ structureResults.procedures
+        , procedure
+        , extensionManager
+        )
       namer.validateProcedure()
       TransformableTokenStream(letNamedTokens, namer)
     }

--- a/parser-core/src/main/parse/SetSplitter.scala
+++ b/parser-core/src/main/parse/SetSplitter.scala
@@ -1,0 +1,40 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.parse
+
+import org.nlogo.core.{ Command, Token, TokenType }
+import org.nlogo.core.Fail._
+import org.nlogo.core.prim.{ _multiset, _set }
+
+object SplitSet {
+  def apply(s: _set, tokens: BufferedIterator[Token]): Command = {
+    tokens.head match {
+      case _ @ Token(_, TokenType.OpenBracket, _) =>
+        var sets: Seq[Token] = Seq()
+        tokens.next()
+        while (tokens.hasNext && tokens.head.tpe != TokenType.CloseBracket) {
+          val token = tokens.head
+          if (token.text != "set" && token.text != "_multisetitem") {
+            sets = sets :+ token
+          }
+          tokens.next()
+        }
+        // pop the close bracket...
+        if (tokens.hasNext) {
+          tokens.next()
+        }
+
+        if (sets.length == 0) {
+          exception("The list of variables names given to SET must contain at least one item.", s.token)
+        }
+
+        val multi = _multiset(sets)
+        s.token.refine(multi, text = "_multiset")
+        multi
+
+      case _ =>
+        s
+
+    }
+  }
+}

--- a/parser-core/src/test/lex/TokenizerTests.scala
+++ b/parser-core/src/test/lex/TokenizerTests.scala
@@ -110,7 +110,7 @@ class TokenizerTests extends AnyFunSuite {
   testLexFailure("\"\\b\"",      0, 4,  "Illegal character after backslash")
   testLexFailure("\"\\\"",       0, 3,  "Closing double quote is missing")
   testLexFailure(""""abc""",     0, 4,  "Closing double quote is missing")
-   // check that parser errors when string contains newline
+  // check that parser errors when string contains newline
   testLexFailure("\"abc\n\"",    0, 4,  "Closing double quote is missing")
   testLexFailure("1.2.3",        0, 5,  "Illegal number format")
   testLexFailure("{{array: 1: ", 0, 12, "End of file reached unexpectedly")

--- a/parser-core/src/test/parse/FrontEndTests.scala
+++ b/parser-core/src/test/parse/FrontEndTests.scala
@@ -250,6 +250,16 @@ class FrontEndTests extends AnyFunSuite with BaseParserTest {
     val noNameProcedure = FrontEnd.findProcedurePositions("""to show "foo" end""", None)
     assert(noNameProcedure.isEmpty)
   }
+
+  test("regular old multi-let") {
+    testParse("let multilet-var-1 [1 2 3] let v1 (item 0 multilet-var-1) let v2 (item 1 multilet-var-1)",
+      "_let(Let(MULTILET-VAR-1),multilet-var-1)[_const([1, 2, 3])[]] _let(Let(V1),v1)[_item()[_const(0)[], _letvariable(Let(MULTILET-VAR-1))[]]] _let(Let(V2),v2)[_item()[_const(1)[], _letvariable(Let(MULTILET-VAR-1))[]]]")
+  }
+
+  test("fancy new multi-let") {
+    testParse("let [v1 v2] [1 2 3]",
+      "_let(Let(MULTILET-VAR-1),multilet-var-1)[_const([1, 2, 3])[]] _let(Let(V1),v1)[_multiletitem(0,2)[_letvariable(Let(MULTILET-VAR-1))[]]] _let(Let(V2),v2)[_multiletitem(1,2)[_letvariable(Let(MULTILET-VAR-1))[]]]")
+  }
 }
 
 object FrontEndTests {

--- a/parser-core/src/test/parse/FrontEndTests.scala
+++ b/parser-core/src/test/parse/FrontEndTests.scala
@@ -258,7 +258,7 @@ class FrontEndTests extends AnyFunSuite with BaseParserTest {
 
   test("fancy new multi-let") {
     testParse("let [v1 v2] [1 2 3]",
-      "_let(Let(MULTILET-VAR-1),multilet-var-1)[_const([1, 2, 3])[]] _let(Let(V1),v1)[_multiletitem(0,2)[_letvariable(Let(MULTILET-VAR-1))[]]] _let(Let(V2),v2)[_multiletitem(1,2)[_letvariable(Let(MULTILET-VAR-1))[]]]")
+      "_multilet(List((Token(v1,Reporter,_unknownidentifier()),Let(V1)), (Token(v2,Reporter,_unknownidentifier()),Let(V2))))[_const([1, 2, 3])[]] _let(Let(V1),v1)[_multiletitem(0)[]] _let(Let(V2),v2)[_multiletitem(1)[]]")
   }
 }
 

--- a/parser-core/src/test/parse/FrontEndTests.scala
+++ b/parser-core/src/test/parse/FrontEndTests.scala
@@ -258,8 +258,19 @@ class FrontEndTests extends AnyFunSuite with BaseParserTest {
 
   test("fancy new multi-let") {
     testParse("let [v1 v2] [1 2 3]",
-      "_multilet(List((Token(v1,Reporter,_unknownidentifier()),Let(V1)), (Token(v2,Reporter,_unknownidentifier()),Let(V2))))[_const([1, 2, 3])[]] _let(Let(V1),v1)[_multiletitem(0)[]] _let(Let(V2),v2)[_multiletitem(1)[]]")
+      "_multilet(List((Token(v1,Reporter,_unknownidentifier()),Let(V1)), (Token(v2,Reporter,_unknownidentifier()),Let(V2))))[_const([1, 2, 3])[]] _let(Let(V1),v1)[_multiletitem()[]] _let(Let(V2),v2)[_multiletitem()[]]")
   }
+
+  test("regular old multi-set") {
+    testParse("let v1 0 let v2 0 let multiset-var-1 [1 2 3] set v1 (item 0 multiset-var-1) set v2 (item 1 multiset-var-1)",
+      "_let(Let(V1),v1)[_const(0)[]] _let(Let(V2),v2)[_const(0)[]] _let(Let(MULTISET-VAR-1),multiset-var-1)[_const([1, 2, 3])[]] _set()[_letvariable(Let(V1))[], _item()[_const(0)[], _letvariable(Let(MULTISET-VAR-1))[]]] _set()[_letvariable(Let(V2))[], _item()[_const(1)[], _letvariable(Let(MULTISET-VAR-1))[]]]")
+  }
+
+  test("fancy new multi-set") {
+    testParse("let v1 0 let v2 0 set [v1 v2] [1 2 3]",
+      "_let(Let(V1),v1)[_const(0)[]] _let(Let(V2),v2)[_const(0)[]] _multiset(List(Token(v1,Reporter,_unknownidentifier()), Token(v2,Reporter,_unknownidentifier())))[_const([1, 2, 3])[]] _set()[_letvariable(Let(V1))[], _multiletitem()[]] _set()[_letvariable(Let(V2))[], _multiletitem()[]]")
+  }
+
 }
 
 object FrontEndTests {

--- a/parser-jvm/src/test/parse/AstRewriterTests.scala
+++ b/parser-jvm/src/test/parse/AstRewriterTests.scala
@@ -135,7 +135,7 @@ class AstRewriterTests extends AnyFunSuite {
   testLambda("show is-list? [ [] -> tick ]", "show is-list? task [tick]")
   testLambda("let a-value 1 let a-task [ [] -> a-value ]", "let a-value 1 let a-task task [a-value]")
   testLambda("baz ([ [] ->  fd 1 ]) ([ [?1 ?2] -> bk ?2 ])", "baz (task [ fd 1 ]) (task [ bk ?2 ])", preamble = "TO baz [a b] END TO FOO ")
-  testLambda("show reduce [ [x y] -> x + y] [1 2 3]", "show reduce [[x y] -> x + y] [1 2 3]")
+  testLambda("show reduce [ [x y] -> x + y ] [1 2 3]", "show reduce [[x y] -> x + y ] [1 2 3]")
   testLambda("foreach [1 2 3] [ [x] -> show x ]", "foreach [1 2 3] [ [x] -> show x ]")
   testLambda("foreach [1 2 3] [ x -> show x ]", "foreach [1 2 3] [ x -> show x ]")
   testLambda("foreach [1 2 3] [ -> show 4 ]", "foreach [1 2 3] [ -> show 4 ]")

--- a/test/commands/MultiLetSetAndArgs.txt
+++ b/test/commands/MultiLetSetAndArgs.txt
@@ -1,0 +1,82 @@
+LetWithLists
+  globals [g1 g2 l]
+
+  to set-globals [v1 v2] /
+    (set g1 v1) /
+    (set g2 v2) /
+  end
+
+  to-report report-nums /
+    (report [70 80]) /
+  end
+
+  O> let [v1 v2] [10 20] (set-globals v1 v2)
+  g1 => 10
+  g2 => 20
+
+  O> let [v3 v4] [30 40 50] (set-globals v3 v4)
+  g1 => 30
+  g2 => 40
+
+  O> set l [50 60]
+  O> let [v5 v6] l (set-globals v5 v6)
+  g1 => 50
+  g2 => 60
+
+  O> let [v7 v8] report-nums (set-globals v7 v8)
+  g1 => 70
+  g2 => 80
+
+  O> let [] [0] => COMPILER ERROR The list of variables names given to LET must contain at least one item.
+  O> let [v1 g1] [0 1] => COMPILER ERROR There is already a global variable called G1
+  O> let [v9 v10] [0] => ERROR The list of values for LET must be at least as long as the list of names.  We need 2 value(s) but only got 1 from the list [0].
+
+# TaskDisplayPreservesMultis
+#   globals [t g1 g2]
+#   O> set t [ [x] -> [ let [v1 v2] (list x 100) ]]
+#   word t => [ [x] -> [ let [v1 v2] (list x 100) ]]
+#   O> set t [ [x y] -> [ set [g1 g2] (list x y 300) ]]
+#   word t => [ [x y] -> [ set [g1 g2] (list x y 300) ]]
+#   # once we have task args destructuring...
+#   # O> set t [ [[x y]] -> [ set [g1 g2] (list x y 300 ) ]]
+#   # word t => [ [[x y]] -> [ set [g1 g2] (list x y 300 ) ]]
+#
+# SetWithLists
+#   globals [g1 g2 l]
+#
+#   to set-globals [v1 v2] /
+#     (set g1 v1) /
+#     (set g2 v2) /
+#   end
+#
+#   to-report report-nums /
+#     (report [70 80]) /
+#   end
+#
+#   O> set [g1 g2] [10 20]
+#   g1 => 10
+#   g2 => 20
+#
+#   O> set [g1 g2] [30 40 50]
+#   g1 => 30
+#   g2 => 40
+#
+#   O> set l [50 60]
+#   O> set [g1 g2] l
+#   g1 => 50
+#   g2 => 60
+#
+#   O> set [g1 g2] report-nums
+#   g1 => 70
+#   g2 => 80
+#
+#   set [] [0] => COMPILER ERROR It shoud've been you Gordo (must have at least 1 name for a multi-set).
+#   set [g1 g2] [0] => ERROR It should've been you Gordo (not enough elements).
+#   set [g1 g3] [0 1] => ERROR It should've been you Gordo (g3 doesn't exist).
+#
+# ArgsProc
+#   true => true
+#
+# ArgsAnonProc
+#   true => true
+#

--- a/test/commands/MultiLetSetAndArgs.txt
+++ b/test/commands/MultiLetSetAndArgs.txt
@@ -1,4 +1,4 @@
-LetWithLists
+Let
   globals [g1 g2 l]
 
   to set-globals [v1 v2] /
@@ -31,6 +31,53 @@ LetWithLists
   O> let [v1 g1] [0 1] => COMPILER ERROR There is already a global variable called G1
   O> let [v9 v10] [0] => ERROR The list of values for LET must be at least as long as the list of names.  We need 2 value(s) but only got 1 from the list [0].
 
+SetOnGlobals
+  globals [g1 g2 l]
+
+  to-report report-nums /
+    (report [70 80]) /
+  end
+
+  O> set [g1 g2] [10 20]
+  g1 => 10
+  g2 => 20
+
+  O> set [g1 g2] [30 40 50]
+  g1 => 30
+  g2 => 40
+
+  O> set l [50 60]
+  O> set [g1 g2] l
+  g1 => 50
+  g2 => 60
+
+  O> set [g1 g2] report-nums
+  g1 => 70
+  g2 => 80
+
+  O> set [] [0] => COMPILER ERROR The list of variables names given to SET must contain at least one item.
+  O> set [v1 g1] [0 1] => COMPILER ERROR There is no variable called V1.
+  O> set [g1 g2] [0] => ERROR The list of values for SET must be at least as long as the list of names.  We need 2 value(s) but only got 1 from the list [0].
+
+SetOnLets
+  globals [g1 g2 l]
+
+  to set-globals [v1 v2] /
+    (set g1 v1) /
+    (set g2 v2) /
+  end
+
+  O> let v1 0 let v2 0 set [v1 v2] [10 20] (set-globals v1 v2)
+  g1 => 10
+  g2 => 20
+
+# ArgsProc
+#   true => true
+#
+# ArgsAnonProc
+#   true => true
+#
+
 # TaskDisplayPreservesMultis
 #   globals [t g1 g2]
 #   O> set t [ [x] -> [ let [v1 v2] (list x 100) ]]
@@ -40,43 +87,3 @@ LetWithLists
 #   # once we have task args destructuring...
 #   # O> set t [ [[x y]] -> [ set [g1 g2] (list x y 300 ) ]]
 #   # word t => [ [[x y]] -> [ set [g1 g2] (list x y 300 ) ]]
-#
-# SetWithLists
-#   globals [g1 g2 l]
-#
-#   to set-globals [v1 v2] /
-#     (set g1 v1) /
-#     (set g2 v2) /
-#   end
-#
-#   to-report report-nums /
-#     (report [70 80]) /
-#   end
-#
-#   O> set [g1 g2] [10 20]
-#   g1 => 10
-#   g2 => 20
-#
-#   O> set [g1 g2] [30 40 50]
-#   g1 => 30
-#   g2 => 40
-#
-#   O> set l [50 60]
-#   O> set [g1 g2] l
-#   g1 => 50
-#   g2 => 60
-#
-#   O> set [g1 g2] report-nums
-#   g1 => 70
-#   g2 => 80
-#
-#   set [] [0] => COMPILER ERROR It shoud've been you Gordo (must have at least 1 name for a multi-set).
-#   set [g1 g2] [0] => ERROR It should've been you Gordo (not enough elements).
-#   set [g1 g3] [0 1] => ERROR It should've been you Gordo (g3 doesn't exist).
-#
-# ArgsProc
-#   true => true
-#
-# ArgsAnonProc
-#   true => true
-#

--- a/test/commands/MultiLetSetAndArgs.txt
+++ b/test/commands/MultiLetSetAndArgs.txt
@@ -78,12 +78,13 @@ SetOnLets
 #   true => true
 #
 
-# TaskDisplayPreservesMultis
-#   globals [t g1 g2]
-#   O> set t [ [x] -> [ let [v1 v2] (list x 100) ]]
-#   word t => [ [x] -> [ let [v1 v2] (list x 100) ]]
-#   O> set t [ [x y] -> [ set [g1 g2] (list x y 300) ]]
-#   word t => [ [x y] -> [ set [g1 g2] (list x y 300) ]]
-#   # once we have task args destructuring...
-#   # O> set t [ [[x y]] -> [ set [g1 g2] (list x y 300 ) ]]
-#   # word t => [ [[x y]] -> [ set [g1 g2] (list x y 300 ) ]]
+TaskDisplayPreservesMultis
+  globals [t g1 g2]
+  O> set t [ [x] -> let [v1 v2] (list x 100) ]
+  word t => "(anonymous command: [ [x] -> let [v1 v2] list x 100 ])"
+  O> set t [ [x y] -> set [g1 g2] (list x y 300) ]
+  # This is actually wrong as dropping the parens around `list` makes it incorrect syntax, but that's a separate issue.
+  word t => "(anonymous command: [ [x y] -> set [g1 g2] list x y 300 ])"
+  # once we have task args destructuring...
+  # O> set t [ [[x y]] -> set [g1 g2] (list x y 300) ]
+  # word t => "(anonymous command: [ [[x y]] -> set [g1 g2] list x y 300 ] "


### PR DESCRIPTION
Example lets:

```netlogo
let [x y z] [10 15 20]
show x ; prints 10
show y ; prints 15
show z ; prints 20
```

Example sets:

```netlogo
ask turtles [
  set [color size shape] [red 2 "arrow"]
  show color ; prints 15
  show size ; prints 2
  show shape ; prints "arrow"
]
```

That only uses agent variables, but you can freely mix agent variables, local variables, code globals, and interface globals.  

All compile time and runtime checks are the same way as with the existing non-multi-variable usage.

### TBD

This does not include:

- Argument destructuring for code procedures or anonymous procedures: `to report [[a b] c] report a + b + c end`.
- "Recursive" destructuring, things like `let [[a b] [x y]] [[10 20] [30 40]]`.  
