### PR TITLE
Allow ends in LinkManager.dummyLink to be AnyRef. Fixes #1999

### DIFF
--- a/netlogo-core/src/main/agent/AgentManagement.scala
+++ b/netlogo-core/src/main/agent/AgentManagement.scala
@@ -97,7 +97,7 @@ trait AgentManagement
         end2.asInstanceOf[Turtle].agentKey, breed))
 
     linkOption.getOrElse(
-      linkManager.dummyLink(end1.asInstanceOf[Turtle], end2.asInstanceOf[Turtle], breed))
+      linkManager.dummyLink(end1, end2, breed) )
   }
 
   def indexOfVariable(agent: Agent, name: String): Int = {

--- a/netlogo-core/src/main/agent/LinkManager.scala
+++ b/netlogo-core/src/main/agent/LinkManager.scala
@@ -75,8 +75,9 @@ trait LinkManager {
   def outLinks(src: Turtle, linkBreed: AgentSet): Array[Link]
   def inLinks(target: Turtle, linkBreed: AgentSet): Array[Link]
   def links(target: Turtle, linkSet: AgentSet): Array[Link]
-
-  def dummyLink(end1: Turtle, end2: Turtle, breed: AgentSet): DummyLink
+  // The ends of the dummyLink are AnyRef because they can be a Turtle or null.
+  // null is used when only one end of a link has been specified in a Link Inspector (Monitor)
+  def dummyLink(end1: AnyRef, end2: AnyRef, breed: AgentSet): DummyLink
 }
 
 //
@@ -206,7 +207,7 @@ class LinkManagerImpl[W <: World](world: W, linkFactory: LinkFactory[W]) extends
     if ((linkBreed eq world.links) && (world.linkBreeds.size > 1)) result.distinct else result
   }
 
-  def dummyLink(end1: Turtle, end2: Turtle, breed: AgentSet): DummyLink = {
+  def dummyLink(end1: AnyRef, end2: AnyRef, breed: AgentSet): DummyLink = {
     new DummyLink(world, end1, end2, breed)
   }
 }

--- a/netlogo-gui/src/main/app/tools/AgentMonitorEditor.scala
+++ b/netlogo-gui/src/main/app/tools/AgentMonitorEditor.scala
@@ -308,7 +308,7 @@ with WindowEvents.JobRemovedEvent.Handler
   }
 
   private def get =
-    if(agent == null || agent.id == -1)
+    if(agent == null || agent.id == -1  || agent.getVariable(index) == null)
       ""
     else workspace.world.synchronized{
       Dump.logoObject(agent.getVariable(index), true, false)


### PR DESCRIPTION
If you open NetLogo with a new model, do Tools > Link Monitor to get the empty link monitor window, then type 1 into the end1 box, you will get the exception ljava.lang.ClassCastException: org.nlogo.core.Nobody$ cannot be cast to org.nlogo.agent.Turtle.

The original code attempted to create a DummyLink by casting end1 and end2 to be a Turtle, which caused the exception when one of the ends was Nobody.

However the class DummyLink(world: World, _end1: AnyRef, _end2: AnyRef, breed: AgentSet) allows an end to be AnyRef and replaces any end that is not a Turtle with null. This leads to the solution.
