### PR TITLE
Remove ImportOption and ImportAlias in StructureDeclarations

### DIFF
--- a/parser-core/src/main/core/StructureDeclarations.scala
+++ b/parser-core/src/main/core/StructureDeclarations.scala
@@ -53,7 +53,4 @@ object StructureDeclarations {
     override val start: Token = token
     override val end: Token = token
   }
-  sealed trait ImportOption
-  case class ImportAlias(name: String, token: Token)
-    extends ImportOption
 }


### PR DESCRIPTION
These are no longer used by anything.