### PR TITLE
Fixed naming of Show/Hide Command Center option in Tools menu

### DIFF
--- a/netlogo-gui/src/main/app/interfacetab/InterfaceTab.scala
+++ b/netlogo-gui/src/main/app/interfacetab/InterfaceTab.scala
@@ -127,6 +127,7 @@ class InterfaceTab(workspace: GUIWorkspace,
   def handle(e: LoadBeginEvent) {
     scrollPane.getHorizontalScrollBar.setValue(0)
     scrollPane.getVerticalScrollBar.setValue(0)
+    commandCenterToggleAction.putValue(Action.NAME, I18N.gui.get("menu.tools.hideCommandCenter"))
   }
 
   /// output

--- a/netlogo-gui/src/main/app/interfacetab/InterfaceTab.scala
+++ b/netlogo-gui/src/main/app/interfacetab/InterfaceTab.scala
@@ -6,6 +6,7 @@ import java.awt.{ BorderLayout, Component, Container,
   ContainerOrderFocusTraversalPolicy, Dimension, Graphics, Graphics2D }
 import java.awt.event.{ ActionEvent, FocusEvent, FocusListener }
 import java.awt.print.{ PageFormat, Printable }
+import java.beans.{ PropertyChangeEvent, PropertyChangeListener }
 import javax.swing.{ AbstractAction, Action, BorderFactory, JComponent,
   JPanel, JScrollPane, JSplitPane, ScrollPaneConstants }
 
@@ -70,6 +71,13 @@ class InterfaceTab(workspace: GUIWorkspace,
     scrollPane, commandCenter)
   splitPane.setOneTouchExpandable(true)
   splitPane.setResizeWeight(1) // give the InterfacePanel all
+  splitPane.addPropertyChangeListener("dividerLocation", new PropertyChangeListener {
+    def propertyChange(e: PropertyChangeEvent) {
+      commandCenterToggleAction.putValue(Action.NAME,
+        if (e.getNewValue.asInstanceOf[Int] < maxDividerLocation) I18N.gui.get("menu.tools.hideCommandCenter")
+        else I18N.gui.get("menu.tools.showCommandCenter"))
+    }
+  })
   add(splitPane, BorderLayout.CENTER)
 
   object TrackingFocusListener extends FocusListener {
@@ -127,7 +135,6 @@ class InterfaceTab(workspace: GUIWorkspace,
   def handle(e: LoadBeginEvent) {
     scrollPane.getHorizontalScrollBar.setValue(0)
     scrollPane.getVerticalScrollBar.setValue(0)
-    commandCenterToggleAction.putValue(Action.NAME, I18N.gui.get("menu.tools.hideCommandCenter"))
   }
 
   /// output
@@ -203,9 +210,6 @@ class InterfaceTab(workspace: GUIWorkspace,
         showCommandCenter()
         commandCenter.requestFocus()
       }
-      putValue(Action.NAME,
-        if (splitPane.getDividerLocation < maxDividerLocation) I18N.gui.get("menu.tools.hideCommandCenter")
-        else I18N.gui.get("menu.tools.showCommandCenter"))
     }
   }
 
@@ -220,7 +224,6 @@ class InterfaceTab(workspace: GUIWorkspace,
       if (! commandCenter.getDefaultComponentForFocus.isFocusOwner) {
         showCommandCenter()
         commandCenter.requestFocusInWindow()
-        commandCenterToggleAction.putValue(Action.NAME, I18N.gui.get("menu.tools.hideCommandCenter"))
       }
     }
   }

--- a/netlogo-gui/src/main/app/interfacetab/InterfaceTab.scala
+++ b/netlogo-gui/src/main/app/interfacetab/InterfaceTab.scala
@@ -42,9 +42,11 @@ class InterfaceTab(workspace: GUIWorkspace,
   commandCenter.locationToggleAction = new CommandCenterLocationToggleAction
   val iP = new InterfacePanel(workspace.viewWidget, workspace)
 
+  val commandCenterToggleAction = new CommandCenterToggleAction()
+
   override val activeMenuActions =
     WorkspaceActions.interfaceActions(workspace) ++
-    Seq(iP.undoAction, iP.redoAction, new CommandCenterToggleAction(), new JumpToCommandCenterAction())
+    Seq(iP.undoAction, iP.redoAction, commandCenterToggleAction, new JumpToCommandCenterAction())
 
   var lastFocusedComponent: JComponent = commandCenter
   setLayout(new BorderLayout)
@@ -217,6 +219,7 @@ class InterfaceTab(workspace: GUIWorkspace,
       if (! commandCenter.getDefaultComponentForFocus.isFocusOwner) {
         showCommandCenter()
         commandCenter.requestFocusInWindow()
+        commandCenterToggleAction.putValue(Action.NAME, I18N.gui.get("menu.tools.hideCommandCenter"))
       }
     }
   }


### PR DESCRIPTION
This pull request fixes some naming inconsistencies with the Show/Hide Command Center option in the Tools menu. See issue #2051 for initial bug report; this fix applies to a few other related places as well.