### PR TITLE
Added property for focusing tabs on error

### DIFF
--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -477,6 +477,7 @@ tools.preferences.includedFilesMenu = Always show "Included Files" menu (in Code
 tools.preferences.proceduresMenuSortOrder = Sort order of procedures menu (in Code tab):
 tools.preferences.proceduresSortAlphabetical = Alphabetical
 tools.preferences.proceduresSortByOrderOfAppearance = Order of appearance
+tools.preferences.focusOnError = Auto-focus tab with error when an error is detected
 
 tools.libraries = Extensions
 tools.libraries.categories.extensions = Extensions

--- a/netlogo-gui/src/main/app/Tabs.scala
+++ b/netlogo-gui/src/main/app/Tabs.scala
@@ -53,6 +53,8 @@ class Tabs(workspace:           GUIWorkspace,
   private var watcherThread: FileWatcherThread = null
   private val prefs = Preferences.userRoot.node("/org/nlogo/NetLogo")
 
+  def focusOnError = prefs.getBoolean("focusOnError", true)
+
   def stopWatcherThread() {
     if (watcherThread != null) {
       watcherThread.interrupt
@@ -313,7 +315,7 @@ class Tabs(workspace:           GUIWorkspace,
     }
 
     def recolorInterfaceTab(): Unit = {
-      if (e.error != null) setSelectedIndex(0)
+      if (e.error != null && focusOnError) setSelectedIndex(0)
       recolorTab(interfaceTab, e.error != null)
     }
 
@@ -325,7 +327,7 @@ class Tabs(workspace:           GUIWorkspace,
           clearErrors()
         }
         else {
-          tabManager.setSelectedCodeTab(mainCodeTab)
+          if (focusOnError) tabManager.setSelectedCodeTab(mainCodeTab)
           recolorTab(mainCodeTab, true)
         }
         // I don't really know why this is necessary when you delete a slider (by using the menu
@@ -342,7 +344,7 @@ class Tabs(workspace:           GUIWorkspace,
           tab.get.handle(e) // it was late to the party, let it handle the event too
         }
         if (e.error != null) {
-          tabManager.setPanelsSelectedComponent(tab.get)
+          if (focusOnError) tabManager.setPanelsSelectedComponent(tab.get)
         }
         recolorTab(tab.get, e.error != null)
         requestFocus()

--- a/netlogo-gui/src/main/app/ToolActions.scala
+++ b/netlogo-gui/src/main/app/ToolActions.scala
@@ -43,7 +43,8 @@ with MenuAction {
     new Preferences.LogDirectory(frame),
     Preferences.LogEvents,
     Preferences.IncludedFilesMenu,
-    Preferences.ProceduresMenuSortOrder
+    Preferences.ProceduresMenuSortOrder,
+    Preferences.FocusOnError
   )
 }
 

--- a/netlogo-gui/src/main/app/tools/Preferences.scala
+++ b/netlogo-gui/src/main/app/tools/Preferences.scala
@@ -163,4 +163,6 @@ object Preferences {
       prefs.put("proceduresMenuSortOrder", chosenSortOrder)
     }
   }
+
+  object FocusOnError extends BooleanPreference("focusOnError", false, true) {}
 }


### PR DESCRIPTION
Users have reported an annoying bug-like feature where tabs steal focus every time an error occurs during compilation (see #2111). This pull request adds a preference option that if unchecked would prevent compilation errors from stealing focus from the current tab. It defaults to being checked so that it is not a breaking change.