### PR TITLE
New optional argument for default input in user-input primitive

### DIFF
--- a/netlogo-gui/src/main/prim/gui/_userinput.scala
+++ b/netlogo-gui/src/main/prim/gui/_userinput.scala
@@ -22,7 +22,7 @@ class _userinput extends Reporter {
               gw.view.mouseDown(false)
               new org.nlogo.swing.InputDialog(
                 gw.getFrame, "User Input", Dump.logoObject(inputMessage),
-                I18N.gui.fn).showInputDialog()
+                I18N.gui.fn, args(1).report(context).toString).showInputDialog()
             }})
         Option(result).getOrElse(
           throw new org.nlogo.nvm.HaltException(true))

--- a/netlogo-gui/src/main/prim/gui/_userinput.scala
+++ b/netlogo-gui/src/main/prim/gui/_userinput.scala
@@ -22,7 +22,7 @@ class _userinput extends Reporter {
               gw.view.mouseDown(false)
               new org.nlogo.swing.InputDialog(
                 gw.getFrame, "User Input", Dump.logoObject(inputMessage),
-                I18N.gui.fn, args(1).report(context).toString).showInputDialog()
+                I18N.gui.fn, if (args.size > 1) args(1).report(context).toString else "").showInputDialog()
             }})
         Option(result).getOrElse(
           throw new org.nlogo.nvm.HaltException(true))

--- a/netlogo-gui/src/main/swing/InputDialog.scala
+++ b/netlogo-gui/src/main/swing/InputDialog.scala
@@ -4,9 +4,9 @@ package org.nlogo.swing
 
 import java.awt.Frame
 
-class InputDialog(owner: Frame, title: String, message: String, i18n: String => String)
+class InputDialog(owner: Frame, title: String, message: String, i18n: String => String, defaultInput: String = "")
 extends UserDialog(owner, title, i18n) {
-  private val field = new javax.swing.JTextField
+  private val field = new javax.swing.JTextField(defaultInput)
   addComponents(field, message)
   def showInputDialog(): String = {
     val r = getOwner.getBounds

--- a/netlogo-gui/src/test/compile/TestAllSyntaxes.scala
+++ b/netlogo-gui/src/test/compile/TestAllSyntaxes.scala
@@ -274,7 +274,7 @@ class TestAllSyntaxes extends AnyFunSuite {
                      |_uptonof number/list or agentset,list or agentset,OTPL,None,10,2,2
                      |_userdirectory ,TRUE/FALSE or string,OTPL,None,10,0,0
                      |_userfile ,TRUE/FALSE or string,OTPL,None,10,0,0
-                     |_userinput anything,string,OTPL,None,10,1,1
+                     |_userinput anything/string,string,OTPL,None,10,1,1
                      |_usernewfile ,TRUE/FALSE or string,OTPL,None,10,0,0
                      |_useroneof anything/list,anything,OTPL,None,10,2,2
                      |_useryesorno anything,TRUE/FALSE,OTPL,None,10,1,1

--- a/parser-core/src/main/core/prim/etc/etc.scala
+++ b/parser-core/src/main/core/prim/etc/etc.scala
@@ -1093,7 +1093,8 @@ case class _userinput() extends Reporter {
   override def syntax =
     Syntax.reporterSyntax(
       right = List(Syntax.WildcardType, Syntax.StringType | Syntax.RepeatableType),
-      ret = Syntax.StringType)
+      ret = Syntax.StringType,
+      defaultOption = Some(1))
 }
 case class _usermessage() extends Command {
   override def syntax =

--- a/parser-core/src/main/core/prim/etc/etc.scala
+++ b/parser-core/src/main/core/prim/etc/etc.scala
@@ -1092,7 +1092,7 @@ case class _userfile() extends Reporter {
 case class _userinput() extends Reporter {
   override def syntax =
     Syntax.reporterSyntax(
-      right = List(Syntax.WildcardType),
+      right = List(Syntax.WildcardType, Syntax.StringType | Syntax.RepeatableType),
       ret = Syntax.StringType)
 }
 case class _usermessage() extends Command {

--- a/parser-jvm/src/test/parse/TestAllSyntaxes.scala
+++ b/parser-jvm/src/test/parse/TestAllSyntaxes.scala
@@ -256,7 +256,7 @@ class TestAllSyntaxes extends AnyFunSuite {
                      |_uptonof number/list or agentset,list or agentset,OTPL,None,10,2,2
                      |_userdirectory ,TRUE/FALSE or string,OTPL,None,10,0,0
                      |_userfile ,TRUE/FALSE or string,OTPL,None,10,0,0
-                     |_userinput anything,string,OTPL,None,10,1,1
+                     |_userinput anything/string,string,OTPL,None,10,1,1
                      |_usernewfile ,TRUE/FALSE or string,OTPL,None,10,0,0
                      |_useroneof anything/list,anything,OTPL,None,10,2,2
                      |_useryesorno anything,TRUE/FALSE,OTPL,None,10,1,1


### PR DESCRIPTION
As recommended in issue #2250: Adds a new optional argument that can be used to specify a default input for the user-input primitive. For example, `(user-input "what is your name" "bob")` would open a dialog box with the title "what is your name" and the text box would have "bob" in it by default. This change is also added to the Dialog Extension in this pull request: https://github.com/NetLogo/Dialog-Extension/pull/2.