### PR TITLE
Improved logging path checking

### DIFF
--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -482,7 +482,9 @@ tools.preferences.proceduresSortByOrderOfAppearance = Order of appearance
 tools.preferences.focusOnError = Auto-focus text or tab with errors when model is compiled
 tools.preferences.startSeparateCodeTab = Open code tab in separate window on startup
 
+tools.preferences.emptyDirectory = Logging was enabled, but no log directory was specified.
 tools.preferences.missingDirectory = The specified log directory does not exist, would you like to create it?
+tools.preferences.badPermissions = NetLogo does not have permission to write to the specified log directory.
 
 tools.libraries = Extensions
 tools.libraries.categories.extensions = Extensions

--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -481,6 +481,11 @@ tools.preferences.proceduresSortAlphabetical = Alphabetical
 tools.preferences.proceduresSortByOrderOfAppearance = Order of appearance
 tools.preferences.focusOnError = Auto-focus text or tab with errors when model is compiled
 tools.preferences.startSeparateCodeTab = Open code tab in separate window on startup
+tools.preferences.emptyDirectory = Logging was enabled, but no log directory was specified.
+tools.preferences.missingDirectory = The specified log directory does not exist, would you like to create it?
+tools.preferences.badPermissions = NetLogo does not have permission to write to the specified log directory.
+tools.preferences.uiScale = UI Scale
+tools.preferences.scaleError = UI Scale must be a valid floating point number.
 
 tools.preferences.emptyDirectory = Logging was enabled, but no log directory was specified.
 tools.preferences.missingDirectory = The specified log directory does not exist, would you like to create it?

--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -487,10 +487,6 @@ tools.preferences.badPermissions = NetLogo does not have permission to write to 
 tools.preferences.uiScale = UI Scale
 tools.preferences.scaleError = UI Scale must be a valid floating point number.
 
-tools.preferences.emptyDirectory = Logging was enabled, but no log directory was specified.
-tools.preferences.missingDirectory = The specified log directory does not exist, would you like to create it?
-tools.preferences.badPermissions = NetLogo does not have permission to write to the specified log directory.
-
 tools.libraries = Extensions
 tools.libraries.categories.extensions = Extensions
 tools.libraries.install = Install

--- a/netlogo-gui/src/main/app/tools/PreferencesDialog.scala
+++ b/netlogo-gui/src/main/app/tools/PreferencesDialog.scala
@@ -59,6 +59,15 @@ extends ToolDialog(parent, "preferences") {
         return false
       }
     }
+    try {
+      preferences.find(_.i18nKey == "uiScale").map(_.asInstanceOf[Preferences.StringPreference].component.getText.toDouble)
+    } catch {
+      case e: NumberFormatException =>
+        new OptionPane(this, I18N.gui.get("common.messages.error"), I18N.gui.get("tools.preferences.scaleError"),
+                       OptionPane.Options.Ok, OptionPane.Icons.Error)
+        return false
+      }
+    }
     true
   }
 

--- a/netlogo-gui/src/main/app/tools/PreferencesDialog.scala
+++ b/netlogo-gui/src/main/app/tools/PreferencesDialog.scala
@@ -4,6 +4,7 @@ package org.nlogo.app.tools
 
 import java.awt.{ BorderLayout, Frame }
 import java.io.File
+import java.nio.file.Files
 import java.util.prefs.{ Preferences => JavaPreferences }
 import javax.swing.{ BorderFactory, Box, BoxLayout, JButton, SwingConstants }
 
@@ -37,13 +38,25 @@ extends ToolDialog(parent, "preferences") {
       val path = preferences.find(x => x.i18nKey == "logDirectory").get.
                  asInstanceOf[Preferences.LogDirectory].textField.getText
       val file = new File(path)
-      if (path.nonEmpty && !file.exists) {
+      if (path.isEmpty) {
+        OptionDialog.showMessage(this, I18N.gui.get("common.messages.error"),
+                                 I18N.gui.get("tools.preferences.emptyDirectory"),
+                                 Array[Object](I18N.gui.get("common.buttons.ok")))
+        return false
+      }
+      else if (!file.exists) {
         if (OptionDialog.showMessage(this, I18N.gui.get("common.messages.warning"),
                                               I18N.gui.get("tools.preferences.missingDirectory"),
                                               Array[Object](I18N.gui.get("common.buttons.ok"),
                                                             I18N.gui.get("common.buttons.cancel"))) == 1)
           return false
         file.mkdirs
+      }
+      if (!Files.isWritable(file.toPath)) {
+        OptionDialog.showMessage(this, I18N.gui.get("common.messages.error"),
+                                 I18N.gui.get("tools.preferences.badPermissions"),
+                                 Array[Object](I18N.gui.get("common.buttons.ok")))
+        return false
       }
     }
     true


### PR DESCRIPTION
Fixed the problem detailed in issue #2327. This pull request improves the functionality added in pull request #2269, catching more errors before the preferences dialog is closed. Improvements include:

- The preferences dialog shows an error dialog and prevents the user from closing it if logging is enabled but no log directory is specified
- The preferences dialog shows an error dialog and prevents the user from closing it if the specified log directory does not exist or if NetLogo does not have the necessary permissions to write to the directory