### PR TITLE
Fix auto-reload not respecting user prefs

### DIFF
--- a/netlogo-gui/src/main/app/Tabs.scala
+++ b/netlogo-gui/src/main/app/Tabs.scala
@@ -86,6 +86,8 @@ class Tabs(workspace:           GUIWorkspace,
     setWatchingFiles(value)
   }
 
+  def getAutoReload = prefs.get("reloadOnExternalChanges", "false").toBoolean
+
   def reload() {
     if (!reloading) {
       reloading = true
@@ -491,9 +493,10 @@ class Tabs(workspace:           GUIWorkspace,
   def handle(e: LoadModelEvent) {
     // We need to restart the watcher thread every load because the list of
     // included files may have changed.
+
     stopWatcherThread()
 
-    if(prefs.get("reloadOnExternalChanges", "false").toBoolean) {
+    if(getAutoReload) {
       startWatcherThread()
 
       externalFileTabs foreach { tab =>
@@ -511,9 +514,8 @@ class Tabs(workspace:           GUIWorkspace,
   }
 
   def handle(e: ModelSavedEvent) {
-    val autoReload = prefs.get("reloadOnExternalChanges", "false").toBoolean
-    setWatchingFiles(autoReload, e.modelPath)
+    setWatchingFiles(getAutoReload, e.modelPath)
   }
 
-  watchingFiles = prefs.get("reloadOnExternalChanges", "false").toBoolean
+  watchingFiles = getAutoReload
 }

--- a/netlogo-gui/src/main/app/Tabs.scala
+++ b/netlogo-gui/src/main/app/Tabs.scala
@@ -492,10 +492,13 @@ class Tabs(workspace:           GUIWorkspace,
     // We need to restart the watcher thread every load because the list of
     // included files may have changed.
     stopWatcherThread()
-    startWatcherThread()
 
-    externalFileTabs foreach { tab =>
-      tab.reload
+    if(prefs.get("reloadOnExternalChanges", "false").toBoolean) {
+      startWatcherThread()
+
+      externalFileTabs foreach { tab =>
+        tab.reload
+      }
     }
 
     reloading = false

--- a/netlogo-gui/src/main/app/common/TabsInterface.scala
+++ b/netlogo-gui/src/main/app/common/TabsInterface.scala
@@ -22,6 +22,9 @@ trait TabsInterface {
   def lineNumbersVisible: Boolean
   def lineNumbersVisible_=(b: Boolean): Unit
 
+  def watchingFiles: Boolean
+  def watchingFiles_=(b: Boolean): Unit
+
   def newExternalFile(): Unit
   def openExternalFile(filename: String): Unit
   def closeExternalFile(filename: Filename): Unit

--- a/netlogo-gui/src/main/app/tools/Preferences.scala
+++ b/netlogo-gui/src/main/app/tools/Preferences.scala
@@ -74,7 +74,9 @@ object Preferences {
     }
 
     def save(prefs: JavaPreferences) = {
-      prefs.put("reloadOnExternalChanges", component.isSelected.toString)
+      val enabled = component.isSelected
+      prefs.put("reloadOnExternalChanges", enabled.toString)
+      tabs.watchingFiles = enabled
     }
   }
 


### PR DESCRIPTION
Auto-reload is getting enabled regardless of user prefs due to the `LoadModelEvent` handler in `Tabs` starting up watcher thread without checking user prefs first. This PR makes it so that the handler checks user prefs before starting the thread. I also included a commit that makes it possible to enable/disable auto-reload without restarting NetLogo.