### PR TITLE
German translation: add newly added translation strings

### DIFF
--- a/netlogo-gui/resources/i18n/GUI_Strings_de.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_de.properties
@@ -195,6 +195,7 @@ tabs.run.speedslider.modelSpeed = Geschwindigkeit des Modells
 tabs.run.speedslider.faster = Schneller
 tabs.run.speedslider.slower = Langsamer
 tabs.run.speedslider.tooltip = Geschwindigkeit des Modells anpassen
+tabs.run.speedslider.ticks = Zeittakte
 
 tabs.run.widgets.button = Schaltfläche
 tabs.run.widgets.slider = Schieberegler
@@ -306,7 +307,7 @@ file.save.offer.external.shouldSave = Speichern?
 file.save.offer.external.filename = Dateiname
 file.save.offer.external.saveSelected = Ausgewählte Dateien speichern
 file.save.offer.external.discardAll = Alle verwerfen
-file.save.offer.thisModel = dieses Modell
+file.save.offer.thisModel = diesem Modell
 file.save.offer.confirm = Möchten Sie die Änderungen, die Sie an {0} vorgenommen haben, speichern?
 file.save.error = Speichern fehlgeschlagen.  Fehler: {0}
 file.save.warn.overwrite = Eine Datei mit dem Namen „{0}“ existiert bereits.  Möchten Sie sie ersetzen?
@@ -344,6 +345,8 @@ dialog.userYesOrNo = Benutzer Ja oder Nein
 
 # Andere Dialoge
 dialog.about = Über NetLogo
+dialog.about.credits = Danksagungen
+dialog.about.system = System
 
 # widget editors
 
@@ -571,6 +574,7 @@ tools.preferences.loadLastOnStartup = Laden Sie das zuletzt verwendete Modell be
 tools.preferences.reloadOnExternalChanges = Modell bei externen Änderungen neu laden
 tools.preferences.boldWidgetText = Fettschrift Text Widgets
 tools.preferences.jumpOnClick = <html>Der Regler des Schieberegler-Widgets springt beim Klicken zur Mausposition<br> (anstatt den Wert zu erhöhen)</html>
+tools.preferences.sendAnalytics = Anonyme Nutzungsstatistiken senden
 tools.preferences.uiScale = Skalierung Benutzeroberfläche
 tools.preferences.scaleError = Skalierwert muss eine gültige Fließkommazahl sein.
 
@@ -852,6 +856,10 @@ tools.loggingMode.errorComment.label = Wie lautet Ihr Kommentar zu dem Fehler?
 tools.magicModelMatcher = Magischer Modellvergleich
 tools.magicModelMatcher.mustChoose = Sie müssen wählen!
 
+tools.previewCommands.title = Editor Vorschau-Befehle
+tools.previewCommands.default = Standard Vorschau-Befehle
+tools.previewCommands.custom = Benutzerdefinierte Vorschau-Befehle
+tools.previewCommands.manual = Vorschau manuell erstellen
 tools.previewPanel.runPreviewCommands = Vorschau-Befehle ausführen
 tools.previewPanel.runningPreviewCommands = Vorschau-Befehle werden ausführen
 tools.previewPanel.loadManualPreviewImage = Manuelles Vorschaubild laden


### PR DESCRIPTION
This PR comes with the German translation for newly added translation strings.
It also fixes one grammar error I just spotted.