### PR TITLE
BehaviorSpace Plots Bug

### DIFF
--- a/netlogo-gui/src/main/lab/gui/Supervisor.scala
+++ b/netlogo-gui/src/main/lab/gui/Supervisor.scala
@@ -312,6 +312,7 @@ class Supervisor(
         workspace.jobManager.haltSecondary()
         workspace.behaviorSpaceRunNumber(0)
         workspace.behaviorSpaceExperimentName("")
+        workspace.setShouldUpdatePlots(true)
         if (paused)
           progressDialog.saveProtocolP()
         else


### PR DESCRIPTION
Fixed a bug where if an experiment is run with "update plots and monitors" unchecked, it disables the plots in the main NetLogo workspace where experiments are run manually.