### PR TITLE
Use English locale when converting to uppercase for parsing text from user

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -386,6 +386,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform).
         "org.scala-lang.modules" %%% "scala-parser-combinators" %    "2.4.0"
       ,          "org.scalatest" %%%                "scalatest" %   "3.2.19" % Test
       ,      "org.scalatestplus" %%%          "scalacheck-1-18" % "3.2.19.0" % Test
+      ,      "io.github.cquiroz" %%%       "scala-java-locales" %    "1.2.0"
       )
     }).
   jvmConfigure(_.dependsOn(sharedResources % "compile-internal->compile")).

--- a/netlogo-core/src/main/agent/CompilationManagement.scala
+++ b/netlogo-core/src/main/agent/CompilationManagement.scala
@@ -2,7 +2,7 @@
 
 package org.nlogo.agent
 
-import java.util.{ HashMap => JHashMap, Map => JMap }
+import java.util.{ HashMap => JHashMap, Locale, Map => JMap }
 
 import org.nlogo.{ core, api },
   core.{ AgentKind, Breed, NetLogoCore, Program },
@@ -87,7 +87,7 @@ trait CompilationManagement extends CoreWorld { this: AgentManagement =>
 
     programBreeds
       .filterNot {
-        case (name: String, _) => worldBreeds.containsKey(name.toUpperCase)
+        case (name: String, _) => worldBreeds.containsKey(name.toUpperCase(Locale.ENGLISH))
       }
       .foreach {
         case (name: String, breed: Breed) =>
@@ -96,7 +96,7 @@ trait CompilationManagement extends CoreWorld { this: AgentManagement =>
           if (breed.isLinkBreed) {
             agentset.setDirected(breed.isDirected)
           }
-          worldBreeds.put(name.toUpperCase, agentset)
+          worldBreeds.put(name.toUpperCase(Locale.ENGLISH), agentset)
       }
   }
 

--- a/netlogo-core/src/main/agent/DimensionManagement.scala
+++ b/netlogo-core/src/main/agent/DimensionManagement.scala
@@ -2,10 +2,11 @@
 
 package org.nlogo.agent
 
+import java.lang.{ Double => JDouble }
+import java.util.Locale
+
 import org.nlogo.api.{ AgentException, WorldDimensionException }
 import org.nlogo.core.WorldDimensions
-
-import java.lang.{ Double => JDouble }
 
 trait DimensionManagement { this: WorldJ =>
   def topology: Topology
@@ -67,7 +68,7 @@ trait DimensionManagement { this: WorldJ =>
     topology.isInstanceOf[Torus] || topology.isInstanceOf[HorizCylinder]
 
   def isDimensionVariable(variableName: String): Boolean =
-    dimensionVariableNames.contains(variableName.toUpperCase)
+    dimensionVariableNames.contains(variableName.toUpperCase(Locale.ENGLISH))
 
   @throws(classOf[WorldDimensionException])
   def setDimensionVariable(variableName: String, value: Int, d: WorldDimensions): WorldDimensions = {

--- a/netlogo-core/src/main/agent/ImporterJ.java
+++ b/netlogo-core/src/main/agent/ImporterJ.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -563,7 +564,7 @@ public abstract class ImporterJ
   }
 
   boolean validBreed(String breed) {
-    return (world.getBreed(breed.toUpperCase()) != null)
+    return (world.getBreed(breed.toUpperCase(Locale.ENGLISH)) != null)
         || breed.equalsIgnoreCase("TURTLES")
         || breed.equalsIgnoreCase("PATCHES")
         || breed.equalsIgnoreCase("LINKS");

--- a/netlogo-core/src/main/agent/ObserverManagement.scala
+++ b/netlogo-core/src/main/agent/ObserverManagement.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.agent
 
+import java.util.Locale
+
 import org.nlogo.api.{ AgentException, LogoException }
 import org.nlogo.log.LogManager
 
@@ -18,7 +20,7 @@ trait ObserverManagement extends WorldKernel {
   @throws(classOf[AgentException])
   @throws(classOf[LogoException])
   def setObserverVariableByName(varName: String, value: Object): Unit = {
-    val index = observer.variableIndex(varName.toUpperCase)
+    val index = observer.variableIndex(varName.toUpperCase(Locale.ENGLISH))
     if (index != -1) {
       val oldValue = observer.getVariable(index)
       observer.setVariable(index, value)
@@ -29,7 +31,7 @@ trait ObserverManagement extends WorldKernel {
   }
 
   def getObserverVariableByName(varName: String): AnyRef = {
-    val index = observer.variableIndex(varName.toUpperCase)
+    val index = observer.variableIndex(varName.toUpperCase(Locale.ENGLISH))
     if (index >= 0)
       observer.variables(index)
     else

--- a/netlogo-core/src/main/agent/Realloc.scala
+++ b/netlogo-core/src/main/agent/Realloc.scala
@@ -1,7 +1,8 @@
 package org.nlogo.agent
 
-import
-  org.nlogo.core.{ AgentKind, Program }
+import java.util.Locale
+
+import org.nlogo.core.{ AgentKind, Program }
 
 object Realloc {
   def realloc(world: AgentManagement & CompilationManagement, oldProgram: Program, newProgram: Program): Unit = {
@@ -17,11 +18,11 @@ object Realloc {
     for(breedName <- newProgram.breeds.keys)
       world.breeds.put(breedName,
         Option(world.breeds.get(breedName)).getOrElse(
-          new TreeAgentSet(AgentKind.Turtle, breedName.toUpperCase)))
+          new TreeAgentSet(AgentKind.Turtle, breedName.toUpperCase(Locale.ENGLISH))))
     for(breedName <- newProgram.linkBreeds.keys)
       world.linkBreeds.put(breedName,
         Option(world.linkBreeds.get(breedName)).getOrElse(
-          new TreeAgentSet(AgentKind.Link, breedName.toUpperCase)))
+          new TreeAgentSet(AgentKind.Link, breedName.toUpperCase(Locale.ENGLISH))))
     // make sure directednesses are up-to-date
     for((name, breed) <- newProgram.linkBreeds)
       world.linkBreeds.get(name).setDirected(breed.isDirected)

--- a/netlogo-core/src/main/agent/World3D.scala
+++ b/netlogo-core/src/main/agent/World3D.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.agent
 
+import java.util.Locale
+
 import org.nlogo.api.{ AgentException, Color, ImporterUser,
   NetLogoThreeDDialect, WorldDimensionException }
 import org.nlogo.core.{ AgentKind, Program, WorldDimensions, WorldDimensions3D }
@@ -204,7 +206,7 @@ class World3D extends World
     program.breeds.foreach {
       case (name, breed) =>
         val agentset = new TreeAgentSet(AgentKind.Turtle, breed.name)
-        breeds.put(name.toUpperCase, agentset)
+        breeds.put(name.toUpperCase(Locale.ENGLISH), agentset)
     }
 
     _turtles.clear() // so a SimpleChangeEvent is published
@@ -285,7 +287,7 @@ class World3D extends World
   @throws(classOf[WorldDimensionException])
   override def setDimensionVariable(variableName: String, value: Int, d: WorldDimensions): WorldDimensions = {
     val wd = d.asInstanceOf[WorldDimensions3D]
-    variableName.toUpperCase match {
+    variableName.toUpperCase(Locale.ENGLISH) match {
       case "MIN-PZCOR" => wd.copyThreeD(minPzcor = value)
       case "MAX-PZCOR" => wd.copyThreeD(maxPzcor = value)
       case "WORLD-DEPTH" =>

--- a/netlogo-core/src/main/api/NetLogoLegacyDialect.scala
+++ b/netlogo-core/src/main/api/NetLogoLegacyDialect.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.api
 
+import java.util.Locale
+
 import org.nlogo.core.{ AgentVariableSet, Command, Dialect, Femto, Instruction, Reporter, Resource, Syntax,
                         TokenMapperInterface }
 
@@ -61,11 +63,11 @@ trait DelegatingMapper extends TokenMapperInterface {
   def overrideBreedInstruction(primName: String, breedName: String): Option[Instruction] = None
 
   def getCommand(s: String): Option[Command] =
-    commands.get(s.toUpperCase).map(instantiate[Command]) orElse
+    commands.get(s.toUpperCase(Locale.ENGLISH)).map(instantiate[Command]) orElse
       magicOpenToken(s) orElse defaultMapper.getCommand(s)
 
   def getReporter(s: String): Option[Reporter] =
-    reporters.get(s.toUpperCase).map(instantiate[Reporter]) orElse
+    reporters.get(s.toUpperCase(Locale.ENGLISH)).map(instantiate[Reporter]) orElse
       defaultMapper.getReporter(s)
 
   def breedInstruction(primName: String, breedName: String): Option[Instruction] =

--- a/netlogo-core/src/main/fileformat/PlotConverter.scala
+++ b/netlogo-core/src/main/fileformat/PlotConverter.scala
@@ -3,6 +3,7 @@
 package org.nlogo.fileformat
 
 import java.nio.file.Path
+import java.util.Locale
 
 import org.nlogo.core.{ CompilationEnvironment, Dialect, ExtensionManager,
   LibraryManager, LiteralParser, Model, Plot, SourceRewriter }
@@ -32,7 +33,7 @@ object PlotConverter {
             case (original, index) => {
               var new_name = s"${original}_${index}"
               var new_index = index
-              while(groupedNames.map(_._1).contains(new_name.toUpperCase)){
+              while(groupedNames.map(_._1).contains(new_name.toUpperCase(Locale.ENGLISH))){
                 new_index = new_index + 1
                 new_name  = s"${original}_${new_index}"
               }
@@ -45,11 +46,12 @@ object PlotConverter {
 
   private[fileformat] def determinePenSubstitutions(names: Seq[(String, Seq[String])]): Seq[(String, Seq[(String, String)])] = {
     names.map(plotAndPens =>
-        (plotAndPens._1, generateRenameMappings(plotAndPens._2.groupBy(_.toUpperCase).toSeq))).filterNot(_._2.isEmpty)
+        (plotAndPens._1, generateRenameMappings(plotAndPens._2.groupBy(_.toUpperCase(Locale.ENGLISH)).toSeq)))
+                                                              .filterNot(_._2.isEmpty)
   }
 
   private[fileformat] def determinePlotSubstitutions(names: Seq[String]): Seq[(String, String)] = {
-    generateRenameMappings(names.groupBy(_.toUpperCase).toSeq)
+    generateRenameMappings(names.groupBy(_.toUpperCase(Locale.ENGLISH)).toSeq)
   }
 
   private def modifyPlotNameKeys(groupedPlotAndPens: Seq[(String, Seq[(String, String)])], nameMappings: Seq[(String, String)]): Seq[(String, Seq[(String, String)])] =

--- a/netlogo-core/src/main/lab/Worker.scala
+++ b/netlogo-core/src/main/lab/Worker.scala
@@ -2,11 +2,14 @@
 
 package org.nlogo.lab
 
-import java.util.concurrent.{Callable, Executors, TimeUnit}
+import java.util.Locale
+import java.util.concurrent.{ Callable, Executors, TimeUnit }
+
 import org.nlogo.core.{ AgentKind, I18N, WorldDimensions }
-import org.nlogo.api.{Dump, ExportPlotWarningAction, LabProtocol,
-  LogoException, MersenneTwisterFast, LabPostProcessorInputFormat, WorldDimensionException, SimpleJobOwner}
-import org.nlogo.nvm.{Command, LabInterface, Workspace}
+import org.nlogo.api.{ Dump, ExportPlotWarningAction, LabProtocol,
+  LogoException, MersenneTwisterFast, LabPostProcessorInputFormat, WorldDimensionException, SimpleJobOwner }
+import org.nlogo.nvm.{ Command, LabInterface, Workspace }
+
 import LabInterface.ProgressListener
 
 class Worker(val protocol: LabProtocol, val supervisorWriting: () => Unit = () => {})
@@ -169,7 +172,7 @@ class Worker(val protocol: LabProtocol, val supervisorWriting: () => Unit = () =
         for((name, value) <- settings)
           if (!world.isDimensionVariable(name) && !name.equalsIgnoreCase("RANDOM-SEED"))
             ws.world.synchronized {
-              if (ws.world.observerOwnsIndexOf(name.toUpperCase) == -1)
+              if (ws.world.observerOwnsIndexOf(name.toUpperCase(Locale.ENGLISH)) == -1)
                 throw new FailedException(
                   "Global variable does not exist:\n" + name)
               ws.world.setObserverVariableByName(name, value)

--- a/netlogo-core/src/main/nvm/Instruction.scala
+++ b/netlogo-core/src/main/nvm/Instruction.scala
@@ -2,10 +2,11 @@
 
 package org.nlogo.nvm
 
+import java.util.{ List => JList, Locale }
+
 import org.nlogo.core.{ AgentKind, I18N, LogoList, Syntax, Token, TokenHolder }
 import org.nlogo.api.{ AnonymousReporter => ApiAnonymousReporter, AnonymousCommand => ApiAnonymousCommand }
 import org.nlogo.agent.{ Agent, AgentSet, AgentBit, Turtle, Patch, Link }
-import java.util.{ List => JList }
 
 object Instruction {
   def agentKindDescription(kind: AgentKind): String = {
@@ -308,12 +309,13 @@ abstract class Instruction extends InstructionJ with TokenHolder {
    * instead returning the displayName() of the GeneratedInstruction. ~Forrest (summer 2006)
    */
   def displayName: String =
-    if (token != null)
-      token.text.toUpperCase
-    else
+    if (token != null) {
+      token.text.toUpperCase(Locale.ENGLISH)
+    } else {
       // well, returning some weird ugly internal class name
       // is better than nothing, I guess
       getClass.getSimpleName
+    }
 
   override def toString =
     getClass.getSimpleName

--- a/netlogo-core/src/main/sdm/Translator.scala
+++ b/netlogo-core/src/main/sdm/Translator.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.sdm
 
+import java.util.Locale
+
 import org.nlogo.core.{ CompilerException, LiteralParser }
 
 /**
@@ -22,7 +24,7 @@ class Translator(model: Model, compiler: LiteralParser) {
       case r: Rate => if(!r.expression.isEmpty) rates += r
       case c: Converter =>
         if(!c.expression.isEmpty)
-          if(isConstant(c.expression.toUpperCase))
+          if(isConstant(c.expression.toUpperCase(Locale.ENGLISH)))
             constantConverters += c
           else converters += c
       case _ => // ignore
@@ -132,10 +134,10 @@ class Translator(model: Model, compiler: LiteralParser) {
     // Stock ordering is as follows: constants first, then alphabetical by name.  Ideally we should
     // also order depending upon which expressions refer to other stocks.  -- 11/09/05 CLB
     def compare(s1: Stock, s2: Stock) = {
-      val sname1 = s1.name.toUpperCase
-      val sname2 = s2.name.toUpperCase
-      val sexp1 = s1.initialValueExpression.toUpperCase
-      val sexp2 = s2.initialValueExpression.toUpperCase
+      val sname1 = s1.name.toUpperCase(Locale.ENGLISH)
+      val sname2 = s2.name.toUpperCase(Locale.ENGLISH)
+      val sexp1 = s1.initialValueExpression.toUpperCase(Locale.ENGLISH)
+      val sexp2 = s2.initialValueExpression.toUpperCase(Locale.ENGLISH)
       if(isConstant(sexp1))
         if(isConstant(sexp2))
           // both constant, compare names

--- a/netlogo-core/src/main/workspace/ModelsLibrary.scala
+++ b/netlogo-core/src/main/workspace/ModelsLibrary.scala
@@ -4,6 +4,7 @@ package org.nlogo.workspace
 
 import java.io.File
 import java.nio.file.{ Files, Path }
+import java.util.Locale
 import javax.swing.tree.DefaultMutableTreeNode
 
 import org.nlogo.api.{ FileIO, Version }
@@ -48,20 +49,20 @@ object ModelsLibrary {
 
     def exactMatch(node: Node): Option[Seq[String]] =
       node.depthFirstIterable
-        .find(n => n.name.toUpperCase.startsWith(s"${targetName.toUpperCase}.NLOGOX"))
+        .find(n => n.name.toUpperCase(Locale.ENGLISH).startsWith(s"${targetName.toUpperCase(Locale.ENGLISH)}.NLOGOX"))
         .filter(_.isLeaf)
         .map(n => Seq(n.name))
 
     def initialMatch(node: Node): Seq[String] =
       node.depthFirstIterable
-        .filter(n => n.name.toUpperCase.startsWith(targetName.toUpperCase))
+        .filter(n => n.name.toUpperCase(Locale.ENGLISH).startsWith(targetName.toUpperCase(Locale.ENGLISH)))
         .filter(_.isLeaf)
         .map(n => n.name)
         .toSeq
 
     def anywhereMatch(node: Node): Seq[String] =
       node.depthFirstIterable
-        .filter(n => n.name.toUpperCase.contains(targetName.toUpperCase))
+        .filter(n => n.name.toUpperCase(Locale.ENGLISH).contains(targetName.toUpperCase(Locale.ENGLISH)))
         .filter(_.isLeaf)
         .map(n => n.name)
         .toSeq
@@ -87,7 +88,8 @@ object ModelsLibrary {
     rootNode.flatMap {
       _.depthFirstIterable
         .find(n =>
-            n.path.toUpperCase.split(File.separator(0)).last.startsWith(s"${targetName.toUpperCase}"))
+            n.path.toUpperCase(Locale.ENGLISH).split(File.separator(0)).last
+             .startsWith(s"${targetName.toUpperCase(Locale.ENGLISH)}"))
         .map(_.path)
     }
   }
@@ -180,7 +182,7 @@ object ModelsLibrary {
             if (Files.isDirectory(p)) {
               scanDirectory(p, exclusive, nameOverride)
             } else {
-              val fileName = p.getFileName.toString.toUpperCase
+              val fileName = p.getFileName.toString.toUpperCase(Locale.ENGLISH)
               if (fileName.endsWith(".NLOGO") || fileName.endsWith(".NLOGO3D") ||
                   fileName.endsWith(".NLOGOX") || fileName.endsWith(".NLOGOX3D")) {
                 Some(Leaf(p.getFileName.toString, p.toString))
@@ -208,15 +210,15 @@ object ModelsLibrary {
   object NLogoModelOrdering
     extends scala.math.Ordering[String] {
     def compare(s1: String, s2: String): Int =
-      if (s2.toUpperCase == "UNVERIFIED")
+      if (s2.toUpperCase(Locale.ENGLISH) == "UNVERIFIED")
         -1
-      else if (s1.toUpperCase == "UNVERIFIED")
+      else if (s1.toUpperCase(Locale.ENGLISH) == "UNVERIFIED")
         1
       else
         String.CASE_INSENSITIVE_ORDER.compare(munge(s1), munge(s2))
 
     private def munge(_s: String): String = {
-      val s = _s.toUpperCase()
+      val s = _s.toUpperCase(Locale.ENGLISH)
       if (s.endsWith(".NLOGOX"))        s.substring(0, s.length - 7)
       else if (s.endsWith(".NLOGOX3D")) s.substring(0, s.length - 9)
       else                              s
@@ -243,7 +245,7 @@ object ModelsLibrary {
           Seq()
 
       def indexOf(s: String) = {
-        val i = orderedNames.indexOf(s.toUpperCase)
+        val i = orderedNames.indexOf(s.toUpperCase(Locale.ENGLISH))
         if (i == -1) orderedNames.length
         else i
       }

--- a/netlogo-core/src/test/headless/test/Parser.scala
+++ b/netlogo-core/src/test/headless/test/Parser.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.headless.test
 
+import java.util.Locale
+
 import org.nlogo.core.{AgentKind, Keywords}
 
 object Parser {
@@ -53,7 +55,7 @@ object Parser {
 
   def parse(line: String): Entry = {
     if (line.split(' ').headOption.exists(s =>
-        Keywords.isKeyword(s) || s.toUpperCase == "BREED"))
+        Keywords.isKeyword(s) || s.toUpperCase(Locale.ENGLISH) == "BREED"))
       Declaration(line)
     else line.trim match {
       case CommandErrorRegex(kind, command, err) =>

--- a/netlogo-gui/src/main/app/codetab/IncludedFilesMenu.scala
+++ b/netlogo-gui/src/main/app/codetab/IncludedFilesMenu.scala
@@ -5,6 +5,7 @@ package org.nlogo.app.codetab
 import java.awt.{ Dimension, FileDialog }
 import java.awt.event.ActionEvent
 import java.io.File
+import java.util.Locale
 import javax.swing.AbstractAction
 
 import scala.util.control.Exception.ignoring
@@ -55,11 +56,12 @@ with WindowEvents.CompiledEvent.Handler with RoundedBorderPanel with ThemeSync {
           menu.add(new MenuItem(I18N.gui.get("common.menus.empty"))).setEnabled(false)
 
         else {
-          filtered.sortBy(_.toUpperCase).foreach(include => menu.add(new MenuItem(new AbstractAction(include) {
-            def actionPerformed(e: ActionEvent): Unit = {
-              tabs.openExternalFile(includePaths(include))
-            }
-          })))
+          filtered.sortBy(_.toUpperCase(Locale.ENGLISH)).foreach(include =>
+            menu.add(new MenuItem(new AbstractAction(include) {
+              def actionPerformed(e: ActionEvent): Unit = {
+                tabs.openExternalFile(includePaths(include))
+              }
+            })))
         }
       case None =>
         menu.add(new MenuItem(I18N.gui.get("common.menus.empty"))).setEnabled(false)

--- a/netlogo-gui/src/main/app/codetab/SmartIndenter.scala
+++ b/netlogo-gui/src/main/app/codetab/SmartIndenter.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.app.codetab
 
+import java.util.Locale
+
 import org.nlogo.api.{ CompilerServices, EditorAreaInterface}
 import org.nlogo.core.{ Token, TokenType }
 import org.nlogo.editor.Indenter
@@ -218,9 +220,10 @@ extends Indenter {
       None
   }
 
-  private def indentationChange(indentLevels: List[Int], line: TokenizedLine, priorLine: Option[TokenizedLine], priorAdjustment: Option[LineIndent]): List[Int] = {
+  private def indentationChange(indentLevels: List[Int], line: TokenizedLine, priorLine: Option[TokenizedLine],
+                                priorAdjustment: Option[LineIndent]): List[Int] = {
     val priorIndentLevel = indentLevels.headOption.getOrElse(0)
-    line.tokens.headOption.map(t => (t.tpe, t.text.toUpperCase)) match {
+    line.tokens.headOption.map(t => (t.tpe, t.text.toUpperCase(Locale.ENGLISH))) match {
       case Some((TokenType.Keyword, ("TO" | "TO-REPORT"))) => List(TAB_WIDTH)
       case Some((TokenType.Keyword, _)) if line.bracketDelta == 0 => List()
       case Some((TokenType.OpenBracket, _)) if line.bracketDelta > 0 =>

--- a/netlogo-gui/src/main/app/common/FindDialog.scala
+++ b/netlogo-gui/src/main/app/common/FindDialog.scala
@@ -4,6 +4,7 @@ package org.nlogo.app.common
 
 import java.awt.{ BorderLayout, Frame, Toolkit }
 import java.awt.event.{ ActionEvent, ActionListener, FocusEvent }
+import java.util.Locale
 import javax.swing.{ AbstractAction, Action, Box, BoxLayout, JDialog, JEditorPane, JLabel, JPanel, SwingConstants }
 import javax.swing.border.EmptyBorder
 import javax.swing.text.{ BadLocationException, JTextComponent, TextAction }
@@ -338,8 +339,8 @@ class FindDialog(val owner: Frame) extends JDialog(owner, I18N.gui.get("dialog.f
 
     if (ignoreCase) {
       // this might get slow with big programs. should be tested. -AZS
-      searchMut = searchMut.toUpperCase
-      text = text.toUpperCase
+      searchMut = searchMut.toUpperCase(Locale.ENGLISH)
+      text = text.toUpperCase(Locale.ENGLISH)
     }
 
     var matchIndex = text.indexOf(searchMut, target.getSelectionEnd)
@@ -362,8 +363,8 @@ class FindDialog(val owner: Frame) extends JDialog(owner, I18N.gui.get("dialog.f
 
     if (ignoreCase) {
       // this might get slow with big programs. should be tested. -AZS
-      searchMut = searchMut.toUpperCase
-      text = text.toUpperCase
+      searchMut = searchMut.toUpperCase(Locale.ENGLISH)
+      text = text.toUpperCase(Locale.ENGLISH)
     }
 
     var matchIndex = text.lastIndexOf(searchMut, target.getSelectionStart - 1)

--- a/netlogo-gui/src/main/app/tools/AgentMonitorEditor.scala
+++ b/netlogo-gui/src/main/app/tools/AgentMonitorEditor.scala
@@ -4,6 +4,7 @@ package org.nlogo.app.tools
 
 import java.awt.{ BorderLayout, FlowLayout, Font, GridBagConstraints, GridBagLayout, Insets, Rectangle }
 import java.awt.event.{ FocusEvent, FocusListener, KeyEvent, KeyListener }
+import java.util.Locale
 import javax.swing.{ JLabel, JPanel, ScrollPaneConstants }
 
 import org.nlogo.agent.{ Agent, AgentSet, Turtle, Patch, Link }
@@ -417,7 +418,7 @@ with ThemeSync {
     if(text.equalsIgnoreCase("LINKS"))
       workspace.world.links
     else {
-      val breed = workspace.world.getLinkBreed(text.toUpperCase)
+      val breed = workspace.world.getLinkBreed(text.toUpperCase(Locale.ENGLISH))
       if(breed == null)
         throw new org.nlogo.api.AgentException(I18N.gui.get("tools.agentMonitor.editor.edpectedLinkBreed"))
       breed

--- a/netlogo-gui/src/main/app/tools/ModelsLibraryDialog.scala
+++ b/netlogo-gui/src/main/app/tools/ModelsLibraryDialog.scala
@@ -12,7 +12,7 @@ import java.awt.event.{ ActionEvent, KeyAdapter, KeyEvent, MouseAdapter, MouseEv
 import java.io.File
 import java.nio.file.Paths
 import java.net.URI
-import java.util.{ Enumeration, LinkedList, List => JList }
+import java.util.{ Enumeration, LinkedList, List => JList, Locale }
 import javax.swing.{ AbstractAction, Action, Box, BorderFactory, BoxLayout, InputMap, JComponent, JDialog, JEditorPane,
                      JLabel, JPanel, JTree, KeyStroke, SwingUtilities, WindowConstants }
 import javax.swing.text.{ BadLocationException, DefaultHighlighter }
@@ -401,7 +401,7 @@ class ModelsLibraryDialog(parent: Frame, node: Node)
     if (newText.length == 0) {
       searchText = None
     } else {
-      searchText = Some(newText.toUpperCase)
+      searchText = Some(newText.toUpperCase(Locale.ENGLISH))
     }
     val isEmpty = searchText.isEmpty
     val root = tree.getModel.getRoot.asInstanceOf[Node]
@@ -485,7 +485,7 @@ class ModelsLibraryDialog(parent: Frame, node: Node)
     if (searchText.isEmpty) {
       null
     } else {
-      val ucText = text.toUpperCase();
+      val ucText = text.toUpperCase(Locale.ENGLISH)
       val indices: JList[Integer] = new LinkedList[Integer]()
       var index = 0
       var containsCharacter = true
@@ -715,9 +715,9 @@ class ModelsLibraryDialog(parent: Frame, node: Node)
 
     private def matchesSearchText(node: Node): Boolean = {
       searchText.exists(t =>
-          node.name.toUpperCase.contains(t) ||
-          node.info.toUpperCase.contains(t) ||
-          node.path.toUpperCase.contains(t))
+          node.name.toUpperCase(Locale.ENGLISH).contains(t) ||
+          node.info.toUpperCase(Locale.ENGLISH).contains(t) ||
+          node.path.toUpperCase(Locale.ENGLISH).contains(t))
     }
   }
 

--- a/netlogo-gui/src/main/compile/Backifier.scala
+++ b/netlogo-gui/src/main/compile/Backifier.scala
@@ -2,9 +2,12 @@
 
 package org.nlogo.compile
 
-import scala.collection.immutable.ListMap
+import java.util.Locale
+
 import org.nlogo.core.{ Fail, I18N, Instantiator, Program, BreedIdentifierHandler }, Fail.exception
 import org.nlogo.{ api => nlogoApi, core, nvm, prim => nvmprim }
+
+import scala.collection.immutable.ListMap
 
 class Backifier(program: Program,
   extensionManager: core.ExtensionManager) extends api.Backifier {
@@ -113,7 +116,7 @@ class Backifier(program: Program,
   }
 
   private def fallback[T1 <: core.Instruction, T2 <: nvm.Instruction](i: T1): T2 = {
-    BreedIdentifierHandler.process(i.token.copy(value = i.token.text.toUpperCase)(), program) match {
+    BreedIdentifierHandler.process(i.token.copy(value = i.token.text.toUpperCase(Locale.ENGLISH))(), program) match {
       case None =>
         try {
           val klass = Class.forName(backifyName(i.getClass.getName))
@@ -138,7 +141,7 @@ class Backifier(program: Program,
     val result: nvm.Command = c match {
       case core.prim._extern(_) =>
         new nvmprim._extern(
-          extensionManager.replaceIdentifier(c.token.text.toUpperCase)
+          extensionManager.replaceIdentifier(c.token.text.toUpperCase(Locale.ENGLISH))
             .asInstanceOf[nlogoApi.Command])
 
       case core.prim._call(proc) =>
@@ -206,7 +209,7 @@ class Backifier(program: Program,
 
       case core.prim._externreport(_) =>
         new nvmprim._externreport(
-          extensionManager.replaceIdentifier(r.token.text.toUpperCase)
+          extensionManager.replaceIdentifier(r.token.text.toUpperCase(Locale.ENGLISH))
             .asInstanceOf[nlogoApi.Reporter])
 
       case core.prim._breedvariable(varName) =>

--- a/netlogo-gui/src/main/headless/HeadlessModelOpener.scala
+++ b/netlogo-gui/src/main/headless/HeadlessModelOpener.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.headless
 
+import java.util.Locale
+
 import org.nlogo.agent.{BooleanConstraint, ChooserConstraint, CompilationManagement,
   ConstantSliderConstraint, InputBoxConstraint, NumericConstraint }
 import org.nlogo.api.{ LogoException, NetLogoLegacyDialect, NetLogoThreeDDialect,
@@ -117,7 +119,7 @@ class HeadlessModelOpener(ws: HeadlessWorkspace) {
         case NumericInputConstraintSpecification(typeName, default) => new InputBoxConstraint(typeName, default)
         case _ => throw new IllegalStateException
       }
-      ws.world.observer.setConstraint(ws.world.observerOwnsIndexOf(vname.toUpperCase), con)
+      ws.world.observer.setConstraint(ws.world.observerOwnsIndexOf(vname.toUpperCase(Locale.ENGLISH)), con)
     }
 
     ws.command(interfaceGlobalCommands)

--- a/netlogo-gui/src/main/ide/JumpToDeclaration.scala
+++ b/netlogo-gui/src/main/ide/JumpToDeclaration.scala
@@ -2,6 +2,7 @@
 
 package org.nlogo.ide
 
+import java.util.Locale
 import javax.swing.text.JTextComponent
 
 import org.nlogo.core._
@@ -57,11 +58,15 @@ object JumpToDeclaration {
             argIndex += 1
           }
         }
-        return globals.get(token.text.toUpperCase) orElse owns.get(token.text.toUpperCase) orElse functions.get(token.text.toUpperCase)
+        return globals.get(token.text.toUpperCase(Locale.ENGLISH))
+                      .orElse(owns.get(token.text.toUpperCase(Locale.ENGLISH)))
+                      .orElse(functions.get(token.text.toUpperCase(Locale.ENGLISH)))
       }
       i -= 1
     }
-    globals.get(token.text.toUpperCase) orElse owns.get(token.text.toUpperCase) orElse functions.get(token.text.toUpperCase)
+    globals.get(token.text.toUpperCase(Locale.ENGLISH))
+           .orElse(owns.get(token.text.toUpperCase(Locale.ENGLISH)))
+           .orElse(functions.get(token.text.toUpperCase(Locale.ENGLISH)))
   }
 
   /**
@@ -82,15 +87,15 @@ object JumpToDeclaration {
         while (token.tpe != TokenType.CloseBracket && i < tokens.length) {
           token = tokens(i)
           if (token.tpe == TokenType.Ident)
-            globals += token.text.toUpperCase -> token
+            globals += token.text.toUpperCase(Locale.ENGLISH) -> token
           i += 1
         }
-      } else if (token.text.toUpperCase.endsWith("-OWN")) {
+      } else if (token.text.toUpperCase(Locale.ENGLISH).endsWith("-OWN")) {
         i += 1
         while (token.tpe != TokenType.CloseBracket && i < tokens.length) {
           token = tokens(i)
-          if (token.tpe == TokenType.Ident && owns.get(token.text.toUpperCase).isEmpty) {
-            owns += token.text.toUpperCase -> token
+          if (token.tpe == TokenType.Ident && owns.get(token.text.toUpperCase(Locale.ENGLISH)).isEmpty) {
+            owns += token.text.toUpperCase(Locale.ENGLISH) -> token
           }
           i += 1
         }
@@ -98,7 +103,7 @@ object JumpToDeclaration {
         i += 1
         if(i < tokens.length) {
           token = tokens(i)
-          functions += token.text.toUpperCase -> token
+          functions += token.text.toUpperCase(Locale.ENGLISH) -> token
         }
       } else {
         i += 1

--- a/netlogo-gui/src/main/ide/NetLogoTokenMaker.scala
+++ b/netlogo-gui/src/main/ide/NetLogoTokenMaker.scala
@@ -2,6 +2,7 @@
 
 package org.nlogo.ide
 
+import java.util.Locale
 import javax.swing.text.Segment
 
 import org.fife.ui.rsyntaxtextarea.{ TokenMakerBase }
@@ -33,7 +34,7 @@ trait NetLogoTokenMaker extends TokenMakerBase {
       (dialect.agentVariables.implicitObserverVariableTypeMap.keySet ++
       dialect.agentVariables.implicitTurtleVariableTypeMap.keySet ++
       dialect.agentVariables.implicitPatchVariableTypeMap.keySet ++
-      dialect.agentVariables.implicitLinkVariableTypeMap.keySet).contains(t.text.toUpperCase)
+      dialect.agentVariables.implicitLinkVariableTypeMap.keySet).contains(t.text.toUpperCase(Locale.ENGLISH))
     }
 
     def tagToken(t: Token): Token = {
@@ -41,7 +42,7 @@ trait NetLogoTokenMaker extends TokenMakerBase {
       named.tpe match {
         case TokenType.Ident =>
           extensionManager.flatMap { manager =>
-            manager.cachedType(t.text.toUpperCase)
+            manager.cachedType(t.text.toUpperCase(Locale.ENGLISH))
               .map(tokenType => t.copy(tpe = tokenType)())
           }.getOrElse(t)
         case _ => named
@@ -60,9 +61,9 @@ trait NetLogoTokenMaker extends TokenMakerBase {
           case Keyword  => TokenTypes.RESERVED_WORD
           case Literal  => literalToken(namedToken.value)
           case _        =>
-            if (dialect.tokenMapper.getCommand(t.text.toUpperCase).isDefined)
+            if (dialect.tokenMapper.getCommand(t.text.toUpperCase(Locale.ENGLISH)).isDefined)
               TokenTypes.OPERATOR
-            else if (dialect.tokenMapper.getReporter(t.text.toUpperCase).isDefined)
+            else if (dialect.tokenMapper.getReporter(t.text.toUpperCase(Locale.ENGLISH)).isDefined)
               TokenTypes.FUNCTION
             else if (t.text.equalsIgnoreCase("BREED") && firstOnLine)
               TokenTypes.RESERVED_WORD

--- a/netlogo-gui/src/main/swing/FixedLengthDocument.scala
+++ b/netlogo-gui/src/main/swing/FixedLengthDocument.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.swing
 
+import java.util.Locale
+
 /**
  * enforces a given maximum length; also enforces all caps (that could easily be made optional)
  */
@@ -9,10 +11,10 @@ package org.nlogo.swing
 class FixedLengthDocument(maxLength: Int) extends javax.swing.text.PlainDocument {
   override def insertString(offset: Int, str: String, a: javax.swing.text.AttributeSet): Unit = {
     if(getLength + str.length <= maxLength)
-      super.insertString(offset, str.toUpperCase, a)
+      super.insertString(offset, str.toUpperCase(Locale.ENGLISH), a)
   }
   override def replace(offset: Int, length: Int, str: String, a: javax.swing.text.AttributeSet): Unit = {
     if(getLength - length + str.length <= maxLength )
-      super.replace(offset, length, str.toUpperCase, a)
+      super.replace(offset, length, str.toUpperCase(Locale.ENGLISH), a)
   }
 }

--- a/netlogo-gui/src/main/window/AbstractPlotWidget.scala
+++ b/netlogo-gui/src/main/window/AbstractPlotWidget.scala
@@ -4,6 +4,7 @@ package org.nlogo.window
 
 import java.awt.{ Color, Dimension, Graphics, GridBagConstraints, GridBagLayout, Insets }
 import java.awt.image.BufferedImage
+import java.util.Locale
 import javax.swing.{ JLabel, JPanel, SwingConstants }
 
 import org.nlogo.core.{ I18N, Pen => CorePen, Plot => CorePlot, Widget => CoreWidget }
@@ -355,10 +356,11 @@ abstract class AbstractPlotWidget(val plot: Plot, val plotManager: PlotManagerIn
   override def errorString: Option[String] = {
     val hasDuplicatedName =
       widgetContainer.map(_.allWidgets).getOrElse(Seq()).collect {
-        case p: CorePlot if p.display.map(_.toUpperCase).getOrElse("") == plotName.toUpperCase => p
+        case p: CorePlot if p.display.map(_.toUpperCase(Locale.ENGLISH))
+                                     .getOrElse("") == plotName.toUpperCase(Locale.ENGLISH) => p
       }.length > 1
     if (hasDuplicatedName) {
-      Some(I18N.gui.getN("edit.plot.name.duplicate", plotName.toUpperCase))
+      Some(I18N.gui.getN("edit.plot.name.duplicate", plotName.toUpperCase(Locale.ENGLISH)))
     } else {
       None
     }

--- a/netlogo-gui/src/main/window/CompilerManager.scala
+++ b/netlogo-gui/src/main/window/CompilerManager.scala
@@ -1,6 +1,8 @@
 // (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
 
-package org.nlogo.window;
+package org.nlogo.window
+
+import java.util.Locale
 
 import org.nlogo.core.{ CompilerException, Program }
 import org.nlogo.api.{ AgentException, Exceptions, JobOwner, LogoException, SourceOwner, ValueConstraint }
@@ -96,7 +98,7 @@ class CompilerManager(val workspace: AbstractWorkspace,
       compileAll()
     // this check is needed because it might be a brand new widget
     // that doesn't have a variable yet - ST 3/3/04
-    else if (world.observerOwnsIndexOf(widget.name.toUpperCase) != -1) {
+    else if (world.observerOwnsIndexOf(widget.name.toUpperCase(Locale.ENGLISH)) != -1) {
       if (e.updating) {
         widget.valueObject(world.getObserverVariableByName(widget.name))
       }
@@ -237,7 +239,7 @@ class CompilerManager(val workspace: AbstractWorkspace,
       try {
         // we could do `world.setObserverVariableByName()`, but since compilation may have failed we cannot rely on the
         // variable names existing - Jeremy B August 2019
-        val index = world.observerOwnsIndexOf(widget.name.toUpperCase)
+        val index = world.observerOwnsIndexOf(widget.name.toUpperCase(Locale.ENGLISH))
         if (index != -1) {
           world.observer.setVariable(index, widget.valueObject())
         }

--- a/netlogo-gui/src/main/window/GUIWorkspace.scala
+++ b/netlogo-gui/src/main/window/GUIWorkspace.scala
@@ -9,6 +9,7 @@ import java.io.{ IOException, InputStream, PrintWriter, Reader }
 import java.lang.Thread
 import java.net.MalformedURLException
 import java.nio.file.Paths
+import java.util.Locale
 import java.util.concurrent.TimeoutException
 import javax.swing.{ AbstractAction, Action, Timer }
 import javax.swing.border.LineBorder
@@ -782,7 +783,7 @@ abstract class GUIWorkspace(world: World, kioskLevel: GUIWorkspace.KioskLevel, f
 
   def handle(e: AddBooleanConstraintEvent): Unit = {
     // now we set the constraint in the observer, so that it is enforced.
-    val index = world.observerOwnsIndexOf(e.varname.toUpperCase)
+    val index = world.observerOwnsIndexOf(e.varname.toUpperCase(Locale.ENGLISH))
 
     if (index != -1)
       world.observer.setConstraint(index, new BooleanConstraint(e.defaultValue))
@@ -790,7 +791,7 @@ abstract class GUIWorkspace(world: World, kioskLevel: GUIWorkspace.KioskLevel, f
 
   def handle(e: AddInputBoxConstraintEvent): Unit = {
     // now we set the constraint in the observer, so that it is enforced.
-    val index = world.observerOwnsIndexOf(e.varname.toUpperCase)
+    val index = world.observerOwnsIndexOf(e.varname.toUpperCase(Locale.ENGLISH))
 
     if (index != -1)
       world.observer.setConstraint(index, e.constraint)
@@ -798,7 +799,7 @@ abstract class GUIWorkspace(world: World, kioskLevel: GUIWorkspace.KioskLevel, f
 
   def handle(e: AddChooserConstraintEvent): Unit = {
     // now we set the constraint in the observer, so that it is enforced.
-    val index = world.observerOwnsIndexOf(e.varname.toUpperCase)
+    val index = world.observerOwnsIndexOf(e.varname.toUpperCase(Locale.ENGLISH))
 
     if (index != -1)
       world.observer.setConstraint(index, e.constraint)
@@ -813,7 +814,7 @@ abstract class GUIWorkspace(world: World, kioskLevel: GUIWorkspace.KioskLevel, f
       e.slider.setSliderConstraint(con)
 
       // now we set the constraint in the observer, so that it is enforced.
-      val index = world.observerOwnsIndexOf(e.varname.toUpperCase)
+      val index = world.observerOwnsIndexOf(e.varname.toUpperCase(Locale.ENGLISH))
 
       if (index != -1)
         world.observer.setConstraint(index, con)
@@ -825,7 +826,7 @@ abstract class GUIWorkspace(world: World, kioskLevel: GUIWorkspace.KioskLevel, f
   }
 
   def handle(e: RemoveConstraintEvent): Unit = {
-    val index = world.observerOwnsIndexOf(e.varname.toUpperCase)
+    val index = world.observerOwnsIndexOf(e.varname.toUpperCase(Locale.ENGLISH))
 
     if (index != -1)
       world.observer.setConstraint(index, null)

--- a/netlogo-gui/src/main/window/PlotPensEditor.scala
+++ b/netlogo-gui/src/main/window/PlotPensEditor.scala
@@ -5,6 +5,7 @@ package org.nlogo.window
 import java.awt.{ BorderLayout, Color, Cursor, Dimension, Font, Frame, Graphics, GridBagConstraints, GridBagLayout,
                   Insets }
 import java.awt.event.ActionEvent
+import java.util.Locale
 import javax.swing.{ AbstractAction, AbstractCellEditor, JButton, JLabel, JPanel, JTable }
 import javax.swing.border.EmptyBorder
 import javax.swing.event.{ ListSelectionEvent, ListSelectionListener }
@@ -119,13 +120,13 @@ class PlotPensEditor(accessor: PropertyAccessor[List[PlotPen]], colorizer: Color
     val names = table.model.pens.map(_.name)
     // It was an intentional decision made Q2 2011 to allow multiple pens with
     // a blank name. - RG 2/21/2018
-    val groupedNames = (names.groupBy(_.toUpperCase) - "").toSeq
+    val groupedNames = (names.groupBy(_.toUpperCase(Locale.ENGLISH)) - "").toSeq
     val duplicateNames = groupedNames.filter(_._2.length > 1)
     if (duplicateNames.nonEmpty) {
       new OptionPane(this, I18N.gui.get("edit.plot.pen.invalidEntry"),
                      I18N.gui.getN("edit.plot.pen.duplicateNames",
-                                   duplicateNames.map(_._1.toUpperCase).mkString(", ")), OptionPane.Options.Ok,
-                     OptionPane.Icons.Error)
+                                   duplicateNames.map(_._1.toUpperCase(Locale.ENGLISH)).mkString(", ")),
+                     OptionPane.Options.Ok, OptionPane.Icons.Error)
       None
     } else {
       Some(table.getPlotPens)

--- a/netlogo-gui/src/main/window/QuickHelp.scala
+++ b/netlogo-gui/src/main/window/QuickHelp.scala
@@ -4,6 +4,7 @@ package org.nlogo.window
 
 import java.awt.Component
 import java.nio.file.Path
+import java.util.Locale
 
 import org.nlogo.api.{ FileIO, Version }
 import org.nlogo.core.I18N
@@ -62,8 +63,9 @@ object QuickHelp {
       openDictionary(comp, tokenLower, quickHelpWords)
     else {
       if (new OptionPane(comp, I18N.gui.get("common.netlogo"),
-                         I18N.gui.getN("tabs.code.rightclick.quickhelp.notfound", tokenLower.toUpperCase),
-                         OptionPane.Options.OkCancel, OptionPane.Icons.Error).getSelectedIndex == 0)
+                         I18N.gui.getN("tabs.code.rightclick.quickhelp.notfound",
+                         tokenLower.toUpperCase(Locale.ENGLISH)), OptionPane.Options.OkCancel,
+                         OptionPane.Icons.Error).getSelectedIndex == 0)
         BrowserLauncher.openPath(comp, docPath("index2.html"), null)
     }
   }

--- a/netlogo-gui/src/main/workspace/AbstractWorkspace.java
+++ b/netlogo-gui/src/main/workspace/AbstractWorkspace.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import scala.collection.mutable.WeakHashMap;
 import org.nlogo.agent.Agent;
@@ -228,7 +229,7 @@ public abstract class AbstractWorkspace
   public boolean isGlobalVariable(String name) {
     if (!_world.isDimensionVariable(name) && !name.equalsIgnoreCase("RANDOM-SEED")) {
       synchronized (_world) {
-        if (_world.observerOwnsIndexOf(name.toUpperCase()) == -1) {
+        if (_world.observerOwnsIndexOf(name.toUpperCase(Locale.ENGLISH)) == -1) {
           return false;
         }
       }

--- a/netlogo-gui/src/main/workspace/ExtensionManager.scala
+++ b/netlogo-gui/src/main/workspace/ExtensionManager.scala
@@ -5,7 +5,7 @@ package org.nlogo.workspace
 import java.io.{ Closeable, IOException, PrintWriter }
 import java.lang.{ ClassLoader, Iterable => JIterable }
 import java.net.URL
-import java.util.{ List => JList }
+import java.util.{ List => JList, Locale }
 
 import org.nlogo.api.{ ClassManager, Dump, ExtensionException, ImportErrorHandler, Reporter }
 import org.nlogo.core.{ CompilerException, ErrorSource, ExtensionObject, Primitive, PrimitiveCommand, PrimitiveReporter, TokenType }
@@ -63,7 +63,7 @@ object ExtensionManager {
 
   class JarContainer(val jarClassLoader: ClassLoader, data: ExtensionData) {
     val extensionName  = data.extensionName
-    val normalizedName = data.extensionName.toUpperCase
+    val normalizedName = data.extensionName.toUpperCase(Locale.ENGLISH)
     val fileURL        = data.fileURL
     val modified: Long = data.modified
     val primManager: ExtensionPrimitiveManager = new ExtensionPrimitiveManager(extensionName)
@@ -80,8 +80,8 @@ object ExtensionManager {
     }
 
     private def primName(name: String): String = {
-      if (primManager.autoImportPrimitives) name.toUpperCase
-      else s"${extensionName.toUpperCase}:${name.toUpperCase}"
+      if (primManager.autoImportPrimitives) name.toUpperCase(Locale.ENGLISH)
+      else s"${extensionName.toUpperCase(Locale.ENGLISH)}:${name.toUpperCase(Locale.ENGLISH)}"
     }
 
     def unload(extensionManager: ExtensionManager) = {
@@ -216,7 +216,7 @@ class ExtensionManager(val workspace: ExtendableWorkspace, loader: ExtensionLoad
 
   @throws(classOf[CompilerException])
   def readExtensionObject(extName: String, typeName: String, value: String): ExtensionObject = {
-    val upcaseExtName = extName.toUpperCase
+    val upcaseExtName = extName.toUpperCase(Locale.ENGLISH)
     def catchExtensionException(f: JarContainer => ExtensionObject): JarContainer => ExtensionObject = { (j: JarContainer) =>
       try { f(j) }
       catch {
@@ -233,7 +233,8 @@ class ExtensionManager(val workspace: ExtendableWorkspace, loader: ExtensionLoad
 
   def replaceIdentifier(name: String): Primitive = {
     val (primName, isRelevantJar) = name.split(":") match {
-      case Array(prefix, pname) => (pname, (jc: JarContainer) => prefix.toUpperCase == jc.normalizedName)
+      case Array(prefix, pname) => (pname, (jc: JarContainer) =>
+                                     prefix.toUpperCase(Locale.ENGLISH) == jc.normalizedName)
       case _                    => (name,  (jc: JarContainer) => jc.primManager.autoImportPrimitives)
     }
     jars.values.filter(liveJars.contains)
@@ -253,7 +254,7 @@ class ExtensionManager(val workspace: ExtendableWorkspace, loader: ExtensionLoad
     typeCache -= name
   }
 
-  def cachedType(name: String): Option[TokenType] = typeCache.get(name.toUpperCase)
+  def cachedType(name: String): Option[TokenType] = typeCache.get(name.toUpperCase(Locale.ENGLISH))
 
   def extensionCommandNames: Set[String] =
     typeCache.filter(_._2 == TokenType.Command).map(_._1).toSet

--- a/netlogo-headless/src/main/compile/Backifier.scala
+++ b/netlogo-headless/src/main/compile/Backifier.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.compile
 
+import java.util.Locale
+
 import org.nlogo.core.{Instantiator, BreedIdentifierHandler, Program}
 import org.nlogo.{ api => nlogoApi, core, nvm, prim => nvmprim },
   nvm.Procedure.ProceduresMap
@@ -17,7 +19,7 @@ class Backifier(
     name.replaceFirst("\\.core\\.", ".")
 
   private def fallback[T1 <: core.Instruction, T2 <: nvm.Instruction](i: T1): T2 =
-    BreedIdentifierHandler.process(i.token.copy(value = i.token.text.toUpperCase)(), program) match {
+    BreedIdentifierHandler.process(i.token.copy(value = i.token.text.toUpperCase(Locale.ENGLISH))(), program) match {
       case None =>
         Instantiator.newInstance[T2](
           Class.forName(backifyName(i.getClass.getName)))
@@ -30,7 +32,7 @@ class Backifier(
     val result = c match {
       case core.prim._extern(_) =>
         new nvmprim._extern(
-          extensionManager.replaceIdentifier(c.token.text.toUpperCase)
+          extensionManager.replaceIdentifier(c.token.text.toUpperCase(Locale.ENGLISH))
             .asInstanceOf[nlogoApi.Command])
 
       case core.prim._call(proc) =>
@@ -85,7 +87,7 @@ class Backifier(
 
       case core.prim._externreport(_) =>
         new nvmprim._externreport(
-          extensionManager.replaceIdentifier(r.token.text.toUpperCase)
+          extensionManager.replaceIdentifier(r.token.text.toUpperCase(Locale.ENGLISH))
             .asInstanceOf[nlogoApi.Reporter])
 
       case core.prim._breedvariable(varName) =>

--- a/netlogo-headless/src/main/headless/HeadlessModelOpener.scala
+++ b/netlogo-headless/src/main/headless/HeadlessModelOpener.scala
@@ -1,6 +1,8 @@
 // (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
 package org.nlogo.headless
 
+import java.util.Locale
+
 import org.nlogo.workspace
 import workspace.WorldLoader
 import org.nlogo.plot.PlotLoader
@@ -116,7 +118,7 @@ class HeadlessModelOpener(ws: HeadlessWorkspace) {
         case NumericInputConstraintSpecification(typeName, default) => new InputBoxConstraint(typeName, default)
         case _ => throw new IllegalStateException
       }
-      ws.world.observer.setConstraint(ws.world.observerOwnsIndexOf(vname.toUpperCase), con)
+      ws.world.observer.setConstraint(ws.world.observerOwnsIndexOf(vname.toUpperCase(Locale.ENGLISH)), con)
     }
 
     ws.command(interfaceGlobalCommands)

--- a/netlogo-headless/src/main/workspace/ExtensionManager.scala
+++ b/netlogo-headless/src/main/workspace/ExtensionManager.scala
@@ -3,6 +3,7 @@
 package org.nlogo.workspace
 
 import java.net.URL
+import java.util.Locale
 
 import org.nlogo.api.{ ClassManager, Dump, ExtensionException, ImportErrorHandler, Reporter }
 import org.nlogo.core.CompilerException
@@ -68,7 +69,7 @@ object ExtensionManager {
 
   class JarContainer(val jarClassLoader: ClassLoader, data: ExtensionData) {
     val extensionName  = data.extensionName
-    val normalizedName = data.extensionName.toUpperCase
+    val normalizedName = data.extensionName.toUpperCase(Locale.ENGLISH)
     val fileURL        = data.fileURL
     val modified: Long = data.modified
     val primManager: ExtensionPrimitiveManager = new ExtensionPrimitiveManager(extensionName)
@@ -205,7 +206,7 @@ class ExtensionManager(val workspace: ExtendableWorkspace, loader: ExtensionLoad
 
   @throws(classOf[CompilerException])
   def readExtensionObject(extName: String, typeName: String, value: String): ExtensionObject = {
-    val upcaseExtName = extName.toUpperCase
+    val upcaseExtName = extName.toUpperCase(Locale.ENGLISH)
     def catchExtensionException(f: JarContainer => ExtensionObject): JarContainer => ExtensionObject = { (j: JarContainer) =>
       try { f(j) }
       catch {
@@ -227,7 +228,7 @@ class ExtensionManager(val workspace: ExtendableWorkspace, loader: ExtensionLoad
           case Array(pr, pn) => (pr, pn)
           case _ => throw new IllegalStateException
         }
-        (pname, { (jc: JarContainer) => prefix.toUpperCase == jc.normalizedName })
+        (pname, { (jc: JarContainer) => prefix.toUpperCase(Locale.ENGLISH) == jc.normalizedName })
       } else
         (name,  { (jc: JarContainer) => jc.primManager.autoImportPrimitives })
     jars.values.filter(liveJars.contains)

--- a/netlogo-headless/src/main/workspace/Shell.scala
+++ b/netlogo-headless/src/main/workspace/Shell.scala
@@ -3,6 +3,7 @@
 package org.nlogo.workspace
 
 import java.io.{ BufferedReader, InputStreamReader }
+import java.util.Locale
 
 abstract class Shell {
   val input: Iterator[String] = {
@@ -12,6 +13,6 @@ abstract class Shell {
   }
 
   def isQuit(s: String) =
-    List(":QUIT", ":EXIT").contains(s.trim.toUpperCase)
+    List(":QUIT", ":EXIT").contains(s.trim.toUpperCase(Locale.ENGLISH))
 
 }

--- a/parser-core/src/main/core/Instruction.scala
+++ b/parser-core/src/main/core/Instruction.scala
@@ -2,12 +2,14 @@
 
 package org.nlogo.core
 
+import java.util.Locale
+
 trait Instruction extends TokenHolder {
   def syntax: Syntax
   var token: Token = null
   var agentClassString = syntax.agentClassString
   var blockAgentClassString = syntax.blockAgentClassString
-  def displayName = token.text.toUpperCase
+  def displayName = token.text.toUpperCase(Locale.ENGLISH)
 
   // Unfortunately, token and instruction are recursively referential and token
   // is immutable, so we must have a bit of ugliness here RG 1/8/2015

--- a/parser-core/src/main/core/Keywords.scala
+++ b/parser-core/src/main/core/Keywords.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.core
 
+import java.util.Locale
+
 // no "BREED" keyword because it conflicts with BREED turtle variable -- CLB
 
 object Keywords {
@@ -11,5 +13,5 @@ object Keywords {
     "DIRECTED-LINK-BREED", "UNDIRECTED-LINK-BREED",
     "EXTENSIONS", "__INCLUDES")
   def isKeyword(s: String) =
-    keywords.contains(s.toUpperCase) || s.toUpperCase.endsWith("-OWN")
+    keywords.contains(s.toUpperCase(Locale.ENGLISH)) || s.toUpperCase(Locale.ENGLISH).endsWith("-OWN")
 }

--- a/parser-core/src/main/core/Program.scala
+++ b/parser-core/src/main/core/Program.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.core
 
+import java.util.Locale
+
 import scala.collection.immutable.ListMap
 
 object Program {
@@ -31,7 +33,7 @@ case class Program(
   val observerVars = dialect.agentVariables.implicitObserverVariableTypeMap
 
   val globals: Seq[String] =
-    observerVars.keys.toSeq ++ interfaceGlobals.map(_.toUpperCase) ++ userGlobals
+    observerVars.keys.toSeq ++ interfaceGlobals.map(_.toUpperCase(Locale.ENGLISH)) ++ userGlobals
 
   val turtlesOwn = turtleVars.keys.toSeq
 

--- a/parser-core/src/main/core/prim/Lambda.scala
+++ b/parser-core/src/main/core/prim/Lambda.scala
@@ -3,6 +3,8 @@
 package org.nlogo.core
 package prim
 
+import java.util.Locale
+
 trait Lambda {
   def arguments: Lambda.Arguments
   def closedVariables: Set[ClosedVariable]
@@ -33,12 +35,12 @@ object Lambda {
     def argumentTokens: Seq[Token] = Seq()
   }
   case class UnbracketedArgument(t: Token) extends Arguments {
-    def argumentNames = Seq(t.text.toUpperCase)
+    def argumentNames = Seq(t.text.toUpperCase(Locale.ENGLISH))
     def argumentTokens: Seq[Token] = Seq(t)
     def argumentSyntax = Seq(Syntax.WildcardType)
   }
   case class BracketedArguments(argumentTokens: Seq[Token]) extends Arguments {
-    def argumentNames  = argumentTokens.map(_.text.toUpperCase)
+    def argumentNames  = argumentTokens.map(_.text.toUpperCase(Locale.ENGLISH))
     def argumentSyntax = argumentTokens.map(_ => Syntax.WildcardType)
   }
 }

--- a/parser-core/src/main/core/prim/misc.scala
+++ b/parser-core/src/main/core/prim/misc.scala
@@ -3,6 +3,8 @@
 package org.nlogo.core
 package prim
 
+import java.util.Locale
+
 //scalastyle:off number.of.types
 case class _and() extends Reporter with Pure {
   override def syntax =
@@ -165,11 +167,11 @@ case class _errormessage(let: Option[Let]) extends Reporter {
 }
 case class _extern(syntax: Syntax) extends Command {
   override def toString =
-    s"_extern(${token.text.toUpperCase})"
+    s"_extern(${token.text.toUpperCase(Locale.ENGLISH)})"
 }
 case class _externreport(syntax: Syntax) extends Reporter {
   override def toString =
-    s"_externreport(${token.text.toUpperCase})"
+    s"_externreport(${token.text.toUpperCase(Locale.ENGLISH)})"
 }
 case class _fd() extends Command {
   override def syntax =

--- a/parser-core/src/main/lex/TokenLexer.scala
+++ b/parser-core/src/main/lex/TokenLexer.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.lex
 
+import java.util.Locale
+
 import org.nlogo.core.{ NumberParser, StringEscaper, Token, TokenType }
 import LexOperations._
 
@@ -130,7 +132,7 @@ class TokenLexer {
       None
 
   private def tokenizeIdent(identString: String): Option[(String, TokenType, AnyRef)] =
-    Some((identString, TokenType.Ident, identString.toUpperCase))
+    Some((identString, TokenType.Ident, identString.toUpperCase(Locale.ENGLISH)))
 
   private def tokenizeString(stringText: String): Option[(String, TokenType, AnyRef)] = {
     val lastCharEscaped = stringText.dropRight(1).foldLeft(false) {

--- a/parser-core/src/main/parse/AgentTypeChecker.scala
+++ b/parser-core/src/main/parse/AgentTypeChecker.scala
@@ -63,6 +63,8 @@ package org.nlogo.parse
 //
 // Whew!  Got all that?
 
+import java.util.Locale
+
 import org.nlogo.core,
   core.{AstVisitor, Fail, Instruction,
         ProcedureDefinition, ReporterApp, Statement, Syntax,
@@ -186,7 +188,7 @@ class AgentTypeChecker(defs: Seq[ProcedureDefinition]) {
     private def checkSatisfiable(coreInstruction: Instruction, agentClassString: String, instructionClassString: String): String = {
       val classString = combineRestrictions(agentClassString, instructionClassString)
       if (classString == "----") {
-        val name = coreInstruction.token.text.toUpperCase
+        val name = coreInstruction.token.text.toUpperCase(Locale.ENGLISH)
         exception(
           s"""|You can't use $name in ${aOrAn(agentName(agentClassString))} context,
               | because $name is ${agentName(instructionClassString)}-only.""".stripMargin.replaceAll("\n", ""),

--- a/parser-core/src/main/parse/ArrowLambdaScoper.scala
+++ b/parser-core/src/main/parse/ArrowLambdaScoper.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.parse
 
+import java.util.Locale
+
 import org.nlogo.core.{Fail, Token, TokenType}
 import Fail.exception
 import org.nlogo.core.prim.{Lambda, _lambdavariable, _unknownidentifier}
@@ -19,8 +21,8 @@ object ArrowLambdaScoper {
           case (args, remainder, syms) =>
             val body = remainder.map {
               case t @ Token(txt, TokenType.Reporter, _unknownidentifier())
-                if args.argumentNames.contains(t.text.toUpperCase) =>
-                t.refine(_lambdavariable(txt.toUpperCase))
+                if args.argumentNames.contains(t.text.toUpperCase(Locale.ENGLISH)) =>
+                t.refine(_lambdavariable(txt.toUpperCase(Locale.ENGLISH)))
               case t => t
             }
             (args, body, syms)
@@ -45,7 +47,7 @@ object ArrowLambdaScoper {
       def isCloseBracket = t.tpe == TokenType.CloseBracket
       // _taskvariable is an accommodation for the autoconverter
       def isAlreadyDefined(usedNames: SymbolTable) =
-        usedNames.contains(t.text.toUpperCase) && ! t.value.isInstanceOf[LambdaTokenMapper._taskvariable]
+        usedNames.contains(t.text.toUpperCase(Locale.ENGLISH)) && ! t.value.isInstanceOf[LambdaTokenMapper._taskvariable]
     }
 
     @tailrec
@@ -54,11 +56,11 @@ object ArrowLambdaScoper {
       if (tok.isCloseBracket)
         (Lambda.BracketedArguments(acc), toks.tail.tail, usedNames)
       else if (tok.isAlreadyDefined(usedNames))
-        SymbolType.alreadyDefinedException(usedNames(tok.text.toUpperCase), tok)
+        SymbolType.alreadyDefinedException(usedNames(tok.text.toUpperCase(Locale.ENGLISH)), tok)
       else if (tok.isArrow || tok.tpe != TokenType.Reporter)
         exception(s"Expected a variable name here", tok)
       else
-        gatherArgumentToCloseBracket(acc :+ tok, toks.tail, usedNames.addSymbols(Seq(tok.text.toUpperCase), SymbolType.LambdaVariable))
+        gatherArgumentToCloseBracket(acc :+ tok, toks.tail, usedNames.addSymbols(Seq(tok.text.toUpperCase(Locale.ENGLISH)), SymbolType.LambdaVariable))
     }
 
     def gatherUnbracketedArgument(toks: Seq[Token], usedNames: SymbolTable): Option[(Arguments, Seq[Token], SymbolTable)] = {
@@ -70,7 +72,7 @@ object ArrowLambdaScoper {
       else if (tok.isAlreadyDefined(usedNames))
         gatherSymbolsToOpenBracket(Seq(tok), toks.tail, usedNames)
       else
-        gatherArgumentToArrow(tok, toks.tail, usedNames.addSymbols(Seq(tok.text.toUpperCase), SymbolType.LambdaVariable))
+        gatherArgumentToArrow(tok, toks.tail, usedNames.addSymbols(Seq(tok.text.toUpperCase(Locale.ENGLISH)), SymbolType.LambdaVariable))
     }
 
     def gatherArgumentToArrow(arg: Token, toks: Seq[Token], usedNames: SymbolTable): Option[(Arguments, Seq[Token], SymbolTable)] = {
@@ -94,7 +96,7 @@ object ArrowLambdaScoper {
           exception("An anonymous procedures of two or more arguments must enclose its argument list in brackets", gatheredSymbols.head.start, gatheredSymbols.last.end, tok.filename)
         else {
           val initTok = gatheredSymbols.head
-          SymbolType.alreadyDefinedException(usedNames(initTok.text.toUpperCase), initTok)
+          SymbolType.alreadyDefinedException(usedNames(initTok.text.toUpperCase(Locale.ENGLISH)), initTok)
         }
       } else if (tok.isOpenBracket)
         None

--- a/parser-core/src/main/parse/AstPath.scala
+++ b/parser-core/src/main/parse/AstPath.scala
@@ -2,9 +2,10 @@
 
 package org.nlogo.parse
 
+import java.util.Locale
+
 import org.nlogo.core.{ Application, AstNode, CommandBlock,
   Expression, ProcedureDefinition, ReporterApp, ReporterBlock, Statement, Statements }
-
 
 object AstPath {
   trait Component
@@ -81,7 +82,7 @@ case class AstPath(components: Component*) {
 trait PositionalAstFolder[A] {
   import AstPath._
   def visitProcedureDefinition(proc: ProcedureDefinition)(a: A): A = {
-    visitStatements(proc.statements, AstPath(Proc(proc.procedure.name.toUpperCase)))(using a)
+    visitStatements(proc.statements, AstPath(Proc(proc.procedure.name.toUpperCase(Locale.ENGLISH))))(using a)
   }
   def visitCommandBlock(block: CommandBlock, position: AstPath)(implicit a: A): A = {
     visitStatements(block.statements, position)

--- a/parser-core/src/main/parse/AstRewriter.scala
+++ b/parser-core/src/main/parse/AstRewriter.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.parse
 
+import java.util.Locale
+
 import org.nlogo.core.{
   CompilationOperand,
   ProcedureDefinition,
@@ -63,7 +65,7 @@ class AstRewriter(val tokenizer: TokenizerInterface, op: CompilationOperand) ext
 
   def removeExtension(extension: String): String = {
     import TokenType.{OpenBracket, CloseBracket, Ident}
-    val extValue = extension.toUpperCase
+    val extValue = extension.toUpperCase(Locale.ENGLISH)
     val source = op.sources("")
     val tokens = tokenizer.tokenizeString(source).to(LazyList)
     val buf = new StringBuilder(source)
@@ -183,7 +185,7 @@ class AstRewriter(val tokenizer: TokenizerInterface, op: CompilationOperand) ext
       else {
         val newPositions =
           findProcedurePositions(getSource(file), Some(op.containingProgram.dialect)).map {
-            case (k, v) => k.toUpperCase -> v
+            case (k, v) => k.toUpperCase(Locale.ENGLISH) -> v
           }
         procedurePositions = procedurePositions + (file -> newPositions)
         newPositions(procedureName)

--- a/parser-core/src/main/parse/ExpressionParser.scala
+++ b/parser-core/src/main/parse/ExpressionParser.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.parse
 
+import java.util.Locale
+
 import SymbolType.LocalVariable
 
 import org.nlogo.core
@@ -87,7 +89,7 @@ object ExpressionParser {
               case set @ core.prim._set() =>
                 val setVar = set.token.value match {
                   case uv: core.prim._unknownidentifier =>
-                    val varName = set.token.text.toUpperCase
+                    val varName = set.token.text.toUpperCase(Locale.ENGLISH)
                     val tpe = s.get(varName).getOrElse(exception(s"There is no variable called ${varName}.", set.token.sourceLocation))
                     val variable = tpe match {
                       // normally this happens in `LetVariableScope` but that time has passed I guess?
@@ -106,7 +108,7 @@ object ExpressionParser {
                     new core.ReporterApp(r, Seq(), set.token.sourceLocation)
 
                   case _ =>
-                    exception(s"Command found in multi-set where a variable name was expected: ${set.token.text.toUpperCase}.", set.token.sourceLocation)
+                    exception(s"Command found in multi-set where a variable name was expected: ${set.token.text.toUpperCase(Locale.ENGLISH)}.", set.token.sourceLocation)
 
                 }
 
@@ -180,8 +182,9 @@ object ExpressionParser {
 
       case _ =>
         token.value match {
-          case (_: core.prim._symbol | _: core.prim._unknownidentifier) if ! scope.contains(token.text.toUpperCase) =>
-            exception(I18N.errors.getN("compiler.LetVariable.notDefined", token.text.toUpperCase), token)
+          case (_: core.prim._symbol | _: core.prim._unknownidentifier) if ! scope.contains(token.text.toUpperCase(Locale.ENGLISH)) =>
+            exception(I18N.errors.getN("compiler.LetVariable.notDefined", token.text.toUpperCase(Locale.ENGLISH)),
+                      token)
 
           case _ => exception(ExpectedCommand, token)
         }
@@ -505,7 +508,8 @@ object ExpressionParser {
                     case (letReporter, newScope) =>
                       (letReporter.syntax, new core.ReporterApp(letReporter, token.sourceLocation))
                   }.getOrElse {
-                    exception(I18N.errors.getN("compiler.LetVariable.notDefined", token.text.toUpperCase), token)
+                    exception(I18N.errors.getN("compiler.LetVariable.notDefined",
+                                               token.text.toUpperCase(Locale.ENGLISH)), token)
                   }
                 }
               }

--- a/parser-core/src/main/parse/LetScoper.scala
+++ b/parser-core/src/main/parse/LetScoper.scala
@@ -84,6 +84,8 @@ package org.nlogo.parse
 //    LetScoper, but it would result in having to change the syntax of the _let primitive,
 //    seems awkward and confusing.
 
+import java.util.Locale
+
 import org.nlogo.core.{ I18N, Let, Reporter, Token, TokenType }
 import org.nlogo.core.Fail._
 import org.nlogo.core.prim.{ _abstractlet, _let, _multilet }
@@ -100,7 +102,7 @@ object LetScope {
       case _let(None, _) =>
         tokens.head match {
           case nameToken @ Token(text, TokenType.Reporter, _) =>
-            val name = text.toUpperCase
+            val name = text.toUpperCase(Locale.ENGLISH)
             val newLet = Let(name)
             for (tpe <- usedNames.get(name))
               exception("There is already a " + SymbolType.typeName(tpe) + " called " + name, nameToken)
@@ -127,7 +129,7 @@ object LetScope {
         }
 
       case _let(Some(let), _) =>
-        (l, usedNames.addSymbol(let.name.toUpperCase, LocalVariable(let)))
+        (l, usedNames.addSymbol(let.name.toUpperCase(Locale.ENGLISH), LocalVariable(let)))
 
     }
   }
@@ -148,7 +150,7 @@ object LetScope {
         lets = lets :+ subLet
         multiUsedNames = newUsedNames
       } else {
-        val name     = token.text.toUpperCase
+        val name     = token.text.toUpperCase(Locale.ENGLISH)
         val newLet   = Let(name, token)
         val splitLet = new _let(Some(newLet), Some(token.text))
 
@@ -182,7 +184,7 @@ object LetVariableScope {
     r match {
       case u @ core.prim._unknownidentifier() =>
         val newInstruction =
-          usedNames.get(t.text.toUpperCase).collect {
+          usedNames.get(t.text.toUpperCase(Locale.ENGLISH)).collect {
             case LocalVariable(let) =>
               val newLetVariable = core.prim._letvariable(let)
               newLetVariable.token = t

--- a/parser-core/src/main/parse/LetVerifier.scala
+++ b/parser-core/src/main/parse/LetVerifier.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.parse
 
+import java.util.Locale
+
 import org.nlogo.core._,
   org.nlogo.core.prim.{_let, _letvariable},
   Fail._
@@ -27,7 +29,7 @@ class LetVerifier extends AstVisitor {
       case l: _letvariable =>
         cAssert(
           currentLet.isEmpty || (currentLet.get ne l.let),
-          I18N.errors.getN("compiler.LetVariable.notDefined", l.token.text.toUpperCase),
+          I18N.errors.getN("compiler.LetVariable.notDefined", l.token.text.toUpperCase(Locale.ENGLISH)),
           l.token)
       case _ =>
     }

--- a/parser-core/src/main/parse/Namer.scala
+++ b/parser-core/src/main/parse/Namer.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.parse
 
+import java.util.Locale
+
 import org.nlogo.core,
   core.{ Dialect, ExtensionManager, FrontEndInterface, FrontEndProcedure, Instruction,
   Program, Token, TokenType },
@@ -57,7 +59,7 @@ class Namer(
     val ok = newVal.isInstanceOf[core.prim._call] ||
     newVal.isInstanceOf[core.prim._callreport] ||
     newVal.isInstanceOf[core.prim._procedurevariable]
-    cAssert(ok, alreadyTaken(userFriendlyName(newVal), token.text.toUpperCase), token)
+    cAssert(ok, alreadyTaken(userFriendlyName(newVal), token.text.toUpperCase(Locale.ENGLISH)), token)
   }
 
   private def processOne(token: Token): Option[Token] = {

--- a/parser-core/src/main/parse/StructureChecker.scala
+++ b/parser-core/src/main/parse/StructureChecker.scala
@@ -8,6 +8,8 @@ package org.nlogo.parse
 // (I'm not very happy with the code for this stage, but as long as it's
 // well encapsulated, maybe it's good enough. - ST 12/7/12)
 
+import java.util.Locale
+
 import
   org.nlogo.core,
     core.{ BreedIdentifierHandler, I18N, StructureDeclarations, Token, TokenType },
@@ -136,10 +138,13 @@ object StructureChecker {
     usage.declaration match {
       case breed@Breed(_, _, _, _) =>
         val matchedPrimAndType =
-          BreedIdentifierHandler.breedCommands(breed).filter(c => usedNames.contains(c.toUpperCase)).map(i => (i, BreedCommand)) ++
-          BreedIdentifierHandler.breedReporters(breed).filter(r => usedNames.contains(r.toUpperCase)).map(i => (i, BreedReporter))
+          BreedIdentifierHandler.breedCommands(breed).filter(c => usedNames.contains(c.toUpperCase(Locale.ENGLISH)))
+                                                     .map(i => (i, BreedCommand)) ++
+          BreedIdentifierHandler.breedReporters(breed).filter(r => usedNames.contains(r.toUpperCase(Locale.ENGLISH)))
+                                                      .map(i => (i, BreedReporter))
         matchedPrimAndType.foreach {
-          case (p, st) => exception(breedOverridesBuiltIn(breed, usedNames(p.toUpperCase), p), usage.identifier.token)
+          case (p, st) => exception(breedOverridesBuiltIn(breed, usedNames(p.toUpperCase(Locale.ENGLISH)), p),
+                                    usage.identifier.token)
         }
       case _ =>
     }
@@ -148,7 +153,7 @@ object StructureChecker {
   private def occurrencesFromDeclarations(declarations: Seq[Declaration]): Seq[Occurrence] = {
     val os = declarations.foldLeft(Seq[Occurrence]()) {
       case (occs, decl@Variables(kind, names)) =>
-        val vars = kind.name.toUpperCase match {
+        val vars = kind.name.toUpperCase(Locale.ENGLISH) match {
           case "TURTLES-OWN" => names.map(Occurrence(decl, _, TurtleVariable))
           case "PATCHES-OWN" => names.map(Occurrence(decl, _, PatchVariable))
           case "LINKS-OWN"   => names.map(Occurrence(decl, _, LinkVariable))

--- a/parser-core/src/main/parse/StructureParser.scala
+++ b/parser-core/src/main/parse/StructureParser.scala
@@ -18,6 +18,8 @@ package org.nlogo.parse
 // will be discovered as we parse, through __include declarations.  (Included files might themselves
 // include further files.)
 
+import java.util.Locale
+
 import org.nlogo.core.{ CompilationEnvironment, CompilationOperand, CompilerException, ErrorSource, I18N, ProcedureSyntax, Program, StructureResults, Token, TokenizerInterface, TokenType }
 import org.nlogo.core.Fail._
 import org.nlogo.core.FrontEndInterface.ProceduresMap
@@ -196,7 +198,7 @@ class StructureParser(
           subprogram)
       case Left((msg, token)) =>
         if (token.tpe == TokenType.Keyword) {
-          exception(s"""Keyword ${token.text.toUpperCase} cannot be used in this context.""", token)
+          exception(s"""Keyword ${token.text.toUpperCase(Locale.ENGLISH)} cannot be used in this context.""", token)
         } else {
           exception(msg, token)
         }

--- a/parser-core/src/main/parse/SymbolTable.scala
+++ b/parser-core/src/main/parse/SymbolTable.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.parse
 
+import java.util.Locale
+
 import scala.collection.{ Iterable, IterableOnce, WithFilter }
 
 object SymbolTable {
@@ -23,29 +25,29 @@ class SymbolTable(private val syms: Map[String, SymbolType], private val uniqueV
     syms.foreach(f)
 
   def addSymbols(symNames: Iterable[String], tpe: SymbolType): SymbolTable =
-    new SymbolTable(syms ++ symNames.map(_.toUpperCase -> tpe).toMap, uniqueVarID)
+    new SymbolTable(syms ++ symNames.map(_.toUpperCase(Locale.ENGLISH) -> tpe).toMap, uniqueVarID)
 
   def addSymbol(symName: String, tpe: SymbolType): SymbolTable =
-    new SymbolTable(syms + (symName.toUpperCase -> tpe), uniqueVarID)
+    new SymbolTable(syms + (symName.toUpperCase(Locale.ENGLISH) -> tpe), uniqueVarID)
 
   def ++(other: SymbolTable): SymbolTable =
     new SymbolTable(syms ++ other.syms, uniqueVarID + other.uniqueVarID)
 
   def -(name: String): SymbolTable =
-    new SymbolTable(syms - name.toUpperCase, uniqueVarID)
+    new SymbolTable(syms - name.toUpperCase(Locale.ENGLISH), uniqueVarID)
 
-  def apply(name: String) = syms(name.toUpperCase)
+  def apply(name: String) = syms(name.toUpperCase(Locale.ENGLISH))
 
-  def contains(name: String) = syms.isDefinedAt(name.toUpperCase)
+  def contains(name: String) = syms.isDefinedAt(name.toUpperCase(Locale.ENGLISH))
 
-  def get(name: String): Option[SymbolType] = syms.get(name.toUpperCase)
+  def get(name: String): Option[SymbolType] = syms.get(name.toUpperCase(Locale.ENGLISH))
 
   def withFreshSymbol(symType: SymbolType, hint: String = ""): (String, SymbolTable) = {
     var foundSymbolAndID = Option.empty[(String, Int)]
     var currentVarID = uniqueVarID
 
     while (foundSymbolAndID.isEmpty) {
-      val potentialName = (hint + "_" + currentVarID.toString).toUpperCase
+      val potentialName = (hint + "_" + currentVarID.toString).toUpperCase(Locale.ENGLISH)
       if (contains(potentialName)) currentVarID += 1
       else foundSymbolAndID = Some((potentialName, currentVarID))
     }

--- a/parser-core/src/main/parse/SymbolType.scala
+++ b/parser-core/src/main/parse/SymbolType.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.parse
 
+import java.util.Locale
+
 import org.nlogo.core.{ Fail, Let, Token }, Fail.exception
 
 sealed trait SymbolType
@@ -80,6 +82,7 @@ object SymbolType {
   }
 
   def alreadyDefinedException(symType: SymbolType, t: Token): Nothing = {
-    exception("There is already a " + SymbolType.typeName(symType) + " called " + t.text.toUpperCase, t)
+    exception("There is already a " + SymbolType.typeName(symType) + " called " + t.text.toUpperCase(Locale.ENGLISH),
+              t)
   }
 }

--- a/parser-core/src/main/parse/TokenMapper.scala
+++ b/parser-core/src/main/parse/TokenMapper.scala
@@ -2,6 +2,8 @@
 
 package org.nlogo.parse
 
+import java.util.Locale
+
 import org.nlogo.core.{ Command, Instruction, Reporter, TokenMapperInterface }
 
 class TokenMapper extends TokenMapperInterface {
@@ -15,9 +17,9 @@ class TokenMapper extends TokenMapperInterface {
   def allReporterClassNames: Set[String] = reporters.values.toSet
 
   def getCommand(s: String): Option[Command] =
-    TokenMapping.commandPrimToInstance(s.toUpperCase)
+    TokenMapping.commandPrimToInstance(s.toUpperCase(Locale.ENGLISH))
   def getReporter(s: String): Option[Reporter] =
-    TokenMapping.reporterPrimToInstance(s.toUpperCase)
+    TokenMapping.reporterPrimToInstance(s.toUpperCase(Locale.ENGLISH))
   def breedInstruction(primName: String, breedName: String): Option[Instruction] =
     TokenMapping.breeded(breedName)(primName)
 


### PR DESCRIPTION
This PR addresses issue #317 by forcing the `toUpperCase` method to use the English locale whenever text from the user is being parsed for compilation or comparisons.