### PR TITLE
Display an error when there are duplicates in the import list

### DIFF
--- a/parser-core/src/main/parse/StructureCombinators.scala
+++ b/parser-core/src/main/parse/StructureCombinators.scala
@@ -26,7 +26,7 @@ package org.nlogo.parse
 // and discard input).
 
 import
-  org.nlogo.core.{ Token, TokenType, StructureDeclarations },
+  org.nlogo.core.{ I18N, Token, TokenType, StructureDeclarations },
   StructureDeclarations._
 
 object StructureCombinators {
@@ -122,10 +122,25 @@ extends scala.util.parsing.combinator.Parsers {
       case from ~ _ ~ to => (from.name, to.name)
     }
 
-  def importedIdentifierList: Parser[Map[String, String]] =
-    openBracket ~> commit(rep(renamableIdentifier) <~ closeBracket) ^^ {
-      case x => x.toMap
+  def importedIdentifierList: Parser[Map[String, String]] = {
+    def hasDuplicates(xs: List[String], found: Set[String] = Set()): Boolean = {
+      !xs.isEmpty && (found(xs.head) || hasDuplicates(xs.tail, found + xs.head))
     }
+
+    val parser = openBracket ~> commit(rep(renamableIdentifier) <~ closeBracket) ^^ {
+      case xs => {
+        val (src, dst) = xs.unzip
+
+        if (hasDuplicates(src) || hasDuplicates(dst)) {
+          Left(I18N.errors.get("compiler.StructureCombinators.duplicateIdentifiers"))
+        } else {
+          Right(xs.toMap)
+        }
+      }
+    }
+
+    parser.flatMap(_.fold(err, success))
+  }
 
   def extensions: Parser[Extensions] =
     keyword("EXTENSIONS") ~! identifierList ^^ {

--- a/parser-core/src/test/parse/StructureParserTests.scala
+++ b/parser-core/src/test/parse/StructureParserTests.scala
@@ -138,6 +138,25 @@ class StructureParserTests extends AnyFunSuite {
     assertResult(Map("FOO" -> "OOF", "BAR" -> "BAR", "BAZ" -> "ZAB"))(results.imports.head.importedIdentifiers)
   }
 
+  test("import with duplicate identifiers") {
+    val src = """
+      |export [baz qaz]
+      |
+      |to baz
+      |  show "baz"
+      |end
+      |
+      |to qaz
+      |  show "qaz"
+      |end
+    """.stripMargin
+
+    expectParseAllError("import [baz baz] from foo", "Identifier list contains duplicates", src)
+    expectParseAllError("import [baz (qaz as baz)] from foo", "Identifier list contains duplicates", src)
+    expectParseAllError("import [(baz as zzz) (qaz as zzz)] from foo", "Identifier list contains duplicates", src)
+    expectParseAllError("import [(baz as zzz) (baz as yyy)] from foo", "Identifier list contains duplicates", src)
+  }
+
   test("includes") {
     val results = compile("__includes [\"foo.nls\"]")
     assertResult(0)(results.procedures.size)

--- a/shared/resources/main/i18n/Errors_en.properties
+++ b/shared/resources/main/i18n/Errors_en.properties
@@ -202,6 +202,7 @@ compiler.LetVariable.notDefined = Nothing named {0} has been defined.
 compiler.MultiAssign.emptyVarList = The list of variables names given to {0} must contain at least one item.
 compiler.MultiAssign.tooFewValues = The list of values for {0} must be at least as long as the list of names.  We need {1} value(s) but only got {2} from the list {3}.
 compiler.Backifier.replaced = {0} is no longer a primitive, use {1} instead.
+compiler.StructureCombinators.duplicateIdentifiers = Identifier list contains duplicates
 compiler.StructureParser.includeNotFound = Could not find {0}
 compiler.StructureParser.importNotFound = Could not find {0}
 compiler.StructureParser.importMultipleImports = Attempted to import a module multiple times


### PR DESCRIPTION
This adjusts the parser for the second form of the import syntax so that listing duplicate identifiers will result in an error, e.g. `import [foo foo] from baz`.