### PR TITLE
BehaviorSpace Edit Bug Fixes

### DIFF
--- a/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
+++ b/netlogo-gui/src/main/lab/gui/ManagerDialog.scala
@@ -18,7 +18,7 @@ private class ManagerDialog(manager:       LabManager,
   with javax.swing.event.ListSelectionListener
 {
   def saveProtocol(protocol: LabProtocol): Unit = {
-    manager.protocols(selectedIndex) = protocol
+    manager.protocols(editIndex) = protocol
     update()
     select(protocol)
   }
@@ -39,6 +39,7 @@ private class ManagerDialog(manager:       LabManager,
   private val abortAction = action(I18N.gui("abort"), { () => abort() })
   private val runAction = action(I18N.gui("run"), { () => run() })
   private var blockActions = false
+  private var editIndex = 0
   /// initialization
   init()
   private def init() {
@@ -162,10 +163,12 @@ private class ManagerDialog(manager:       LabManager,
               variableName, List(manager.workspace.world.getObserverVariableByName(variableName)))}}),
       true)
   }
-  private def duplicate() { editProtocol(selectedProtocol.copy(runsCompleted = 0), true) }
+  private def duplicate() { editProtocol(selectedProtocol.copy(name = selectedProtocol.name + " (copy)",
+                                                               runsCompleted = 0), true) }
   private def edit() { editProtocol(selectedProtocol, false) }
   private def editProtocol(protocol: LabProtocol, isNew: Boolean) {
     blockActions = true
+    if (!isNew) editIndex = selectedIndex
     update()
     val editable = new ProtocolEditable(protocol, manager.workspace.getFrame,
                                         manager.workspace, manager.workspace.world,
@@ -176,7 +179,7 @@ private class ManagerDialog(manager:       LabManager,
         if (success) {
           val newProtocol = editable.get.get
           if (isNew) manager.protocols += newProtocol
-          else manager.protocols(selectedIndex) = newProtocol
+          else manager.protocols(editIndex) = newProtocol
           update()
           select(newProtocol)
           manager.dirty()


### PR DESCRIPTION
Fixed the following two bugs:

- When an experiment is duplicated, the new experiment has its name by default set to the same as the old experiment, so you have to manually change the name in order for the names to not conflict
- Editing an experiment always overwrites the first one in the list, regardless of which experiment was chosen to edit