### PR TITLE
Added more descriptive error for BehaviorSpace output file conflicts

### DIFF
--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -582,6 +582,7 @@ tools.behaviorSpace.error.lists = Lists output selected with no spreadsheet or t
 tools.behaviorSpace.error.pause.table = Table output file has been moved or deleted.
 tools.behaviorSpace.error.pause.spreadsheet = Spreadsheet output file has been moved or deleted.
 tools.behaviorSpace.error.pause.invalidSpreadsheet = Unable to read existing spreadsheet output, data is not intact.
+tools.behaviorSpace.error.pause.alreadyOpen = Unable to start experiment, selected output file is open in another program.
 tools.behaviorSpace.error.print.runNumber = Run \#
 tools.behaviorSpace.error.print.runtime = RUNTIME ERROR
 tools.behaviorSpace.error.print.javaException = JAVA EXCEPTION


### PR DESCRIPTION
If you try to run an experiment with one or more output files that are open in another program, it now aborts the experiment and shows a clean and understandable error, instead of the strange computer-science-y error shown previously. See issues #243 and #2232 for details.