### PR TITLE
Fixed some HubNet client editor issues

### DIFF
--- a/netlogo-gui/src/main/app/App.scala
+++ b/netlogo-gui/src/main/app/App.scala
@@ -174,7 +174,7 @@ object App {
         "org.nlogo.app.tools.PreviewCommandsEditor",
         new ComponentParameter(classOf[AppFrame]),
         new ComponentParameter(), new ComponentParameter())
-      pico.add(classOf[MenuBar], "org.nlogo.app.MenuBar",
+      pico.add(classOf[MainMenuBar], "org.nlogo.app.MainMenuBar",
         new ConstantParameter(AbstractWorkspace.isApp))
       pico.add(classOf[CommandCenter], "org.nlogo.app.interfacetab.CommandCenter", new ComponentParameter(),
                new ConstantParameter(true))
@@ -311,7 +311,7 @@ class App extends org.nlogo.window.Event.LinkChild
   lazy val owner = new SimpleJobOwner("App", workspace.world.mainRNG, AgentKind.Observer)
   private var _tabManager: TabManager = null
   def tabManager = _tabManager
-  var menuBar: MenuBar = null
+  var menuBar: MainMenuBar = null
   var _fileManager: FileManager = null
   var monitorManager: AgentMonitorManager = null
   def getMonitorManager = monitorManager
@@ -513,7 +513,7 @@ class App extends org.nlogo.window.Event.LinkChild
       dirtyMonitor = pico.getComponent(classOf[DirtyMonitor])
       frame.addLinkComponent(dirtyMonitor)
 
-      val menuBar = pico.getComponent(classOf[MenuBar])
+      val menuBar = pico.getComponent(classOf[MainMenuBar])
 
       pico.add(classOf[FileManager],
         "org.nlogo.app.FileManager",
@@ -732,7 +732,7 @@ class App extends org.nlogo.window.Event.LinkChild
     osSpecificActions ++ generalActions
   }
 
-  def setMenuBar(menuBar: MenuBar): Unit = {
+  def setMenuBar(menuBar: MainMenuBar): Unit = {
     if (menuBar != this.menuBar) {
       this.menuBar = menuBar
       allActions.foreach(menuBar.offerAction)

--- a/netlogo-gui/src/main/app/AppFrame.scala
+++ b/netlogo-gui/src/main/app/AppFrame.scala
@@ -2,25 +2,18 @@
 
 package org.nlogo.app
 
-import java.awt.{ SecondaryLoop, Toolkit }
 import java.awt.event.{ WindowAdapter, WindowEvent }
 import javax.swing.{ JFrame, WindowConstants }
 
 import org.nlogo.api.Exceptions
 import org.nlogo.awt.UserCancelException
-import org.nlogo.swing.{ ModalProgress, ModalProgressPanel, NetLogoIcon }
+import org.nlogo.swing.{ ModalProgress, NetLogoIcon }
 import org.nlogo.theme.ThemeSync
 import org.nlogo.window.LinkRoot
 import org.nlogo.window.Event.LinkParent
 import org.nlogo.window.Events.IconifiedEvent
 
 class AppFrame extends JFrame with LinkParent with LinkRoot with NetLogoIcon with ModalProgress with ThemeSync {
-  private val modalProgressPanel = new ModalProgressPanel
-
-  private var modalProgressLoop: Option[SecondaryLoop] = None
-
-  setGlassPane(modalProgressPanel)
-
   setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE)
 
   addWindowListener(new WindowAdapter() {
@@ -35,26 +28,6 @@ class AppFrame extends JFrame with LinkParent with LinkRoot with NetLogoIcon wit
       new IconifiedEvent(AppFrame.this, false).raise(App.app)
     }
   })
-
-  override def showModalProgressPanel(message: String): Unit = {
-    modalProgressPanel.setMessage(message)
-
-    getGlassPane.setVisible(true)
-
-    val loop = Toolkit.getDefaultToolkit.getSystemEventQueue.createSecondaryLoop()
-
-    modalProgressLoop = Some(loop)
-
-    loop.enter()
-  }
-
-  override def hideModalProgressPanel(): Unit = {
-    getGlassPane.setVisible(false)
-
-    modalProgressLoop.foreach(_.exit())
-
-    modalProgressLoop = None
-  }
 
   override def syncTheme(): Unit = {
     App.app.syncWindowThemes()

--- a/netlogo-gui/src/main/app/CodeTabsWindow.scala
+++ b/netlogo-gui/src/main/app/CodeTabsWindow.scala
@@ -10,7 +10,7 @@ import org.nlogo.theme.ThemeSync
 import org.nlogo.window.Event.LinkChild
 
 class CodeTabsWindow(parent: Frame, tabs: TabsPanel) extends JFrame with LinkChild with ThemeSync with NetLogoIcon {
-  val menuBar: MenuBar = new MenuBar(false)
+  val menuBar: MainMenuBar = new MainMenuBar(false)
 
   setJMenuBar(menuBar)
 

--- a/netlogo-gui/src/main/app/MainMenuBar.scala
+++ b/netlogo-gui/src/main/app/MainMenuBar.scala
@@ -7,11 +7,11 @@ import javax.swing.{ Action, JMenuBar }
 
 import org.nlogo.core.I18N
 import org.nlogo.editor.EditorMenu
-import org.nlogo.swing.{ UserAction, Utils },
+import org.nlogo.swing.{ MenuBar, UserAction, Utils },
   UserAction.{ ActionCategoryKey, EditCategory, FileCategory, HelpCategory, TabsCategory, ToolsCategory }
 import org.nlogo.theme.{ InterfaceColors, ThemeSync }
 
-class MenuBar(isApplicationWide: Boolean) extends JMenuBar with EditorMenu with UserAction.Menu with ThemeSync {
+class MainMenuBar(isApplicationWide: Boolean) extends MenuBar with EditorMenu with UserAction.Menu {
   val editMenu  = new EditMenu
   val fileMenu  = new FileMenu
   val tabsMenu  = new TabsMenu(I18N.gui.get("menu.tabs"))
@@ -57,28 +57,5 @@ class MenuBar(isApplicationWide: Boolean) extends JMenuBar with EditorMenu with 
       case _ => ""
     }
     categoryMenus.get(categoryKey).foreach(_.revokeAction(action))
-  }
-
-  override def paintComponent(g: Graphics): Unit = {
-    val g2d = Utils.initGraphics2D(g)
-
-    g2d.setColor(InterfaceColors.menuBackground())
-    g2d.fillRect(0, 0, getWidth, getHeight)
-  }
-
-  override def paintBorder(g: Graphics): Unit = {
-    val g2d = Utils.initGraphics2D(g)
-
-    g2d.setColor(InterfaceColors.menuBarBorder())
-    g2d.drawLine(0, getHeight - 1, getWidth, getHeight - 1)
-  }
-
-  override def syncTheme(): Unit = {
-    fileMenu.syncTheme()
-    editMenu.syncTheme()
-    toolsMenu.syncTheme()
-    zoomMenu.syncTheme()
-    tabsMenu.syncTheme()
-    helpMenu.syncTheme()
   }
 }

--- a/netlogo-gui/src/main/app/MainMenuBar.scala
+++ b/netlogo-gui/src/main/app/MainMenuBar.scala
@@ -2,14 +2,12 @@
 
 package org.nlogo.app
 
-import java.awt.Graphics
-import javax.swing.{ Action, JMenuBar }
+import javax.swing.Action
 
 import org.nlogo.core.I18N
 import org.nlogo.editor.EditorMenu
-import org.nlogo.swing.{ MenuBar, UserAction, Utils },
+import org.nlogo.swing.{ MenuBar, UserAction },
   UserAction.{ ActionCategoryKey, EditCategory, FileCategory, HelpCategory, TabsCategory, ToolsCategory }
-import org.nlogo.theme.{ InterfaceColors, ThemeSync }
 
 class MainMenuBar(isApplicationWide: Boolean) extends MenuBar with EditorMenu with UserAction.Menu {
   val editMenu  = new EditMenu

--- a/netlogo-gui/src/main/app/TabManager.scala
+++ b/netlogo-gui/src/main/app/TabManager.scala
@@ -54,7 +54,7 @@ class TabManager(val workspace: GUIWorkspace, val interfaceTab: InterfaceTab,
 
   var fileManager: FileManager = null
   var dirtyMonitor: DirtyMonitor = null
-  var menuBar: MenuBar = null
+  var menuBar: MainMenuBar = null
 
   private var widgetErrors = Set[Widget]()
 
@@ -165,7 +165,7 @@ class TabManager(val workspace: GUIWorkspace, val interfaceTab: InterfaceTab,
   smartTabbingEnabled = prefs.getBoolean("indentAutomatically", true)
   lineNumbersVisible = prefs.getBoolean("editorLineNumbers", true)
 
-  def init(fileManager: FileManager, dirtyMonitor: DirtyMonitor, menuBar: MenuBar, actions: Seq[Action]): Unit = {
+  def init(fileManager: FileManager, dirtyMonitor: DirtyMonitor, menuBar: MainMenuBar, actions: Seq[Action]): Unit = {
     this.fileManager = fileManager
     this.dirtyMonitor = dirtyMonitor
     this.menuBar = menuBar

--- a/netlogo-gui/src/main/app/ToolActions.scala
+++ b/netlogo-gui/src/main/app/ToolActions.scala
@@ -159,8 +159,12 @@ class ConvertWidgetSizes(frame: Frame, widgetPanel: WidgetPanel)
       case 0 =>
         widgetPanel.convertWidgetSizes(true)
 
+        App.app.smartPack(frame.getPreferredSize, false)
+
       case 1 =>
         widgetPanel.convertWidgetSizes(false)
+
+        App.app.smartPack(frame.getPreferredSize, false)
 
       case _ =>
     }

--- a/netlogo-gui/src/main/app/interfacetab/InterfacePanel.scala
+++ b/netlogo-gui/src/main/app/interfacetab/InterfacePanel.scala
@@ -42,7 +42,6 @@ class InterfacePanel(val viewWidget: ViewWidgetInterface, workspace: GUIWorkspac
   ///
 
   override def focusGained(e: FocusEvent): Unit = {
-    UndoManager.setCurrentManager(WidgetActions.undoManager)
     enableButtonKeys(true)
   }
 

--- a/netlogo-gui/src/main/app/interfacetab/InterfacePanel.scala
+++ b/netlogo-gui/src/main/app/interfacetab/InterfacePanel.scala
@@ -15,7 +15,7 @@ import org.nlogo.core.{
   AgentKind, I18N, Button => CoreButton, Chooser => CoreChooser, InputBox => CoreInputBox, Monitor => CoreMonitor,
   Output => CoreOutput, Plot => CorePlot, Slider => CoreSlider, Switch => CoreSwitch, TextBox => CoreTextBox,
   View => CoreView, Widget => CoreWidget }
-import org.nlogo.editor.{ Colorizer, EditorArea, UndoManager }
+import org.nlogo.editor.{ Colorizer, EditorArea }
 import org.nlogo.log.LogManager
 import org.nlogo.swing.{ MenuItem, PopupMenu }
 import org.nlogo.window.{ ButtonWidget, ChooserWidget, Editable, Events => WindowEvents, GUIWorkspace, InputBoxWidget,

--- a/netlogo-gui/src/main/app/interfacetab/InterfacePanel.scala
+++ b/netlogo-gui/src/main/app/interfacetab/InterfacePanel.scala
@@ -46,12 +46,6 @@ class InterfacePanel(val viewWidget: ViewWidgetInterface, workspace: GUIWorkspac
   }
 
   override def focusLost(e: FocusEvent): Unit = {
-    if (interfaceMode == InterfaceMode.Add) {
-      setInterfaceMode(InterfaceMode.Interact, false)
-    } else if (interfaceMode == InterfaceMode.Interact) {
-      interceptPane.disableIntercept()
-    }
-
     enableButtonKeys(false)
   }
 

--- a/netlogo-gui/src/main/app/interfacetab/WidgetPanel.scala
+++ b/netlogo-gui/src/main/app/interfacetab/WidgetPanel.scala
@@ -230,7 +230,7 @@ class WidgetPanel(val workspace: GUIWorkspace)
     getWrappers.filter(ww => ww.getBounds().contains(point)).sortBy(getPosition(_)).headOption
 
   override def empty: Boolean =
-    getComponents.exists {
+    !getComponents.exists {
       case w: WidgetWrapper => true
       case _ => false
     }

--- a/netlogo-gui/src/main/app/interfacetab/WidgetPanel.scala
+++ b/netlogo-gui/src/main/app/interfacetab/WidgetPanel.scala
@@ -3,8 +3,8 @@
 package org.nlogo.app.interfacetab
 
 import java.awt.{ Component, Dimension, Graphics, MouseInfo, Point, Rectangle, Color => AwtColor }
-import java.awt.event.{ ActionEvent, KeyAdapter, KeyEvent, KeyListener, MouseAdapter, MouseEvent, MouseListener,
-                        MouseMotionAdapter, MouseMotionListener }
+import java.awt.event.{ ActionEvent, FocusEvent, FocusAdapter, KeyAdapter, KeyEvent, KeyListener, MouseAdapter,
+                        MouseEvent, MouseListener, MouseMotionAdapter, MouseMotionListener }
 import javax.swing.{ AbstractAction, JComponent, JLayeredPane, SwingUtilities }
 
 import org.nlogo.app.common.EditorFactory
@@ -12,7 +12,7 @@ import org.nlogo.awt.{ Fonts => NlogoFonts, Mouse => NlogoMouse }
 import org.nlogo.core.{ I18N, Button => CoreButton, Chooser => CoreChooser, InputBox => CoreInputBox,
   Monitor => CoreMonitor, Plot => CorePlot, Slider => CoreSlider, Switch => CoreSwitch, TextBox => CoreTextBox,
   View => CoreView, Widget => CoreWidget }
-import org.nlogo.editor.{ EditorArea, EditorConfiguration }
+import org.nlogo.editor.{ EditorArea, EditorConfiguration, UndoManager }
 import org.nlogo.log.LogManager
 import org.nlogo.nvm.DefaultCompilerServices
 import org.nlogo.swing.{ MenuItem, PopupMenu }
@@ -170,6 +170,12 @@ class WidgetPanel(val workspace: GUIWorkspace)
   addMouseListener(this)
   addMouseMotionListener(this)
   addKeyListener(this)
+
+  addFocusListener(new FocusAdapter {
+    override def focusGained(e: FocusEvent): Unit = {
+      UndoManager.setCurrentManager(WidgetActions.undoManager)
+    }
+  })
 
   // our children may overlap
   override def isOptimizedDrawingEnabled: Boolean = false

--- a/netlogo-gui/src/main/app/interfacetab/WidgetPanel.scala
+++ b/netlogo-gui/src/main/app/interfacetab/WidgetPanel.scala
@@ -175,6 +175,14 @@ class WidgetPanel(val workspace: GUIWorkspace)
     override def focusGained(e: FocusEvent): Unit = {
       UndoManager.setCurrentManager(WidgetActions.undoManager)
     }
+
+    override def focusLost(e: FocusEvent): Unit = {
+      if (interfaceMode == InterfaceMode.Add) {
+        setInterfaceMode(InterfaceMode.Interact, false)
+      } else if (interfaceMode == InterfaceMode.Interact) {
+        interceptPane.disableIntercept()
+      }
+    }
   })
 
   // our children may overlap

--- a/netlogo-gui/src/main/app/interfacetab/WidgetPanel.scala
+++ b/netlogo-gui/src/main/app/interfacetab/WidgetPanel.scala
@@ -1304,7 +1304,7 @@ class WidgetPanel(val workspace: GUIWorkspace)
   // of widgets like the note widget for improved aesthetics. this happens in two phases, first on the
   // x axis and then on the y axis, which although slightly less efficient allows for more accurate
   // repositioning of the widgets. (Isaac B 3/1/25)
-  def convertWidgetSizes(reposition: Boolean): Unit = {
+  override def convertWidgetSizes(reposition: Boolean): Unit = {
     setInterfaceMode(InterfaceMode.Interact, true)
 
     val originalBounds = getWrappers.map(w => (w, w.getBounds()))

--- a/netlogo-gui/src/main/hubnet/client/ClientApp.scala
+++ b/netlogo-gui/src/main/hubnet/client/ClientApp.scala
@@ -7,7 +7,7 @@ import javax.swing.{WindowConstants, JFrame}
 import org.nlogo.api.CompilerServices
 import org.nlogo.core.I18N
 import org.nlogo.window.{ ClientAppInterface, DefaultEditorFactory }
-import org.nlogo.swing.{ Implicits, ModalProgressTask, OptionPane, SetSystemLookAndFeel }, Implicits._
+import org.nlogo.swing.{ Implicits, ModalProgress, ModalProgressTask, OptionPane, SetSystemLookAndFeel }, Implicits._
 import org.nlogo.theme.InterfaceColors
 import org.nlogo.awt.{ Hierarchy, Images, Positioning, EventQueue }
 import org.nlogo.hubnet.connection.Ports
@@ -52,7 +52,7 @@ object ClientApp {
   }
 }
 
-class ClientApp extends JFrame("HubNet") with ErrorHandler with ClientAppInterface {
+class ClientApp extends JFrame("HubNet") with ErrorHandler with ClientAppInterface with ModalProgress {
   import ClientApp.localClientIndex
 
   private var clientPanel: ClientPanel = null

--- a/netlogo-gui/src/main/hubnet/server/gui/HubNetClientEditor.scala
+++ b/netlogo-gui/src/main/hubnet/server/gui/HubNetClientEditor.scala
@@ -3,7 +3,7 @@
 package org.nlogo.hubnet.server.gui
 
 import java.awt.{ BorderLayout, Component, Dimension, GridBagConstraints, GridBagLayout, Insets }
-import java.awt.event.ActionEvent
+import java.awt.event.{ ActionEvent, WindowAdapter, WindowEvent }
 import javax.swing.{ AbstractAction, JFrame, JMenuBar, ScrollPaneConstants }
 
 import org.nlogo.api.ModelType
@@ -56,14 +56,18 @@ class HubNetClientEditor(workspace: GUIWorkspace,
     add(menuFactory.createHelpMenu)
   }
 
-  locally {
-    setTitle(getTitle(workspace.modelNameForDisplay, workspace.getModelDir, workspace.getModelType))
-    getContentPane.setLayout(new BorderLayout())
-    getContentPane.add(scrollPane, BorderLayout.CENTER)
-    getContentPane.add(toolbar, BorderLayout.NORTH)
-    setJMenuBar(menuBar)
-    setSize(getPreferredSize)
-  }
+  setTitle(getTitle(workspace.modelNameForDisplay, workspace.getModelDir, workspace.getModelType))
+  getContentPane.setLayout(new BorderLayout())
+  getContentPane.add(scrollPane, BorderLayout.CENTER)
+  getContentPane.add(toolbar, BorderLayout.NORTH)
+  setJMenuBar(menuBar)
+  setSize(getPreferredSize)
+
+  addWindowFocusListener(new WindowAdapter {
+    override def windowGainedFocus(e: WindowEvent): Unit = {
+      interfacePanel.requestFocus()
+    }
+  })
 
   override def getPreferredSize = if (interfacePanel.empty) new Dimension(700, 550) else super.getPreferredSize
   def getLinkParent = linkParent

--- a/netlogo-gui/src/main/hubnet/server/gui/HubNetClientEditor.scala
+++ b/netlogo-gui/src/main/hubnet/server/gui/HubNetClientEditor.scala
@@ -133,8 +133,12 @@ class HubNetClientEditor(workspace: GUIWorkspace,
         case 0 =>
           interfacePanel.convertWidgetSizes(true)
 
+          setSize(getPreferredSize)
+
         case 1 =>
           interfacePanel.convertWidgetSizes(false)
+
+          setSize(getPreferredSize)
 
         case _ =>
       }

--- a/netlogo-gui/src/main/hubnet/server/gui/HubNetClientEditor.scala
+++ b/netlogo-gui/src/main/hubnet/server/gui/HubNetClientEditor.scala
@@ -4,7 +4,7 @@ package org.nlogo.hubnet.server.gui
 
 import java.awt.{ BorderLayout, Component, Dimension, GridBagConstraints, GridBagLayout, Insets }
 import java.awt.event.{ ActionEvent, WindowAdapter, WindowEvent }
-import javax.swing.{ AbstractAction, JFrame, JMenuBar, ScrollPaneConstants }
+import javax.swing.{ AbstractAction, JFrame, ScrollPaneConstants }
 
 import org.nlogo.api.ModelType
 import org.nlogo.core.{ I18N, Widget => CoreWidget }

--- a/netlogo-gui/src/main/sdm/gui/AggregateModelEditor.scala
+++ b/netlogo-gui/src/main/sdm/gui/AggregateModelEditor.scala
@@ -17,7 +17,7 @@ import org.nlogo.awt.EventQueue
 import org.nlogo.core.{ CompilerException, I18N }
 import org.nlogo.editor.Colorizer
 import org.nlogo.sdm.Translator
-import org.nlogo.swing.{ MenuItem, NetLogoIcon, Utils => SwingUtils }
+import org.nlogo.swing.{ MenuBar, MenuItem, NetLogoIcon, Utils => SwingUtils }
 import org.nlogo.theme.{ InterfaceColors, ThemeSync }
 import org.nlogo.window.{ Editable, EditDialogFactory, Events, MenuBarFactory }
 import org.nlogo.window.Event.LinkChild
@@ -250,29 +250,6 @@ class AggregateModelEditor(
     tabs.syncTheme()
     toolbar.syncTheme()
     view.syncTheme()
-  }
-
-  private class MenuBar extends JMenuBar with ThemeSync {
-    override def paintComponent(g: Graphics): Unit = {
-      val g2d = SwingUtils.initGraphics2D(g)
-
-      g2d.setColor(InterfaceColors.menuBackground())
-      g2d.fillRect(0, 0, getWidth, getHeight)
-    }
-
-    override def paintBorder(g: Graphics): Unit = {
-      val g2d = SwingUtils.initGraphics2D(g)
-
-      g2d.setColor(InterfaceColors.menuBarBorder())
-      g2d.drawLine(0, getHeight - 1, getWidth, getHeight - 1)
-    }
-
-    def syncTheme(): Unit = {
-      getComponents.foreach(_ match {
-        case ts: ThemeSync => ts.syncTheme()
-        case _ =>
-      })
-    }
   }
 
   private class SyncedCommandMenu(name: String) extends CommandMenu(name) with ThemeSync {

--- a/netlogo-gui/src/main/sdm/gui/AggregateModelEditor.scala
+++ b/netlogo-gui/src/main/sdm/gui/AggregateModelEditor.scala
@@ -2,9 +2,9 @@
 
 package org.nlogo.sdm.gui
 
-import java.awt.{ Component, Dimension, Graphics }
+import java.awt.{ Component, Dimension }
 import java.awt.event.ActionEvent
-import javax.swing.{ AbstractAction, JFrame, JMenuBar, JMenuItem, JPopupMenu, WindowConstants },
+import javax.swing.{ AbstractAction, JFrame, JMenuItem, JPopupMenu, WindowConstants },
   WindowConstants.HIDE_ON_CLOSE
 import javax.swing.border.LineBorder
 import javax.swing.plaf.basic.BasicMenuUI
@@ -17,7 +17,7 @@ import org.nlogo.awt.EventQueue
 import org.nlogo.core.{ CompilerException, I18N }
 import org.nlogo.editor.Colorizer
 import org.nlogo.sdm.Translator
-import org.nlogo.swing.{ MenuBar, MenuItem, NetLogoIcon, Utils => SwingUtils }
+import org.nlogo.swing.{ MenuBar, MenuItem, NetLogoIcon }
 import org.nlogo.theme.{ InterfaceColors, ThemeSync }
 import org.nlogo.window.{ Editable, EditDialogFactory, Events, MenuBarFactory }
 import org.nlogo.window.Event.LinkChild

--- a/netlogo-gui/src/main/swing/MenuBar.scala
+++ b/netlogo-gui/src/main/swing/MenuBar.scala
@@ -1,0 +1,31 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.swing
+
+import java.awt.Graphics
+import javax.swing.JMenuBar
+
+import org.nlogo.theme.{ InterfaceColors, ThemeSync }
+
+class MenuBar extends JMenuBar with ThemeSync {
+  override def paintComponent(g: Graphics): Unit = {
+    val g2d = Utils.initGraphics2D(g)
+
+    g2d.setColor(InterfaceColors.menuBackground())
+    g2d.fillRect(0, 0, getWidth, getHeight)
+  }
+
+  override def paintBorder(g: Graphics): Unit = {
+    val g2d = Utils.initGraphics2D(g)
+
+    g2d.setColor(InterfaceColors.menuBarBorder())
+    g2d.drawLine(0, getHeight - 1, getWidth, getHeight - 1)
+  }
+
+  override def syncTheme(): Unit = {
+    getSubElements.foreach(_ match {
+      case ts: ThemeSync => ts.syncTheme()
+      case _ =>
+    })
+  }
+}

--- a/netlogo-gui/src/main/swing/ModalProgressTask.scala
+++ b/netlogo-gui/src/main/swing/ModalProgressTask.scala
@@ -2,16 +2,40 @@
 
 package org.nlogo.swing
 
-import java.awt.Frame
+import java.awt.{ Frame, SecondaryLoop, Toolkit }
+import javax.swing.JFrame
 
 import org.nlogo.awt.EventQueue
 
 import scala.concurrent.{ Await, Promise }
 import scala.concurrent.duration.{ Duration, MILLISECONDS }
 
-trait ModalProgress {
-  def showModalProgressPanel(message: String): Unit
-  def hideModalProgressPanel(): Unit
+trait ModalProgress extends JFrame {
+  private val panel = new ModalProgressPanel
+
+  private var loop: Option[SecondaryLoop] = None
+
+  setGlassPane(panel)
+
+  def showModalProgressPanel(message: String): Unit = {
+    panel.setMessage(message)
+
+    getGlassPane.setVisible(true)
+
+    loop = Option(Toolkit.getDefaultToolkit.getSystemEventQueue.createSecondaryLoop())
+
+    loop.foreach(_.enter())
+  }
+
+  def hideModalProgressPanel(): Unit = {
+    getGlassPane.setVisible(false)
+
+    loop.foreach(_.exit())
+
+    loop = None
+
+    repaint()
+  }
 }
 
 object ModalProgressTask {

--- a/netlogo-gui/src/main/window/AbstractWidgetPanel.scala
+++ b/netlogo-gui/src/main/window/AbstractWidgetPanel.scala
@@ -11,6 +11,7 @@ abstract class AbstractWidgetPanel extends JLayeredPane with Zoomable with Theme
   def removeAllWidgets(): Unit
   def getWidgetsForSaving: Seq[CoreWidget]
   def loadWidgets(widgets: Seq[CoreWidget], widgetSizesOption: WidgetSizes): Unit
+  def convertWidgetSizes(reposition: Boolean): Unit
   def hasView: Boolean
   def empty: Boolean
   def setBoldWidgetText(value: Boolean): Unit

--- a/netlogo-gui/src/main/window/DummyButtonWidget.scala
+++ b/netlogo-gui/src/main/window/DummyButtonWidget.scala
@@ -2,9 +2,9 @@
 
 package org.nlogo.window
 
-import java.awt.{ Dimension, Graphics }
+import java.awt.Dimension
+import javax.swing.JLabel
 
-import org.nlogo.awt.Fonts
 import org.nlogo.core.{ AgentKind, I18N, Button => CoreButton, Widget => CoreWidget }
 import org.nlogo.theme.InterfaceColors
 
@@ -20,12 +20,24 @@ class DummyButtonWidget extends SingleErrorWidget with Editable {
   private var _keyEnabled: Boolean = false
   private var _name: String = ""
 
+  private val nameLabel = new JLabel
+  private val keyLabel = new JLabel
+
+  keyLabel.setFont(keyLabel.getFont.deriveFont(11.0f))
+
+  setLayout(null)
+
+  add(nameLabel)
+  add(keyLabel)
+
   override def editPanel: EditPanel = new DummyButtonEditPanel(this)
 
   def actionKey: Char = _actionKey
 
   def setActionKey(actionKey: Char): Unit = {
     _actionKey = actionKey
+    keyLabel.setText(actionKeyString)
+    repaint()
   }
 
   private def actionKeyString: String =
@@ -53,6 +65,8 @@ class DummyButtonWidget extends SingleErrorWidget with Editable {
   def setDisplayName(name: String): Unit = {
     _name = name
     displayName(name)
+    nameLabel.setText(displayName)
+    repaint()
   }
 
   /// sizing
@@ -63,45 +77,20 @@ class DummyButtonWidget extends SingleErrorWidget with Editable {
   override def getPreferredSize: Dimension =
     new Dimension(MinimumWidth.max(super.getPreferredSize.width), MinimumHeight.max(super.getPreferredSize.height))
 
-  /// painting
+  override def doLayout(): Unit = {
+    val nameSize = nameLabel.getPreferredSize
+    val keySize = keyLabel.getPreferredSize
 
-  override def paintComponent(g: Graphics): Unit = {
-    super.paintComponent(g)
-    val size = getSize()
-    val fontMetrics = g.getFontMetrics
-    val labelHeight =
-      fontMetrics.getMaxDescent + fontMetrics.getMaxAscent
-    val availableWidth = size.width - 8
-    val stringWidth = fontMetrics.stringWidth(displayName)
-    g.setColor(InterfaceColors.buttonText())
-
-    val shortString =
-      Fonts.shortenStringToFit(displayName, availableWidth, fontMetrics)
-
-    val nx =
-      if (stringWidth > availableWidth) 4
-      else (size.width / 2) - (stringWidth / 2)
-    val ny = (size.height / 2) + (labelHeight / 2)
-    g.drawString(shortString, nx, ny)
-
-    // now draw keyboard shortcut
-    if (actionKeyString != "") {
-      val ax = size.width - 4 - fontMetrics.stringWidth(actionKeyString)
-      val ay = fontMetrics.getMaxAscent + 2
-
-      g.setColor(
-        if (keyEnabled)
-          InterfaceColors.buttonText()
-        else
-          InterfaceColors.buttonTextDisabled()
-      )
-
-      g.drawString(actionKeyString, ax - 1, ay)
-    }
+    nameLabel.setBounds(getWidth / 2 - nameSize.width / 2, getHeight / 2 - nameSize.height / 2, nameSize.width,
+                        nameSize.height)
+    keyLabel.setBounds(getWidth - keySize.width - 4, 2, keySize.width, keySize.height)
   }
 
   override def syncTheme(): Unit = {
     setBackgroundColor(InterfaceColors.buttonBackground())
+
+    nameLabel.setForeground(InterfaceColors.buttonText())
+    keyLabel.setForeground(InterfaceColors.buttonText())
   }
 
   ///

--- a/netlogo-gui/src/main/window/Event.java
+++ b/netlogo-gui/src/main/window/Event.java
@@ -185,7 +185,7 @@ public abstract class Event {
         // findHandlers does the grunt work of actually
         // walking the component hierarchy looking for
         // handlers
-        handlersV = findHandlers(findTop(raiser), eventClass);
+        handlersV = new ArrayList<>(new HashSet<>(findHandlers(findTop(raiser), eventClass)));
         events.put(eventClass, handlersV);
       }
 


### PR DESCRIPTION
This PR fixes the following issues:

- The HubNet client editor has no menu bar on Windows or Linux and therefore no menu actions can be performed
- HubNet widget actions cannot be undone
- The Convert Widget Sizes tool does not work in the HubNet client editor
- Canceling a widget placement in the HubNet client editor causes inconsistent tool state
- HubNet client editor doesn't resize to fit widgets on load