### PR TITLE
New error message for string/number used in globals

### DIFF
--- a/parser-core/src/main/parse/StructureChecker.scala
+++ b/parser-core/src/main/parse/StructureChecker.scala
@@ -26,7 +26,10 @@ object StructureChecker {
         case Variables(_, names) =>
           for (name <- names) {
             if (name.token.tpe == TokenType.Literal) {
-              exception(I18N.errors.get("compiler.StructureChecker.variableConstant"), name.token)
+              if (!Constants.get(name.token.text).isEmpty) {
+                exception(I18N.errors.get("compiler.StructureChecker.variableConstant"), name.token)
+              }
+              exception(I18N.errors.get("compiler.StructureChecker.variableLiteral"), name.token)
             }
           }
         case Procedure(_, _, inputs, _) =>

--- a/parser-core/src/test/parse/StructureParserTests.scala
+++ b/parser-core/src/test/parse/StructureParserTests.scala
@@ -167,6 +167,12 @@ class StructureParserTests extends AnyFunSuite {
   test("constant in globals") {
     expectError("globals [d e f]",
       "Variable name conflicts with a constant.") }
+  test("string in globals") {
+    expectError("globals [g \"varname\"]",
+      "You cannot use a string/number as a global variable name.") }
+  test("number in globals") {
+    expectError("globals [d 2 f]",
+      "You cannot use a string/number as a global variable name.") }
   test("constant in turtles-own") {
     expectError("turtles-own [d e f]",
       "Variable name conflicts with a constant.") }

--- a/shared/resources/main/i18n/Errors_en.properties
+++ b/shared/resources/main/i18n/Errors_en.properties
@@ -204,6 +204,7 @@ compiler.MultiAssign.tooFewValues = The list of values for {0} must be at least 
 compiler.Backifier.replaced = {0} is no longer a primitive, use {1} instead.
 compiler.StructureParser.includeNotFound = Could not find {0}
 compiler.StructureConverter.noBreed = There is no breed "{0}"
+compiler.StructureChecker.variableLiteral = You cannot use a string/number as a global variable name.
 compiler.StructureChecker.variableConstant = Variable name conflicts with a constant.
 compiler.StructureChecker.inputConstant = Input name conflicts with a constant.
 compiler.StructureChecker.breedOverrides = Defining a breed {0} redefines {1}, a {2}


### PR DESCRIPTION
Previously using a string or a number instead of a variable name in the `globals` declaration threw the error "Variable name conflicts with a constant." This is correct for cases like e and pi, but for strings and numbers it's more accurate to have a separate error message "You cannot use a string/number as a global variable name."