### PR TITLE
I18N GUI Strings: add closing HTML tag

### DIFF
--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -585,7 +585,7 @@ tools.preferences.editorLineNumbers = Show line numbers
 tools.preferences.logging = Logging
 tools.preferences.logging.message = <html>The following preferences can be used to help you figure out what&#39;s<br>going \
   wrong when you encounter a bug or unexpected behavior.<br>With logging enabled, information about events that happen while NetLogo<br> \
-  is running will be written to the specified file on your computer.
+  is running will be written to the specified file on your computer.</html>
 tools.preferences.loggingEnabled = Enable logging
 tools.preferences.logDirectory = Directory to store logs
 tools.preferences.logEvents = Events to log


### PR DESCRIPTION
This PR adds a missing closing `html` tag to an English translation term.