### PR TITLE
Add gogo6 extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,6 +40,9 @@
 [submodule "gogo-hid"]
 	path = extensions/gogo
 	url = https://github.com/NetLogo/GoGo-HID-Extension
+[submodule "gogo6-hid"]
+	path = extensions/gogo6
+	url = https://github.com/kgmt0/GoGo6-HID-Extension
 [submodule "extensions/palette"]
 	path = extensions/palette
 	url = https://github.com/NetLogo/Palette-Extension


### PR DESCRIPTION
This is a fork of the `gogo` extension that I modified to support GGB6. There are enough differences between GGB6 and earlier versions that I think warrants creating a separate extension for it.

This commits just adds a submodule pointing to my repo [here](https://github.com/kgmt0/GoGo6-HID-Extension), but I think it would make sense to move it under the NetLogo organization before merging.