### PR TITLE
Fix crash in FileWatcherThread when attempting to watch non-existent files

### DIFF
--- a/netlogo-gui/src/main/app/FileWatcherThread.scala
+++ b/netlogo-gui/src/main/app/FileWatcherThread.scala
@@ -6,13 +6,14 @@ import java.nio.file.{ FileSystems, Path, WatchKey, WatchService, WatchEvent }
 import java.nio.file.StandardWatchEventKinds.{ ENTRY_CREATE, ENTRY_MODIFY }
 
 import scala.jdk.CollectionConverters.ListHasAsScala
+import scala.util.Try
 
 private class FileWatcherThread(paths: List[Path], callback: () => Boolean) extends Thread {
   private val watchService: WatchService = FileSystems.getDefault.newWatchService
   private val parentSet: Set[Path] = paths.map(_.getParent).toSet
 
   private def f(x: Path): (WatchKey, Path) = x.register(watchService, ENTRY_CREATE, ENTRY_MODIFY) -> x
-  private val keyPathMap: Map[WatchKey, Path] = parentSet.map(f).toMap
+  private val keyPathMap: Map[WatchKey, Path] = parentSet.map(x => Try(f(x)).toOption).flatten.toMap
 
   override def run(): Unit = {
     try {


### PR DESCRIPTION
If one more more non-existent file paths are passed to FileWatcherThread and the parent folders of those files are also non-existent, the calls to register() may throw exceptions that are currently not being handled, resulting in a crash. Fix this by using Try to handle the exceptions.