### PR TITLE
Fix small error in tutorial2

### DIFF
--- a/autogen/docs/tutorial2.md.mustache
+++ b/autogen/docs/tutorial2.md.mustache
@@ -224,7 +224,7 @@ Let's take a closer look at the turtle monitor:
 > 
 > | What shape is this turtle?
 
-This turtle monitor is showing a turtle who that has a who number of 0, a color
+This turtle monitor is showing a turtle that has a who number of 0, a color
 of 15 (red -- see chart above), and the shape of a car.
 
 There are two other ways to open a turtle monitor besides right-clicking. One


### PR DESCRIPTION
I'm learning to use NetLogo. In tutorial 2, in the turtle inspection section, it says:

> This turtle monitor is showing a turtle _who that_ has a who number of 0, a color of 15 (red -- see chart above), and the shape of a car.

Two relative pronouns are given. I've corrected this to only use one (in this case, I chose *that*):

> This turtle monitor is showing a turtle _that_ has a who number of 0, a color of 15 (red -- see chart above), and the shape of a car.

It's not much, but it's honest work :). Love the project, many thanks.