### PR TITLE
Fix MacOS assertion problem in ModalProgressDialog

### DIFF
--- a/netlogo-gui/src/main/swing/ModalProgressDialog.scala
+++ b/netlogo-gui/src/main/swing/ModalProgressDialog.scala
@@ -8,7 +8,6 @@ import javax.swing.{ BorderFactory, JDialog, JLabel, JPanel, JProgressBar, Swing
 import org.nlogo.awt.Positioning.center
 
 class ModalProgressDialog(parent: Frame, message: String) extends JDialog(parent, true) {
-  setFocusableWindowState(false)
   setResizable(false)
   setUndecorated(true)
 

--- a/netlogo-gui/src/main/swing/ModalProgressTask.scala
+++ b/netlogo-gui/src/main/swing/ModalProgressTask.scala
@@ -18,6 +18,7 @@ object ModalProgressTask {
     EventQueue.invokeLater { () => perform(dialog) }
 
     dialog.setVisible(true)
+    dialog.setFocusableWindowState(false)
   }
 
   def onUIThread(parent: Frame, message: String, r: Runnable): Unit = {
@@ -54,6 +55,7 @@ object ModalProgressTask {
 
     dialog.setVisible(true)
 
+    dialog.setFocusableWindowState(false)
     // if this is being run, it means that the dialog should have been hidden
     // and therefore the promise completed.
     Await.result(completionPromise.future, Duration(10, MILLISECONDS))


### PR DESCRIPTION

**Short version:**
To reproduce the problem just run ./sbt from the NetLogo directory on a MacOS machine. The error `Assertion failure in -[AWTWindow_Normal _changeJustMain], NSWindow.m:14120` will appear twice during the NetLogo startup.
I was able to remove this error by moving a recently added call `setFocusableWindowState(false)` from _ModalProgressDialog_ to _ModalProgressTask_ which is the method that calls it.


I haven't tracked any user visible problems to the assertion failure.
I also don't understand why the new code location works. The documentation says 

> Setting the focusability state on a visible Window can have a delayed effect on some platforms — the actual change may happen only when the Window becomes hidden and then visible again. To ensure consistent behavior across platforms, set the Window's focusable state when the Window is invisible and then show it. 

However the change that removed the error was to put the new code after the dialog is made visible. Earlier locations did not work.

**Here is an account of how I found and fixed the problem**:
(not required reading)

While working on some changes of the way separate code tabs work I ran into some problems.
I also noticed I was getting two errors `Assertion failure in -[AWTWindow_Normal _changeJustMain], NSWindow.m:14120` when NetLogo was starting up (in sbt).
I thought it might be related to my problems, and added debugging statements to my changed code, but didn't isolate the problem. However there did seem to be some strange changes in focus going on.


I then tried starting from clean up-to-date hexy code looking at when focus change events happened. I saw that the same assertion failure appeared! I ran a test with the NetLogo 6.4.0 release code and there was no problem. I thought the focus changes might have to do with Kritphong's watcher code that checks if files have been changed outside of NetLogo. However his first PR did not cause the problem. I then used git bisect and it turned out the problem was caused by the commit

> commit 2b98eaabd344d7a22aef170a18252b47e9fd8c69 (HEAD)

> Author: Kritphong Mongkhonvanit <kritphong@u.northwestern.edu>
> Date:   Tue Nov 21 20:37:19 2023 -0600
> 
>     Make ModalProgressDialog non-focusable
>     
>     This stops NetLogo from stealing focus when ModalProgressDialog is
>     displayed.
> 

and I was then able to identify the added line  ` setFocusableWindowState(false)` as the cause of the assertion error.  Ultimately I found that if setFocusableWindowState(false)  was called after the ModalProgressDialog was made visible in ModalProgressTask the assertion error went away.

