### PR TITLE
Fix stack overflow when a module imports itself

### DIFF
--- a/netlogo-gui/src/main/compile/Compiler.scala
+++ b/netlogo-gui/src/main/compile/Compiler.scala
@@ -170,12 +170,25 @@ class Compiler(dialect: Dialect) extends PresentationCompilerInterface {
   def findProcedurePositions(source: String): Map[String, ProcedureSyntax] =
     frontEnd.findProcedurePositions(source, Some(dialect))
 
-  def findAllImportedFiles(source: String, compilationEnvironment: CompilationEnvironment, currentFile: Option[String] = None): Seq[String] = {
+  def findAllImportedFiles(
+    source: String,
+    compilationEnvironment: CompilationEnvironment,
+    currentFile: Option[String] = None,
+    oldPaths: Set[String] = Set()
+  ): Seq[String] = {
     val imports = frontEnd.findImports(source)
     val paths = imports.flatMap(compilationEnvironment.resolveModulePath(currentFile, _))
     val sources = paths.flatMap(x => Try(compilationEnvironment.getSource(x)).toOption)
 
-    paths ++ (sources zip paths).flatMap((x, y) => findAllImportedFiles(x, compilationEnvironment, Some(y)))
+    def findRecursively(source: String, path: String): Seq[String] = {
+      if (oldPaths contains path) {
+        Seq()
+      } else {
+        findAllImportedFiles(source, compilationEnvironment, Some(path), oldPaths + path)
+      }
+    }
+
+    paths ++ (sources zip paths).flatMap(findRecursively)
   }
 
   // used for includes menu


### PR DESCRIPTION
`findAllImportedFiles()` rescursively finds imports on all imported files, so a module that imports itself will cause an infinite recursion. Fix this by keeping track of files that have already been seen in a Set and not recursing if the current file is in that Set.

Tests are failing here because GHA is using a stale commit for some reason. They're passing in my fork: [![build-and-test](https://github.com/kgmt0/NetLogo/actions/workflows/main.yml/badge.svg?branch=fix-self-import)](https://github.com/kgmt0/NetLogo/actions/workflows/main.yml)