### PR TITLE
Fix ignored imports

### DIFF
--- a/parser-core/src/main/parse/StructureParser.scala
+++ b/parser-core/src/main/parse/StructureParser.scala
@@ -164,7 +164,7 @@ object StructureParser {
                   )
 
                   newResults = newResults.copy(
-                    imports = newImports.toSeq,
+                    imports = newResults.imports ++ newImports.toSeq,
                     procedures = newProcedures,
                     procedureTokens = newProcedureTokens
                   )

--- a/parser-core/src/test/parse/StructureParserTests.scala
+++ b/parser-core/src/test/parse/StructureParserTests.scala
@@ -333,6 +333,30 @@ class StructureParserTests extends AnyFunSuite {
     assert(results.imports.nonEmpty || results.includedSources.nonEmpty)
   }
 
+  test("multiple import statements return correct results") {
+    val src = """
+      |import foo
+      |import bar
+      |
+      """.stripMargin
+    val nlsSrc1 = """
+      |to hello
+      |  show 12345
+      |end
+      """.stripMargin
+    val nlsSrc2 = """
+      |to bye
+      |  show 54321
+      |end
+      """.stripMargin
+    val results = compileAll(src, nlsSrc1, nlsSrc2)
+
+    if (!results.procedures.contains(("FOO:HELLO", None)) ||
+        !results.procedures.contains(("BAR:BYE", None))) {
+      fail()
+    }
+  }
+
   test("import syntax detects duplicate imports") {
     expectParseAllError("import foo import bar import foo as baz", "Attempted to import a module multiple times")
   }


### PR DESCRIPTION
The list of imports were not being preserved across iterations, causing some import statements to be ignored.

Tests are failing here because GHA is using a stale commit for some reason. They're passing in my fork: [![build-and-test](https://github.com/kgmt0/NetLogo/actions/workflows/main.yml/badge.svg?branch=fix-ignored-imports)](https://github.com/kgmt0/NetLogo/actions/workflows/main.yml)