### PR TITLE
BehaviorSpace Edit Dialog Bug Fix

### DIFF
--- a/netlogo-gui/src/main/properties/EditDialogFactory.scala
+++ b/netlogo-gui/src/main/properties/EditDialogFactory.scala
@@ -2,6 +2,7 @@
 
 package org.nlogo.properties
 
+import java.util.function.Consumer
 import org.nlogo.api.{ CompilerServices, Editable }
 import org.nlogo.editor.Colorizer
 
@@ -33,7 +34,7 @@ class EditDialogFactory(_compiler: CompilerServices, _colorizer: Colorizer)
        }).canceled
   }
 
-  def create(frame: java.awt.Frame, _target: Editable, finish: Runnable) = {
+  def create(frame: java.awt.Frame, _target: Editable, finish: Consumer[java.lang.Boolean]) = {
     dialog = new javax.swing.JDialog(frame, _target.classDisplayName, false)
                with EditDialog {
                  override def window = frame
@@ -44,13 +45,12 @@ class EditDialogFactory(_compiler: CompilerServices, _colorizer: Colorizer)
                }
     dialog.addWindowListener(new java.awt.event.WindowAdapter {
       override def windowClosed(e: java.awt.event.WindowEvent) {
-        if (dialog != null && !dialog.canceled)
-          finish.run()
+        finish.accept(dialog != null && !dialog.canceled)
       }
     })
   }
 
-  def create(_dialog: java.awt.Dialog, _target: Editable, finish: Runnable) = {
+  def create(_dialog: java.awt.Dialog, _target: Editable, finish: Consumer[java.lang.Boolean]) = {
     dialog = new javax.swing.JDialog(_dialog, _target.classDisplayName, false)
                     with EditDialog {
                       override def window = _dialog
@@ -61,8 +61,7 @@ class EditDialogFactory(_compiler: CompilerServices, _colorizer: Colorizer)
                     }
     dialog.addWindowListener(new java.awt.event.WindowAdapter {
       override def windowClosed(e: java.awt.event.WindowEvent) {
-        if (dialog != null && !dialog.canceled)
-          finish.run()
+        finish.accept(dialog != null && !dialog.canceled)
       }
     })
   }

--- a/netlogo-gui/src/main/window/EditDialogFactoryInterface.java
+++ b/netlogo-gui/src/main/window/EditDialogFactoryInterface.java
@@ -2,6 +2,7 @@
 
 package org.nlogo.window;
 
+import java.util.function.Consumer;
 import org.nlogo.api.Editable;
 
 // This is used so that other packages don't depend on the properties package.  It gets instantiated
@@ -22,8 +23,8 @@ public interface EditDialogFactoryInterface {
   boolean canceled(java.awt.Dialog dialog, Editable target);
   
   //used for non-modal dialog
-  void create(java.awt.Frame frame, Editable target, Runnable finish);
-  void create(java.awt.Dialog dialog, Editable target, Runnable finish);
+  void create(java.awt.Frame frame, Editable target, Consumer<Boolean> finish);
+  void create(java.awt.Dialog dialog, Editable target, Consumer<Boolean> finish);
 
   javax.swing.JDialog getDialog();
   void clearDialog();


### PR DESCRIPTION
Disabled main window buttons when edit dialog is open to preserve non-modality of edit dialog while disallowing multiple edit dialogs and running experiments with the edit dialog open.