### PR TITLE
Added BehaviorSearch tests to main GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,6 +101,7 @@ jobs:
         , "headless/Test/slow"
         , "nogen; headless/Test/fast"
         , "nogen; headless/Test/medium"
+        , "behaviorsearchProject/test"
         ]
 
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -415,7 +415,7 @@ lazy val netlogoCore = (project in file("netlogo-core")).
   settings(scalastyleSettings: _*).
   settings(Compile / compile / skip := true)
 
-// only exists for packaging
+// only exists for testing and packaging
 lazy val behaviorsearchProject: Project =
   project.in(file("behaviorsearch"))
     .dependsOn(netlogo % "test-internal->test;compile-internal->compile")


### PR DESCRIPTION
This PR updates the BehaviorSearch tests so they pass with the latest version of NetLogo and adds them to the main GitHub actions, per @TheBizzle's request.