### PR TITLE
Fixed tilt-up/tilt-down floating point error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,8 @@ jobs:
           java-package: jdk+fx
           cache: 'sbt'
 
+      - uses: sbt/setup-sbt@v1
+
       - name: Build NetLogo
         run: |
           ./sbt update all headless/compile parserJS/compile

--- a/netlogo-gui/src/main/prim/threed/_tiltdown.scala
+++ b/netlogo-gui/src/main/prim/threed/_tiltdown.scala
@@ -12,17 +12,19 @@ class _tiltdown extends Command {
 
   override def perform(context: Context) {
     val delta = argEvalDoubleValue(context, 0)
-    val turtle = context.agent.asInstanceOf[Turtle3D]
-    val v = Vect.toVectors(turtle.heading,
-                           turtle.pitch,
-                           turtle.roll)
-    val pitch = new Vect(
-      0, StrictMath.cos(StrictMath.toRadians(-delta)),
-      StrictMath.sin(StrictMath.toRadians(-delta)))
-    val orthogonal = v(1).cross(v(0))
-    val forward = Vect.axisTransformation(pitch, v(1), v(0), orthogonal)
-    val angles = Vect.toAngles(forward, v(1))
-    turtle.headingPitchAndRoll(angles(0), angles(1), angles(2))
+    if (delta != 0) {
+      val turtle = context.agent.asInstanceOf[Turtle3D]
+      val v = Vect.toVectors(turtle.heading,
+                            turtle.pitch,
+                            turtle.roll)
+      val pitch = new Vect(
+        0, StrictMath.cos(StrictMath.toRadians(-delta)),
+        StrictMath.sin(StrictMath.toRadians(-delta)))
+      val orthogonal = v(1).cross(v(0))
+      val forward = Vect.axisTransformation(pitch, v(1), v(0), orthogonal)
+      val angles = Vect.toAngles(forward, v(1))
+      turtle.headingPitchAndRoll(angles(0), angles(1), angles(2))
+    }
     context.ip = next
   }
 }

--- a/netlogo-gui/src/main/prim/threed/_tiltup.scala
+++ b/netlogo-gui/src/main/prim/threed/_tiltup.scala
@@ -13,17 +13,19 @@ class _tiltup extends Command {
 
   override def perform(context: Context) {
     val delta = argEvalDoubleValue(context, 0)
-    val turtle = context.agent.asInstanceOf[Turtle3D]
-    val v = Vect.toVectors(turtle.heading,
-                           turtle.pitch,
-                           turtle.roll)
-    val pitch = new Vect(
-      0, StrictMath.cos(StrictMath.toRadians(delta)),
-      StrictMath.sin(StrictMath.toRadians(delta)))
-    val orthogonal = v(1).cross(v(0))
-    val forward = Vect.axisTransformation(pitch, v(1), v(0), orthogonal)
-    val angles = Vect.toAngles(forward, v(1))
-    turtle.headingPitchAndRoll(angles(0), angles(1), angles(2))
+    if (delta != 0) {
+      val turtle = context.agent.asInstanceOf[Turtle3D]
+      val v = Vect.toVectors(turtle.heading,
+                            turtle.pitch,
+                            turtle.roll)
+      val pitch = new Vect(
+        0, StrictMath.cos(StrictMath.toRadians(delta)),
+        StrictMath.sin(StrictMath.toRadians(delta)))
+      val orthogonal = v(1).cross(v(0))
+      val forward = Vect.axisTransformation(pitch, v(1), v(0), orthogonal)
+      val angles = Vect.toAngles(forward, v(1))
+      turtle.headingPitchAndRoll(angles(0), angles(1), angles(2))
+    }
     context.ip = next
   }
 }


### PR DESCRIPTION
Reasonably often, a pull request will fail due to a floating point error when the `tilt-up` or `tilt-down` primitives are called with 0 as an input. This pull request adds a check in those primitives to ensure that nothing changes if the input is 0.