### PR TITLE
Window 'Model Settings': i18n for window heading

### DIFF
--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -464,6 +464,7 @@ edit.text.markdown = Enable Markdown
 edit.switch.globalVar = Global Variable
 edit.switch.previewName = (switch)
 
+edit.viewSettings.modelSettings = Model Settings
 edit.viewSettings.world = World
 edit.viewSettings.view = View
 edit.viewSettings.tickCounter = Tick counter

--- a/netlogo-gui/src/main/window/WorldViewSettings.scala
+++ b/netlogo-gui/src/main/window/WorldViewSettings.scala
@@ -3,7 +3,7 @@
 package org.nlogo.window
 
 import org.nlogo.api.WorldPropertiesInterface
-import org.nlogo.core.{ CompilerException, UpdateMode, View => CoreView, Widget => CoreWidget, WorldDimensions }
+import org.nlogo.core.{ CompilerException, I18N, UpdateMode, View => CoreView, Widget => CoreWidget, WorldDimensions }
 import org.nlogo.workspace.WorldLoaderInterface
 
 trait WorldIntegerEditor {
@@ -40,8 +40,7 @@ abstract class WorldViewSettings(protected val workspace: GUIWorkspace, protecte
 
   protected var _error: Option[CompilerException] = None
 
-  def classDisplayName: String = "Model Settings"
-
+  def classDisplayName: String = I18N.gui.get("edit.viewSettings.modelSettings")
   def resizeWithProgress(showProgress: Boolean): Unit
 
   def model: CoreWidget


### PR DESCRIPTION
Currently, the heading title of the window 'Model Settings' is not localized yet.
This PR fixes that issue.
