### PR TITLE
I18N GUI Strings: remove duplicates

### DIFF
--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -343,13 +343,6 @@ dialog.userYesOrNo = User Yes or No
 # other dialogs
 dialog.about = About NetLogo
 
-# primitive dialogs
-dialog.userOneOf = User One Of
-dialog.userYesOrNo = User Yes or No
-
-# other dialogs
-dialog.about = About NetLogo
-
 # widget editors
 
 edit.general.invalidSettings = Invalid Settings


### PR DESCRIPTION
This PR removes duplicates from the English `.properties` file used for internationalization of the GUI.