### PR TITLE
Prevent imported modules from accessing agent variables in the model

### DIFF
--- a/parser-core/src/main/parse/Namer.scala
+++ b/parser-core/src/main/parse/Namer.scala
@@ -32,7 +32,7 @@ class Namer(
   lazy val handlers = Seq[Token => Option[(TokenType, core.Instruction)]](
     new CommandHandler(program.dialect.tokenMapper),
     new ReporterHandler(program.dialect.tokenMapper),
-    new BreedHandler(program),
+    new BreedHandler(if (procedure.module.isDefined) Program.empty() else program),
     new AgentVariableReporterHandler(if (procedure.module.isDefined) Program.empty() else program),
     new ExtensionPrimitiveHandler(extensionManager),
     new ProcedureVariableHandler(procedure.args),

--- a/parser-core/src/main/parse/Namer.scala
+++ b/parser-core/src/main/parse/Namer.scala
@@ -33,7 +33,7 @@ class Namer(
     new CommandHandler(program.dialect.tokenMapper),
     new ReporterHandler(program.dialect.tokenMapper),
     new BreedHandler(program),
-    new AgentVariableReporterHandler(program),
+    new AgentVariableReporterHandler(if (procedure.module.isDefined) Program.empty() else program),
     new ExtensionPrimitiveHandler(extensionManager),
     new ProcedureVariableHandler(procedure.args),
     new CallHandler(procedures, procedure.module))

--- a/parser-core/src/main/parse/NetLogoParser.scala
+++ b/parser-core/src/main/parse/NetLogoParser.scala
@@ -15,18 +15,19 @@ trait NetLogoParser {
   def basicParse(compilationOperand: CompilationOperand): (Seq[ProcedureDefinition], StructureResults) = {
     import compilationOperand.{ extensionManager, oldProcedures }
     val structureResults = StructureParser.parseSources(tokenizer, compilationOperand)
-    val globallyUsedNames =
-      StructureParser.usedNames(structureResults.program,
-        (oldProcedures ++ structureResults.procedures).filter { case ((_, procModule), _ ) => procModule.isEmpty })
-
     val nonAliasProcedures = structureResults.procedures.filter {
       case ((name, module), proc) => name == proc.name && module == proc.module
     }
 
-    val newTopLevelProcedures = (nonAliasProcedures -- oldProcedures.keys)
+    val allProcedures = oldProcedures ++ structureResults.procedures
+    val newTopLevelProcedures = nonAliasProcedures -- oldProcedures.keys
 
-    val topLevelDefs = newTopLevelProcedures.values
-      .map(parseProcedure(structureResults, globallyUsedNames, oldProcedures, extensionManager)).toSeq
+    val topLevelDefs = newTopLevelProcedures.values.map { x =>
+        val scope = StructureParser.usedNames(structureResults.program,
+          allProcedures.filter { case ((_, module), _ ) => module == x.module },
+          x.module.isDefined)
+        parseProcedure(structureResults, scope, oldProcedures, extensionManager)(x)
+      }.toSeq
     (topLevelDefs, structureResults)
   }
 

--- a/parser-core/src/main/parse/StructureParser.scala
+++ b/parser-core/src/main/parse/StructureParser.scala
@@ -296,20 +296,35 @@ object StructureParser {
       structureParser.parse(tokens, ownerModuleFilename, oldResults, filename)
     }
 
-  private[parse] def usedNames(program: Program, procedures: ProceduresMap): SymbolTable = {
-    val symTable =
+  private[parse] def usedNames(program: Program, procedures: ProceduresMap, isModule: Boolean): SymbolTable = {
+    val baseSymTable =
       SymbolTable.empty
         .addSymbols(program.dialect.tokenMapper.allCommandNames, SymbolType.PrimitiveCommand)
         .addSymbols(program.dialect.tokenMapper.allReporterNames, SymbolType.PrimitiveReporter)
-        .addSymbols(program.globals, SymbolType.GlobalVariable)
-        .addSymbols(program.turtlesOwn, SymbolType.TurtleVariable)
-        .addSymbols(program.patchesOwn, SymbolType.PatchVariable)
-        .addSymbols(program.linksOwn.filterNot(program.turtlesOwn.contains), SymbolType.LinkVariable)
-        .addSymbols(program.breeds.values.map(_.singular), SymbolType.TurtleBreedSingular)
-        .addSymbols(program.breeds.keys, SymbolType.TurtleBreed)
-        .addSymbols(program.linkBreeds.values.map(_.singular), SymbolType.LinkBreedSingular)
-        .addSymbols(program.linkBreeds.keys, SymbolType.LinkBreed)
         .addSymbols(procedures.keys.map(_._1), SymbolType.ProcedureSymbol)
+    val symTable =
+      if(isModule) {
+        val emptyProgram = Program.empty()
+        baseSymTable
+          .addSymbols(emptyProgram.globals, SymbolType.GlobalVariable)
+          .addSymbols(emptyProgram.turtlesOwn, SymbolType.TurtleVariable)
+          .addSymbols(emptyProgram.patchesOwn, SymbolType.PatchVariable)
+          .addSymbols(emptyProgram.linksOwn.filterNot(emptyProgram.turtlesOwn.contains), SymbolType.LinkVariable)
+          .addSymbols(emptyProgram.breeds.values.map(_.singular), SymbolType.TurtleBreedSingular)
+          .addSymbols(emptyProgram.breeds.keys, SymbolType.TurtleBreed)
+          .addSymbols(emptyProgram.linkBreeds.values.map(_.singular), SymbolType.LinkBreedSingular)
+          .addSymbols(emptyProgram.linkBreeds.keys, SymbolType.LinkBreed)
+      } else {
+        baseSymTable
+          .addSymbols(program.globals, SymbolType.GlobalVariable)
+          .addSymbols(program.turtlesOwn, SymbolType.TurtleVariable)
+          .addSymbols(program.patchesOwn, SymbolType.PatchVariable)
+          .addSymbols(program.linksOwn.filterNot(program.turtlesOwn.contains), SymbolType.LinkVariable)
+          .addSymbols(program.breeds.values.map(_.singular), SymbolType.TurtleBreedSingular)
+          .addSymbols(program.breeds.keys, SymbolType.TurtleBreed)
+          .addSymbols(program.linkBreeds.values.map(_.singular), SymbolType.LinkBreedSingular)
+          .addSymbols(program.linkBreeds.keys, SymbolType.LinkBreed)
+      }
 
     program.breeds.values.foldLeft(symTable) {
       case (table, breed) if breed.isLinkBreed =>
@@ -427,7 +442,9 @@ class StructureParser(
         StructureChecker.rejectDuplicateDeclarations(declarations)
         StructureChecker.rejectDuplicateNames(declarations,
           StructureParser.usedNames(
-            oldResults.program, oldResults.procedures.filter{ case ((_, procModule), _) => procModule == module }))
+            oldResults.program,
+            oldResults.procedures.filter{ case ((_, procModule), _) => procModule == module },
+            module.isDefined))
         StructureChecker.rejectMissingReport(declarations)
         StructureConverter.convert(declarations, displayName, module,
           if (subprogram)


### PR DESCRIPTION
For example, if the model file contains this code:
```
import test

turtles-own [foo]
```

And `test-nls` contains this code:
```
to test
   ask tutles [show foo]
end
```

Without this PR, the example above will compile because `test.nls` has access to `foo` declared in the model file. This patch makes it so that the module no longer has access, so the example would trigger an error.
