### PR TITLE
Fix auto-reload breaking on load errors

### DIFF
--- a/autogen/events/events.txt
+++ b/autogen/events/events.txt
@@ -36,6 +36,7 @@ window.JobStopping - org.nlogo.api.JobOwner owner
 window.Load3DShapes - String filename
 window.LoadBegin
 window.LoadEnd
+window.LoadError
 window.LoadModel - org.nlogo.core.Model model - boolean shouldAutoInstallLibs
 window.LoadSection - String version - Object section - String[] lines - String text
 window.LoadWidgets - scala.collection.Seq<org.nlogo.core.Widget> widgets

--- a/netlogo-gui/src/main/app/Tabs.scala
+++ b/netlogo-gui/src/main/app/Tabs.scala
@@ -43,6 +43,7 @@ class Tabs(workspace:           GUIWorkspace,
   with CompiledEvent.Handler
   with AfterLoadEvent.Handler
   with LoadModelEvent.Handler
+  with LoadErrorEvent.Handler
   with AboutToSaveModelEvent.Handler
   with ModelSavedEvent.Handler
   with ExternalFileSavedEvent.Handler {
@@ -504,6 +505,10 @@ class Tabs(workspace:           GUIWorkspace,
       }
     }
 
+    reloading = false
+  }
+
+  def handle(e: LoadErrorEvent) {
     reloading = false
   }
 


### PR DESCRIPTION
If NetLogo encounters an error reloading the model, auto-reload can't be triggered again until the model is re-opened. This is because `Tabs` sets a flag to block auto-reloads if one is already in-progress. Since it never gets notified when an error occurs, the flag will remain set indefinitely. Fix this by defining a new event `LoadErrorEvent`, raise it when an error occurs, and unset the flag when the event is raised.

To test:
1. Make sure `Reload model on external changes` is enabled.
2. Open a model in NetLogo.
3. Clear the contents the file. NetLogo should display an error dialog.
4. Dismiss the dialog.
5. Restore the file.

Without the patch, NetLogo won't reload the model at step 5.