### PR TITLE
Improved logic for load last model on startup

### DIFF
--- a/netlogo-gui/src/main/app/App.scala
+++ b/netlogo-gui/src/main/app/App.scala
@@ -621,9 +621,9 @@ class App extends
       // if recent list is empty we need the new model, or if loading the recent model
       // fails then we'll fall back on it.  -Jeremy B June 2021
       fileManager.newModel()
-      val recentFiles = new RecentFiles
-      if (!recentFiles.models.isEmpty) {
-        val modelEntry = recentFiles.models.head
+      val recentFiles = (new RecentFiles).models.filter(x => Version.is3D == x.path.endsWith(".nlogo3d"))
+      if (!recentFiles.isEmpty) {
+        val modelEntry = recentFiles.head
         fileManager.openFromPath(modelEntry.path, modelEntry.modelType)
       }
     } else {


### PR DESCRIPTION
It now filters by model type (2D/3D) before attempting to load. See #2054.