### PR TITLE
Fixed incorrect unmatched parenthesis error

### DIFF
--- a/parser-core/src/main/parse/ExpressionParser.scala
+++ b/parser-core/src/main/parse/ExpressionParser.scala
@@ -309,7 +309,10 @@ object ExpressionParser {
       parseExpressionInternal(tokens, false, syntax.precedence, goalType, scope)
     catch {
       case _: MissingPrefixException | _: UnexpectedTokenException =>
-        exception(missingInput(syntax, displayName, true), sourceLocation)
+        if (tokens.head.tpe == TokenType.CloseParen)
+          exception("Unexpected closing parenthesis.", tokens.head.sourceLocation)
+        else
+          exception(missingInput(syntax, displayName, true), sourceLocation)
     }
   }
 

--- a/parser-core/src/main/parse/ExpressionParser.scala
+++ b/parser-core/src/main/parse/ExpressionParser.scala
@@ -309,10 +309,12 @@ object ExpressionParser {
       parseExpressionInternal(tokens, false, syntax.precedence, goalType, scope)
     catch {
       case _: MissingPrefixException | _: UnexpectedTokenException =>
-        if (tokens.head.tpe == TokenType.CloseParen)
-          exception("Unexpected closing parenthesis.", tokens.head.sourceLocation)
-        else
-          exception(missingInput(syntax, displayName, true), sourceLocation)
+        tokens.head.tpe match {
+          case TokenType.CloseParen => exception("Unexpected closing parenthesis.", tokens.head.sourceLocation)
+          case TokenType.CloseBracket => exception("Unexpected closing bracket.", tokens.head.sourceLocation)
+          case TokenType.CloseBrace => exception("Unexpected closing brace.", tokens.head.sourceLocation)
+          case _ => exception(missingInput(syntax, displayName, true), sourceLocation)
+        }
     }
   }
 


### PR DESCRIPTION
Fixed the bug detailed in issue #2309. Also throws a similar error for unmatched closing brackets and braces.