### PR TITLE
Added included file merging for export as NetLogo Web

### DIFF
--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -48,6 +48,7 @@ menu.file.nlw.prompt.fromCurrentCopy = From open copy
 menu.file.nlw.prompt.title = Choose Export Source
 menu.file.nlw.prompt.message.fromSave = Export model from last save or from open copy?
 menu.file.nlw.prompt.message.fromLibrary = Export model from Models Library or open copy?
+menu.file.nlw.prompt.includesWarning = This model contains included files, which are not supported in NetLogo Web. The contents of these files will be merged with the main code.
 menu.file.print = Print…
 menu.file.export = Export
 menu.file.export.failed = Export Failed

--- a/netlogo-gui/src/main/app/FileManager.scala
+++ b/netlogo-gui/src/main/app/FileManager.scala
@@ -150,8 +150,8 @@ object FileManager {
         AWTFileDialog.SAVE, suggestedFileName)
 
       val exportFile = new File(exportPath)
-      val saver = NetLogoWebSaver(exportPath)
-      saver.save(modelToSave, exportFile.getName)
+      val saver = NetLogoWebSaver(exportPath, workspace)
+      saver.save(modelToSave, exportFile.getName, parent)
     }
 
     @throws(classOf[UserCancelException])


### PR DESCRIPTION
As a temporary fix until included files work in NetLogo Web, all included files are now merged with the main code file before exporting as NetLogo Web, as requested in issue #2253. A warning dialog is displayed before the merge, and the start of each included file is marked with a comment in the merged main code file. The current code will work for recursive includes, but it will break the exported model if the text `__includes` is present in any unexpected places such as string literals.