### PR TITLE
Fixed various bugs with included files

### DIFF
--- a/netlogo-gui/src/main/app/AbstractTabsPanel.scala
+++ b/netlogo-gui/src/main/app/AbstractTabsPanel.scala
@@ -9,7 +9,7 @@ import javax.swing.plaf.ComponentUI
 import org.nlogo.app.codetab.{ ExternalFileManager, MainCodeTab }
 import org.nlogo.app.interfacetab.InterfaceTab
 import org.nlogo.window.GUIWorkspace
-import org.nlogo.window.LinkRoot
+import org.nlogo.window.{ Events => WindowEvents, LinkRoot }
 
 // AbstractTabsPanel contains functionality common to Tabs and CodeTabsPanel. AAB 10/2020
 
@@ -59,7 +59,7 @@ abstract class AbstractTabsPanel(val workspace:           GUIWorkspace,
   }
 
   def updateState() {
-    fireStateChanged
+    new WindowEvents.CompileAllEvent().raise(this)
   }
 
   override def processMouseMotionEvent(e: MouseEvent) {

--- a/netlogo-gui/src/main/app/AbstractTabsPanel.scala
+++ b/netlogo-gui/src/main/app/AbstractTabsPanel.scala
@@ -58,6 +58,10 @@ abstract class AbstractTabsPanel(val workspace:           GUIWorkspace,
     assert(fileManager != null && dirtyMonitor != null)
   }
 
+  def updateState() {
+    fireStateChanged
+  }
+
   override def processMouseMotionEvent(e: MouseEvent) {
     // do nothing.  mouse moves are for some reason causing doLayout to be called in the tabbed
     // components on windows and linux (but not Mac) in java 6 it never did this before and I don't

--- a/netlogo-gui/src/main/app/AppTabManager.scala
+++ b/netlogo-gui/src/main/app/AppTabManager.scala
@@ -307,7 +307,7 @@ class AppTabManager(val appTabsPanel:          Tabs,
       }
       appTabsPanel.getAppFrame.addLinkComponent(codeTabsPanel.getCodeTabContainer)
       createCodeTabAccelerators()
-      switchingCodeTabs = true
+      switchingCodeTabs = false
       codeTabsPanel.updateState
       Event.rehash()
       codeTabsPanel.mainCodeTab.requestFocus

--- a/netlogo-gui/src/main/app/AppTabManager.scala
+++ b/netlogo-gui/src/main/app/AppTabManager.scala
@@ -2,7 +2,7 @@
 
 package org.nlogo.app
 
-import java.awt.Component
+import java.awt.{ Component, KeyboardFocusManager }
 import java.awt.event.{ ActionEvent, KeyEvent }
 import javax.swing.{ Action, AbstractAction, ActionMap, InputMap, JComponent, JMenu, JMenuItem, JTabbedPane, KeyStroke }
 
@@ -49,6 +49,8 @@ class AppTabManager(val appTabsPanel:          Tabs,
   var menuBar: MenuBar = null
 
   var dirtyMonitor: DirtyMonitor = null
+
+  val focusManager = KeyboardFocusManager.getCurrentKeyboardFocusManager()
 
   var switchingCodeTabs = false
 
@@ -585,6 +587,18 @@ class AppTabManager(val appTabsPanel:          Tabs,
     require(tab != null)
     val (tabOwner, tabIndex) = ownerAndIndexOfTab(tab)
     setPanelsSelectedIndexHelper(tabOwner, tabIndex)
+  }
+
+  /**
+   * Gets selected tab, regardless of type or whether a separate code window exists.
+   */
+  def getSelectedComponent(): Component = {
+    codeTabsPanelOption match {
+      case Some(codeTabsPanel) if (codeTabsPanel.isAncestorOf(focusManager.getFocusOwner())) =>
+        codeTabsPanel.getComponentAt(codeTabsPanel.getSelectedIndex)
+      case _ =>
+        appTabsPanel.getComponentAt(appTabsPanel.getSelectedIndex)
+    }
   }
 
   /**

--- a/netlogo-gui/src/main/app/AppTabManager.scala
+++ b/netlogo-gui/src/main/app/AppTabManager.scala
@@ -249,8 +249,8 @@ class AppTabManager(val appTabsPanel:          Tabs,
     codeTabsPanelOption match {
       case None                => // nothing to do
       case Some(codeTabsPanel) => {
-        setCodeTabsPanelOption(None)
         switchingCodeTabs = true
+        setCodeTabsPanelOption(None)
         // Move the tabs to the AppTabsPanel (Tabs), retaining order. AAB 10/2020
         for (_ <- 0 until codeTabsPanel.getTabCount) {
           appTabsPanel.add(codeTabsPanel.getTitleAt(0), codeTabsPanel.getComponentAt(0))
@@ -260,7 +260,7 @@ class AppTabManager(val appTabsPanel:          Tabs,
         appTabsPanel.mainCodeTab.requestFocus
         appTabsPanel.getAppFrame.removeLinkComponent(codeTabsPanel.getCodeTabContainer)
         switchingCodeTabs = false
-        appTabsPanel.codeTabsSwitched
+        appTabsPanel.updateState
         Event.rehash()
       } // end case where work was done. AAB 10/2020
     }
@@ -269,6 +269,7 @@ class AppTabManager(val appTabsPanel:          Tabs,
   // Does the work needed to go back to the separate code window state
   def switchToSeparateCodeWindow(): Unit = {
     if (!isCodeTabSeparate) {
+      switchingCodeTabs = true
       val codeTabsPanel = new CodeTabsPanel(appTabsPanel.workspace,
         appTabsPanel.interfaceTab,
         appTabsPanel.externalFileManager,
@@ -306,6 +307,8 @@ class AppTabManager(val appTabsPanel:          Tabs,
       }
       appTabsPanel.getAppFrame.addLinkComponent(codeTabsPanel.getCodeTabContainer)
       createCodeTabAccelerators()
+      switchingCodeTabs = true
+      codeTabsPanel.updateState
       Event.rehash()
       codeTabsPanel.mainCodeTab.requestFocus
     }

--- a/netlogo-gui/src/main/app/AppTabManager.scala
+++ b/netlogo-gui/src/main/app/AppTabManager.scala
@@ -50,6 +50,8 @@ class AppTabManager(val appTabsPanel:          Tabs,
 
   var dirtyMonitor: DirtyMonitor = null
 
+  var switchingCodeTabs = false
+
   // The appTabsPanel and the main code tab are unique unchanging entities
   // of class Tabs and MainCodeTab respectively. AAB 10/2020
   def getAppTabsPanel = { appTabsPanel }
@@ -248,6 +250,7 @@ class AppTabManager(val appTabsPanel:          Tabs,
       case None                => // nothing to do
       case Some(codeTabsPanel) => {
         setCodeTabsPanelOption(None)
+        switchingCodeTabs = true
         // Move the tabs to the AppTabsPanel (Tabs), retaining order. AAB 10/2020
         for (_ <- 0 until codeTabsPanel.getTabCount) {
           appTabsPanel.add(codeTabsPanel.getTitleAt(0), codeTabsPanel.getComponentAt(0))
@@ -256,6 +259,8 @@ class AppTabManager(val appTabsPanel:          Tabs,
         appTabsPanel.mainCodeTab.getPoppingCheckBox.setSelected(false)
         appTabsPanel.mainCodeTab.requestFocus
         appTabsPanel.getAppFrame.removeLinkComponent(codeTabsPanel.getCodeTabContainer)
+        switchingCodeTabs = false
+        appTabsPanel.codeTabsSwitched
         Event.rehash()
       } // end case where work was done. AAB 10/2020
     }

--- a/netlogo-gui/src/main/app/CodeTabsPanel.scala
+++ b/netlogo-gui/src/main/app/CodeTabsPanel.scala
@@ -96,11 +96,6 @@ class CodeTabsPanel(workspace:            GUIWorkspace,
       if (currentTab == null) {
         currentTab = mainCodeTab
       }
-      (previousTab.isInstanceOf[TemporaryCodeTab], currentTab.isInstanceOf[TemporaryCodeTab]) match {
-        case (true, false) => tabManager.appTabsPanel.saveModelActions foreach tabManager.menuBar.offerAction
-        case (false, true) => tabManager.appTabsPanel.saveModelActions foreach tabManager.menuBar.revokeAction
-        case _             =>
-      }
       // The SwitchedTabsEvent will cause compilation when the user leaves an edited CodeTab. AAB 10/2020
       new AppEvents.SwitchedTabsEvent(previousTab, currentTab).raise(this)
     }

--- a/netlogo-gui/src/main/app/CodeTabsPanel.scala
+++ b/netlogo-gui/src/main/app/CodeTabsPanel.scala
@@ -89,7 +89,7 @@ class CodeTabsPanel(workspace:            GUIWorkspace,
 
   def stateChanged(e: ChangeEvent) = {
     // for explanation of index -1, see comment in Tabs.stateChanged. AAB 10/2020
-    if (tabManager.getSelectedAppTabIndex != -1) {
+    if (!tabManager.switchingCodeTabs && tabManager.getSelectedAppTabIndex != -1) {
       val previousTab = getCurrentTab
       currentTab = getSelectedComponent
       // currentTab could be null in the case where the CodeTabPanel has only the MainCodeTab. AAB 10/2020

--- a/netlogo-gui/src/main/app/FileManager.scala
+++ b/netlogo-gui/src/main/app/FileManager.scala
@@ -246,6 +246,12 @@ class FileManager(workspace: AbstractWorkspaceScala,
 
   val controller = new FileController(parent, workspace)
 
+  private var tabManager: AppTabManager = null
+
+  def setTabManager(tabManager: AppTabManager) {
+    this.tabManager = tabManager
+  }
+
   def handle(e: OpenModelEvent): Unit = {
     openFromPath(e.path, ModelType.Library, e.shouldAutoInstallLibs)
   }
@@ -418,7 +424,14 @@ class FileManager(workspace: AbstractWorkspaceScala,
         rank = 0
 
         @throws(classOf[UserCancelException])
-        override def action(): Unit = saveModel(saveAs)
+        override def action(): Unit = {
+          println(tabManager.getSelectedComponent.getClass.getName)
+
+          tabManager.getSelectedComponent match {
+            case tempTab: TemporaryCodeTab => tempTab.save(saveAs)
+            case _ => saveModel(saveAs)
+          }
+        }
       }
 
     Seq(saveAction(false), saveAction(true))

--- a/netlogo-gui/src/main/app/FileManager.scala
+++ b/netlogo-gui/src/main/app/FileManager.scala
@@ -425,8 +425,6 @@ class FileManager(workspace: AbstractWorkspaceScala,
 
         @throws(classOf[UserCancelException])
         override def action(): Unit = {
-          println(tabManager.getSelectedComponent.getClass.getName)
-
           tabManager.getSelectedComponent match {
             case tempTab: TemporaryCodeTab => tempTab.save(saveAs)
             case _ => saveModel(saveAs)

--- a/netlogo-gui/src/main/app/Tabs.scala
+++ b/netlogo-gui/src/main/app/Tabs.scala
@@ -176,6 +176,8 @@ class Tabs(workspace:           GUIWorkspace,
 
     // Set hotkey to create a separate code window. AAB 12/2020
     tabManager.setAppCodeTabBindings
+
+    manager.setTabManager(tabManager)
   }
 
     // When there is a separate code tab window, there will be a selected tab in
@@ -214,12 +216,7 @@ class Tabs(workspace:           GUIWorkspace,
         case mt: MenuTab => mt.activeMenuActions foreach menu.offerAction
         case _ =>
       }
-
-      (previousTab.isInstanceOf[TemporaryCodeTab], currentTab.isInstanceOf[TemporaryCodeTab]) match {
-        case (true, false) => saveModelActions foreach menu.offerAction
-        case (false, true) => saveModelActions foreach menu.revokeAction
-        case _             =>
-      }
+      
       new AppEvents.SwitchedTabsEvent(previousTab, currentTab).raise(this)
     }
   }

--- a/netlogo-gui/src/main/app/Tabs.scala
+++ b/netlogo-gui/src/main/app/Tabs.scala
@@ -207,8 +207,6 @@ class Tabs(workspace:           GUIWorkspace,
     // In that case do nothing. The correct action will happen when
     // the selected index is reset. AAB 10/2020
     if (!tabManager.switchingCodeTabs && tabManager.getSelectedAppTabIndex != -1) {
-      println("switch")
-
       val previousTab = currentTab
       currentTab = getSelectedComponent
 

--- a/netlogo-gui/src/main/app/Tabs.scala
+++ b/netlogo-gui/src/main/app/Tabs.scala
@@ -53,6 +53,10 @@ class Tabs(workspace:           GUIWorkspace,
   private var watcherThread: FileWatcherThread = null
   private val prefs = Preferences.userRoot.node("/org/nlogo/NetLogo")
 
+  def codeTabsSwitched() {
+    fireStateChanged
+  }
+
   def stopWatcherThread() {
     if (watcherThread != null) {
       watcherThread.interrupt
@@ -202,7 +206,9 @@ class Tabs(workspace:           GUIWorkspace,
     // tab index of the parent JTabbedPane to -1
     // In that case do nothing. The correct action will happen when
     // the selected index is reset. AAB 10/2020
-    if (tabManager.getSelectedAppTabIndex != -1) {
+    if (!tabManager.switchingCodeTabs && tabManager.getSelectedAppTabIndex != -1) {
+      println("switch")
+
       val previousTab = currentTab
       currentTab = getSelectedComponent
 

--- a/netlogo-gui/src/main/app/Tabs.scala
+++ b/netlogo-gui/src/main/app/Tabs.scala
@@ -53,10 +53,6 @@ class Tabs(workspace:           GUIWorkspace,
   private var watcherThread: FileWatcherThread = null
   private val prefs = Preferences.userRoot.node("/org/nlogo/NetLogo")
 
-  def codeTabsSwitched() {
-    fireStateChanged
-  }
-
   def stopWatcherThread() {
     if (watcherThread != null) {
       watcherThread.interrupt

--- a/netlogo-gui/src/main/app/codetab/TemporaryCodeTab.scala
+++ b/netlogo-gui/src/main/app/codetab/TemporaryCodeTab.scala
@@ -8,13 +8,11 @@ import java.io.{ File, IOException }
 import javax.swing.{ Action, AbstractAction }
 
 import org.nlogo.api.FileIO
-import org.nlogo.app.common.{ Dialogs, Events => AppEvents, TabsInterface }//,
-  // Actions.Ellipsis
+import org.nlogo.app.common.{ Dialogs, Events => AppEvents, TabsInterface }
 import org.nlogo.awt.UserCancelException
 import org.nlogo.core.I18N
 import org.nlogo.ide.FocusedOnlyAction
-import org.nlogo.swing.{ FileDialog => SwingFileDialog, ToolBarActionButton }//,
-  // UserAction.MenuAction
+import org.nlogo.swing.{ FileDialog => SwingFileDialog, ToolBarActionButton }
 import org.nlogo.window.{ Events => WindowEvents, ExternalFileInterface }
 import org.nlogo.workspace.{ AbstractWorkspace, ModelTracker }
 

--- a/netlogo-gui/src/main/app/codetab/TemporaryCodeTab.scala
+++ b/netlogo-gui/src/main/app/codetab/TemporaryCodeTab.scala
@@ -8,13 +8,13 @@ import java.io.{ File, IOException }
 import javax.swing.{ Action, AbstractAction }
 
 import org.nlogo.api.FileIO
-import org.nlogo.app.common.{ Actions, Dialogs, Events => AppEvents, ExceptionCatchingAction, TabsInterface },
-  Actions.Ellipsis
+import org.nlogo.app.common.{ Dialogs, Events => AppEvents, TabsInterface }//,
+  // Actions.Ellipsis
 import org.nlogo.awt.UserCancelException
 import org.nlogo.core.I18N
 import org.nlogo.ide.FocusedOnlyAction
-import org.nlogo.swing.{ FileDialog => SwingFileDialog, ToolBarActionButton, UserAction },
-  UserAction.MenuAction
+import org.nlogo.swing.{ FileDialog => SwingFileDialog, ToolBarActionButton }//,
+  // UserAction.MenuAction
 import org.nlogo.window.{ Events => WindowEvents, ExternalFileInterface }
 import org.nlogo.workspace.{ AbstractWorkspace, ModelTracker }
 
@@ -76,21 +76,7 @@ class TemporaryCodeTab(workspace: AbstractWorkspace with ModelTracker,
   lineNumbersVisible = tabs.lineNumbersVisible
 
   override val activeMenuActions = {
-    def saveAction(saveAs: Boolean) = {
-      new ExceptionCatchingAction(if (saveAs) I18N.gui.get("menu.file.saveAs") + Ellipsis else I18N.gui.get("menu.file.save"), TemporaryCodeTab.this)
-      with MenuAction {
-        category    = UserAction.FileCategory
-        group       = UserAction.FileSaveGroup
-        accelerator = UserAction.KeyBindings.keystroke('S', withMenu = true, withShift = saveAs)
-        rank = 0
-
-        @throws(classOf[UserCancelException])
-        override def action(): Unit = {
-          save(saveAs)
-        }
-      }
-    }
-    Seq(saveAction(false), saveAction(true), undoAction, redoAction) ++
+    Seq(undoAction, redoAction) ++
       editorConfiguration.contextActions.filter(_.isInstanceOf[FocusedOnlyAction]) ++
       filename.fold(_ => Seq(), name => Seq(conversionAction(this)))
   }


### PR DESCRIPTION
Fixed the bug detailed in issue #2123, which previously occurred as described in the issue and also when closing the separate code tab with changes made to an unsaved included file. Fixed the bug detailed in issue #2113, along with the bug detailed in issue #2022. Also fixed desync in errors and error colors when switching the state of the code tabs.

Current known bugs:

- Saving an included file occasionally results in it being marked as dirty (asterisk before name)
- Switching between the main window and the separate code tab doesn't always retain focus, sometimes it immediately switches the focus back to the originally selected window (could be related to issue #1996)