### PR TITLE
Fixed widget edits not causing save prompt

### DIFF
--- a/netlogo-gui/src/main/widget/Switch.scala
+++ b/netlogo-gui/src/main/widget/Switch.scala
@@ -47,6 +47,7 @@ abstract class Switch extends MultiErrorWidget with MouseWheelListener
       constraint.defaultValue = on
       updateConstraints()
       doLayout()
+      new Events.WidgetEditedEvent(this).raise(this)
     }
   }
 

--- a/netlogo-gui/src/main/window/ChooserWidget.scala
+++ b/netlogo-gui/src/main/window/ChooserWidget.scala
@@ -95,6 +95,7 @@ class ChooserWidget(val compiler: CompilerServices)
     if ((index: Int) != newIndex) {
       super.index(newIndex)
       new InterfaceGlobalEvent(this, false, false, true, false).raise(this)
+      new Events.WidgetEditedEvent(this).raise(this)
     }
   }
 

--- a/netlogo-gui/src/main/window/InputBoxWidget.scala
+++ b/netlogo-gui/src/main/window/InputBoxWidget.scala
@@ -32,6 +32,7 @@ class InputBoxWidget(textArea: AbstractEditorArea, dialogTextArea: AbstractEdito
       if (!text.equals(textArea.getText())) textArea.setText(text)
       if (raiseEvent) new org.nlogo.window.Events.InterfaceGlobalEvent(this, false, false, true, false).raise(this)
       inputType.colorPanel(colorSwatch)
+      new Events.WidgetEditedEvent(this).raise(this)
     }
   }
 }

--- a/netlogo-gui/src/main/window/SliderWidget.scala
+++ b/netlogo-gui/src/main/window/SliderWidget.scala
@@ -49,11 +49,13 @@ trait AbstractSliderWidget extends MultiErrorWidget {
     sliderData.value = d;
     revalidate();
     repaint()
+    new Events.WidgetEditedEvent(this).raise(this)
   }
   def value_=(d:Double, buttonRelease:Boolean){
     sliderData.value_=(d, buttonRelease);
     revalidate();
     repaint()
+    new Events.WidgetEditedEvent(this).raise(this)
   }
   def coerceValue(value: Double): Double = sliderData.coerceValue(value)
 


### PR DESCRIPTION
Fixed issue #1832. Editing the value of a widget without using the Edit dialog now causes the model to be dirty and prompts for save on closing.