### PR TITLE
Display an error when encountering scoped identifiers with consecutive colons

### DIFF
--- a/parser-core/src/main/parse/ExpressionParser.scala
+++ b/parser-core/src/main/parse/ExpressionParser.scala
@@ -180,6 +180,9 @@ object ExpressionParser {
         val arguments = parsePotentiallyVariadicArgumentList(stmt.instruction.syntax, variadic, stmt, tokens, newScope)
         (stmt.withArguments(arguments), newScope)
 
+      case TokenType.Bad if token.value.isInstanceOf[String] =>
+        exception(token.value.asInstanceOf[String], token)
+
       case _ =>
         token.value match {
           case (_: core.prim._symbol | _: core.prim._unknownidentifier) if ! scope.contains(token.text.toUpperCase(Locale.ENGLISH)) =>

--- a/parser-core/src/main/parse/ScopedIdentifierConsolidator.scala
+++ b/parser-core/src/main/parse/ScopedIdentifierConsolidator.scala
@@ -3,7 +3,7 @@
 package org.nlogo.parse
 
 import org.nlogo.core,
-  core.{ Token, TokenType }
+  core.{ I18N, Token, TokenType }
 
 type StateType = (Option[Token], Boolean)
 
@@ -12,7 +12,13 @@ object ScopedIdentifierConsolidator extends TokenConsolidator[StateType] {
 
   override def transform(token: Token, state: StateType, hasNext: Boolean): (Seq[Token], StateType) = {
     val result = (token, state) match {
-      case (t @ Token(_, TokenType.Colon, _), (Some(pendingToken), _)) =>
+      case (t @ Token(_, TokenType.Colon, _), (Some(pendingToken), true)) => {
+        val errorMessage = I18N.errors.getN("compiler.ScopedIdentifierConsolidator.consecutiveColons")
+        val newToken = t.copy(tpe = TokenType.Bad, value = errorMessage)(t.sourceLocation)
+        (Seq(newToken), (None, true))
+      }
+
+      case (t @ Token(_, TokenType.Colon, _), (Some(pendingToken), false)) =>
         (Seq(), (Some(pendingToken), true))
 
       case (t @ Token(text, TokenType.Ident, value: String), (Some(pendingToken), true)) => {

--- a/shared/resources/main/i18n/Errors_en.properties
+++ b/shared/resources/main/i18n/Errors_en.properties
@@ -202,6 +202,7 @@ compiler.LetVariable.notDefined = Nothing named {0} has been defined.
 compiler.MultiAssign.emptyVarList = The list of variables names given to {0} must contain at least one item.
 compiler.MultiAssign.tooFewValues = The list of values for {0} must be at least as long as the list of names.  We need {1} value(s) but only got {2} from the list {3}.
 compiler.Backifier.replaced = {0} is no longer a primitive, use {1} instead.
+compiler.ScopedIdentifierConsolidator.consecutiveColons = Expected identifier between colons
 compiler.StructureCombinators.duplicateIdentifiers = Identifier list contains duplicates
 compiler.StructureParser.includeNotFound = Could not find {0}
 compiler.StructureParser.importNotFound = Could not find {0}


### PR DESCRIPTION
Example: `foo:::bar`. Previously, this was just treated as `foo:bar`. This PR makes it an error instead.