### PR TITLE
[NetLogo/Tortoise/Galapagos] Configurable Extensions for NetLogo; URL Extensions for NetLogo Web #434

### DIFF
--- a/parser-core/src/main/core/ExtensionManager.scala
+++ b/parser-core/src/main/core/ExtensionManager.scala
@@ -41,7 +41,15 @@ trait ExtensionManager {
    * @param errors  the ErrorSource to use when a CompilerException needs
    *                to be thrown.
    */
-  def importExtension(jarPath: String, errors: ErrorSource): Unit
+  def importExtension(jarPath: String, errors: ErrorSource): Unit 
+  def importExtension(nameOrJarPath: String, url: Option[String], errors: ErrorSource): Unit = {
+    // In NetLogo Desktop, URL extensions are not supported, so we error if this is called.
+    if (url.isDefined) {
+      throw new UnsupportedOperationException(
+        s"URL extensions are not supported in NetLogo Desktop: ${nameOrJarPath}")
+    }
+    importExtension(nameOrJarPath, errors)
+  }
 
   def readExtensionObject(extensionName: String, typeName: String, value: String): ExtensionObject
 }

--- a/parser-core/src/main/core/FrontEndInterface.scala
+++ b/parser-core/src/main/core/FrontEndInterface.scala
@@ -12,6 +12,11 @@ object FrontEndInterface {
   val NoProcedures: ProceduresMap = ListMap()
   type FrontEndResults = (Seq[ProcedureDefinition], StructureResults)
 
+  case class ConfigurableExtension(
+    name: String,
+    url: Option[String]
+  )
+
   def hasIncludes(source: String): Boolean = {
     val includesRegEx = """(?m)^\s*__includes""".r
     includesRegEx.findFirstMatchIn(source) match {

--- a/parser-core/src/main/core/Keywords.scala
+++ b/parser-core/src/main/core/Keywords.scala
@@ -11,7 +11,7 @@ object Keywords {
     "TO", "TO-REPORT", "END",
     "GLOBALS", "TURTLES-OWN", "LINKS-OWN", "PATCHES-OWN",
     "DIRECTED-LINK-BREED", "UNDIRECTED-LINK-BREED",
-    "EXTENSIONS", "__INCLUDES")
+    "EXTENSIONS", "EXTENSION", "__INCLUDES")
   def isKeyword(s: String) =
     keywords.contains(s.toUpperCase(Locale.ENGLISH)) || s.toUpperCase(Locale.ENGLISH).endsWith("-OWN")
 }

--- a/parser-core/src/main/core/StructureDeclarations.scala
+++ b/parser-core/src/main/core/StructureDeclarations.scala
@@ -16,5 +16,20 @@ object StructureDeclarations {
       extends Declaration
   case class Procedure(name: Identifier, isReporter: Boolean, inputs: Seq[Identifier], tokens: Seq[Token])
       extends Declaration
+  case class ExtensionDeclaration(
+    token: Token,    // This token is the "EXTENSION" keyword
+    name: Identifier,
+    url: Option[Identifier],
+    // May be extended in the future to include more information
+    ) extends Declaration {
+        override def toString: String = {
+            val urlPart = url match {
+                case Some(u) => s"[url ${u.name}]"
+                case None => ""
+            }
+            // e.g. extension [phys[url <url>]]
+            s"extension [${name.name}$urlPart]"
+        }
+    } 
   case class Identifier(name: String, token: Token)
 }

--- a/parser-core/src/main/core/StructureDeclarations.scala
+++ b/parser-core/src/main/core/StructureDeclarations.scala
@@ -29,5 +29,22 @@ object StructureDeclarations {
     override val end: Token = tokens.last
   }
 
+  case class ExtensionDeclaration(
+    start: Token,    // This token is the "EXTENSION" keyword
+    name: Identifier,
+    url: Option[Identifier],
+    end: Token
+    // May be extended in the future to include more information
+    ) extends Declaration {
+      override def toString: String = {
+        val urlPart = url match {
+            case Some(u) => s"[url ${u.name}]"
+            case None => ""
+        }
+        // e.g. extension [phys[url <url>]]
+        s"extension [${name.name}$urlPart]"
+      }
+    }
+
   case class Identifier(name: String, token: Token)
 }

--- a/parser-core/src/main/core/StructureResults.scala
+++ b/parser-core/src/main/core/StructureResults.scala
@@ -2,6 +2,7 @@
 
 package org.nlogo.core
 
+import org.nlogo.core.StructureDeclarations.ExtensionDeclaration
 import FrontEndInterface._
 
 case class StructureResults(program: Program,
@@ -9,7 +10,8 @@ case class StructureResults(program: Program,
                         procedureTokens: Map[String, Iterable[Token]] = Map(),
                         includes: Seq[Token] = Seq(),
                         includedSources: Seq[String] = Seq(),
-                        extensions: Seq[Token] = Seq())
+                        extensions: Seq[Token] = Seq(),
+                        configurableExtensions: Seq[ExtensionDeclaration] = Seq())
 
 object StructureResults {
   val empty = StructureResults(Program.empty())

--- a/parser-core/src/main/parse/FrontEnd.scala
+++ b/parser-core/src/main/parse/FrontEnd.scala
@@ -81,8 +81,11 @@ trait FrontEndMain extends NetLogoParser {
   }
 
   def findAllExtensions(source: String): Seq[(String, Option[String])] = {
-    val tokens = tokenizer.tokenizeString(source)
+    var tokens = tokenizer.tokenizeString(source)
     val classicExtensions = StructureParser.findExtensions(tokens)
+
+    // Reset the tokens iterator to re-use it
+    tokens = tokenizer.tokenizeString(source)
     val configurableExtensions = StructureParser.findConfigurableExtensions(tokens)
     classicExtensions.map(name => (name, None)) ++
       configurableExtensions.map { case (name, url) => (name, url) }

--- a/parser-core/src/main/parse/FrontEnd.scala
+++ b/parser-core/src/main/parse/FrontEnd.scala
@@ -74,4 +74,17 @@ trait FrontEndMain extends NetLogoParser {
 
   def findExtensions(source: String): Seq[String] =
     StructureParser.findExtensions(tokenizer.tokenizeString(source))
+
+  def findConfigurableExtensions(source: String): Seq[(String, Option[String])] = {
+    val tokens = tokenizer.tokenizeString(source)
+    StructureParser.findConfigurableExtensions(tokens)
+  }
+
+  def findAllExtensions(source: String): Seq[(String, Option[String])] = {
+    val tokens = tokenizer.tokenizeString(source)
+    val classicExtensions = StructureParser.findExtensions(tokens)
+    val configurableExtensions = StructureParser.findConfigurableExtensions(tokens)
+    classicExtensions.map(name => (name, None)) ++
+      configurableExtensions.map { case (name, url) => (name, url) }
+  }
 }

--- a/parser-core/src/main/parse/FrontEnd.scala
+++ b/parser-core/src/main/parse/FrontEnd.scala
@@ -85,4 +85,17 @@ trait FrontEndMain extends NetLogoParser {
       decls => decls
     )
   }
+
+  def findConfigurableExtensions(source: String): Seq[(String, Option[String])] = {
+    val tokens = tokenizer.tokenizeString(source)
+    StructureParser.findConfigurableExtensions(tokens)
+  }
+
+  def findAllExtensions(source: String): Seq[(String, Option[String])] = {
+    val tokens = tokenizer.tokenizeString(source)
+    val classicExtensions = StructureParser.findExtensions(tokens)
+    val configurableExtensions = StructureParser.findConfigurableExtensions(tokens)
+    classicExtensions.map(name => (name, None)) ++
+      configurableExtensions.map { case (name, url) => (name, url) }
+  }
 }

--- a/parser-core/src/main/parse/FrontEnd.scala
+++ b/parser-core/src/main/parse/FrontEnd.scala
@@ -92,8 +92,11 @@ trait FrontEndMain extends NetLogoParser {
   }
 
   def findAllExtensions(source: String): Seq[(String, Option[String])] = {
-    val tokens = tokenizer.tokenizeString(source)
+    var tokens = tokenizer.tokenizeString(source)
     val classicExtensions = StructureParser.findExtensions(tokens)
+
+    // Reset the tokens iterator to re-use it
+    tokens = tokenizer.tokenizeString(source)
     val configurableExtensions = StructureParser.findConfigurableExtensions(tokens)
     classicExtensions.map(name => (name, None)) ++
       configurableExtensions.map { case (name, url) => (name, url) }

--- a/parser-core/src/main/parse/StructureCombinators.scala
+++ b/parser-core/src/main/parse/StructureCombinators.scala
@@ -182,10 +182,8 @@ extends scala.util.parsing.combinator.Parsers {
   def closeBracket: Parser[Token] =
     tokenType("closing bracket", TokenType.CloseBracket)
   
-
   def modifier(key: String): Parser[Token] =
     acceptMatch(key, { case token @ Token(_, TokenType.Ident, `key`) => token })
-
 
   def identifier: Parser[Identifier] =
     tokenType("identifier", TokenType.Ident) ^^ {

--- a/parser-core/src/main/parse/StructureCombinators.scala
+++ b/parser-core/src/main/parse/StructureCombinators.scala
@@ -87,7 +87,7 @@ extends scala.util.parsing.combinator.Parsers {
     rep(declaration | procedure) <~ (eof | failure("keyword expected"))
 
   def declaration: Parser[Declaration] =
-    includes | extensions | breed | directedLinkBreed | undirectedLinkBreed |
+    includes | extensions | extension | breed | directedLinkBreed | undirectedLinkBreed |
       variables("GLOBALS") | variables("TURTLES-OWN") | variables("PATCHES-OWN") |
       variables("LINKS-OWN") | breedVariables
 
@@ -100,6 +100,19 @@ extends scala.util.parsing.combinator.Parsers {
     keyword("EXTENSIONS") ~! identifierList ^^ {
       case token ~ (names ~ closeBracket) =>
         Extensions(token, names, closeBracket) }
+
+  def extension: Parser[ExtensionDeclaration] =
+    keyword("EXTENSION") ~! (
+      openBracket ~> identifier ~ opt(extensionURL) ~ closeBracket) ^^ {
+        case keyToken ~ (name ~ urlOpt ~ closeBracket) =>
+          ExtensionDeclaration(keyToken, name, urlOpt, closeBracket)
+    }
+
+  def extensionURL: Parser[Identifier] =
+    openBracket ~> modifier("URL") ~! literal <~ closeBracket ^^ {
+      case urlToken ~ url =>
+        url
+    }
 
   def variables(key: String): Parser[Variables] =
     keyword(key) ~! identifierList ^^ {
@@ -168,6 +181,11 @@ extends scala.util.parsing.combinator.Parsers {
 
   def closeBracket: Parser[Token] =
     tokenType("closing bracket", TokenType.CloseBracket)
+
+
+  def modifier(key: String): Parser[Token] =
+    acceptMatch(key, { case token @ Token(_, TokenType.Ident, `key`) => token })
+
 
   def identifier: Parser[Identifier] =
     tokenType("identifier", TokenType.Ident) ^^ {

--- a/parser-core/src/main/parse/StructureCombinators.scala
+++ b/parser-core/src/main/parse/StructureCombinators.scala
@@ -182,10 +182,8 @@ extends scala.util.parsing.combinator.Parsers {
   def closeBracket: Parser[Token] =
     tokenType("closing bracket", TokenType.CloseBracket)
 
-
   def modifier(key: String): Parser[Token] =
     acceptMatch(key, { case token @ Token(_, TokenType.Ident, `key`) => token })
-
 
   def identifier: Parser[Identifier] =
     tokenType("identifier", TokenType.Ident) ^^ {

--- a/parser-core/src/main/parse/StructureConverter.scala
+++ b/parser-core/src/main/parse/StructureConverter.scala
@@ -4,7 +4,6 @@ package org.nlogo.parse
 
 import org.nlogo.core,
   core.{ CompilerException, Fail, FrontEndProcedure, I18N, StructureResults, Program, Syntax, Token, TokenType }
-
 /// Stage #3 of StructureParser
 
 object StructureConverter {
@@ -38,8 +37,13 @@ object StructureConverter {
         declarations.collect {
           case e: Extensions =>
             e.names.map(_.token)
-        }.flatten)
-  }
+        }.flatten,
+      configurableExtensions = oldResults.configurableExtensions ++
+        declarations.collect {
+          case e: ExtensionDeclaration =>
+            e
+        })
+    }
 
   def buildProcedure(p: Procedure, displayName: Option[String]): (FrontEndProcedure, Iterable[Token]) = {
     val proc = new RawProcedure(p, displayName)

--- a/parser-core/src/main/parse/StructureParser.scala
+++ b/parser-core/src/main/parse/StructureParser.scala
@@ -19,6 +19,7 @@ package org.nlogo.parse
 // include further files.)
 
 import java.util.Locale
+import scala.collection.mutable.ListBuffer
 
 import org.nlogo.core.{ CompilationEnvironment, CompilationOperand, CompilerException, ErrorSource, I18N,
                         ProcedureSyntax, Program, StructureResults, Token, TokenizerInterface, TokenType }
@@ -68,14 +69,28 @@ object StructureParser {
       compilationData.extensionManager.startFullCompilation()
 
       val r = results
+      val allExtensions =
+        r.extensions.map(                    // Old extensions
+          e => (
+            e.text.toLowerCase,
+            None,
+            new ErrorSource(e)
+        )) ++
+        r.configurableExtensions.map(        // Configurable extensions
+          e => (
+            e.name.name.toLowerCase,
+            e.url.map(_.name),
+            new ErrorSource(e.name.token)
+          )
+        )
+      
 
-      for (token <- r.extensions) {
-        val text = token.text.toLowerCase
+      for ((name, url, errorSource) <- allExtensions) {
         if (compilationData.shouldAutoInstallLibs) {
           val lm = compilationData.libraryManager
-          lm.lookupExtension(text, "").filter(_.status == CanInstall).foreach(lm.installExtension)
+          lm.lookupExtension(name, "").filter(_.status == CanInstall).foreach(lm.installExtension)
         }
-        compilationData.extensionManager.importExtension(text, new ErrorSource(token))
+        compilationData.extensionManager.importExtension(name, url, errorSource) // New importExtension method
       }
 
       compilationData.extensionManager.finishFullCompilation()
@@ -187,6 +202,62 @@ object StructureParser {
       openBracket.takeWhile(_.tpe != TokenType.CloseBracket).filter(_.tpe == TokenType.Ident)
                  .map(_.value.toString).toSeq
     }
+  }
+
+  def findConfigurableExtensions(tokens: Iterator[Token]): Seq[(String, Option[String])] = {
+    // Look for the keyword "EXTENSION"
+    // syntax: extension [name [url <url>]?]
+    val extensions = ListBuffer[(String, Option[String])]()
+    while (tokens.hasNext) {
+      val token = tokens.next() // Keep moving until we find "EXTENSION"
+      if (token.tpe == TokenType.Keyword && token.value == "EXTENSION") {
+        // Open bracket
+        if (!tokens.hasNext || tokens.next().tpe != TokenType.OpenBracket) {
+          exception("Expected open bracket after 'EXTENSION' keyword", token)
+        }
+
+        // Identifier for the extension name
+        val nameToken = tokens.next()
+        if (nameToken.tpe != TokenType.Ident) {
+          exception("Expected identifier after 'EXTENSION' keyword", nameToken)
+        }
+
+        // Optional URL
+        var url: Option[String] = None
+        if (tokens.hasNext) { 
+          val nextToken = tokens.next() // [url <url>]? is optional + ]
+          if (nextToken.tpe == TokenType.OpenBracket) {
+            // We have a URL specification
+            if (!tokens.hasNext || !tokens.next().value.toString.equalsIgnoreCase("url")) {
+              exception("Expected 'url' keyword after open bracket", nextToken)
+            }
+            val urlToken = tokens.next()
+            if (urlToken.tpe != TokenType.Literal) {
+              exception("Expected URL literal", urlToken)
+            }
+            if (!tokens.hasNext || tokens.next().tpe != TokenType.CloseBracket) {
+              exception("Expected close bracket after URL", urlToken)
+            }
+            url = Some(urlToken.value.toString)
+            
+            // Now consume the final close bracket
+            if (!tokens.hasNext || tokens.next().tpe != TokenType.CloseBracket) {
+              exception("Expected close bracket after extension declaration", urlToken)
+            }
+          } else if (nextToken.tpe == TokenType.CloseBracket) {
+            // No URL, just the closing bracket - this is fine
+          } else {
+            exception("Expected close bracket or URL specification", nextToken)
+          }
+        } else {
+          exception("Expected close bracket after extension name", nameToken)
+        }
+
+        // Add the extension to the list
+        extensions.addOne((nameToken.value.toString, url))
+      }
+    }
+    extensions.toSeq
   }
 }
 

--- a/parser-core/src/main/parse/StructureParser.scala
+++ b/parser-core/src/main/parse/StructureParser.scala
@@ -210,7 +210,7 @@ object StructureParser {
     val extensions = ListBuffer[(String, Option[String])]()
     while (tokens.hasNext) {
       val token = tokens.next() // Keep moving until we find "EXTENSION"
-      if (token.tpe == TokenType.Keyword && token.value == "EXTENSION") {
+      if (token.value == "EXTENSION") {
         // Open bracket
         if (!tokens.hasNext || tokens.next().tpe != TokenType.OpenBracket) {
           exception("Expected open bracket after 'EXTENSION' keyword", token)

--- a/parser-core/src/test/parse/FrontEndTests.scala
+++ b/parser-core/src/test/parse/FrontEndTests.scala
@@ -296,6 +296,37 @@ class FrontEndTests extends AnyFunSuite with BaseParserTest {
     assert(FrontEnd.findExtensions("extensions\n\n\t[     array\n\n\t\t\t\t    bitmap csv \t\t\t \n]")
                    .sameElements(Seq("ARRAY", "BITMAP", "CSV")))
   }
+
+  test("find configurable extensions") {
+    val code = "extension [foo]\n"                                         
+             + "extension [bar [ url \"https://example.com/bar.jar\" ]]\n"
+             + "extensions [ qux ]"
+
+    assert(
+      FrontEnd.findConfigurableExtensions(code).sameElements(
+        Seq(
+          ("FOO", None),
+          ("BAR", Some("https://example.com/bar.jar"))
+        )
+      )
+    )
+  }
+
+  test("find all extensions") {
+    val code = "extension [foo]\n"                                         
+             + "extension [bar [ url \"https://example.com/bar.jar\" ]]\n"
+             + "extensions [ qux ]"
+
+    assert(
+      FrontEnd.findAllExtensions(code).sameElements(
+        Seq(
+          ("QUX", None),
+          ("FOO", None),
+          ("BAR", Some("https://example.com/bar.jar"))
+        )
+      )
+    )
+  }
 }
 
 object FrontEndTests {

--- a/parser-core/src/test/parse/StructureParserTests.scala
+++ b/parser-core/src/test/parse/StructureParserTests.scala
@@ -126,6 +126,36 @@ class StructureParserTests extends AnyFunSuite {
       "link-breeds EDGES = Breed(EDGES, EDGE, LWEIGHT, false)"), dump)
   }
 
+  test("configurableExtension") {
+    var results = compile("extension [foo]")
+    assert(results.configurableExtensions.size == 1)
+    assert(results.configurableExtensions.head.name.name.toLowerCase() == "foo")
+    
+    results = compile("extension [foo] extension [bar]")
+    assert(results.configurableExtensions.size == 2)
+    assert(results.configurableExtensions.exists(_.name.name.toLowerCase() == "foo"))
+    assert(results.configurableExtensions.exists(_.name.name.toLowerCase() == "bar"))
+
+    results = compile("extension [foo] extension [bar [ url \"text\"]]")
+    assert(results.configurableExtensions.size == 2)
+    assert(results.configurableExtensions.exists(_.name.name.toLowerCase() == "foo"))
+    assert(results.configurableExtensions.exists(_.name.name.toLowerCase() == "bar"))
+    assert(results.configurableExtensions.exists(_.url.isDefined))
+    assert(results.configurableExtensions.find(_.name.name.toLowerCase() == "bar").get.url.get.name == "text")
+    assert(results.configurableExtensions.find(_.name.name.toLowerCase() == "foo").get.url.isEmpty)
+
+    results = compile("extensions [foo bar] extension [baz] extension [qux [url \"text\"]]")
+    assert(results.configurableExtensions.size == 2)
+    assert(results.extensions.size == 2) 
+    assert(results.configurableExtensions.exists(_.name.name.toLowerCase() == "baz"))
+    assert(results.configurableExtensions.exists(_.name.name.toLowerCase() == "qux"))
+    assert(results.configurableExtensions.exists(_.url.isDefined))
+    assert(results.configurableExtensions.find(_.name.name.toLowerCase() == "qux").get.url.get.name == "text")
+    assert(results.configurableExtensions.find(_.name.name.toLowerCase() == "baz").get.url.isEmpty)
+    assert(results.extensions.exists(_.text.toLowerCase() == "foo"))
+    assert(results.extensions.exists(_.text.toLowerCase() == "bar"))
+  }
+
   test("declarations1") {
     val results = compile("extensions [foo] globals [g1 g2] turtles-own [t1 t2] patches-own [p1 p2]")
     assert(results.procedures.isEmpty)


### PR DESCRIPTION
# [**WIP**] [NetLogo/Tortoise/Galapagos] Configurable Extensions for NetLogo; URL Extensions for NetLogo Web

## Branches
* **NetLogo**: https://github.com/NetLogo/NetLogo/tree/nl-extensions
     * https://github.com/NetLogo/NetLogo/pull/2508
* **Tortoise**: https://github.com/NetLogo/Tortoise/tree/nl-extensions
     * https://github.com/NetLogo/Tortoise/pull/254
* **Galapagos**: https://github.com/NetLogo/Galapagos/tree/nl-extensions
    * https://github.com/NetLogo/Galapagos/pull/434

## Specification
* Introduce a new keyword `extension` with the intention of _allowing arbitrary modifiers to be used alongside the keyword_. In practice, `extensions` either loads an extension similar to `extensions` or allows for a `url` modifier, which is only supported in NetLogo Web.
   * Syntax: `extension [ <extensionName> [url <url literal>]? ]*`
* New `extension` keyword is dubbed `ConfigurableExtensions`

## Implementation Details
1. In `Galapagos` the `tortoise.coffee` file contains functions to compile `NLogo` and `NLogoX` files. Before compilation, and _after_ rewrites, we extract the code from the `.nlogo[x]` file.The call stack from there is:
    1.`Galapagos:NLWExtensionsLoader.loadURLExtensions`
    2. which calls `org.nlogo.tortoise:BroswerCompiler.listExtensions`
    3. which calls `org.nlogo.core:FrontEnd.findAllExtensions`
    4. which calls `org.nlogo.parse:StructureParser.findExtensions` and `org.nlogo.parse:StructureParser.findConfigurableExtensions`
    5. which tokenizes the code and extracts the extension list
2. The extension list is returned to `Galapagos:NLWExtensionsLoader.loadURLExtensions` which figures out the extension module URL and primitives JSON url by changing `.js` at the end of the URL to `.json` and creates a lazy loader for the module as well as fetching the primitives JSON and caching it in `window.URLExtensionsRepo`.
3. `Galapagos:NLWExtensionsLoader.getPrimitivesFromURL` is exposed to `org.nlogo.tortoise` using `scala.js`, which uses it to get primitives if `extURL` is defined in `org.nlogo.tortoise:NLWExtensionsManager.importExtension`.

## Current Work
### NetLogo
- Add new syntax and parser results to NetLogo.
- Add methods in `FrontEnd`: `findConfigurableExtensions` and `findAllExtensions`
- Add syntax, parser, and front-end tests.
- Update `ExtensionManager` to support URL as a parameters (this throws on Desktop)

### Tortoise
- Add a new `BrowserCompiler.listExtensions(source: String)` that delegates to `FrontEnd.findAllExtensions` and returns a JSON `[{ name: String, url: String?}]`.
- Implement new `ExtensionManager` for `NLWExtensionManager`.

### Galapagos
- Add `NLWExtensionsLoader` to load URL extensions before compilation
- Integrate `NLWExtensionsLoader` to the compilation function for `.nlogox` files.