### PR TITLE
Scala dependency updates: Batch 8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val scalatestSettings = Seq(
   Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oS")
 , Test / testOnly / logBuffered := false
 , libraryDependencies ++= Seq(
-    "org.scalatest"     %% "scalatest"       % "3.2.14"   % Test
+    "org.scalatest"     %% "scalatest"       % "3.2.17"   % Test
   , "org.scalatestplus" %% "scalacheck-1-16" % "3.2.14.0" % Test
   )
   // This lets us mock up some Java library classes for testing.
@@ -363,7 +363,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform).
       import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
       Seq(
         "org.scala-lang.modules" %%% "scala-parser-combinators" %    "2.1.1"
-      ,          "org.scalatest" %%%                "scalatest" %   "3.2.14" % Test
+      ,          "org.scalatest" %%%                "scalatest" %   "3.2.17" % Test
       ,      "org.scalatestplus" %%%          "scalacheck-1-16" % "3.2.14.0" % Test
       )
     }).

--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ lazy val scalatestSettings = Seq(
 )
 
 lazy val flexmarkDependencies = {
-  val flexmarkVersion = "0.20.0"
+  val flexmarkVersion = "0.20.2"
   Seq(
     libraryDependencies ++= Seq(
       "com.vladsch.flexmark" % "flexmark" % flexmarkVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -188,7 +188,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "com.googlecode.json-simple" % "json-simple" % "1.1.1",
       "com.fifesoft" % "rsyntaxtextarea" % "3.3.4",
       "com.typesafe" % "config" % "1.4.3",
-      "net.lingala.zip4j" % "zip4j" % "2.9.1"
+      "net.lingala.zip4j" % "zip4j" % "2.11.5"
     ),
     all := {},
     all := {
@@ -259,7 +259,7 @@ lazy val headless = (project in file ("netlogo-headless")).
       "org.parboiled" %% "parboiled" % "2.4.1",
       "commons-codec" % "commons-codec" % "1.16.0",
       "com.typesafe" % "config" % "1.4.3",
-      "net.lingala.zip4j" % "zip4j" % "2.9.1",
+      "net.lingala.zip4j" % "zip4j" % "2.11.5",
       "org.reflections" % "reflections" % "0.9.10" % "test",
     ),
     (Runtime / fullClasspath)  ++= (parserJVM / Runtime / fullClasspath).value,

--- a/build.sbt
+++ b/build.sbt
@@ -186,7 +186,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "org.apache.httpcomponents" % "httpclient" % "4.2",
       "org.apache.httpcomponents" % "httpmime" % "4.2",
       "com.googlecode.json-simple" % "json-simple" % "1.1.1",
-      "com.fifesoft" % "rsyntaxtextarea" % "3.3.0",
+      "com.fifesoft" % "rsyntaxtextarea" % "3.3.4",
       "com.typesafe" % "config" % "1.4.2",
       "net.lingala.zip4j" % "zip4j" % "2.9.1"
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -187,7 +187,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "org.apache.httpcomponents" % "httpmime" % "4.2",
       "com.googlecode.json-simple" % "json-simple" % "1.1.1",
       "com.fifesoft" % "rsyntaxtextarea" % "3.3.4",
-      "com.typesafe" % "config" % "1.4.2",
+      "com.typesafe" % "config" % "1.4.3",
       "net.lingala.zip4j" % "zip4j" % "2.9.1"
     ),
     all := {},
@@ -258,7 +258,7 @@ lazy val headless = (project in file ("netlogo-headless")).
     libraryDependencies        ++= Seq(
       "org.parboiled" %% "parboiled" % "2.4.1",
       "commons-codec" % "commons-codec" % "1.15",
-      "com.typesafe" % "config" % "1.4.2",
+      "com.typesafe" % "config" % "1.4.3",
       "net.lingala.zip4j" % "zip4j" % "2.9.1",
       "org.reflections" % "reflections" % "0.9.10" % "test",
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -178,7 +178,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
     libraryDependencies ++= Seq(
       "org.picocontainer" % "picocontainer" % "2.15",
       "javax.media" % "jmf" % "2.1.1e",
-      "commons-codec" % "commons-codec" % "1.15",
+      "commons-codec" % "commons-codec" % "1.16.0",
       "org.parboiled" %% "parboiled" % "2.4.1",
       "org.jogamp.jogl" % "jogl-all" % "2.4.0" from "https://jogamp.org/deployment/archive/rc/v2.4.0/jar/jogl-all.jar",
       "org.jogamp.gluegen" % "gluegen-rt" % "2.4.0" from "https://jogamp.org/deployment/archive/rc/v2.4.0/jar/gluegen-rt.jar",
@@ -257,7 +257,7 @@ lazy val headless = (project in file ("netlogo-headless")).
     Compile / mainClass         := Some("org.nlogo.headless.Main"),
     libraryDependencies        ++= Seq(
       "org.parboiled" %% "parboiled" % "2.4.1",
-      "commons-codec" % "commons-codec" % "1.15",
+      "commons-codec" % "commons-codec" % "1.16.0",
       "com.typesafe" % "config" % "1.4.3",
       "net.lingala.zip4j" % "zip4j" % "2.9.1",
       "org.reflections" % "reflections" % "0.9.10" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -113,7 +113,7 @@ lazy val mockDependencies = {
 }
 
 lazy val asmDependencies = {
-  val asmVersion = "9.4"
+  val asmVersion = "9.6"
   Seq(
     libraryDependencies ++= Seq(
       "org.ow2.asm" % "asm"         % asmVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val mockDependencies = {
         exclude ("org.hamcrest", "hamcrest")
     , "org.jmock"     % "jmock-legacy" % mockVersion % "test"
     , "org.jmock"     % "jmock-junit5" % mockVersion % "test"
-    , "net.bytebuddy" % "byte-buddy"   % "1.12.18"   % "test"
+    , "net.bytebuddy" % "byte-buddy"   % "1.12.23"   % "test"
     , "org.hamcrest"  % "hamcrest"     % "2.2"       % "test"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -179,7 +179,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "org.picocontainer" % "picocontainer" % "2.15",
       "javax.media" % "jmf" % "2.1.1e",
       "commons-codec" % "commons-codec" % "1.16.0",
-      "org.parboiled" %% "parboiled" % "2.4.1",
+      "org.parboiled" %% "parboiled" % "2.5.0",
       "org.jogamp.jogl" % "jogl-all" % "2.4.0" from "https://jogamp.org/deployment/archive/rc/v2.4.0/jar/jogl-all.jar",
       "org.jogamp.gluegen" % "gluegen-rt" % "2.4.0" from "https://jogamp.org/deployment/archive/rc/v2.4.0/jar/gluegen-rt.jar",
       "org.jhotdraw" % "jhotdraw" % "6.0b1" % "provided,optional" from cclArtifacts("jhotdraw-6.0b1.jar"),
@@ -256,7 +256,7 @@ lazy val headless = (project in file ("netlogo-headless")).
     javacOptions ++= Seq("--release", "11"),
     Compile / mainClass         := Some("org.nlogo.headless.Main"),
     libraryDependencies        ++= Seq(
-      "org.parboiled" %% "parboiled" % "2.4.1",
+      "org.parboiled" %% "parboiled" % "2.5.0",
       "commons-codec" % "commons-codec" % "1.16.0",
       "com.typesafe" % "config" % "1.4.3",
       "net.lingala.zip4j" % "zip4j" % "2.11.5",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.1
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -30,7 +30,7 @@ libraryDependencies ++= Seq(
   "https://s3.amazonaws.com/ccl-artifacts/classycle-1.4.2.jar"
 , "com.github.spullara.mustache.java" % "scala-extensions-2.10" % "0.9.5"
 , "org.jsoup"                         % "jsoup"                 % "1.15.3"
-, "org.apache.commons"                % "commons-lang3"         % "3.12.0"
+, "org.apache.commons"                % "commons-lang3"         % "3.13.0"
 , "commons-io"                        % "commons-io"            % "2.14.0"
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,7 +25,7 @@ addSbtPlugin("com.timushev.sbt"   %  "sbt-updates"                     % "0.6.4"
 
 libraryDependencies ++= Seq(
   "com.github.spullara.mustache.java" % "compiler"              % "0.9.5"
-, "de.jflex"                          % "jflex"                 % "1.8.2"
+, "de.jflex"                          % "jflex"                 % "1.9.1"
 , "classycle"                         % "classycle"             % "1.4.2" from
   "https://s3.amazonaws.com/ccl-artifacts/classycle-1.4.2.jar"
 , "com.github.spullara.mustache.java" % "scala-extensions-2.10" % "0.9.5"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
 , "com.github.spullara.mustache.java" % "scala-extensions-2.10" % "0.9.5"
 , "org.jsoup"                         % "jsoup"                 % "1.15.3"
 , "org.apache.commons"                % "commons-lang3"         % "3.12.0"
-, "commons-io"                        % "commons-io"            % "2.11.0"
+, "commons-io"                        % "commons-io"            % "2.14.0"
 )
 
 {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ resolvers ++= Seq(
 
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin"           % "1.0.0")
 addSbtPlugin("org.portable-scala" %  "sbt-scalajs-crossproject"        % "1.3.2")
-addSbtPlugin("org.scala-js"       %  "sbt-scalajs"                     % "1.11.0")
+addSbtPlugin("org.scala-js"       %  "sbt-scalajs"                     % "1.14.0")
 addSbtPlugin("org.nlogo"          %  "publish-versioned-plugin"        % "3.0.0")
 addSbtPlugin("org.nlogo"          %  "netlogo-extension-documentation" % "0.8.3")
 addSbtPlugin("com.timushev.sbt"   %  "sbt-updates"                     % "0.6.4")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@ resolvers ++= Seq(
 )
 
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin"           % "1.0.0")
-addSbtPlugin("org.portable-scala" %  "sbt-scalajs-crossproject"        % "1.2.0")
+addSbtPlugin("org.portable-scala" %  "sbt-scalajs-crossproject"        % "1.3.2")
 addSbtPlugin("org.scala-js"       %  "sbt-scalajs"                     % "1.11.0")
 addSbtPlugin("org.nlogo"          %  "publish-versioned-plugin"        % "3.0.0")
 addSbtPlugin("org.nlogo"          %  "netlogo-extension-documentation" % "0.8.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= Seq(
 , "classycle"                         % "classycle"             % "1.4.2" from
   "https://s3.amazonaws.com/ccl-artifacts/classycle-1.4.2.jar"
 , "com.github.spullara.mustache.java" % "scala-extensions-2.10" % "0.9.5"
-, "org.jsoup"                         % "jsoup"                 % "1.15.3"
+, "org.jsoup"                         % "jsoup"                 % "1.15.4"
 , "org.apache.commons"                % "commons-lang3"         % "3.13.0"
 , "commons-io"                        % "commons-io"            % "2.14.0"
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -35,7 +35,7 @@ libraryDependencies ++= Seq(
 )
 
 {
-  val flexmarkVersion = "0.20.0"
+  val flexmarkVersion = "0.20.2"
   libraryDependencies ++= Seq(
     "com.vladsch.flexmark" % "flexmark" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-anchorlink" % flexmarkVersion,

--- a/sbt
+++ b/sbt
@@ -8,7 +8,7 @@ if [ -z "$JAVA_VERSION_NUMBER" ] ; then
 fi
 
 if [ -z "$SBT_LAUNCH_VERSION" ] ; then
-  SBT_LAUNCH_VERSION=1.3.13
+  SBT_LAUNCH_VERSION=1.9.7
 fi
 
 


### PR DESCRIPTION
It's almost [a year ago](https://github.com/NetLogo/NetLogo/pull/2065) since the last batch of Scala dependency updates, so here's another batch!

1. **Build Dependencies:**
   - `org.scalatest:scalatest`: `3.2.14` → `3.2.17`
   - `flexmarkVersion`: `0.20.0` → `0.20.2`
   - `net.bytebuddy:byte-buddy`: `1.12.18` → `1.12.23`
   - `asmVersion`: `9.4` → `9.6`
   - `commons-codec:commons-codec`: `1.15` → `1.16.0`
   - `org.parboiled:parboiled`: `2.4.1` → `2.5.0`
   - `com.fifesoft:rsyntaxtextarea`: `3.3.0` → `3.3.4`
   - `com.typesafe:config`: `1.4.2` → `1.4.3`
   - `net.lingala.zip4j:zip4j`: `2.9.1` → `2.11.5`

2. **Project Build Properties:**
   - `sbt.version`: `1.9.1` → `1.9.7`

3. **Project Plugins:**
   - `sbt-scalajs-crossproject`: `1.2.0` → `1.3.2`
   - `sbt-scalajs`: `1.11.0` → `1.14.0`
   - `jflex`: `1.8.2` → `1.9.1`
   - `jsoup`: `1.15.3` → `1.15.4`
   - `commons-lang3`: `3.12.0` → `3.13.0`
   - `commons-io`: `2.11.0` → `2.14.0`
   - `flexmarkVersion` (repeated): `0.20.0` → `0.20.2`

4. **SBT Launch Script:**
   - `SBT_LAUNCH_VERSION`: `1.3.13` → `1.9.7`

All updates have passed the CI individually. The dependency updates are generated using [this workflow](https://github.com/EwoutH/NetLogo/blob/scala-steward-app/.github/workflows/scala-steward.yml) using the [Scala Steward](https://github.com/scala-steward-org/scala-steward).

When merging, the "Squash and Merge"-button can be used in the interface of this PR, to merge it as one single commit.

Part of https://github.com/NetLogo/NetLogo/issues/1968.

Some notable updates:

 - Updates ASM from 9.4 to 9.6 ([release notes](https://asm.ow2.io/versions.html)):
  > 30 September 2023: ASM 9.6 (tag ASM_9_6)
  > 
  > - new Opcodes.V22 constant for Java 22
  > - bug fixes
  >   - 317991: Analyzer produces frames that have different locals than those detected by JRE bytecode verifier
  >   - 317995: Invalid stackmap generated when the instruction stream has new instruction after invokespecial to <init>
  >   - 317998: Analyzer can fail to catch thrown exceptions
  >   - 318002: asm-analysis Frame allocates an array unnecessarily inside executeInvokeInsn
  >   - bug in CheckFrameAnalyzer with static methods
  > 
  > 24 March 2023: ASM 9.5 (tag ASM_9_5)
  > 
  > - new Opcodes.V21 constant for Java 21
  > - new readBytecodeInstructionOffset hook in ClassReader
  > - more detailed exception messages
  > - Javadoc improvements and fixes
  > - bug fixes
  >   - 317989: Silent removal of zero-valued entries from the line-number table
- Multiple [Scala.js](https://www.scala-js.org/news/index.html) updates
- [JFlex 1.9](https://www.jflex.de/changelog.html) .