### PR TITLE
Reject path separators in module paths

### DIFF
--- a/parser-core/src/main/parse/StructureChecker.scala
+++ b/parser-core/src/main/parse/StructureChecker.scala
@@ -13,7 +13,7 @@ import java.util.Locale
 import
   org.nlogo.core,
     core.{ BreedIdentifierHandler, I18N, StructureDeclarations, Token, TokenType },
-      StructureDeclarations.{ Breed, Declaration, Export, Extensions, Identifier, Includes, Procedure, Variables },
+      StructureDeclarations.{ Breed, Declaration, Export, Extensions, Identifier, Import, Includes, Procedure, Variables },
     core.Fail._
 
 import SymbolType._
@@ -51,6 +51,20 @@ object StructureChecker {
             exception(I18N.errors.getN("compiler.StructureParser.importContainsVariables"), start)
           case _ =>
         }
+      }
+    }
+  }
+
+  def rejectPathSeparatorsInImportPaths(declarations: Seq[Declaration]): Unit = {
+    val separators = Set("/", System.getProperty("file.separator"))
+
+    for (declaration <- declarations) {
+      declaration match {
+        case Import(pathComponents, _, _, token) =>
+          if (pathComponents.exists(x => separators.exists(x.contains))) {
+            exception(I18N.errors.getN("compiler.StructureParser.importContainsPathSeparator"), token)
+          }
+        case _ =>
       }
     }
   }

--- a/parser-core/src/main/parse/StructureParser.scala
+++ b/parser-core/src/main/parse/StructureParser.scala
@@ -439,6 +439,7 @@ class StructureParser(
         StructureChecker.rejectMisplacedConstants(declarations)
         StructureChecker.rejectExportOutsideModule(declarations, module.isDefined)
         StructureChecker.rejectNonProceduresInModule(declarations, module.isDefined)
+        StructureChecker.rejectPathSeparatorsInImportPaths(declarations)
         StructureChecker.rejectDuplicateDeclarations(declarations)
         StructureChecker.rejectDuplicateNames(declarations,
           StructureParser.usedNames(

--- a/parser-core/src/test/parse/StructureParserTests.scala
+++ b/parser-core/src/test/parse/StructureParserTests.scala
@@ -383,6 +383,10 @@ class StructureParserTests extends AnyFunSuite {
     expectParseAllError("""import foobar:baz""", "Could not find FOOBAR:BAZ", SourceType.NLInclude)
   }
 
+  test("import rejects path separator") {
+    expectParseAllError("""import foo:bar/baz""", "Import paths may not contain slash or the system path separator", SourceType.NLModule)
+  }
+
   test("import syntax returns correct results") {
     val results = compileAll("""import foo""", SourceType.NLModule, "")
     assert(results.imports.nonEmpty || results.includedSources.nonEmpty)

--- a/shared/resources/main/i18n/Errors_en.properties
+++ b/shared/resources/main/i18n/Errors_en.properties
@@ -210,6 +210,7 @@ compiler.StructureParser.importConflict = There is already an imported {0} calle
 compiler.StructureParser.importContainsExtensions = Extensions cannot be used in a module
 compiler.StructureParser.importContainsBreed = Breeds cannot be declared in a module
 compiler.StructureParser.importContainsVariables = Agent variables cannot be declared in a module
+compiler.StructureParser.importContainsPathSeparator = Import paths may not contain slash or the system path separator
 compiler.StructureParser.importSelectiveFromNonModule = Selective import only works when importing directly from a module
 compiler.StructureParser.importSelectiveNotExported = Attempted to import a non-exported identifier
 compiler.StructureParser.exportMultiple = EXPORT may only be used once per file


### PR DESCRIPTION
This makes it so that NetLogo displays an error whenever a path separator is found in a module path. Example: "import foo:bar/baz".