### PR TITLE
Added check for missing report in to-report

### DIFF
--- a/netlogo-gui/src/test/compile/AssemblerTests.scala
+++ b/netlogo-gui/src/test/compile/AssemblerTests.scala
@@ -39,8 +39,8 @@ class AssemblerTests extends AnyFunSuite {
       test1("while [true] [die die]"))
   }
   test("assembleReporterProcedure") {
-    assertResult("_returnreport")(
-      compile("to-report", "").code.mkString(" "))
+    assertResult("_report _returnreport")(
+      compile("to-report", "report 10").code.mkString(" "))
   }
 
   // these tests are more about checking argument stuffing is working.

--- a/netlogo-gui/src/test/headless/TestCompiler.scala
+++ b/netlogo-gui/src/test/headless/TestCompiler.scala
@@ -66,7 +66,7 @@ class TestCompiler extends AnyFunSuite with OneInstancePerTest with BeforeAndAft
                "There is already a procedure called A")
   }
   test("LetSameNameAsReporterProcedure1") {
-    declare("to-report a end")
+    declare("to-report a report 10 end")
     badCommand("let a 5",
                "There is already a procedure called A")
   }

--- a/netlogo-gui/src/test/headless/TestCompiler.scala
+++ b/netlogo-gui/src/test/headless/TestCompiler.scala
@@ -71,7 +71,7 @@ class TestCompiler extends AnyFunSuite with OneInstancePerTest with BeforeAndAft
                "There is already a procedure called A")
   }
   test("LetSameNameAsReporterProcedure2") {
-    declareBad("to b let a 5 end  to-report a end",
+    declareBad("to b let a 5 end  to-report a report 10 end",
                "There is already a procedure called A")
   }
   test("LetSameNameAsGlobal") {

--- a/netlogo-headless/src/test/compile/back/AssemblerTests.scala
+++ b/netlogo-headless/src/test/compile/back/AssemblerTests.scala
@@ -39,8 +39,8 @@ class AssemblerTests extends AnyFunSuite {
       test1("while [true] [die die]"))
   }
   test("assembleReporterProcedure") {
-    assertResult("_returnreport")(
-      compile("to-report", "").code.mkString(" "))
+    assertResult("_report _returnreport")(
+      compile("to-report", "report 10").code.mkString(" "))
   }
 
   // these tests are more about checking argument stuffing is working.

--- a/parser-core/src/main/parse/StructureChecker.scala
+++ b/parser-core/src/main/parse/StructureChecker.scala
@@ -107,7 +107,7 @@ object StructureChecker {
     declarations.foreach(_ match {
       case Procedure(_, true, _, tokens) =>
         if (!tokens.exists(_ match {
-          case Token("report", TokenType.Keyword, "REPORT") => true
+          case Token("report", TokenType.Ident, "REPORT") => true
           case _ => false
         })) {
           exception("Reporter procedures must report a value", tokens(0))

--- a/parser-core/src/main/parse/StructureChecker.scala
+++ b/parser-core/src/main/parse/StructureChecker.scala
@@ -110,7 +110,7 @@ object StructureChecker {
           case Token("report", TokenType.Ident, "REPORT") => true
           case _ => false
         })) {
-          exception("Reporter procedures must report a value", tokens(0))
+          exception("Reporter procedures must report a value", tokens(1))
         }
 
       case _ =>

--- a/parser-core/src/main/parse/StructureChecker.scala
+++ b/parser-core/src/main/parse/StructureChecker.scala
@@ -107,7 +107,9 @@ object StructureChecker {
     declarations.foreach(_ match {
       case Procedure(_, true, _, tokens) =>
         if (!tokens.exists(_ match {
-          case Token("report", TokenType.Ident, "REPORT") => true
+          case Token(_, TokenType.Ident, "REPORT") => true
+          case Token(_, TokenType.Ident, "RUN") => true
+          case Token(_, TokenType.Ident, "RUNRESULT") => true
           case _ => false
         })) {
           exception("Reporter procedures must report a value", tokens(1))

--- a/parser-core/src/main/parse/StructureChecker.scala
+++ b/parser-core/src/main/parse/StructureChecker.scala
@@ -103,6 +103,20 @@ object StructureChecker {
     }
   }
 
+  def rejectMissingReport(declarations: Seq[Declaration]): Unit = {
+    declarations.foreach(_ match {
+      case Procedure(_, true, _, tokens) =>
+        if (!tokens.exists(_ match {
+          case Token("report", TokenType.Keyword, "REPORT") => true
+          case _ => false
+        })) {
+          exception("Reporter procedures must report a value", tokens(0))
+        }
+
+      case _ =>
+    })
+  }
+
   def breedPrimitives(declarations: Seq[Declaration]): SymbolTable = {
     import BreedIdentifierHandler._
     import org.nlogo.core.StructureDeclarations.{ Breed => DeclBreed }

--- a/parser-core/src/main/parse/StructureChecker.scala
+++ b/parser-core/src/main/parse/StructureChecker.scala
@@ -107,9 +107,10 @@ object StructureChecker {
     declarations.foreach(_ match {
       case Procedure(_, true, _, tokens) =>
         if (!tokens.exists(_ match {
-          case Token(_, TokenType.Ident, "REPORT") => true
-          case Token(_, TokenType.Ident, "RUN") => true
-          case Token(_, TokenType.Ident, "RUNRESULT") => true
+          case Token(_, TokenType.Ident, "REPORT") |
+               Token(_, TokenType.Ident, "RUN") |
+               Token(_, TokenType.Ident, "RUNRESULT") |
+               Token(_, TokenType.Ident, "ERROR") => true
           case _ => false
         })) {
           exception("Reporter procedures must report a value", tokens(1))

--- a/parser-core/src/main/parse/StructureParser.scala
+++ b/parser-core/src/main/parse/StructureParser.scala
@@ -188,6 +188,7 @@ class StructureParser(
         StructureChecker.rejectDuplicateNames(declarations,
           StructureParser.usedNames(
             oldResults.program, oldResults.procedures))
+        StructureChecker.rejectMissingReport(declarations)
         StructureConverter.convert(declarations, displayName,
           if (subprogram)
             StructureResults(program = oldResults.program)

--- a/parser-core/src/test/parse/ScopingTests.scala
+++ b/parser-core/src/test/parse/ScopingTests.scala
@@ -54,7 +54,7 @@ class ScopingTests extends AnyFunSuite with BaseParserTest {
       "There is already a procedure called A")
   }
   test("LetSameNameAsReporterProcedure2") {
-    duplicateName("to b let a 5 end  to-report a end",
+    duplicateName("to b let a 5 end  to-report a report 10 end",
       "There is already a procedure called A")
   }
   test("LetNameSameAsEnclosingCommandProcedureName") {

--- a/parser-jvm/src/test/parse/AstRewriterTests.scala
+++ b/parser-jvm/src/test/parse/AstRewriterTests.scala
@@ -36,7 +36,7 @@ class AstRewriterTests extends AnyFunSuite {
   test("preserves complex source") {
     assertPreservesSource("to foo end\n\nto baz end", "", "")
     assertPreservesSource("to foo end\nto baz end", "", "")
-    assertPreservesSource("to-report foo [bar] end\n\nto baz [qux] end", "", "")
+    assertPreservesSource("to-report foo [bar] report 10 end\n\nto baz [qux] end", "", "")
     assertPreservesSource("breed [as a] breed [bs b] globals [glob1] to foo if is-a? glob1 [ create-bs (100 - (count as)) ] end", "", "")
     assertModifiesSource("to foo  \nend", "to foo\nend")
   }

--- a/test/commands/Let.txt
+++ b/test/commands/Let.txt
@@ -137,7 +137,7 @@ LetSameNameAsCommandProcedure1
   O> let a 5 => COMPILER ERROR There is already a procedure called A
 
 LetSameNameAsReporterProcedure1
-  to-report a end
+  to-report a report 10 end
   O> let a 5 => COMPILER ERROR There is already a procedure called A
 
 LetSameNameAsPrimitiveCommand

--- a/test/commands/Run.txt
+++ b/test/commands/Run.txt
@@ -118,7 +118,7 @@ StringRunLetVarsDoNotEscape4
   O> foo => ERROR There is already a local variable here called A
 
 CannotReportOutOfRunString
-  to-report foo run "report 10" end
+  to-report foo run "report 10" report 10 end
   foo => ERROR REPORT can only be used inside TO-REPORT.
 
 StopInRunString

--- a/test/commands/Stop.txt
+++ b/test/commands/Stop.txt
@@ -37,11 +37,11 @@ StopFromForeach3
   glob1 => 2
 
 StopFromForeachInsideReporterProcedure
-  to-report foo foreach [1 2 3] [ stop ] end
+  to-report foo foreach [1 2 3] [ stop ] report 10 end
   O> __ignore foo => ERROR STOP is not allowed inside TO-REPORT.
 
 StopFromNestedForeachInsideReporterProcedure
-  to-report foo foreach [1 2] [ foreach [3 4] [ stop ] ] end
+  to-report foo foreach [1 2] [ foreach [3 4] [ stop ] ] report 10 end
   O> __ignore foo => ERROR STOP is not allowed inside TO-REPORT.
 
 ReportFromNestedAsk
@@ -91,12 +91,6 @@ StopInsideRunOfCommandLambda
   to test let x [[] -> set glob1 1 stop ] run x set glob1 2 end
   O> test set glob1 glob1 * 10
   glob1 => 10
-
-FallOffEndOfReporterProcedure
-  to-report foo1 report 0 end
-  to-report foo2 end
-  foo1 => 0
-  foo2 => ERROR Reached end of reporter procedure without REPORT being called.
 
 Bug86-1
   to setup ca go1 go2 end


### PR DESCRIPTION
Previously, procedures defined with `to-report` would compile successfully without a `report`, but a runtime error would be thrown once the procedure finished. This PR adds a compile-time check to ensure that a `report` is present somewhere in the procedure. It will also compile successfully if `run` or `runresult` is used in the procedure, because those primitives can cause the procedure to report a value without explicitly calling `report`.