### PR TITLE
Made logging errors more user friendly

### DIFF
--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -478,6 +478,8 @@ tools.preferences.proceduresMenuSortOrder = Sort order of procedures menu (in Co
 tools.preferences.proceduresSortAlphabetical = Alphabetical
 tools.preferences.proceduresSortByOrderOfAppearance = Order of appearance
 
+tools.preferences.missingDirectory = The specified log directory does not exist, would you like to create it?
+
 tools.libraries = Extensions
 tools.libraries.categories.extensions = Extensions
 tools.libraries.install = Install
@@ -753,3 +755,4 @@ error.dialog.openFAQ = Open FAQ
 warn.dialog.badjvm = You have started NetLogo under the GNU libgcj Java VM. NetLogo may not run well, or at \
 all, under libgcj. We recommend using the Oracle Java VM to run NetLogo. Recent OpenJDK versions may \
 also work. If you choose to continue, NetLogo may not function properly.
+error.dialog.logDirectory = Error writing to the specified log directory. Logs will not be written for this NetLogo session.

--- a/netlogo-gui/src/main/app/App.scala
+++ b/netlogo-gui/src/main/app/App.scala
@@ -439,7 +439,7 @@ class App extends
       val studentName       = askForName()
       val addListener       = (l) => listenerManager.addListener(l)
       val loggerFactory     = (p) => new JsonFileLogger(p)
-      LogManager.start(addListener, loggerFactory, finalLogDirectory, events, studentName)
+      LogManager.start(addListener, loggerFactory, finalLogDirectory, events, studentName, frame)
     }
 
   }

--- a/netlogo-gui/src/main/app/App.scala
+++ b/netlogo-gui/src/main/app/App.scala
@@ -22,6 +22,7 @@ import org.nlogo.fileformat
 import org.nlogo.log.{ JsonFileLogger, LogEvents, LogManager }
 import org.nlogo.nvm.{ PresentationCompilerInterface, Workspace }
 import org.nlogo.shape.{ LinkShapesManagerInterface, ShapesManagerInterface, TurtleShapesManagerInterface }
+import org.nlogo.swing.OptionDialog
 import org.nlogo.util.{ NullAppHandler, Pico }
 import org.nlogo.window._
 import org.nlogo.window.Events._
@@ -439,7 +440,10 @@ class App extends
       val studentName       = askForName()
       val addListener       = (l) => listenerManager.addListener(l)
       val loggerFactory     = (p) => new JsonFileLogger(p)
-      LogManager.start(addListener, loggerFactory, finalLogDirectory, events, studentName, frame)
+      LogManager.start(addListener, loggerFactory, finalLogDirectory, events, studentName, () =>
+        OptionDialog.showMessage(frame, I18N.gui.get("common.messages.warning"),
+                                 I18N.gui.get("error.dialog.logDirectory"),
+                                 Array[Object](I18N.gui.get("common.buttons.ok"))))
     }
 
   }

--- a/netlogo-gui/src/main/log/JsonFileLogger.scala
+++ b/netlogo-gui/src/main/log/JsonFileLogger.scala
@@ -36,8 +36,7 @@ class JsonFileLogger(private val logDirectoryPath: Path) extends FileLogger {
     val logFileName = s"netlogo_log_${now.format(DateTimeFormats.file)}.json"
     val logFilePath = logDirectoryPath.resolve(logFileName)
     val logFile     = logFilePath.toFile()
-    // There can be exceptions thrown here, but we let them go as they'll signal to the log manager that we're unable to
-    // start and it should fall back to a different logger.  -Jeremy B February 2024
+    logFile.getParentFile.mkdirs
     new PrintWriter(new FileWriter(logFile))
   }
 


### PR DESCRIPTION
As requested in issue #2050, the process of selecting a log directory is now smoother. When you first enter a path that doesn't exist and click OK or Apply, it asks you whether you want to create the path or not, only allowing the preferences to save and close if you confirm. It also ensures that the specified path exists when a model loads, displaying a warning dialog if anything goes wrong.