### PR TITLE
Fix parsing for imports with identifier renaming

### DIFF
--- a/parser-core/src/main/parse/StructureCombinators.scala
+++ b/parser-core/src/main/parse/StructureCombinators.scala
@@ -117,9 +117,9 @@ extends scala.util.parsing.combinator.Parsers {
     }
 
   def renamableIdentifier: Parser[(String, String)] =
-    identifier ~ opt(exactIdentifier("AS") ~ identifier) ^^ {
-      case from ~ Some(_ ~ to) => (from.name, to.name)
-      case x ~ None => (x.name, x.name)
+    identifier ^^ (x => (x.name, x.name)) |
+    openParen ~>! identifier ~ exactIdentifier("AS") ~ identifier <~ closeParen ^^ {
+      case from ~ _ ~ to => (from.name, to.name)
     }
 
   def importedIdentifierList: Parser[Map[String, String]] =
@@ -199,6 +199,12 @@ extends scala.util.parsing.combinator.Parsers {
 
   def closeBracket: Parser[Token] =
     tokenType("closing bracket", TokenType.CloseBracket)
+
+  def openParen: Parser[Token] =
+    tokenType("opening paren", TokenType.OpenParen)
+
+  def closeParen: Parser[Token] =
+    tokenType("closing paren", TokenType.CloseParen)
 
   def colon: Parser[Token] =
     tokenType("colon", TokenType.Colon)

--- a/parser-core/src/main/parse/StructureCombinators.scala
+++ b/parser-core/src/main/parse/StructureCombinators.scala
@@ -211,7 +211,7 @@ extends scala.util.parsing.combinator.Parsers {
 
   def exactIdentifier(text: String): Parser[Token] =
     acceptMatch("identifier", {
-      case t @ Token(text, TokenType.Ident, _) =>
+      case t @ Token(_, TokenType.Ident, `text`) =>
         t })
 
   def identifierToken: Parser[Token] =

--- a/parser-core/src/test/parse/StructureParserTests.scala
+++ b/parser-core/src/test/parse/StructureParserTests.scala
@@ -120,6 +120,24 @@ class StructureParserTests extends AnyFunSuite {
     assertResult(Some("BAR"))(results.imports.head.pathAlias)
   }
 
+  test("import specific identifiers") {
+    val results = compile("import [foo bar baz] from qaz")
+    assertResult(0)(results.procedures.size)
+    assertResult(1)(results.imports.size)
+    assertResult("QAZ")(results.imports.head.pathComponents.head)
+    assertResult(None)(results.imports.head.pathAlias)
+    assertResult(Map("FOO" -> "FOO", "BAR" -> "BAR", "BAZ" -> "BAZ"))(results.imports.head.importedIdentifiers)
+  }
+
+  test("import specific identifiers with renames") {
+    val results = compile("import [(foo as oof) bar (baz as zab)] from qaz")
+    assertResult(0)(results.procedures.size)
+    assertResult(1)(results.imports.size)
+    assertResult("QAZ")(results.imports.head.pathComponents.head)
+    assertResult(None)(results.imports.head.pathAlias)
+    assertResult(Map("FOO" -> "OOF", "BAR" -> "BAR", "BAZ" -> "ZAB"))(results.imports.head.importedIdentifiers)
+  }
+
   test("includes") {
     val results = compile("__includes [\"foo.nls\"]")
     assertResult(0)(results.procedures.size)


### PR DESCRIPTION
The parser was accepting any identifier instead of just `as` for renaming. For example, `import [foo bar baz] from qaz` would import `foo` from `qaz` renaming it to `baz`. 5783090 fixes that, making it import `foo`, `bar`, and `baz` as it's supposed to.

a35ecd9 makes it so that parens are required around renames, e.g. `import [(foo as bar)] from qaz`. This is to eliminate ambiguity when parsing something like `import [foo as bar] from qaz`. In that case, it isn't clear if it's supposed to just import `foo` renaming it to `bar`, or import `foo`, `as`, and `bar`.

0b9e54c has test cases for imports with identifier lists and renames.

Tests are failing here because GHA is using a stale commit for some reason. They're passing in my fork: [![build-and-test](https://github.com/kgmt0/NetLogo/actions/workflows/main.yml/badge.svg?branch=fix-renaming-import)](https://github.com/kgmt0/NetLogo/actions/workflows/main.yml)

