### PR TITLE
Implement remote commands

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -264,6 +264,7 @@ lazy val netlogo = project.in(file("netlogo-gui")).
       "org.scala-lang" %% "scala3-compiler" % "3.7.0",
       "it.unimi.dsi" % "fastutil" % "8.5.16",
       "net.java.dev.jna" % "jna-platform" % "5.17.0",
+      "com.kohlschutter.junixsocket" % "junixsocket-core" % "2.10.1",
       "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf",
       "com.softwaremill.sttp.client4" %% "core" % "4.0.15",
       "com.softwaremill.sttp.client4" %% "upickle" % "4.0.15",

--- a/netlogo-gui/resources/i18n/GUI_Strings_en.properties
+++ b/netlogo-gui/resources/i18n/GUI_Strings_en.properties
@@ -658,6 +658,7 @@ tools.preferences.uiLanguage = User Interface language
 tools.preferences.detectLanguage = <detect language>
 tools.preferences.loadLastOnStartup = Reload the last used model on startup
 tools.preferences.reloadOnExternalChanges = Reload model on external changes
+tools.preferences.enableRemoteCommands = Enable remote commands
 tools.preferences.boldWidgetText = Bold widget text
 tools.preferences.jumpOnClick = <html>Jump sliders to click location<br>(instead of incrementing)</html>
 tools.preferences.sendAnalytics = Send anonymous usage statistics

--- a/netlogo-gui/src/main/app/TabManager.scala
+++ b/netlogo-gui/src/main/app/TabManager.scala
@@ -337,10 +337,23 @@ class TabManager(val workspace: GUIWorkspace, val interfaceTab: InterfaceTab,
     getExternalFileTabs.foreach(_.setIncludedFilesShown(visible))
   }
 
+  def remoteCommandsEnabled: Boolean = interfaceTab.commandCenter.commandServer.running
+  def remoteCommandsEnabled_=(b: Boolean): Unit = {
+    if (b) {
+      interfaceTab.commandCenter.commandServer.start()
+    } else {
+      interfaceTab.commandCenter.commandServer.stop()
+    }
+  }
+
+  remoteCommandsEnabled = getRemoteCommands
+
   def watchingFiles: Boolean = watcherThread != null
   def watchingFiles_=(value: Boolean): Unit = setWatchingFiles(value)
 
   watchingFiles = getAutoReload
+
+  def getRemoteCommands: Boolean = NetLogoPreferences.get("enableRemoteCommands", "false").toBoolean
 
   def getAutoReload: Boolean = NetLogoPreferences.get("reloadOnExternalChanges", "false").toBoolean
 

--- a/netlogo-gui/src/main/app/common/CommandLine.scala
+++ b/netlogo-gui/src/main/app/common/CommandLine.scala
@@ -166,17 +166,22 @@ class CommandLine(commandCenter: CommandCenterInterface,
     executeCurrentBuffer()
   }
 
-  private def executeCurrentBuffer(): Unit = {
-    var inner = getText
-    if (inner.trim.equals("")) {
-      setText("")
-      return
+  private def preprocess(code: String): String = {
+    if (code.trim.equals("")) {
+      ""
+    } else if (workspace.isReporter(code)) {
+      "show " + code
+    } else {
+      code
     }
-    if (workspace.isReporter(inner)) {
-      inner = "show " + inner
-      setText(inner)
-    }
+  }
+
+  def execute(_kind: AgentKind, code: String, shouldPreprocess: Boolean): Unit = {
     var header = "to __commandline [] "
+    val oldKind = kind
+
+    agentKind(_kind)
+
     if (kind == AgentKind.Observer) {
       header += "__observercode "
     } else if (kind == AgentKind.Turtle) {
@@ -186,8 +191,16 @@ class CommandLine(commandCenter: CommandCenterInterface,
     } else if (kind == AgentKind.Link) {
       header += "__linkcode "
     }
-    val footer = "\n__done end" // the \n is to protect against comments in inner
-    source(header, inner, footer)
+
+    val footer = "\n__done end" // the \n is to protect against comments in code
+    source(header, if (shouldPreprocess) preprocess(code) else code, footer)
+    agentKind(oldKind)
+  }
+
+  private def executeCurrentBuffer(): Unit = {
+    val inner = preprocess(getText)
+    setText(inner)
+    execute(kind, inner, false)
   }
 
   override def handle(e: WindowEvents.CompiledEvent): Unit = {

--- a/netlogo-gui/src/main/app/common/CommandServer.scala
+++ b/netlogo-gui/src/main/app/common/CommandServer.scala
@@ -1,0 +1,167 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.app.common
+
+import org.nlogo.app.common.CommandLine
+import org.nlogo.api.FileIO
+import org.nlogo.awt.EventQueue
+import org.nlogo.core.AgentKind
+
+import org.json.simple.JSONObject
+import org.json.simple.parser.JSONParser
+
+import org.newsclub.net.unix.{ AFUNIXServerSocket, AFUNIXSocketAddress }
+
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+import java.net.{ ServerSocket, Socket }
+import java.io.{ BufferedReader, BufferedWriter, File, InputStream, InputStreamReader, IOException,
+  OutputStream, OutputStreamWriter }
+
+private class CommandRequest(var code: String = "") {
+  // Example: {"type": "nl-run-code", "code": "show 123"}
+  def fromJSONString(input: String): Boolean = {
+    val parser = new JSONParser()
+    var successful = false
+
+    try {
+      val obj = parser.parse(input).asInstanceOf[JSONObject]
+
+      val type_ = obj.get("type").asInstanceOf[String]
+      if (type_ != "nl-run-code") {
+        throw RuntimeException("Unsupported remote command: " + type_)
+      }
+
+      code = obj.get("code").asInstanceOf[String]
+
+      if (code == null) {
+        throw RuntimeException("No code provided")
+      } else {
+        successful = true
+      }
+    } catch {
+      case e: RuntimeException => System.err.println(e.getMessage)
+      case _ => System.err.println("Failed to parse remote command")
+    }
+
+    successful
+  }
+}
+
+private class CommandThread(serverSocket: CommandServerSocket, callback: CommandRequest => Unit) extends Thread {
+  override def run() = {
+    var socket: Option[Socket] = None
+    var input: Option[InputStream] = None
+    var output: Option[OutputStream] = None
+
+    try {
+      while (!isInterrupted) {
+        socket = Some(serverSocket.accept())
+        input = socket.map(_.getInputStream())
+        output = socket.map(_.getOutputStream())
+
+        (input, output) match {
+          case (Some(x), Some(y)) => processRequests(x, y)
+          case _ => throw new IllegalStateException("Failed to open input/output stream")
+        }
+      }
+    } catch {
+      case _: InterruptedException => ()
+
+      // This exception is raised when accept() is waiting for a connection and the server socket is closed. This can
+      // happen when we stop the thread. - February 2026 Kritphong M
+      case _: IOException => ()
+    } finally {
+      input.foreach(_.close)
+      output.foreach(_.close)
+      socket.foreach(_.close)
+    }
+  }
+
+  private def processRequests(input: InputStream, output: OutputStream): Unit = {
+    val request = new CommandRequest
+    val reader = new BufferedReader(new InputStreamReader(input))
+    val writer = new BufferedWriter(new OutputStreamWriter(output))
+
+    for (line <- reader.lines.iterator.asScala) {
+      if (request.fromJSONString(line)) {
+        callback(request)
+        writer.write(s"{\"type\": \"nl-status\", \"status\": \"ok\"}\n")
+      } else {
+        writer.write(s"{\"type\": \"nl-status\", \"status\": \"failed\", \"message\": \"Failed to parse request\"}\n")
+      }
+
+      writer.flush
+    }
+  }
+}
+
+class CommandServerSocket {
+  val path: String = getSocketPath
+  private val socket: ServerSocket = makeSocket(getSocketPath)
+
+  private def getSocketPath: String = {
+    val pid: Long = ProcessHandle.current.pid
+
+    Option(System.getenv("XDG_RUNTIME_DIR")) match {
+      case Some(x) => s"${x}/netlogo-$pid"
+      case None => FileIO.perUserFile(s"netlogo-$pid", false)
+    }
+  }
+
+  private def makeSocket(path: String): ServerSocket = {
+    println(s"Creating remote command socket at ${path}")
+    val file = new File(path)
+    file.deleteOnExit()
+    AFUNIXServerSocket.bindOn(AFUNIXSocketAddress.of(file), true)
+  }
+
+  def accept(): Socket = {
+    socket.accept()
+  }
+
+  def close(): Unit = {
+    socket.close()
+  }
+}
+
+class CommandServer(commandLine: CommandLine) {
+
+  private var serverSocket: Option[CommandServerSocket] = None
+  private var serverThread: Option[Thread] = None
+
+  def start(): Unit = {
+    stop()
+    initServerSocket()
+    serverThread = serverSocket.map(x => new CommandThread(x, commandCallback))
+    serverThread.map(_.start)
+  }
+
+  def stop(): Unit = {
+    serverThread.foreach(_.interrupt())
+
+    // Calling interrupt() doesn't stop the accept() call from blocking, so just calling join() here can result in
+    // deadlock. Instead, we can close the socket which will trigger an exception and allow the thread to exit.
+    // - February 2026 Kritphong M
+    serverSocket.foreach(_.close())
+    serverThread.foreach(_.join())
+    serverThread = None
+    serverSocket = None
+  }
+
+  def running: Boolean = serverThread.isDefined
+
+  private def commandCallback(request: CommandRequest) = {
+    EventQueue.invokeAndWait(() => commandLine.execute(AgentKind.Observer, request.code, true))
+  }
+
+  private def initServerSocket(): Unit = {
+    serverSocket.foreach(_.close())
+    serverSocket = Try(new CommandServerSocket).toOption
+
+    if (serverSocket.isEmpty) {
+      System.err.println(s"Failed to create remote command socket")
+    }
+  }
+}

--- a/netlogo-gui/src/main/app/common/TabsInterface.scala
+++ b/netlogo-gui/src/main/app/common/TabsInterface.scala
@@ -27,6 +27,9 @@ trait TabsInterface {
 
   def setIncludedFilesShown(visible: Boolean): Unit
 
+  def remoteCommandsEnabled: Boolean
+  def remoteCommandsEnabled_=(b: Boolean): Unit
+
   def watchingFiles: Boolean
   def watchingFiles_=(b: Boolean): Unit
 

--- a/netlogo-gui/src/main/app/interfacetab/CommandCenter.scala
+++ b/netlogo-gui/src/main/app/interfacetab/CommandCenter.scala
@@ -9,7 +9,7 @@ import javax.swing.{ AbstractAction, Action, JButton, JLabel, JPanel }
 import javax.swing.border.EmptyBorder
 
 import org.nlogo.api.Exceptions
-import org.nlogo.app.common.{ CommandLine, HistoryPrompt, LinePrompt }
+import org.nlogo.app.common.{ CommandLine, CommandServer, HistoryPrompt, LinePrompt }
 import org.nlogo.awt.{ Hierarchy, UserCancelException }
 import org.nlogo.core.{ AgentKind, I18N }
 import org.nlogo.swing.{ FileDialog => SwingFileDialog, ModalProgressTask, MenuItem, PopupMenu, RichAction,
@@ -27,6 +27,7 @@ class CommandCenter(workspace: AbstractWorkspace, showToggle: Boolean, packSplit
 
   // true = echo commands to output
   val commandLine = new CommandLine(this, true, 12, workspace)
+  val commandServer = new CommandServer(commandLine)
   private val prompt = new LinePrompt(commandLine, true)
   private val northPanel = new JPanel(new GridBagLayout)
   private val southPanel = new JPanel

--- a/netlogo-gui/src/main/app/tools/Preferences.scala
+++ b/netlogo-gui/src/main/app/tools/Preferences.scala
@@ -205,6 +205,14 @@ object Preferences {
     }
   }
 
+  class EnableRemoteCommands(tabs: TabsInterface)
+    extends BooleanPreference("enableRemoteCommands", None, false) {
+
+    override def onSelect(selected: Boolean): Unit = {
+      tabs.remoteCommandsEnabled = selected
+    }
+  }
+
   object IsLoggingEnabled extends BooleanPreference("loggingEnabled", Some(RequiredAction.Restart), false)
 
   class LogDirectory(val frame: Frame) extends StringPreference("logDirectory", Some(RequiredAction.Restart), "") {

--- a/netlogo-gui/src/main/app/tools/PreferencesDialog.scala
+++ b/netlogo-gui/src/main/app/tools/PreferencesDialog.scala
@@ -26,6 +26,7 @@ class PreferencesDialog(parent: Frame & ThemeSync, tabManager: TabsInterface, wi
     Preferences.Language,
     Preferences.LoadLastOnStartup,
     new Preferences.ReloadOnExternalChanges(tabManager),
+    Preferences.EnableRemoteCommands(tabManager),
     new Preferences.BoldWidgetText(widgetPanel),
     new Preferences.JumpOnClick(tabManager),
     Preferences.SendAnalytics


### PR DESCRIPTION
When enabled, this creates a Unix socket (or a named pipe on Windows) that listens to commands. An external editor can use this socket to send commands for NetLogo to run in the form of JSON objects that look like this: `{"type": "nl-run-code", "code": "show 123"}`.

This still needs to be tested on Windows and OSX. I've only tested it on Linux. On Linux (and probably OSX too), an easy way to test this is to use OpenBSD Netcat (GNU Netcat doesn't support Unix sockets). You can open a connection like this `nc -U /path/to/socket/netlogo-1234` and enter the JSON Object you wan to send. On Linux and OSX, the socket will be put in `XDG_RUNTIME_DIR` if it is set, otherwise it will be put in  `~/.netlogo/7.0`. You can also see the exact path in the console output.