### PR TITLE
Add request for a reproducible example to the post runtime error user message

### DIFF
--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -737,13 +737,13 @@ error.dialog.librariesMetadata.message = We had a problem parsing the libraries 
 at https://github.com/NetLogo/NetLogo-Libraries/issues, or to bugs@ccl.northwestern.edu, and paste the \n\
 contents of this window into your report.
 error.dialog.pleaseReport = \
-NetLogo is unable to supply you with more details about this error.  Please report the problem at https://github.com/NetLogo/NetLogo/issues,\
-or to bugs@ccl.northwestern.edu, and paste the contents of this window into your report.\n\
-Please also include, if possible, the steps necessary to reproduce the problem. \
+NetLogo is unable to supply you with more details about this error.  Please report the problem at https://github.com/NetLogo/NetLogo/issues \
+or to bugs@ccl.northwestern.edu and paste the contents of this window into your report.\n\n\
+Please also include the steps necessary to reproduce the problem. \
 If you need to attach a NetLogo model (i.e. .nlogo file), to ensure it gets through please \
-put it and any accessory files in a zip file. If you cannot reproduce the error then describe \
-what you were doing when it happened.".\n\
-We recommend that you use the latest version of NetLogo which is available at https://ccl.northwestern.edu/netlogo/download.shtml.
+put it and any accessory files in a zip file. If you cannot reproduce the error then please try to describe \
+what you were doing when it happened.\n\n\
+We recommend that you use the latest version of NetLogo which is available at https://ccl.northwestern.edu/netlogo/download.shtml
 error.dialog.suppress = Don''t show again
 error.dialog.showInternals = Show internal details
 error.dialog.outOfMemory = \

--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -737,9 +737,13 @@ error.dialog.librariesMetadata.message = We had a problem parsing the libraries 
 at https://github.com/NetLogo/NetLogo-Libraries/issues, or to bugs@ccl.northwestern.edu, and paste the \n\
 contents of this window into your report.
 error.dialog.pleaseReport = \
-NetLogo is unable to supply you with more details about this error.  Please report the problem \n \
-at https://github.com/NetLogo/NetLogo/issues, or to bugs@ccl.northwestern.edu, and paste the \n\
-contents of this window into your report. \n
+NetLogo is unable to supply you with more details about this error.  Please report the problem at https://github.com/NetLogo/NetLogo/issues,\
+or to bugs@ccl.northwestern.edu, and paste the contents of this window into your report.\n\
+Please also include, if possible, the steps necessary to reproduce the problem. \
+If you need to attach a NetLogo model (i.e. .nlogo file), to ensure it gets through please \
+put it and any accessory files in a zip file. If you cannot reproduce the error then describe \
+what you were doing when it happened.".\n\
+We recommend that you use the latest version of NetLogo which is available at https://ccl.northwestern.edu/netlogo/download.shtml.
 error.dialog.suppress = Don''t show again
 error.dialog.showInternals = Show internal details
 error.dialog.outOfMemory = \


### PR DESCRIPTION
Currently a runtime error results in a dialog that says

> NetLogo is unable to supply you with more details about this error.  Please report the problem 
> at https://github.com/NetLogo/NetLogo/issues, or to bugs@ccl.northwestern.edu, and paste the
> contents of this window into your report.


Many users send us the contents (stack trace plus system information) without any information which would allow us to reproduce and fix the problem. This revised message asks for that information.

Image of new message:

https://ccl-northwestern.slack.com/files/UP84USHDY/F06JE5Z0YJW/runtime_error_message_2.png?origin_team=T1ZDKKS1G&origin_channel=DPG4YQU0H