### PR TITLE
Improved error message for incorrect keyword usage

### DIFF
--- a/parser-core/src/main/parse/StructureParser.scala
+++ b/parser-core/src/main/parse/StructureParser.scala
@@ -195,7 +195,7 @@ class StructureParser(
           subprogram)
       case Left((msg, token)) =>
         if (token.tpe == TokenType.Keyword) {
-          exception(s"""Keyword "${token.text}" cannot be used in this context.""", token)
+          exception(s"""Keyword ${token.text.toUpperCase} cannot be used in this context.""", token)
         } else {
           exception(msg, token)
         }

--- a/parser-core/src/main/parse/StructureParser.scala
+++ b/parser-core/src/main/parse/StructureParser.scala
@@ -194,7 +194,11 @@ class StructureParser(
           else oldResults,
           subprogram)
       case Left((msg, token)) =>
-        exception(msg, token)
+        if (token.tpe == TokenType.Keyword) {
+          exception(s"""Keyword "${token.text}" cannot be used in this context.""", token)
+        } else {
+          exception(msg, token)
+        }
     }
 
 }

--- a/parser-core/src/test/parse/StructureParserTests.scala
+++ b/parser-core/src/test/parse/StructureParserTests.scala
@@ -163,7 +163,7 @@ class StructureParserTests extends AnyFunSuite {
     expectError("globals [", "closing bracket expected") }
   test("missing close bracket in globals") {
     expectError("globals [g turtles-own [t]",
-      "closing bracket expected") }
+      "Keyword TURTLES-OWN cannot be used in this context.") }
   test("constant in globals") {
     expectError("globals [d e f]",
       "Variable name conflicts with a constant.") }
@@ -230,7 +230,7 @@ class StructureParserTests extends AnyFunSuite {
   // https://github.com/NetLogo/NetLogo/issues/414
   test("missing end 1") {
     expectError("to foo to bar",
-      "END expected") }
+      "Keyword TO cannot be used in this context.") }
   test("missing end 2") {
     expectError("to foo fd 1",
       "END expected") }
@@ -242,13 +242,13 @@ class StructureParserTests extends AnyFunSuite {
       "closing bracket expected") }
   test("missing close bracket in formals 1") {
     expectError("to foo [ end",
-      "closing bracket expected") }
+      "Keyword END cannot be used in this context.") }
   test("missing close bracket in formals 2") {
     expectError("to foo [ to",
-      "closing bracket expected") }
+      "Keyword TO cannot be used in this context.") }
   test("declaration after procedure") {
     expectError("to foo end globals []",
-      "TO or TO-REPORT expected") }
+      "Keyword GLOBALS cannot be used in this context.") }
 
   def compileAll(src: String, nlsSrc: String): StructureResults = {
     StructureParser.parseSources(


### PR DESCRIPTION
Inspired by issue #2329, this PR adds a more helpful error message when a keyword such as `to` or `globals` is used in the wrong context. The improved error message is shown in the command center and in the code tab.