### PR TITLE
Made misplaced constant error message more descriptive

### DIFF
--- a/parser-core/src/main/parse/StructureChecker.scala
+++ b/parser-core/src/main/parse/StructureChecker.scala
@@ -10,13 +10,33 @@ package org.nlogo.parse
 
 import
   org.nlogo.core,
-    core.{ BreedIdentifierHandler, StructureDeclarations, Token },
+    core.{ BreedIdentifierHandler, StructureDeclarations, Token, TokenType },
       StructureDeclarations.{ Breed, Declaration, Extensions, Identifier, Includes, Procedure, Variables },
     core.Fail._
 
 import SymbolType._
 
 object StructureChecker {
+
+  def rejectMisplacedConstants(declarations: Seq[Declaration]) {
+    for (declaration <- declarations) {
+      declaration match {
+        case Variables(_, names) =>
+          for (name <- names) {
+            if (name.token.tpe == TokenType.Literal) {
+              exception("Variable name conflicts with a constant.", name.token)
+            }
+          }
+        case Procedure(_, _, inputs, _) =>
+          for (input <- inputs) {
+            if (input.token.tpe == TokenType.Literal) {
+              exception("Input name conflicts with a constant.", input.token)
+            }
+          }
+        case _ =>
+      }
+    }
+  }
 
   def rejectDuplicateDeclarations(declarations: Seq[Declaration]) {
 

--- a/parser-core/src/main/parse/StructureChecker.scala
+++ b/parser-core/src/main/parse/StructureChecker.scala
@@ -10,7 +10,7 @@ package org.nlogo.parse
 
 import
   org.nlogo.core,
-    core.{ BreedIdentifierHandler, StructureDeclarations, Token, TokenType },
+    core.{ BreedIdentifierHandler, I18N, StructureDeclarations, Token, TokenType },
       StructureDeclarations.{ Breed, Declaration, Extensions, Identifier, Includes, Procedure, Variables },
     core.Fail._
 
@@ -24,13 +24,13 @@ object StructureChecker {
         case Variables(_, names) =>
           for (name <- names) {
             if (name.token.tpe == TokenType.Literal) {
-              exception("Variable name conflicts with a constant.", name.token)
+              exception(I18N.errors.get("compiler.StructureChecker.variableConstant"), name.token)
             }
           }
         case Procedure(_, _, inputs, _) =>
           for (input <- inputs) {
             if (input.token.tpe == TokenType.Literal) {
-              exception("Input name conflicts with a constant.", input.token)
+              exception(I18N.errors.get("compiler.StructureChecker.inputConstant"), input.token)
             }
           }
         case _ =>
@@ -189,23 +189,23 @@ object StructureChecker {
 
   private def breedOverridesBuiltIn(breed: Breed, duplicatedType: SymbolType, duplicatedName: String): String = {
     val typeName = SymbolType.typeName(duplicatedType)
-    s"Defining a breed [${breed.plural.name} ${breed.singular.name}] redefines $duplicatedName, a $typeName"
+    I18N.errors.getN("compiler.StructureChecker.breedOverrides", s"[${breed.plural.name} ${breed.singular.name}]", duplicatedName, typeName)
   }
 
   private def checkNotArrow(ident: Identifier) {
-    cAssert(ident.name != "->", "-> can only be used to create anonymous procedures", ident.token)
+    cAssert(ident.name != "->", I18N.errors.get("compiler.StructureChecker.invalidArrow"), ident.token)
   }
 
   private def redeclarationOf(kind: String) =
-    s"Redeclaration of $kind"
+    I18N.errors.getN("compiler.StructureChecker.redeclaration", kind)
 
   private def duplicateOf(symbolType: SymbolType, origName: String) = {
     val typeName = SymbolType.typeName(symbolType)
-    s"There is already a $typeName called $origName"
+    I18N.errors.getN("compiler.StructureChecker.duplicateType", typeName, origName)
   }
 
   private def duplicateVariableIdentifier(ident: Identifier) =
-    s"There is already a local variable called ${ident.name} here"
+    I18N.errors.getN("compiler.StructureChecker.duplicateVariable", ident.name)
 
   private case class Occurrence(declaration: Declaration, identifier: Identifier, typeOfDeclaration: SymbolType, isGlobal: Boolean = true)
 

--- a/parser-core/src/main/parse/StructureCombinators.scala
+++ b/parser-core/src/main/parse/StructureCombinators.scala
@@ -150,9 +150,9 @@ extends scala.util.parsing.combinator.Parsers {
     tokenType("closing bracket", TokenType.CloseBracket)
 
   def identifier: Parser[Identifier] =
-    tokenType("identifier", TokenType.Ident) ^^ {
+    (tokenType("identifier", TokenType.Ident) | tokenType("literal", TokenType.Literal)) ^^ {
       token =>
-        Identifier(token.value.asInstanceOf[String], token)}
+        Identifier(token.value.toString, token) }
 
   def identifierList: Parser[Seq[Identifier]] =
     openBracket ~> commit(rep(identifier) <~ closeBracket)

--- a/parser-core/src/main/parse/StructureCombinators.scala
+++ b/parser-core/src/main/parse/StructureCombinators.scala
@@ -150,12 +150,17 @@ extends scala.util.parsing.combinator.Parsers {
     tokenType("closing bracket", TokenType.CloseBracket)
 
   def identifier: Parser[Identifier] =
-    (tokenType("identifier", TokenType.Ident) | tokenType("literal", TokenType.Literal)) ^^ {
+    tokenType("identifier", TokenType.Ident) ^^ {
+      token =>
+        Identifier(token.value.asInstanceOf[String], token) }
+
+  def literal: Parser[Identifier] =
+    tokenType("literal", TokenType.Literal) ^^ {
       token =>
         Identifier(token.value.toString, token) }
 
   def identifierList: Parser[Seq[Identifier]] =
-    openBracket ~> commit(rep(identifier) <~ closeBracket)
+    openBracket ~> commit(rep(identifier | literal) <~ closeBracket)
 
   def stringList: Parser[Seq[Token]] =
     openBracket ~> commit(rep(string) <~ closeBracket)

--- a/parser-core/src/main/parse/StructureParser.scala
+++ b/parser-core/src/main/parse/StructureParser.scala
@@ -174,6 +174,7 @@ class StructureParser(
   def parse(tokens: Iterator[Token], oldResults: StructureResults): StructureResults =
     StructureCombinators.parse(tokens) match {
       case Right(declarations) =>
+        StructureChecker.rejectMisplacedConstants(declarations)
         StructureChecker.rejectDuplicateDeclarations(declarations)
         StructureChecker.rejectDuplicateNames(declarations,
           StructureParser.usedNames(

--- a/parser-core/src/test/parse/StructureParserTests.scala
+++ b/parser-core/src/test/parse/StructureParserTests.scala
@@ -167,9 +167,6 @@ class StructureParserTests extends AnyFunSuite {
   test("constant in globals") {
     expectError("globals [d e f]",
       "Variable name conflicts with a constant.") }
-  test("constant in extensions") {
-    expectError("extensions [d e f]",
-      "Can't find extension: d") }
   test("constant in turtles-own") {
     expectError("turtles-own [d e f]",
       "Variable name conflicts with a constant.") }

--- a/parser-core/src/test/parse/StructureParserTests.scala
+++ b/parser-core/src/test/parse/StructureParserTests.scala
@@ -166,25 +166,25 @@ class StructureParserTests extends AnyFunSuite {
       "closing bracket expected") }
   test("constant in globals") {
     expectError("globals [d e f]",
-      "Variable name conflicts with a constant") }
+      "Variable name conflicts with a constant.") }
   test("constant in extensions") {
     expectError("extensions [d e f]",
       "Can't find extension: d") }
   test("constant in turtles-own") {
     expectError("turtles-own [d e f]",
-      "Variable name conflicts with a constant") }
+      "Variable name conflicts with a constant.") }
   test("constant in patches-own") {
     expectError("patches-own [d e f]",
-      "Variable name conflicts with a constant") }
+      "Variable name conflicts with a constant.") }
   test("constant in links-own") {
     expectError("links-own [d e f]",
-      "Variable name conflicts with a constant") }
+      "Variable name conflicts with a constant.") }
   test("constant in breed-own") {
     expectError("breed [tests test] tests-own [d e f]",
-      "Variable name conflicts with a constant") }
+      "Variable name conflicts with a constant.") }
   test("constant in procedure input") {
-    expectError("to test [d e f]",
-      "Input name conflicts with a constant") }
+    expectError("to test [d e f] end",
+      "Input name conflicts with a constant.") }
   test("missing breed singular") {
     expectError("breed [xs]",
       "Breed declarations must have plural and singular. BREED [XS] has only one name.") }

--- a/parser-core/src/test/parse/StructureParserTests.scala
+++ b/parser-core/src/test/parse/StructureParserTests.scala
@@ -164,6 +164,27 @@ class StructureParserTests extends AnyFunSuite {
   test("missing close bracket in globals") {
     expectError("globals [g turtles-own [t]",
       "closing bracket expected") }
+  test("constant in globals") {
+    expectError("globals [d e f]",
+      "Variable name conflicts with a constant") }
+  test("constant in extensions") {
+    expectError("extensions [d e f]",
+      "Can't find extension: d") }
+  test("constant in turtles-own") {
+    expectError("turtles-own [d e f]",
+      "Variable name conflicts with a constant") }
+  test("constant in patches-own") {
+    expectError("patches-own [d e f]",
+      "Variable name conflicts with a constant") }
+  test("constant in links-own") {
+    expectError("links-own [d e f]",
+      "Variable name conflicts with a constant") }
+  test("constant in breed-own") {
+    expectError("breed [tests test] tests-own [d e f]",
+      "Variable name conflicts with a constant") }
+  test("constant in procedure input") {
+    expectError("to test [d e f]",
+      "Input name conflicts with a constant") }
   test("missing breed singular") {
     expectError("breed [xs]",
       "Breed declarations must have plural and singular. BREED [XS] has only one name.") }

--- a/shared/resources/main/i18n/Errors_en.properties
+++ b/shared/resources/main/i18n/Errors_en.properties
@@ -200,6 +200,13 @@ compiler.LetVariable.notDefined = Nothing named {0} has been defined.
 compiler.Backifier.replaced = {0} is no longer a primitive, use {1} instead.
 compiler.StructureParser.includeNotFound = Could not find {0}
 compiler.StructureConverter.noBreed = There is no breed "{0}"
+compiler.StructureChecker.variableConstant = Variable name conflicts with a constant.
+compiler.StructureChecker.inputConstant = Input name conflicts with a constant.
+compiler.StructureChecker.breedOverrides = Defining a breed {0} redefines {1}, a {2}
+compiler.StructureChecker.invalidArrow = -> can only be used to create anonymous procedures
+compiler.StructureChecker.redeclaration = Redeclaration of {0}
+compiler.StructureChecker.duplicateType = There is already a {0} called {1}
+compiler.StructureChecker.duplicateVariable = There is already a local variable called {0} here
 
 fileformat.invalidversion = Invalid NetLogo file. Expected "{0}" formatted model to have version compatible with {1}, but this model had version {2}
 fileformat.notFound = Model file was not found at "{0}".  Double check the path given; the model may have been moved or deleted.


### PR DESCRIPTION
Issue #2131 describes a strange error message being printed when a constant such as `e` or `pi` is used as a global variable name. After further investigation, I found that the same incorrect error message was being printed in multiple other places, like in the extensions statement or in function input lists. The changes in this pull request should fix all such places, now displaying a more descriptive error message about the name conflicting with a constant.